### PR TITLE
feat(telegram): OTP self-approval for non-allowlisted DM users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **Deploy platform detection**: New `MOLTIS_DEPLOY_PLATFORM` env var hides local-only providers (local-llm, Ollama) on cloud deployments. Pre-configured in Fly.io, DigitalOcean, and Render deploy templates.
+- **Telegram OTP self-approval**: Non-allowlisted DM users receive a 6-digit verification code instead of being silently ignored. Correct code entry auto-approves the user to the allowlist. Includes flood protection (non-code messages silently ignored), lockout after 3 failed attempts (configurable cooldown), and 5-minute code expiry. OTP codes visible in web UI Senders tab. Controlled by `otp_self_approval` (default: true) and `otp_cooldown_secs` (default: 300) config fields.
 
 ### Changed
 
@@ -24,6 +25,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Web onboarding clarity**: Add setup-code guidance that points users to the process log (stdout).
 - **WebSocket auth (remote deployments)**: Accept existing session/API-key auth from WebSocket upgrade headers so browser connections don't immediately close after `connect` on hosted setups.
 - **Sandbox UX on unsupported hosts**: Disable sandbox controls in chat/images when no runtime backend is detected, with a tooltip explaining cloud deploy limitations.
+- **Telegram OTP code echoed to LLM**: After OTP self-approval, the verification code message was re-processed as a regular chat message because `sender_approve` restarted the bot polling loop (resetting the Telegram update offset). Sender approve/deny now hot-update the in-memory config without restarting the bot.
+- **Empty allowlist bypassed access control**: When `dm_policy = Allowlist` and all entries were removed, the empty list was treated as "allow everyone" instead of "deny everyone". An explicit Allowlist policy with an empty list now correctly denies all access.
 
 ## [0.1.10] - 2026-02-06
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3352,6 +3352,7 @@ dependencies = [
  "moltis-channels",
  "moltis-common",
  "moltis-metrics",
+ "rand 0.9.2",
  "reqwest 0.12.28",
  "secrecy 0.8.0",
  "serde",

--- a/crates/channels/src/plugin.rs
+++ b/crates/channels/src/plugin.rs
@@ -23,6 +23,24 @@ pub enum ChannelEvent {
         account_id: String,
         reason: String,
     },
+    /// An OTP challenge was issued to a non-allowlisted DM user.
+    OtpChallenge {
+        channel_type: String,
+        account_id: String,
+        peer_id: String,
+        username: Option<String>,
+        sender_name: Option<String>,
+        code: String,
+        expires_at: i64,
+    },
+    /// An OTP challenge was resolved (approved, locked out, or expired).
+    OtpResolved {
+        channel_type: String,
+        account_id: String,
+        peer_id: String,
+        username: Option<String>,
+        resolution: String,
+    },
 }
 
 /// Sink for channel events — the gateway provides the concrete implementation.
@@ -54,6 +72,18 @@ pub trait ChannelEventSink: Send + Sync {
     /// This is used when the polling loop detects an unrecoverable error
     /// (e.g. another bot instance is running with the same token).
     async fn request_disable_account(&self, channel_type: &str, account_id: &str, reason: &str);
+
+    /// Request adding a sender to the allowlist (OTP self-approval).
+    ///
+    /// The gateway implementation calls `sender_approve` to persist the change
+    /// and restart the account.
+    async fn request_sender_approval(
+        &self,
+        _channel_type: &str,
+        _account_id: &str,
+        _identifier: &str,
+    ) {
+    }
 }
 
 /// Metadata about a channel message, used for UI display.

--- a/crates/gateway/src/channel_events.rs
+++ b/crates/gateway/src/channel_events.rs
@@ -309,6 +309,35 @@ impl ChannelEventSink for GatewayChannelEventSink {
         }
     }
 
+    async fn request_sender_approval(
+        &self,
+        _channel_type: &str,
+        account_id: &str,
+        identifier: &str,
+    ) {
+        if let Some(state) = self.state.get() {
+            let params = serde_json::json!({
+                "account_id": account_id,
+                "identifier": identifier,
+            });
+            match state.services.channel.sender_approve(params).await {
+                Ok(_) => {
+                    info!(account_id, identifier, "OTP self-approval: sender approved");
+                },
+                Err(e) => {
+                    warn!(
+                        account_id,
+                        identifier,
+                        error = %e,
+                        "OTP self-approval: failed to approve sender"
+                    );
+                },
+            }
+        } else {
+            warn!("request_sender_approval: gateway not ready");
+        }
+    }
+
     async fn dispatch_command(
         &self,
         command: &str,

--- a/crates/metrics/src/definitions.rs
+++ b/crates/metrics/src/definitions.rs
@@ -447,6 +447,10 @@ pub mod telegram {
     pub const ACCESS_CONTROL_DENIALS_TOTAL: &str = "moltis_telegram_access_control_denials_total";
     /// Update polling duration
     pub const POLLING_DURATION_SECONDS: &str = "moltis_telegram_polling_duration_seconds";
+    /// OTP challenges issued to non-allowlisted users
+    pub const OTP_CHALLENGES_TOTAL: &str = "moltis_telegram_otp_challenges_total";
+    /// OTP verification attempts (labelled by result: approved, wrong_code, locked_out, expired)
+    pub const OTP_VERIFICATIONS_TOTAL: &str = "moltis_telegram_otp_verifications_total";
 }
 
 /// Config loading metrics

--- a/crates/telegram/Cargo.toml
+++ b/crates/telegram/Cargo.toml
@@ -10,6 +10,7 @@ moltis-auto-reply = { workspace = true }
 moltis-channels   = { workspace = true }
 moltis-common     = { workspace = true }
 moltis-metrics    = { optional = true, workspace = true }
+rand              = { workspace = true }
 reqwest           = { workspace = true }
 secrecy           = { workspace = true }
 serde             = { workspace = true }

--- a/crates/telegram/src/access.rs
+++ b/crates/telegram/src/access.rs
@@ -34,6 +34,13 @@ fn check_dm_access(
         DmPolicy::Disabled => Err(AccessDenied::DmsDisabled),
         DmPolicy::Open => Ok(()),
         DmPolicy::Allowlist => {
+            // An empty allowlist with an explicit Allowlist policy means
+            // "deny everyone" — not "allow everyone".  The generic
+            // `is_allowed()` treats empty lists as open, so we
+            // short-circuit here.
+            if config.allowlist.is_empty() {
+                return Err(AccessDenied::NotOnAllowlist);
+            }
             if gating::is_allowed(peer_id, &config.allowlist)
                 || username.is_some_and(|u| gating::is_allowed(u, &config.allowlist))
             {
@@ -55,7 +62,9 @@ fn check_group_access(
         GroupPolicy::Disabled => return Err(AccessDenied::GroupsDisabled),
         GroupPolicy::Allowlist => {
             let gid = group_id.unwrap_or("");
-            if !gating::is_allowed(gid, &config.group_allowlist) {
+            if config.group_allowlist.is_empty()
+                || !gating::is_allowed(gid, &config.group_allowlist)
+            {
                 return Err(AccessDenied::GroupNotOnAllowlist);
             }
         },
@@ -202,6 +211,92 @@ mod tests {
         assert_eq!(
             check_access(&c, &ChatType::Group, "user", None, Some("grp2"), false),
             Err(AccessDenied::GroupNotOnAllowlist)
+        );
+    }
+
+    #[test]
+    fn empty_dm_allowlist_denies_all() {
+        let mut c = cfg();
+        c.dm_policy = DmPolicy::Allowlist;
+        // allowlist is empty — should deny, not allow
+        assert_eq!(
+            check_access(&c, &ChatType::Dm, "anyone", None, None, false),
+            Err(AccessDenied::NotOnAllowlist)
+        );
+        assert_eq!(
+            check_access(&c, &ChatType::Dm, "anyone", Some("user"), None, false),
+            Err(AccessDenied::NotOnAllowlist)
+        );
+    }
+
+    #[test]
+    fn empty_group_allowlist_denies_all() {
+        let mut c = cfg();
+        c.group_policy = GroupPolicy::Allowlist;
+        c.mention_mode = MentionMode::Always;
+        // group_allowlist is empty — should deny, not allow
+        assert_eq!(
+            check_access(&c, &ChatType::Group, "user", None, Some("grp1"), true),
+            Err(AccessDenied::GroupNotOnAllowlist)
+        );
+    }
+
+    /// Security regression: removing the last entry from an allowlist must
+    /// NOT silently switch to open access.  An explicit Allowlist policy with
+    /// an empty list must deny every peer — by peer ID, by username, and in
+    /// groups alike.  Failure here means unauthenticated users can bypass the
+    /// allowlist by convincing an admin to remove all entries.
+    #[test]
+    fn security_removing_last_allowlist_entry_denies_access() {
+        // --- DM: user is on the list, gets removed, must be denied ---
+        let mut c = cfg();
+        c.dm_policy = DmPolicy::Allowlist;
+        c.allowlist = vec!["377114917".into()];
+
+        // While on the list: allowed
+        assert!(check_access(&c, &ChatType::Dm, "377114917", Some("alice"), None, false).is_ok());
+
+        // Simulate admin removing the sole entry via the UI
+        c.allowlist.clear();
+
+        // After removal: denied by peer ID alone
+        assert_eq!(
+            check_access(&c, &ChatType::Dm, "377114917", None, None, false),
+            Err(AccessDenied::NotOnAllowlist),
+            "empty DM allowlist must deny by peer_id"
+        );
+        // After removal: denied even when username is provided
+        assert_eq!(
+            check_access(&c, &ChatType::Dm, "377114917", Some("alice"), None, false),
+            Err(AccessDenied::NotOnAllowlist),
+            "empty DM allowlist must deny by username"
+        );
+        // After removal: other users also denied
+        assert_eq!(
+            check_access(&c, &ChatType::Dm, "999", Some("eve"), None, false),
+            Err(AccessDenied::NotOnAllowlist),
+            "empty DM allowlist must deny unknown users"
+        );
+
+        // --- Group: same invariant ---
+        let mut g = cfg();
+        g.group_policy = GroupPolicy::Allowlist;
+        g.group_allowlist = vec!["grp1".into()];
+        g.mention_mode = MentionMode::Always;
+
+        assert!(check_access(&g, &ChatType::Group, "user", None, Some("grp1"), true).is_ok());
+
+        g.group_allowlist.clear();
+
+        assert_eq!(
+            check_access(&g, &ChatType::Group, "user", None, Some("grp1"), true),
+            Err(AccessDenied::GroupNotOnAllowlist),
+            "empty group allowlist must deny previously-allowed group"
+        );
+        assert_eq!(
+            check_access(&g, &ChatType::Group, "user", None, Some("grp2"), true),
+            Err(AccessDenied::GroupNotOnAllowlist),
+            "empty group allowlist must deny unknown groups"
         );
     }
 }

--- a/crates/telegram/src/bot.rs
+++ b/crates/telegram/src/bot.rs
@@ -72,6 +72,7 @@ pub async fn start_polling(
         accounts: Arc::clone(&accounts),
     });
 
+    let otp_cooldown = config.otp_cooldown_secs;
     let state = AccountState {
         bot: bot.clone(),
         bot_username,
@@ -81,6 +82,7 @@ pub async fn start_polling(
         cancel: cancel.clone(),
         message_log,
         event_sink,
+        otp: std::sync::Mutex::new(crate::otp::OtpState::new(otp_cooldown)),
     };
 
     {

--- a/crates/telegram/src/config.rs
+++ b/crates/telegram/src/config.rs
@@ -54,6 +54,12 @@ pub struct TelegramAccountConfig {
     /// resolves the provider from the model ID at runtime.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub model_provider: Option<String>,
+
+    /// Enable OTP self-approval for non-allowlisted DM users (default: true).
+    pub otp_self_approval: bool,
+
+    /// Cooldown in seconds after 3 failed OTP attempts (default: 300).
+    pub otp_cooldown_secs: u64,
 }
 
 impl std::fmt::Debug for TelegramAccountConfig {
@@ -86,6 +92,8 @@ impl Default for TelegramAccountConfig {
             edit_throttle_ms: 300,
             model: None,
             model_provider: None,
+            otp_self_approval: true,
+            otp_cooldown_secs: 300,
         }
     }
 }

--- a/crates/telegram/src/lib.rs
+++ b/crates/telegram/src/lib.rs
@@ -8,6 +8,7 @@ pub mod bot;
 pub mod config;
 pub mod handlers;
 pub mod markdown;
+pub mod otp;
 pub mod outbound;
 pub mod plugin;
 pub mod state;

--- a/crates/telegram/src/plugin.rs
+++ b/crates/telegram/src/plugin.rs
@@ -79,6 +79,32 @@ impl TelegramPlugin {
             .get(account_id)
             .and_then(|s| serde_json::to_value(&s.config).ok())
     }
+
+    /// Update the in-memory config for an account without restarting the
+    /// polling loop.  Use for allowlist changes that don't need
+    /// re-authentication or bot restart.
+    pub fn update_account_config(&self, account_id: &str, config: serde_json::Value) -> Result<()> {
+        let tg_config: TelegramAccountConfig = serde_json::from_value(config)?;
+        let mut accounts = self.accounts.write().unwrap();
+        if let Some(state) = accounts.get_mut(account_id) {
+            state.config = tg_config;
+            Ok(())
+        } else {
+            Err(anyhow::anyhow!("account not found: {account_id}"))
+        }
+    }
+
+    /// List pending OTP challenges for a specific account.
+    pub fn pending_otp_challenges(&self, account_id: &str) -> Vec<crate::otp::OtpChallengeInfo> {
+        let accounts = self.accounts.read().unwrap();
+        accounts
+            .get(account_id)
+            .map(|s| {
+                let otp = s.otp.lock().unwrap();
+                otp.list_pending()
+            })
+            .unwrap_or_default()
+    }
 }
 
 impl Default for TelegramPlugin {
@@ -189,5 +215,208 @@ impl ChannelStatus for TelegramPlugin {
         }
 
         Ok(result)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        crate::{otp::OtpState, outbound::TelegramOutbound, state::AccountState},
+        moltis_channels::gating::DmPolicy,
+        secrecy::{ExposeSecret, Secret},
+        tokio_util::sync::CancellationToken,
+    };
+
+    /// Build a minimal `AccountState` for unit tests (no network calls).
+    fn test_account_state(accounts: &AccountStateMap, cancel: CancellationToken) -> AccountState {
+        AccountState {
+            bot: teloxide::Bot::new("test:fake_token_for_unit_tests"),
+            bot_username: Some("test_bot".into()),
+            account_id: "test".into(),
+            config: TelegramAccountConfig {
+                token: Secret::new("test:fake_token_for_unit_tests".into()),
+                ..Default::default()
+            },
+            outbound: Arc::new(TelegramOutbound {
+                accounts: Arc::clone(accounts),
+            }),
+            cancel,
+            message_log: None,
+            event_sink: None,
+            otp: std::sync::Mutex::new(OtpState::new(300)),
+        }
+    }
+
+    #[test]
+    fn update_account_config_updates_allowlist() {
+        let plugin = TelegramPlugin::new();
+        let cancel = CancellationToken::new();
+        {
+            let mut map = plugin.accounts.write().unwrap();
+            map.insert("test".into(), test_account_state(&plugin.accounts, cancel));
+        }
+
+        // Initially empty allowlist.
+        {
+            let map = plugin.accounts.read().unwrap();
+            assert!(map.get("test").unwrap().config.allowlist.is_empty());
+        }
+
+        // Update config with a populated allowlist.
+        let new_config = serde_json::json!({
+            "token": "test:fake_token_for_unit_tests",
+            "dm_policy": "allowlist",
+            "allowlist": ["alice", "bob"],
+        });
+        plugin.update_account_config("test", new_config).unwrap();
+
+        // Verify the change is immediately visible.
+        let map = plugin.accounts.read().unwrap();
+        let state = map.get("test").unwrap();
+        assert_eq!(state.config.dm_policy, DmPolicy::Allowlist);
+        assert_eq!(state.config.allowlist, vec!["alice", "bob"]);
+    }
+
+    /// Security: `update_account_config` must NOT cancel the polling
+    /// CancellationToken.  Cancelling it restarts the bot polling loop with
+    /// offset 0, causing Telegram to re-deliver the OTP code message.  The
+    /// re-delivered message would pass access control (user is now on the
+    /// allowlist) and get forwarded to the LLM.
+    #[test]
+    fn security_update_config_does_not_cancel_polling() {
+        let plugin = TelegramPlugin::new();
+        let cancel = CancellationToken::new();
+        let cancel_witness = cancel.clone();
+
+        {
+            let mut map = plugin.accounts.write().unwrap();
+            map.insert("test".into(), test_account_state(&plugin.accounts, cancel));
+        }
+
+        let new_config = serde_json::json!({
+            "token": "test:fake_token_for_unit_tests",
+            "allowlist": ["new_user"],
+        });
+        plugin.update_account_config("test", new_config).unwrap();
+
+        assert!(
+            !cancel_witness.is_cancelled(),
+            "update_account_config must NOT cancel the polling token — \
+             cancelling restarts the bot and causes Telegram to re-deliver messages"
+        );
+    }
+
+    /// Security: after a hot config update, the access control check must
+    /// immediately reflect the new allowlist.  This simulates the exact
+    /// sequence that happens during OTP self-approval.
+    #[test]
+    fn security_config_update_immediately_affects_access_control() {
+        use {crate::access, moltis_common::types::ChatType};
+
+        let plugin = TelegramPlugin::new();
+        let cancel = CancellationToken::new();
+        {
+            let mut map = plugin.accounts.write().unwrap();
+            let mut state = test_account_state(&plugin.accounts, cancel);
+            state.config.dm_policy = DmPolicy::Allowlist;
+            state.config.allowlist = vec![];
+            map.insert("test".into(), state);
+        }
+
+        // Before approval: user is denied.
+        {
+            let map = plugin.accounts.read().unwrap();
+            let config = &map.get("test").unwrap().config;
+            assert!(
+                access::check_access(config, &ChatType::Dm, "12345", Some("alice"), None, false)
+                    .is_err()
+            );
+        }
+
+        // OTP approval adds user to allowlist via update_account_config.
+        let new_config = serde_json::json!({
+            "token": "test:fake_token_for_unit_tests",
+            "dm_policy": "allowlist",
+            "allowlist": ["alice"],
+        });
+        plugin.update_account_config("test", new_config).unwrap();
+
+        // After approval: user is allowed.
+        {
+            let map = plugin.accounts.read().unwrap();
+            let config = &map.get("test").unwrap().config;
+            assert!(
+                access::check_access(config, &ChatType::Dm, "12345", Some("alice"), None, false)
+                    .is_ok(),
+                "approved user must pass access control immediately after config update"
+            );
+        }
+    }
+
+    #[test]
+    fn update_account_config_nonexistent_account_errors() {
+        let plugin = TelegramPlugin::new();
+        let result = plugin.update_account_config("nonexistent", serde_json::json!({"token": "t"}));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn update_account_config_preserves_otp_state() {
+        let plugin = TelegramPlugin::new();
+        let cancel = CancellationToken::new();
+        {
+            let mut map = plugin.accounts.write().unwrap();
+            map.insert("test".into(), test_account_state(&plugin.accounts, cancel));
+        }
+
+        // Create a pending OTP challenge.
+        {
+            let map = plugin.accounts.read().unwrap();
+            let state = map.get("test").unwrap();
+            let mut otp = state.otp.lock().unwrap();
+            otp.initiate("12345", Some("alice".into()), None);
+        }
+
+        // Update config.
+        let new_config = serde_json::json!({
+            "token": "test:fake_token_for_unit_tests",
+            "allowlist": ["alice"],
+        });
+        plugin.update_account_config("test", new_config).unwrap();
+
+        // OTP challenge must still be pending (state was not wiped).
+        let map = plugin.accounts.read().unwrap();
+        let state = map.get("test").unwrap();
+        let otp = state.otp.lock().unwrap();
+        assert!(
+            otp.has_pending("12345"),
+            "config update must preserve in-flight OTP challenges"
+        );
+    }
+
+    #[test]
+    fn update_account_config_preserves_bot_token() {
+        let plugin = TelegramPlugin::new();
+        let cancel = CancellationToken::new();
+        {
+            let mut map = plugin.accounts.write().unwrap();
+            map.insert("test".into(), test_account_state(&plugin.accounts, cancel));
+        }
+
+        // Update config with a new allowlist but same token.
+        let new_config = serde_json::json!({
+            "token": "test:fake_token_for_unit_tests",
+            "allowlist": ["alice"],
+        });
+        plugin.update_account_config("test", new_config).unwrap();
+
+        // Bot instance itself is untouched (same object in memory).
+        let map = plugin.accounts.read().unwrap();
+        let state = map.get("test").unwrap();
+        assert_eq!(
+            state.config.token.expose_secret(),
+            "test:fake_token_for_unit_tests"
+        );
     }
 }

--- a/crates/telegram/src/state.rs
+++ b/crates/telegram/src/state.rs
@@ -1,13 +1,13 @@
 use std::{
     collections::HashMap,
-    sync::{Arc, RwLock},
+    sync::{Arc, Mutex, RwLock},
 };
 
 use tokio_util::sync::CancellationToken;
 
 use moltis_channels::{ChannelEventSink, message_log::MessageLog};
 
-use crate::{config::TelegramAccountConfig, outbound::TelegramOutbound};
+use crate::{config::TelegramAccountConfig, otp::OtpState, outbound::TelegramOutbound};
 
 /// Shared account state map.
 pub type AccountStateMap = Arc<RwLock<HashMap<String, AccountState>>>;
@@ -22,4 +22,8 @@ pub struct AccountState {
     pub cancel: CancellationToken,
     pub message_log: Option<Arc<dyn MessageLog>>,
     pub event_sink: Option<Arc<dyn ChannelEventSink>>,
+    /// In-memory OTP challenges for self-approval (std::sync::Mutex because
+    /// all OTP operations are synchronous HashMap lookups, never held across
+    /// `.await` points).
+    pub otp: Mutex<OtpState>,
 }


### PR DESCRIPTION
## Summary

- **OTP self-approval flow**: Non-allowlisted DM users now receive a 6-digit verification code instead of being silently ignored. Correct code entry auto-approves the user to the allowlist. Includes flood protection (non-code messages silently ignored), lockout after 3 failed attempts (configurable cooldown), and 5-minute code expiry.
- **Security fixes**: Empty allowlist with explicit Allowlist policy now correctly denies all access (previously treated as "allow everyone"). OTP verification code is no longer echoed to the LLM after self-approval — sender approve/deny now hot-updates the in-memory config without restarting the bot polling loop.
- **Web UI improvements**: OTP codes visible in Senders tab with click-to-copy. Edit channel modal now refreshes after approve/deny actions.

## Details

### OTP self-approval
When `dm_policy = Allowlist` and `otp_self_approval = true` (default), unauthorized users receive a challenge message directing them to ask the bot owner for the code (visible in the web UI under Channels → Senders). After entering the correct code, the user is automatically added to the allowlist.

Controlled by two new config fields:
- `otp_self_approval` (default: `true`) — enable/disable the OTP flow
- `otp_cooldown_secs` (default: `300`) — lockout duration after 3 failed attempts

### Security: empty allowlist bypass
When all entries were removed from the allowlist (e.g., via sender deny), the empty list was treated as "allow everyone" instead of "deny everyone". Fixed by short-circuiting in `check_dm_access()` and `check_group_access()` when the policy is explicitly Allowlist but the list is empty.

### Security: OTP code leaked to LLM
After OTP self-approval, the verification code message was re-processed as a regular chat message because `sender_approve` restarted the bot polling loop (resetting the Telegram update offset to 0). Telegram then re-delivered the OTP code, which now passed access control. Fixed by introducing `update_account_config()` that hot-updates the in-memory config without restarting the bot.

### Files changed (16 files, +1147/-24)
- `crates/telegram/src/otp.rs` — New OTP state machine with code generation, validation, expiry, lockout
- `crates/telegram/src/handlers.rs` — OTP challenge/verification handler integrated into message flow
- `crates/telegram/src/access.rs` — Empty allowlist fix + 3 security regression tests
- `crates/telegram/src/plugin.rs` — `update_account_config()` + 6 security tests
- `crates/telegram/src/config.rs` — New config fields (`otp_self_approval`, `otp_cooldown_secs`)
- `crates/gateway/src/channel.rs` — Hot-update instead of stop+restart in sender approve/deny
- `crates/gateway/src/channel_events.rs` — `request_sender_approval` event sink method
- `crates/gateway/src/assets/js/page-channels.js` — OTP click-to-copy, stale modal fix
- `crates/channels/src/plugin.rs` — `ChannelEventSink` trait with `request_sender_approval`

## Test plan

- [x] All 232 existing tests pass (`cargo test` across telegram, gateway, channels crates)
- [x] `empty_dm_allowlist_denies_all` — empty allowlist denies DM access
- [x] `empty_group_allowlist_denies_all` — empty allowlist denies group access
- [x] `security_removing_last_allowlist_entry_denies_access` — simulates full remove-last-entry scenario
- [x] `security_update_config_does_not_cancel_polling` — config update preserves CancellationToken
- [x] `security_config_update_immediately_affects_access_control` — access control reflects changes instantly
- [x] `security_otp_challenge_message_does_not_contain_code` — challenge message doesn't leak the code
- [x] `update_account_config_preserves_otp_state` — in-flight OTP challenges survive config updates
- [x] OTP flow: initiate → validate correct code → user approved
- [x] OTP flow: 3 wrong attempts → lockout → cooldown expiry → can retry
- [x] OTP flow: code expiry after TTL
- [ ] Manual: send DM to bot as non-allowlisted user → receive challenge → enter code from web UI → verified
- [ ] Manual: approve/deny sender in web UI → edit channel modal shows updated allowlist
- [ ] Manual: click OTP badge in Senders tab → code copied to clipboard with toast