### PR TITLE
feat(hooks): add BeforeLLMCall/AfterLLMCall hooks and nonce-based CSP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,32 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **`BeforeLLMCall` / `AfterLLMCall` hooks**: New modifying hook events that fire
+  before sending prompts to the LLM provider and after receiving responses
+  (before tool execution). Enables prompt injection filtering, PII redaction,
+  and response auditing via shell hooks.
+- **Config template**: The generated `moltis.toml` template now lists all 17
+  hook events with correct PascalCase names and one-line descriptions.
+- **Hook event validation**: `moltis config check` now warns on unknown hook
+  event names in the config file.
+
+### Changed
+
+- **Hooks documentation**: Rewritten `docs/src/hooks.md` with complete event
+  reference, corrected `ToolResultPersist` classification (modifying, not
+  read-only), and new "Prompt Injection Filtering" section with examples.
+
+### Security
+
+- **Content-Security-Policy header**: HTML pages now include a nonce-based CSP
+  header (`script-src 'self' 'nonce-<UUID>'`), preventing inline script
+  injection (XSS defense-in-depth). The OAuth callback page also gets a
+  restrictive CSP.
+
 ## [0.5.0] - 2026-02-09
 
 ### Added

--- a/crates/config/src/template.rs
+++ b/crates/config/src/template.rs
@@ -511,20 +511,33 @@ reset_on_exit = true              # Reset serve/funnel when gateway shuts down
 
 # [hooks]
 # [[hooks.hooks]]
-# name = "notify-on-complete"     # Hook name (for logging)
-# command = "/path/to/script.sh"  # Command to run
-# events = [                      # Events that trigger this hook:
-#     "agent.turn.start",         #   Agent turn started
-#     "agent.turn.complete",      #   Agent turn completed
-#     "tool.call.start",          #   Tool call started
-#     "tool.call.complete",       #   Tool call completed
-#     "session.create",           #   Session created
-#     "session.close",            #   Session closed
+# name = "my-hook"                # Hook name (for logging)
+# command = "/path/to/handler.sh" # Command to run
+# events = [
+#     # ── Modifying events (can block or modify payload) ──
+#     "BeforeAgentStart",          # Before the agent loop starts
+#     "BeforeLLMCall",             # Before prompt is sent to the LLM provider
+#     "AfterLLMCall",              # After LLM response, before tool execution
+#     "BeforeToolCall",            # Before a tool executes
+#     "BeforeCompaction",          # Before context window compaction
+#     "MessageSending",            # Before sending a response to the user
+#     "ToolResultPersist",         # When a tool result is persisted
+#     #
+#     # ── Read-only events (observe only, run in parallel) ──
+#     "AfterToolCall",             # After a tool completes
+#     "AfterCompaction",           # After context is compacted
+#     "AgentEnd",                  # When the agent loop finishes
+#     "MessageReceived",           # When a user message arrives
+#     "MessageSent",               # After a response is delivered
+#     "SessionStart",              # When a new session begins
+#     "SessionEnd",                # When a session ends
+#     "GatewayStart",              # When Moltis starts
+#     "GatewayStop",               # When Moltis shuts down
+#     "Command",                   # When a slash command is used
 # ]
 # timeout = 10                    # Command timeout in seconds
 # [hooks.hooks.env]               # Environment variables passed to command
 # CUSTOM_VAR = "value"
-# SESSION_ID = "${{SESSION_ID}}"    # Variables are substituted
 "##
     )
 }

--- a/crates/config/src/validate.rs
+++ b/crates/config/src/validate.rs
@@ -952,6 +952,44 @@ fn check_semantic_warnings(config: &MoltisConfig, diagnostics: &mut Vec<Diagnost
         }
     }
 
+    // Unknown hook event names
+    let valid_hook_events = [
+        "BeforeAgentStart",
+        "AgentEnd",
+        "BeforeLLMCall",
+        "AfterLLMCall",
+        "BeforeCompaction",
+        "AfterCompaction",
+        "MessageReceived",
+        "MessageSending",
+        "MessageSent",
+        "BeforeToolCall",
+        "AfterToolCall",
+        "ToolResultPersist",
+        "SessionStart",
+        "SessionEnd",
+        "GatewayStart",
+        "GatewayStop",
+        "Command",
+    ];
+    if let Some(ref hooks_config) = config.hooks {
+        for (hook_idx, hook) in hooks_config.hooks.iter().enumerate() {
+            for (ev_idx, event) in hook.events.iter().enumerate() {
+                if !valid_hook_events.contains(&event.as_str()) {
+                    diagnostics.push(Diagnostic {
+                        severity: Severity::Warning,
+                        category: "unknown-field",
+                        path: format!("hooks.hooks[{hook_idx}].events[{ev_idx}]"),
+                        message: format!(
+                            "unknown hook event \"{event}\"; expected one of: {}",
+                            valid_hook_events.join(", ")
+                        ),
+                    });
+                }
+            }
+        }
+    }
+
     // port == 0
     if config.server.port == 0 {
         diagnostics.push(Diagnostic {

--- a/crates/gateway/src/server.rs
+++ b/crates/gateway/src/server.rs
@@ -3719,16 +3719,30 @@ async fn oauth_callback_handler(
         }))
         .await
     {
-        Ok(_) => Html(
-            "<h1>Authentication successful!</h1><p>You can close this window.</p><script>window.close();</script>"
-                .to_string(),
-        )
-        .into_response(),
+        Ok(_) => {
+            let nonce = uuid::Uuid::new_v4().to_string();
+            let html = format!(
+                "<h1>Authentication successful!</h1><p>You can close this window.</p>\
+                 <script nonce=\"{nonce}\">window.close();</script>"
+            );
+            let csp = format!(
+                "default-src 'none'; script-src 'nonce-{nonce}'; style-src 'unsafe-inline'"
+            );
+            let mut resp = Html(html).into_response();
+            if let Ok(val) = csp.parse() {
+                resp.headers_mut()
+                    .insert(axum::http::header::CONTENT_SECURITY_POLICY, val);
+            }
+            resp
+        },
         Err(e) => {
             tracing::warn!(error = %e, "OAuth callback completion failed");
             (
                 StatusCode::BAD_REQUEST,
-                Html("<h1>Authentication failed</h1><p>Could not complete OAuth flow.</p>".to_string()),
+                Html(
+                    "<h1>Authentication failed</h1><p>Could not complete OAuth flow.</p>"
+                        .to_string(),
+                ),
             )
                 .into_response()
         },
@@ -3811,11 +3825,14 @@ async fn render_spa_template(
             .replace("/assets/", &versioned)
     };
 
+    // Generate a per-request nonce for CSP script-src.
+    let nonce = uuid::Uuid::new_v4().to_string();
+
     if !onboarding_shell {
         // Build server-side data blob (gon pattern) injected into <head>.
         let gon = build_gon_data(gateway).await;
         let gon_script = format!(
-            "<script>window.__MOLTIS__={};</script>",
+            "<script nonce=\"{nonce}\">window.__MOLTIS__={};</script>",
             serde_json::to_string(&gon).unwrap_or_else(|_| "{}".into()),
         );
         // Inject gon data into <head> so it's available before any module scripts run.
@@ -3824,7 +3841,36 @@ async fn render_spa_template(
         body = body.replace("</head>", &format!("{gon_script}\n</head>"));
     }
 
-    ([("cache-control", "no-cache, no-store")], Html(body)).into_response()
+    // Inject nonce into all existing inline <script> tags.
+    body = body.replace("<script>", &format!("<script nonce=\"{nonce}\">"));
+    // Import maps and module scripts also need the nonce.
+    body = body.replace(
+        "<script type=\"importmap\">",
+        &format!("<script nonce=\"{nonce}\" type=\"importmap\">"),
+    );
+
+    let csp = format!(
+        "default-src 'self'; \
+         script-src 'self' 'nonce-{nonce}'; \
+         style-src 'self' 'unsafe-inline'; \
+         img-src 'self' data: blob:; \
+         font-src 'self'; \
+         connect-src 'self' ws: wss:; \
+         frame-ancestors 'none'; \
+         form-action 'self'; \
+         base-uri 'self'; \
+         object-src 'none'"
+    );
+
+    let mut response = Html(body).into_response();
+    let headers = response.headers_mut();
+    if let Ok(val) = "no-cache, no-store".parse() {
+        headers.insert(axum::http::header::CACHE_CONTROL, val);
+    }
+    if let Ok(val) = csp.parse() {
+        headers.insert(axum::http::header::CONTENT_SECURITY_POLICY, val);
+    }
+    response
 }
 
 #[cfg(feature = "web-ui")]
@@ -5610,5 +5656,56 @@ mod tests {
             "moltis.example.com".parse().unwrap(),
         );
         assert!(!is_local_connection(&headers, addr, false));
+    }
+
+    #[cfg(feature = "web-ui")]
+    #[test]
+    fn csp_nonce_injected_into_inline_scripts() {
+        let html = r#"<head>
+<script>theme()</script>
+<script type="importmap">{"imports":{}}</script>
+</head>
+<body>
+<script>init()</script>
+<script type="module" src="/app.js"></script>
+</body>"#;
+
+        let nonce = "test-nonce-abc";
+        let mut body = html.to_string();
+        body = body.replace("<script>", &format!("<script nonce=\"{nonce}\">"));
+        body = body.replace(
+            "<script type=\"importmap\">",
+            &format!("<script nonce=\"{nonce}\" type=\"importmap\">"),
+        );
+
+        // All inline <script> tags should have the nonce.
+        assert!(body.contains(&format!("<script nonce=\"{nonce}\">theme()")));
+        assert!(body.contains(&format!("<script nonce=\"{nonce}\">init()")));
+        assert!(body.contains(&format!("<script nonce=\"{nonce}\" type=\"importmap\">")));
+        // Module script with src= is NOT modified — covered by 'self' in CSP.
+        assert!(body.contains("<script type=\"module\" src=\"/app.js\">"));
+    }
+
+    #[cfg(feature = "web-ui")]
+    #[test]
+    fn csp_header_contains_nonce() {
+        let nonce = "abc-123";
+        let csp = format!(
+            "default-src 'self'; \
+             script-src 'self' 'nonce-{nonce}'; \
+             style-src 'self' 'unsafe-inline'; \
+             img-src 'self' data: blob:; \
+             font-src 'self'; \
+             connect-src 'self' ws: wss:; \
+             frame-ancestors 'none'; \
+             form-action 'self'; \
+             base-uri 'self'; \
+             object-src 'none'"
+        );
+
+        assert!(csp.contains("'nonce-abc-123'"));
+        assert!(csp.contains("frame-ancestors 'none'"));
+        assert!(csp.contains("object-src 'none'"));
+        assert!(csp.contains("connect-src 'self' ws: wss:"));
     }
 }

--- a/docs/src/hooks.md
+++ b/docs/src/hooks.md
@@ -1,23 +1,32 @@
 # Hooks
 
-Hooks let you observe, modify, or block actions at key points in the agent lifecycle. Use them for auditing, policy enforcement, notifications, and custom integrations.
+Hooks let you observe, modify, or block actions at key points in the agent lifecycle. Use them for auditing, policy enforcement, prompt injection filtering, notifications, and custom integrations.
 
 ## How Hooks Work
 
 ```
-┌─────────────────────────────────────────────────────────┐
-│                      Agent Loop                         │
-│                                                         │
-│  User Message → BeforeToolCall → Tool Execution         │
-│                       │                 │               │
-│                       ▼                 ▼               │
-│                 [Your Hook]      AfterToolCall          │
-│                       │                 │               │
-│                 modify/block      [Your Hook]           │
-│                       │                 │               │
-│                       ▼                 ▼               │
-│                   Continue → Response → MessageSent     │
-└─────────────────────────────────────────────────────────┘
+┌──────────────────────────────────────────────────────────────┐
+│                        Agent Loop                            │
+│                                                              │
+│  User Message ─→ BeforeLLMCall ─→ LLM Provider              │
+│                       │                 │                    │
+│                  modify/block      AfterLLMCall              │
+│                                         │                    │
+│                                    modify/block              │
+│                                         │                    │
+│                                         ▼                    │
+│                                  BeforeToolCall              │
+│                                         │                    │
+│                                    modify/block              │
+│                                         │                    │
+│                                    Tool Execution            │
+│                                         │                    │
+│                                    AfterToolCall             │
+│                                         │                    │
+│                                         ▼                    │
+│                              (loop continues or)             │
+│                             Response → MessageSent           │
+└──────────────────────────────────────────────────────────────┘
 ```
 
 ## Event Types
@@ -28,10 +37,13 @@ These events run hooks sequentially. Hooks can modify the payload or block the a
 
 | Event | Description | Can Modify | Can Block |
 |-------|-------------|------------|-----------|
-| `BeforeToolCall` | Before a tool executes | ✅ | ✅ |
-| `BeforeCompaction` | Before context compaction | ✅ | ✅ |
-| `MessageSending` | Before sending a response | ✅ | ✅ |
-| `BeforeAgentStart` | Before agent loop starts | ✅ | ✅ |
+| `BeforeAgentStart` | Before agent loop starts | yes | yes |
+| `BeforeLLMCall` | Before prompt is sent to the LLM provider | yes | yes |
+| `AfterLLMCall` | After LLM response, before tool execution | yes | yes |
+| `BeforeToolCall` | Before a tool executes | yes | yes |
+| `BeforeCompaction` | Before context compaction | yes | yes |
+| `MessageSending` | Before sending a response | yes | yes |
+| `ToolResultPersist` | When a tool result is persisted | yes | yes |
 
 ### Read-Only Events (Parallel)
 
@@ -41,15 +53,107 @@ These events run hooks in parallel for performance. They cannot modify or block.
 |-------|-------------|
 | `AfterToolCall` | After a tool completes |
 | `AfterCompaction` | After context is compacted |
+| `AgentEnd` | When agent loop completes |
 | `MessageReceived` | When a user message arrives |
 | `MessageSent` | After response is delivered |
-| `AgentEnd` | When agent loop completes |
 | `SessionStart` | When a new session begins |
 | `SessionEnd` | When a session ends |
-| `ToolResultPersist` | When tool result is saved |
 | `GatewayStart` | When Moltis starts |
 | `GatewayStop` | When Moltis shuts down |
 | `Command` | When a slash command is used |
+
+## Prompt Injection Filtering
+
+The `BeforeLLMCall` and `AfterLLMCall` hooks provide filtering points for prompt injection defense.
+
+### BeforeLLMCall
+
+Fires before each LLM API call. The payload includes the full message array, provider name, model ID, and iteration count. Use it to:
+
+- Scan prompts for injection patterns before they reach the LLM
+- Redact PII or sensitive data from the conversation
+- Add safety prefixes to system prompts
+- Block requests that match known attack patterns
+
+**Payload fields:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `session_key` | string | Session identifier |
+| `provider` | string | Provider name (e.g. "openai", "anthropic") |
+| `model` | string | Model ID (e.g. "gpt-4o", "claude-sonnet-4-20250514") |
+| `messages` | array | Serialized message array (OpenAI format) |
+| `tool_count` | number | Number of tool schemas sent to the LLM |
+| `iteration` | number | 1-based loop iteration |
+
+### AfterLLMCall
+
+Fires after the LLM response is received but before tool calls execute. For streaming responses, this fires after the full response is accumulated (text has already been streamed to the UI) but blocking still prevents tool execution.
+
+**Payload fields:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `session_key` | string | Session identifier |
+| `provider` | string | Provider name |
+| `model` | string | Model ID |
+| `text` | string/null | LLM response text |
+| `tool_calls` | array | Tool calls requested by the LLM |
+| `input_tokens` | number | Tokens consumed by the prompt |
+| `output_tokens` | number | Tokens in the response |
+| `iteration` | number | 1-based loop iteration |
+
+### Example: Block Suspicious Tool Calls
+
+```bash
+#!/bin/bash
+# filter-injection.sh — subscribe to AfterLLMCall
+payload=$(cat)
+event=$(echo "$payload" | jq -r '.event')
+
+if [ "$event" = "AfterLLMCall" ]; then
+    # Check if tool calls contain suspicious patterns
+    tool_names=$(echo "$payload" | jq -r '.tool_calls[].name')
+
+    for name in $tool_names; do
+        # Block unexpected tool calls that might come from injection
+        case "$name" in
+            exec|bash|shell)
+                text=$(echo "$payload" | jq -r '.text // ""')
+                if echo "$text" | grep -qi "ignore previous\|disregard\|new instructions"; then
+                    echo "Blocked suspicious tool call after potential injection" >&2
+                    exit 1
+                fi
+                ;;
+        esac
+    done
+fi
+
+exit 0
+```
+
+### Example: External Proxy Filter
+
+```bash
+#!/bin/bash
+# proxy-filter.sh — subscribe to BeforeLLMCall
+payload=$(cat)
+
+# Send to an external moderation API
+result=$(echo "$payload" | curl -s -X POST \
+  -H "Content-Type: application/json" \
+  -d @- \
+  "$MODERATION_API_URL/check")
+
+# Block if the API flags it
+if echo "$result" | jq -e '.flagged' > /dev/null 2>&1; then
+    reason=$(echo "$result" | jq -r '.reason // "content policy violation"')
+    echo "$reason" >&2
+    exit 1
+fi
+
+exit 0
+```
 
 ## Creating a Hook
 
@@ -187,6 +291,12 @@ command = "./hooks/audit.sh"
 events = ["BeforeToolCall", "AfterToolCall"]
 timeout = 5
 priority = 100  # Higher = runs first
+
+[[hooks]]
+name = "llm-filter"
+command = "./hooks/filter-injection.sh"
+events = ["BeforeLLMCall", "AfterLLMCall"]
+timeout = 10
 
 [[hooks]]
 name = "notify-slack"
@@ -339,3 +449,4 @@ exit 0
 3. **Log for debugging** — Write to a log file, not stdout
 4. **Test locally first** — Pipe sample JSON through your script
 5. **Use jq for JSON** — It's reliable and fast for parsing
+6. **Layer defenses** — Use `BeforeLLMCall` for input filtering and `AfterLLMCall` for output filtering


### PR DESCRIPTION
## Summary

- **BeforeLLMCall / AfterLLMCall hooks**: Two new modifying hook events that fire before sending prompts to the LLM provider and after receiving responses (before tool execution). Enables prompt injection filtering, PII redaction, and response auditing via shell hooks. Wired into both streaming and non-streaming agent loop paths.
- **Config template**: Lists all 17 hook events with correct PascalCase names and descriptions. Adds hook event name validation to `moltis config check`.
- **Docs rewrite**: Updated `docs/src/hooks.md` with complete event reference, corrected `ToolResultPersist` classification (modifying, not read-only), and new "Prompt Injection Filtering" section with examples.
- **Content-Security-Policy header**: Nonce-based CSP on all HTML page responses (`script-src 'self' 'nonce-<UUID>'`), preventing inline script injection (XSS defense-in-depth). OAuth callback page also gets a restrictive CSP.

## Validation

### Completed

- [x] `cargo +nightly fmt --all` — no diffs
- [x] `cargo +nightly clippy --workspace --all-targets` — no warnings
- [x] `cargo test --workspace` — all tests pass (0 failures)
- [x] `taplo fmt` — TOML formatted
- [x] `mdbook build` — docs build successfully
- [x] New tests: 5 hook type tests (read_only, payload/event, serde round-trip, ALL count), 2 CSP tests (nonce injection, header content)

### Remaining

- [ ] `./scripts/local-validate.sh` — running post-PR creation
- [ ] Manual QA: verify CSP header in browser DevTools, test BeforeLLMCall hook with shell script

## Manual QA

- Start gateway, open DevTools → Network → verify `Content-Security-Policy` header on page load with `nonce-` value
- Verify no console errors from CSP blocking legitimate scripts
- Configure a `BeforeLLMCall` shell hook, send a message, verify hook fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)