### PR TITLE
security: enforce least-privilege API key scopes and block npm postinstall scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   database health, verifies provider readiness (API keys via config or env vars),
   inspects TLS certificates, and validates MCP server commands on PATH.
 
+### Security
+
+- **npm install --ignore-scripts**: Skill dependency installation now passes
+  `--ignore-scripts` to npm, preventing supply chain attacks via malicious
+  postinstall scripts in npm packages.
+- **API key scope enforcement**: API keys with empty/no scopes are now denied
+  access instead of silently receiving full admin privileges. Keys must specify
+  at least one scope explicitly (least-privilege by default).
+
 ## [0.4.1] - 2026-02-09
 
 ### Fixed

--- a/docs/src/security.md
+++ b/docs/src/security.md
@@ -167,28 +167,26 @@ The gateway API uses role-based access control with scopes:
 
 ### API Keys
 
-API keys authenticate external tools and scripts connecting to Moltis. Keys can
-have **full access** (all scopes) or be restricted to specific scopes for
-defense-in-depth.
+API keys authenticate external tools and scripts connecting to Moltis. Keys
+**must specify at least one scope** — keys without scopes are denied access
+(least-privilege by default).
 
 #### Creating API Keys
 
 **Web UI**: Settings > Security > API Keys
 
 1. Enter a label describing the key's purpose
-2. Choose "Full access" or select specific scopes
+2. Select the required scopes
 3. Click "Generate key"
 4. **Copy the key immediately** — it's only shown once
 
 **CLI**:
 
 ```bash
-# Full access key
-moltis auth create-api-key --label "CI pipeline"
-
 # Scoped key (comma-separated scopes)
 moltis auth create-api-key --label "Monitor" --scopes "operator.read"
 moltis auth create-api-key --label "Automation" --scopes "operator.read,operator.write"
+moltis auth create-api-key --label "CI pipeline" --scopes "operator.admin"
 ```
 
 #### Using API Keys
@@ -218,15 +216,15 @@ Authorization: Bearer mk_abc123...
 | Read-only monitoring | `operator.read` |
 | Automated workflows | `operator.read`, `operator.write` |
 | Approval handling | `operator.read`, `operator.approvals` |
-| Full automation | Full access (no scope restrictions) |
+| Full automation | `operator.admin` |
 
 **Best practice**: Use the minimum necessary scopes. If a key only needs to
 read status and logs, don't grant `operator.write`.
 
 #### Backward Compatibility
 
-Existing API keys (created before scopes were added) have full access. Newly
-created keys without explicit scopes also have full access.
+Existing API keys created without scopes will be **denied access** until
+scopes are added. Re-create keys with explicit scopes to restore access.
 
 ## Network Security
 


### PR DESCRIPTION
## Summary

- **API key scope enforcement**: API keys with empty/no scopes are now rejected instead of silently receiving full admin privileges (`operator.admin`). Keys must specify at least one scope explicitly (least-privilege / default-deny). Non-API-key auth (password, local, legacy) is unaffected and still gets full access.
- **npm install --ignore-scripts**: Skill dependency installation now passes `--ignore-scripts` to npm, preventing supply chain attacks via malicious postinstall scripts in npm packages or their transitive dependencies.

Both issues were identified by cross-referencing the [yubrew/bitsec OpenClaw security disclosure](https://x.com/yubrew/status/2020944984015303023) (VULN-188: default admin on empty scopes, VULN-210: npm install without --ignore-scripts).

## Validation

### Completed

- [x] `cargo check` — clean compile
- [x] `cargo test -p moltis-skills` — 67 passed (includes new `test_npm_install_includes_ignore_scripts`)
- [x] `cargo test -p moltis-gateway -- test_credential_store_api_key` — 2 passed

### Remaining

- [ ] `cargo +nightly fmt --all`
- [ ] `cargo +nightly clippy --workspace --all-targets --all-features`
- [ ] `cargo test` (full workspace)
- [ ] `./scripts/local-validate.sh <PR_NUMBER>`

## Manual QA

None required — these are server-side security policy changes. Existing API keys without scopes will be rejected on next WebSocket connect (breaking change for scopeless keys; documented in security.md backward compatibility section).