### PR TITLE
feat(gateway): auto-detect models after saving provider API key

### DIFF
--- a/crates/gateway/src/methods.rs
+++ b/crates/gateway/src/methods.rs
@@ -3017,12 +3017,30 @@ impl MethodRegistry {
             "providers.save_key",
             Box::new(|ctx| {
                 Box::pin(async move {
-                    ctx.state
+                    let provider_name = ctx
+                        .params
+                        .get("provider")
+                        .and_then(|v| v.as_str())
+                        .map(ToOwned::to_owned);
+
+                    let result = ctx
+                        .state
                         .services
                         .provider_setup
                         .save_key(ctx.params.clone())
                         .await
-                        .map_err(|e| ErrorShape::new(error_codes::UNAVAILABLE, e))
+                        .map_err(|e| ErrorShape::new(error_codes::UNAVAILABLE, e))?;
+
+                    // Kick off background model detection after saving provider
+                    // credentials, matching the behaviour of oauth.complete.
+                    let model_service = Arc::clone(&ctx.state.services.model);
+                    tokio::spawn(async move {
+                        let _ = model_service
+                            .detect_supported(model_probe_params(provider_name.as_deref()))
+                            .await;
+                    });
+
+                    Ok(result)
                 })
             }),
         );


### PR DESCRIPTION
## Summary

- After saving API key credentials via `providers.save_key`, the server now spawns a background `detect_supported` task to probe which models are available for the provider
- This matches the existing behaviour of `providers.oauth.complete`, which already auto-triggers model detection after OAuth credentials are saved
- The ProvidersPage picks up the resulting `models.updated` WebSocket events and shows the detection progress bar automatically

## Validation

### Completed
- [x] `cargo check` passes
- [x] `cargo test --package moltis-gateway` — 6 tests pass
- [x] Verified via Playwright that event subscriptions and state management work correctly on the providers settings page

### Remaining
- [ ] Manual QA: add an API key provider and verify the model detection progress bar appears automatically

## Manual QA
Add a new API key provider (e.g. OpenAI) and verify that after saving credentials, the model detection progress bar appears on the Providers page without needing to click "Detect All Models".