### PR TITLE
feat(config): MOLTIS_* env var overrides for all config fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ prompts
 .DS_Store
 .playwright-mcp/
 features/
+.moltis/

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -12,8 +12,9 @@ pub mod schema;
 
 pub use {
     loader::{
-        clear_config_dir, config_dir, data_dir, discover_and_load, find_or_default_config_path,
-        save_config, set_config_dir, update_config,
+        apply_env_overrides, clear_config_dir, clear_data_dir, config_dir, data_dir,
+        discover_and_load, find_or_default_config_path, save_config, set_config_dir, set_data_dir,
+        update_config,
     },
     schema::{
         AgentIdentity, AuthConfig, ChatConfig, MessageQueueMode, MoltisConfig, ResolvedIdentity,

--- a/crates/config/src/loader.rs
+++ b/crates/config/src/loader.rs
@@ -13,6 +13,9 @@ const CONFIG_FILENAMES: &[&str] = &["moltis.toml", "moltis.yaml", "moltis.yml", 
 /// Override for the config directory, set via `set_config_dir()`.
 static CONFIG_DIR_OVERRIDE: Mutex<Option<PathBuf>> = Mutex::new(None);
 
+/// Override for the data directory, set via `set_data_dir()`.
+static DATA_DIR_OVERRIDE: Mutex<Option<PathBuf>> = Mutex::new(None);
+
 /// Set a custom config directory. When set, config discovery only looks in
 /// this directory (project-local and user-global paths are skipped).
 /// Can be called multiple times (e.g. in tests) — each call replaces the
@@ -30,12 +33,30 @@ fn config_dir_override() -> Option<PathBuf> {
     CONFIG_DIR_OVERRIDE.lock().unwrap().clone()
 }
 
+/// Set a custom data directory. When set, `data_dir()` returns this path
+/// instead of the default.
+pub fn set_data_dir(path: PathBuf) {
+    *DATA_DIR_OVERRIDE.lock().unwrap() = Some(path);
+}
+
+/// Clear the data directory override, restoring default discovery.
+pub fn clear_data_dir() {
+    *DATA_DIR_OVERRIDE.lock().unwrap() = None;
+}
+
+fn data_dir_override() -> Option<PathBuf> {
+    DATA_DIR_OVERRIDE.lock().unwrap().clone()
+}
+
 /// Load config from the given path (any supported format).
+///
+/// After parsing, `MOLTIS_*` env vars are applied as overrides.
 pub fn load_config(path: &Path) -> anyhow::Result<MoltisConfig> {
     let raw = std::fs::read_to_string(path)
         .map_err(|e| anyhow::anyhow!("failed to read {}: {e}", path.display()))?;
     let raw = substitute_env(&raw);
-    parse_config(&raw, path)
+    let config = parse_config(&raw, path)?;
+    Ok(apply_env_overrides(config))
 }
 
 /// Load and parse the config file with env substitution and includes.
@@ -57,7 +78,7 @@ pub fn discover_and_load() -> MoltisConfig {
     if let Some(path) = find_config_file() {
         debug!(path = %path.display(), "loading config");
         match load_config(&path) {
-            Ok(cfg) => return cfg,
+            Ok(cfg) => return cfg, // env overrides already applied by load_config
             Err(e) => {
                 warn!(path = %path.display(), error = %e, "failed to load config, using defaults");
             },
@@ -68,9 +89,9 @@ pub fn discover_and_load() -> MoltisConfig {
         if let Err(e) = write_default_config(&config) {
             warn!(error = %e, "failed to write default config file");
         }
-        return config;
+        return apply_env_overrides(config);
     }
-    MoltisConfig::default()
+    apply_env_overrides(MoltisConfig::default())
 }
 
 /// Find the first config file in standard locations.
@@ -110,16 +131,31 @@ fn find_config_file() -> Option<PathBuf> {
     None
 }
 
-/// Returns the config directory: override, or `~/.config/moltis/` on all platforms.
+/// Returns the config directory: programmatic override → `MOLTIS_CONFIG_DIR` env →
+/// `~/.config/moltis/`.
 pub fn config_dir() -> Option<PathBuf> {
     if let Some(dir) = config_dir_override() {
         return Some(dir);
     }
+    if let Ok(dir) = std::env::var("MOLTIS_CONFIG_DIR") {
+        if !dir.is_empty() {
+            return Some(PathBuf::from(dir));
+        }
+    }
     home_dir().map(|h| h.join(".config").join("moltis"))
 }
 
-/// Returns the data directory: `~/.moltis/` on all platforms.
+/// Returns the data directory: programmatic override → `MOLTIS_DATA_DIR` env →
+/// `~/.moltis/`.
 pub fn data_dir() -> PathBuf {
+    if let Some(dir) = data_dir_override() {
+        return dir;
+    }
+    if let Ok(dir) = std::env::var("MOLTIS_DATA_DIR") {
+        if !dir.is_empty() {
+            return PathBuf::from(dir);
+        }
+    }
     home_dir()
         .map(|h| h.join(".moltis"))
         .unwrap_or_else(|| PathBuf::from(".moltis"))
@@ -192,6 +228,124 @@ fn write_default_config(config: &MoltisConfig) -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Apply `MOLTIS_*` environment variable overrides to a loaded config.
+///
+/// Maps env vars to config fields using `__` as a section separator and
+/// lowercasing. For example:
+/// - `MOLTIS_AUTH_DISABLED=true` → `auth.disabled = true`
+/// - `MOLTIS_TOOLS_EXEC_DEFAULT_TIMEOUT_SECS=60` → `tools.exec.default_timeout_secs = 60`
+/// - `MOLTIS_CHAT_MESSAGE_QUEUE_MODE=collect` → `chat.message_queue_mode = "collect"`
+///
+/// The config is serialized to a JSON value, env overrides are merged in,
+/// then deserialized back. Only env vars with the `MOLTIS_` prefix are
+/// considered. `MOLTIS_CONFIG_DIR`, `MOLTIS_DATA_DIR`, `MOLTIS_ASSETS_DIR`,
+/// `MOLTIS_TOKEN`, `MOLTIS_PASSWORD`, `MOLTIS_TAILSCALE`,
+/// `MOLTIS_WEBAUTHN_RP_ID`, and `MOLTIS_WEBAUTHN_ORIGIN` are excluded
+/// (they are handled separately).
+pub fn apply_env_overrides(config: MoltisConfig) -> MoltisConfig {
+    apply_env_overrides_with(config, std::env::vars())
+}
+
+/// Apply env overrides from an arbitrary iterator of (key, value) pairs.
+/// Exposed for testing without mutating the process environment.
+fn apply_env_overrides_with(
+    config: MoltisConfig,
+    vars: impl Iterator<Item = (String, String)>,
+) -> MoltisConfig {
+    use serde_json::Value;
+
+    const EXCLUDED: &[&str] = &[
+        "MOLTIS_CONFIG_DIR",
+        "MOLTIS_DATA_DIR",
+        "MOLTIS_ASSETS_DIR",
+        "MOLTIS_TOKEN",
+        "MOLTIS_PASSWORD",
+        "MOLTIS_TAILSCALE",
+        "MOLTIS_WEBAUTHN_RP_ID",
+        "MOLTIS_WEBAUTHN_ORIGIN",
+    ];
+
+    let mut root: Value = match serde_json::to_value(&config) {
+        Ok(v) => v,
+        Err(e) => {
+            warn!(error = %e, "failed to serialize config for env override");
+            return config;
+        },
+    };
+
+    for (key, val) in vars {
+        if !key.starts_with("MOLTIS_") {
+            continue;
+        }
+        if EXCLUDED.contains(&key.as_str()) {
+            continue;
+        }
+
+        // MOLTIS_AUTH__DISABLED → ["auth", "disabled"]
+        let path_parts: Vec<String> = key["MOLTIS_".len()..]
+            .split("__")
+            .map(|segment| segment.to_lowercase())
+            .collect();
+
+        if path_parts.is_empty() {
+            continue;
+        }
+
+        // Navigate to the parent object and set the leaf value.
+        let parsed_val = parse_env_value(&val);
+        set_nested(&mut root, &path_parts, parsed_val);
+    }
+
+    match serde_json::from_value(root) {
+        Ok(cfg) => cfg,
+        Err(e) => {
+            warn!(error = %e, "failed to apply env overrides, using config as-is");
+            config
+        },
+    }
+}
+
+/// Parse a string env value into a JSON value, trying bool and number first.
+fn parse_env_value(val: &str) -> serde_json::Value {
+    if val.eq_ignore_ascii_case("true") {
+        return serde_json::Value::Bool(true);
+    }
+    if val.eq_ignore_ascii_case("false") {
+        return serde_json::Value::Bool(false);
+    }
+    if let Ok(n) = val.parse::<i64>() {
+        return serde_json::Value::Number(n.into());
+    }
+    if let Ok(n) = val.parse::<f64>() {
+        if let Some(n) = serde_json::Number::from_f64(n) {
+            return serde_json::Value::Number(n);
+        }
+    }
+    serde_json::Value::String(val.to_string())
+}
+
+/// Set a value at a nested JSON path, creating intermediate objects as needed.
+fn set_nested(root: &mut serde_json::Value, path: &[String], val: serde_json::Value) {
+    if path.is_empty() {
+        return;
+    }
+    let mut current = root;
+    for (i, key) in path.iter().enumerate() {
+        if i == path.len() - 1 {
+            if let serde_json::Value::Object(map) = current {
+                map.insert(key.clone(), val);
+            }
+            return;
+        }
+        if !current.get(key).is_some_and(|v| v.is_object()) {
+            if let serde_json::Value::Object(map) = current {
+                map.insert(key.clone(), serde_json::Value::Object(Default::default()));
+            }
+        }
+        current = current.get_mut(key).unwrap();
+    }
+}
+
 fn parse_config(raw: &str, path: &Path) -> anyhow::Result<MoltisConfig> {
     let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("toml");
 
@@ -217,5 +371,111 @@ fn parse_config_value(raw: &str, path: &Path) -> anyhow::Result<serde_json::Valu
         },
         "json" => Ok(serde_json::from_str(raw)?),
         _ => anyhow::bail!("unsupported config format: .{ext}"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_env_value_bool() {
+        assert_eq!(parse_env_value("true"), serde_json::Value::Bool(true));
+        assert_eq!(parse_env_value("TRUE"), serde_json::Value::Bool(true));
+        assert_eq!(parse_env_value("false"), serde_json::Value::Bool(false));
+    }
+
+    #[test]
+    fn parse_env_value_number() {
+        assert_eq!(parse_env_value("42"), serde_json::json!(42));
+        assert_eq!(parse_env_value("3.14"), serde_json::json!(3.14));
+    }
+
+    #[test]
+    fn parse_env_value_string() {
+        assert_eq!(
+            parse_env_value("hello"),
+            serde_json::Value::String("hello".into())
+        );
+    }
+
+    #[test]
+    fn set_nested_creates_intermediate_objects() {
+        let mut root = serde_json::json!({});
+        set_nested(
+            &mut root,
+            &["a".into(), "b".into(), "c".into()],
+            serde_json::json!(42),
+        );
+        assert_eq!(root, serde_json::json!({"a": {"b": {"c": 42}}}));
+    }
+
+    #[test]
+    fn set_nested_overwrites_existing() {
+        let mut root = serde_json::json!({"auth": {"disabled": false}});
+        set_nested(
+            &mut root,
+            &["auth".into(), "disabled".into()],
+            serde_json::Value::Bool(true),
+        );
+        assert_eq!(root, serde_json::json!({"auth": {"disabled": true}}));
+    }
+
+    #[test]
+    fn apply_env_overrides_auth_disabled() {
+        let vars = vec![("MOLTIS_AUTH__DISABLED".into(), "true".into())];
+        let config = MoltisConfig::default();
+        assert!(!config.auth.disabled);
+        let config = apply_env_overrides_with(config, vars.into_iter());
+        assert!(config.auth.disabled);
+    }
+
+    #[test]
+    fn apply_env_overrides_tools_agent_timeout() {
+        let vars = vec![("MOLTIS_TOOLS__AGENT_TIMEOUT_SECS".into(), "120".into())];
+        let config = apply_env_overrides_with(MoltisConfig::default(), vars.into_iter());
+        assert_eq!(config.tools.agent_timeout_secs, 120);
+    }
+
+    #[test]
+    fn apply_env_overrides_ignores_excluded() {
+        // MOLTIS_CONFIG_DIR should not be treated as a config field override.
+        let vars = vec![("MOLTIS_CONFIG_DIR".into(), "/tmp/test".into())];
+        let config = apply_env_overrides_with(MoltisConfig::default(), vars.into_iter());
+        assert!(!config.auth.disabled);
+    }
+
+    #[test]
+    fn apply_env_overrides_multiple() {
+        let vars = vec![
+            ("MOLTIS_AUTH__DISABLED".into(), "true".into()),
+            ("MOLTIS_TOOLS__AGENT_TIMEOUT_SECS".into(), "300".into()),
+            (
+                "MOLTIS_TAILSCALE__MODE".into(),
+                "funnel".into(),
+            ),
+        ];
+        let config = apply_env_overrides_with(MoltisConfig::default(), vars.into_iter());
+        assert!(config.auth.disabled);
+        assert_eq!(config.tools.agent_timeout_secs, 300);
+        assert_eq!(config.tailscale.mode, "funnel");
+    }
+
+    #[test]
+    fn apply_env_overrides_deep_nesting() {
+        let vars = vec![(
+            "MOLTIS_TOOLS__EXEC__DEFAULT_TIMEOUT_SECS".into(),
+            "60".into(),
+        )];
+        let config = apply_env_overrides_with(MoltisConfig::default(), vars.into_iter());
+        assert_eq!(config.tools.exec.default_timeout_secs, 60);
+    }
+
+    #[test]
+    fn data_dir_override_works() {
+        let path = PathBuf::from("/tmp/test-data-dir-override");
+        set_data_dir(path.clone());
+        assert_eq!(data_dir(), path);
+        clear_data_dir();
     }
 }

--- a/crates/gateway/src/server.rs
+++ b/crates/gateway/src/server.rs
@@ -171,9 +171,12 @@ pub async fn start_gateway(
     data_dir: Option<std::path::PathBuf>,
     #[cfg(feature = "tailscale")] tailscale_opts: Option<TailscaleOpts>,
 ) -> anyhow::Result<()> {
-    // Apply config directory override before loading config.
+    // Apply directory overrides before loading config.
     if let Some(dir) = config_dir {
         moltis_config::set_config_dir(dir);
+    }
+    if let Some(ref dir) = data_dir {
+        moltis_config::set_data_dir(dir.clone());
     }
 
     // Resolve auth from environment (MOLTIS_TOKEN / MOLTIS_PASSWORD).


### PR DESCRIPTION
## Summary
- Any config field can be overridden via `MOLTIS_*` env vars using `__` as section separator (e.g. `MOLTIS_AUTH__DISABLED=true`, `MOLTIS_TOOLS__EXEC__DEFAULT_TIMEOUT_SECS=60`)
- `config_dir()` and `data_dir()` now check `MOLTIS_CONFIG_DIR` / `MOLTIS_DATA_DIR` env vars directly, enabling per-worktree isolation without the CLI
- Added `set_data_dir()` / `clear_data_dir()` programmatic overrides (mirroring existing `config_dir` pattern)
- Added `.moltis/` to `.gitignore` so per-worktree data stays out of VCS

## Test plan
- [x] 9 new unit tests for env override parsing, nesting, exclusions, and data_dir override
- [ ] Manual: set `MOLTIS_AUTH__DISABLED=true` and verify auth is disabled
- [ ] Manual: set `MOLTIS_DATA_DIR=.moltis/data` and verify data files land there

🤖 Generated with [Claude Code](https://claude.com/claude-code)