### PR TITLE
feat(ci): add zizmor workflow security scan to deb-packages

### DIFF
--- a/.github/workflows/deb-packages.yml
+++ b/.github/workflows/deb-packages.yml
@@ -13,7 +13,22 @@ concurrency:
 permissions: {}
 
 jobs:
+  zizmor:
+    name: Workflow Security
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+      - uses: zizmorcore/zizmor-action@135698455da5c3b3e55f73f4419e481ab68cdd95 # v0.4.1
+        with:
+          advanced-security: false
+          online-audits: false
+
   build-deb:
+    needs: zizmor
     strategy:
       matrix:
         include:
@@ -72,6 +87,7 @@ jobs:
           files: target/${{ matrix.target }}/debian/*.deb
 
   build-rpm:
+    needs: zizmor
     strategy:
       matrix:
         include:
@@ -141,6 +157,7 @@ jobs:
           files: target/${{ matrix.target }}/generate-rpm/*.rpm
 
   build-arch:
+    needs: zizmor
     strategy:
       matrix:
         include:
@@ -222,6 +239,7 @@ jobs:
           files: "*.pkg.tar.zst"
 
   build-appimage:
+    needs: zizmor
     strategy:
       matrix:
         include:
@@ -323,6 +341,7 @@ jobs:
           files: "*.AppImage"
 
   build-snap:
+    needs: zizmor
     runs-on: ubuntu-latest
     name: Build Snap
     permissions:
@@ -349,6 +368,7 @@ jobs:
           files: ${{ steps.build-snap.outputs.snap }}
 
   build-homebrew-binaries:
+    needs: zizmor
     strategy:
       matrix:
         include:


### PR DESCRIPTION
## Summary
- Add a `zizmor` workflow security scan job to `deb-packages.yml`, matching the pattern in `ci.yml`
- Gate all build jobs (`build-deb`, `build-rpm`, `build-arch`, `build-appimage`, `build-snap`, `build-homebrew-binaries`) on the zizmor check
- Uses `zizmorcore/zizmor-action` pinned to SHA (v0.4.1) with `advanced-security: false` and `online-audits: false`

## Test plan
- [ ] Verify CI zizmor job passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)