### PR TITLE
feat(brew): add Homebrew formula for tap-based installation

### DIFF
--- a/Formula/moltis.rb
+++ b/Formula/moltis.rb
@@ -1,0 +1,19 @@
+class Moltis < Formula
+  desc "Rust-powered bot framework with LLM agents, plugins, and gateway"
+  homepage "https://github.com/penso/moltis"
+  url "https://github.com/penso/moltis.git",
+      tag:      "v0.1.0",
+      revision: ""
+  license "MIT"
+  head "https://github.com/penso/moltis.git", branch: "main"
+
+  depends_on "rust" => :build
+
+  def install
+    system "cargo", "install", *std_cargo_args(path: "crates/cli")
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/moltis --version", 2)
+  end
+end


### PR DESCRIPTION
Adds a Homebrew formula so users can install moltis via:
  brew tap penso/moltis https://github.com/penso/moltis
  brew install moltis

https://claude.ai/code/session_01P2dgZgxw1iZwAXZPNwcQfL