### PR TITLE
fix(ci): deploy docs to gh-pages branch

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,16 +15,12 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  build:
+  deploy:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      pages: write
-      id-token: write
+      contents: write
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-        with:
-          persist-credentials: false
 
       - name: Install mdBook
         run: |
@@ -43,25 +39,9 @@ jobs:
       - name: Add CNAME for custom domain
         run: echo "docs.moltis.org" > docs/book/CNAME
 
-      - name: Setup Pages
-        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
-
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
+      - name: Deploy to gh-pages branch
+        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4
         with:
-          path: docs/book
-
-  deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
-    needs: build
-    permissions:
-      contents: read
-      pages: write
-      id-token: write
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./docs/book
+          cname: docs.moltis.org


### PR DESCRIPTION
## Summary

- GitHub Pages is configured with legacy `build_type` (deploy from `gh-pages` branch), but the docs workflow was using `actions/deploy-pages` which requires "GitHub Actions" source mode — causing every deploy job to fail instantly
- Switched to `peaceiris/actions-gh-pages` to push built mdBook output directly to the `gh-pages` branch, matching the repo's Pages configuration

## Test plan

- [ ] Merge and verify the docs workflow succeeds on next push to `main` that touches `docs/`
- [ ] Verify https://docs.moltis.org loads correctly