### PR TITLE
test(regressions): add cron and hooks liveness guards

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7594,7 +7594,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3fabb953106c3c8eea8306e4393700d7657561cb43122571b172bbfb7c7ba1d"
 dependencies = [
  "env_home",
- "rustix",
+ "rustix 1.1.3",
  "winsafe",
 ]
 


### PR DESCRIPTION
## Summary
- add a cron scheduler liveness regression test that verifies start() executes due jobs and persists run records
- add gateway smoke coverage that ensures built-in hooks (boot-md, command-logger, session-memory) are discovered and registered
- add a command-dispatch smoke test proving session-memory writes conversation memory files on /new events

## Validation
- cargo +nightly fmt
- cargo test -p moltis-cron test_start_executes_due_jobs_and_records_runs
- cargo test -p moltis-gateway discover_hooks_registers_builtin_handlers
- cargo test -p moltis-gateway command_hook_dispatch_saves_session_memory_file