### PR TITLE
fix: pin deploy templates to explicit versions and auto-update on release

### DIFF
--- a/.do/deploy.template.yaml
+++ b/.do/deploy.template.yaml
@@ -10,7 +10,7 @@ spec:
         registry_type: GHCR
         registry: ghcr.io
         repository: moltis-org/moltis
-        tag: latest
+        tag: "0.8.17"
       instance_count: 1
       instance_size_slug: basic-xxs
       http_port: 8080

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1007,3 +1007,84 @@ jobs:
           fi
           git commit -m "moltis ${VERSION}"
           git push
+
+  update-deploy-tags:
+    needs: merge-docker
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    name: Update deploy template tags
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: main
+
+      - name: Update image tags in deploy templates
+        env:
+          TAG: ${{ github.ref_name }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          VERSION="${TAG#v}"
+          echo "Updating deploy templates to version ${VERSION}"
+
+          # DigitalOcean App Platform
+          sed -i "s/tag: \"[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\"/tag: \"${VERSION}\"/" .do/deploy.template.yaml
+
+          # Render
+          sed -i "s|ghcr.io/moltis-org/moltis:[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*|ghcr.io/moltis-org/moltis:${VERSION}|" render.yaml
+
+          # Fly.io
+          sed -i "s|ghcr.io/moltis-org/moltis:[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*|ghcr.io/moltis-org/moltis:${VERSION}|" fly.toml
+
+          # Check if any files changed
+          if git diff --quiet .do/deploy.template.yaml render.yaml fly.toml; then
+            echo "No deploy template changes needed"
+            exit 0
+          fi
+
+          # Commit via GitHub API so the commit is signed/verified
+          REPO="${{ github.repository }}"
+          MAIN_SHA=$(gh api "repos/${REPO}/git/ref/heads/main" --jq '.object.sha')
+          BASE_TREE=$(gh api "repos/${REPO}/git/commits/${MAIN_SHA}" --jq '.tree.sha')
+
+          # Create blobs for each updated file
+          DO_BLOB=$(gh api "repos/${REPO}/git/blobs" \
+            -f content="$(base64 -w0 .do/deploy.template.yaml)" \
+            -f encoding=base64 --jq '.sha')
+          RENDER_BLOB=$(gh api "repos/${REPO}/git/blobs" \
+            -f content="$(base64 -w0 render.yaml)" \
+            -f encoding=base64 --jq '.sha')
+          FLY_BLOB=$(gh api "repos/${REPO}/git/blobs" \
+            -f content="$(base64 -w0 fly.toml)" \
+            -f encoding=base64 --jq '.sha')
+
+          # Create a new tree with the updated files (JSON input for proper array structure)
+          TREE_SHA=$(jq -n \
+            --arg base "$BASE_TREE" \
+            --arg do_sha "$DO_BLOB" \
+            --arg render_sha "$RENDER_BLOB" \
+            --arg fly_sha "$FLY_BLOB" \
+            '{
+              base_tree: $base,
+              tree: [
+                {path: ".do/deploy.template.yaml", mode: "100644", type: "blob", sha: $do_sha},
+                {path: "render.yaml", mode: "100644", type: "blob", sha: $render_sha},
+                {path: "fly.toml", mode: "100644", type: "blob", sha: $fly_sha}
+              ]
+            }' | gh api "repos/${REPO}/git/trees" --input - --jq '.sha')
+
+          # Create a signed commit
+          COMMIT_SHA=$(jq -n \
+            --arg msg "chore: update deploy templates to ${VERSION}" \
+            --arg tree "$TREE_SHA" \
+            --arg parent "$MAIN_SHA" \
+            '{message: $msg, tree: $tree, parents: [$parent]}' \
+            | gh api "repos/${REPO}/git/commits" --input - --jq '.sha')
+
+          # Update main to point to the new commit
+          gh api "repos/${REPO}/git/refs/heads/main" \
+            -X PATCH -f sha="${COMMIT_SHA}"
+
+          echo "Updated deploy templates to ${VERSION} (commit ${COMMIT_SHA})"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -918,6 +918,15 @@ The Build Packages workflow derives artifact versions from the tag when running
 on tagged pushes, but `Cargo.toml` must still be kept in sync for local builds,
 packaging metadata consistency, and future non-tag runs.
 
+**Deploy template versions.** Deploy templates (`.do/deploy.template.yaml`,
+`render.yaml`, `fly.toml`) pin explicit image versions instead of `latest`
+because cloud platforms cache image tags. These files are **updated
+automatically** by the `update-deploy-tags` job in the release workflow —
+after the Docker image is pushed to GHCR, CI updates the templates on `main`
+with the new version. This avoids a downtime window where templates reference
+a version that hasn't been built yet. **Do not manually update these tags**
+as part of the release commit.
+
 **Cargo.lock must stay in sync.** After changing dependencies or merging
 `main`, run `cargo fetch` (without `--locked`) to sync the lockfile without
 upgrading existing dependency versions, then commit the result. Verify with

--- a/fly.toml
+++ b/fly.toml
@@ -1,5 +1,5 @@
 [build]
-image = 'ghcr.io/moltis-org/moltis:latest'
+image = 'ghcr.io/moltis-org/moltis:0.8.17'
 
 [env]
 MOLTIS_BEHIND_PROXY    = 'true'

--- a/render.yaml
+++ b/render.yaml
@@ -3,7 +3,7 @@ services:
     name: moltis
     runtime: image
     image:
-      url: ghcr.io/moltis-org/moltis:latest
+      url: ghcr.io/moltis-org/moltis:0.8.17
     plan: free
     healthCheckPath: /health
     envVars:


### PR DESCRIPTION
## Summary

- Pin image tags in `.do/deploy.template.yaml`, `render.yaml`, and `fly.toml` to `0.8.17` instead of `latest` (cloud platforms cache `latest` and serve stale versions)
- Add `update-deploy-tags` CI job to `release.yml` that runs after `merge-docker` and automatically updates the pinned versions on `main` via the GitHub API (producing signed/verified commits)
- Document the automated flow in `CLAUDE.md`

## Validation

### Completed
- [x] Verified deploy templates reference `0.8.17`
- [x] Verified DO 1-click URL still points to `tree/main`
- [x] Reviewed GitHub API tree/commit creation uses proper JSON via `jq`

### Remaining
- [ ] Verify `update-deploy-tags` job works on next tag push (first real test)

## Manual QA
- Confirmed GHCR `latest` tag points to `0.8.17`
- Confirmed DO 1-click deploy was failing due to wrong branch reference on website (fixed separately)