### PR TITLE
ci: use self-hosted runners for all workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ env:
 jobs:
   zizmor:
     name: Workflow Security
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     permissions:
       contents: read
     steps:
@@ -32,7 +32,7 @@ jobs:
   biome:
     name: Biome
     needs: zizmor
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     permissions:
       contents: read
     steps:
@@ -47,7 +47,7 @@ jobs:
   fmt:
     name: Format
     needs: zizmor
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     permissions:
       contents: read
     steps:
@@ -63,7 +63,7 @@ jobs:
   clippy:
     name: Clippy
     needs: zizmor
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     permissions:
       contents: read
     steps:
@@ -80,7 +80,7 @@ jobs:
   build:
     name: Build & Test
     needs: zizmor
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     permissions:
       contents: read
     steps:

--- a/.github/workflows/deb-packages.yml
+++ b/.github/workflows/deb-packages.yml
@@ -15,7 +15,7 @@ permissions: {}
 jobs:
   zizmor:
     name: Workflow Security
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     permissions:
       contents: read
     steps:
@@ -37,7 +37,7 @@ jobs:
           - target: aarch64-unknown-linux-gnu
             arch: arm64
 
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     name: Build .deb (${{ matrix.arch }})
     permissions:
       contents: write
@@ -96,7 +96,7 @@ jobs:
           - target: aarch64-unknown-linux-gnu
             arch: aarch64
 
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     name: Build .rpm (${{ matrix.arch }})
     permissions:
       contents: write
@@ -166,7 +166,7 @@ jobs:
           - target: aarch64-unknown-linux-gnu
             arch: aarch64
 
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     name: Build .pkg.tar.zst (${{ matrix.arch }})
     permissions:
       contents: write
@@ -248,7 +248,7 @@ jobs:
           - target: aarch64-unknown-linux-gnu
             arch: aarch64
 
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     name: Build AppImage (${{ matrix.arch }})
     permissions:
       contents: write
@@ -342,7 +342,7 @@ jobs:
 
   build-snap:
     needs: zizmor
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     name: Build Snap
     permissions:
       contents: write
@@ -373,15 +373,11 @@ jobs:
       matrix:
         include:
           - target: x86_64-apple-darwin
-            os: macos-14
           - target: aarch64-apple-darwin
-            os: macos-latest
           - target: x86_64-unknown-linux-gnu
-            os: ubuntu-latest
           - target: aarch64-unknown-linux-gnu
-            os: ubuntu-latest
 
-    runs-on: ${{ matrix.os }}
+    runs-on: self-hosted
     name: Build binary (${{ matrix.target }})
     permissions:
       contents: write

--- a/.github/workflows/homebrew.yml
+++ b/.github/workflows/homebrew.yml
@@ -9,7 +9,7 @@ permissions: {}
 jobs:
   update-formula:
     name: Update Homebrew tap
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     permissions:
       contents: read
     steps:


### PR DESCRIPTION
## Summary
- Switch all GitHub Actions workflows from hosted runners (ubuntu-latest, macos-latest, macos-14) to self-hosted runners
- Updated ci.yml, deb-packages.yml, and homebrew.yml

## Test plan
- [ ] Verify self-hosted runner is configured and online
- [ ] Run a test workflow to confirm jobs execute on self-hosted runner

🤖 Generated with [Claude Code](https://claude.com/claude-code)