### PR TITLE
feat(telegram): send voice replies with text transcript

### DIFF
--- a/crates/telegram/src/markdown.rs
+++ b/crates/telegram/src/markdown.rs
@@ -234,6 +234,9 @@ fn escape_html(text: &str) -> String {
 /// Telegram message size limit.
 pub const TELEGRAM_MAX_MESSAGE_LEN: usize = 4096;
 
+/// Telegram caption size limit for media messages (voice, photo, document).
+pub const TELEGRAM_CAPTION_LIMIT: usize = 1024;
+
 /// Split text into chunks that fit within Telegram's message limit.
 /// Tries to split at newlines or spaces to avoid breaking words.
 pub fn chunk_message(text: &str, max_len: usize) -> Vec<String> {


### PR DESCRIPTION
## Summary

- Voice replies on Telegram were sent without any text caption (empty string), unlike the web UI which shows both audio and text
- `build_tts_payload` now returns the original LLM response text in the `ReplyPayload` instead of `String::new()`
- `deliver_channel_replies_to_targets` respects Telegram's 1024-char caption limit: short replies go as a caption on the voice message, long replies are sent as a follow-up text message
- Added `TELEGRAM_CAPTION_LIMIT` constant alongside the existing `TELEGRAM_MAX_MESSAGE_LEN`

## Validation

### Completed
- [x] `cargo build` — compiles clean
- [x] `cargo test -p moltis-telegram -p moltis-gateway` — all 52 tests pass
- [x] `cargo +nightly clippy -p moltis-telegram -p moltis-gateway --all-targets` — no warnings
- [x] `cargo +nightly fmt --all -- --check` — formatted

### Remaining
- [ ] Manual QA: send a voice message on Telegram, verify response includes both voice audio and text transcript (as caption for short replies, as separate message for long replies)

## Manual QA

Pending — requires a running instance with TTS configured and a Telegram bot connected.