### PR TITLE
feat: add Zaps.ai as native LLM provider

### DIFF
--- a/crates/agents/src/providers/mod.rs
+++ b/crates/agents/src/providers/mod.rs
@@ -540,6 +540,13 @@ const OPENAI_COMPAT_PROVIDERS: &[OpenAiCompatDef] = &[
         models: &[],
     },
     OpenAiCompatDef {
+        config_name: "zaps",
+        env_key: "ZAPS_API_KEY",
+        env_base_url_key: "ZAPS_BASE_URL",
+        default_base_url: "https://zaps.ai/v1",
+        models: &[],
+    },
+    OpenAiCompatDef {
         config_name: "ollama",
         env_key: "OLLAMA_API_KEY",
         env_base_url_key: "OLLAMA_BASE_URL",

--- a/crates/cli/src/doctor_commands.rs
+++ b/crates/cli/src/doctor_commands.rs
@@ -123,6 +123,7 @@ const PROVIDER_ENV_MAP: &[(&str, &str, bool)] = &[
     ("minimax", "MINIMAX_API_KEY", false),
     ("moonshot", "MOONSHOT_API_KEY", false),
     ("venice", "VENICE_API_KEY", false),
+    ("zaps", "ZAPS_API_KEY", false),
     ("ollama", "OLLAMA_API_KEY", true),
     ("kimi-code", "KIMI_API_KEY", false),
 ];

--- a/crates/config/src/template.rs
+++ b/crates/config/src/template.rs
@@ -88,8 +88,8 @@ offered = ["local-llm", "github-copilot", "openai", "anthropic", "ollama", "moon
 # All available providers:
 #   "anthropic", "openai", "gemini", "groq", "xai", "deepseek",
 #   "mistral", "openrouter", "cerebras", "minimax", "moonshot",
-#   "venice", "ollama", "local-llm", "openai-codex", "github-copilot",
-#   "kimi-code"
+#   "venice", "zaps", "ollama", "local-llm", "openai-codex",
+#   "github-copilot", "kimi-code"
 
 # ── Anthropic (Claude) ────────────────────────────────────────
 # [providers.anthropic]
@@ -144,6 +144,15 @@ models = ["gpt-5.3", "gpt-5.2"]              # Preferred models shown first
 # api_key = "..."                             # Or set OPENROUTER_API_KEY env var
 # models = ["anthropic/claude-3.5-sonnet"]    # Any model IDs on OpenRouter
 # base_url = "https://openrouter.ai/api/v1"
+
+# ── Zaps.ai (PII redaction gateway) ────────────────────────────
+# Routes requests through Zaps.ai's privacy gateway which
+# automatically redacts PII before forwarding to upstream LLMs.
+# [providers.zaps]
+# enabled = true
+# api_key = "gk_..."                            # Or set ZAPS_API_KEY env var
+# models = ["gpt-4o", "deepseek-chat"]          # Any model supported by Zaps gateway
+# base_url = "https://zaps.ai/v1"
 
 # ── Moonshot (Kimi) ─────────────────────────────────────────
 [providers.moonshot]

--- a/crates/config/src/validate.rs
+++ b/crates/config/src/validate.rs
@@ -97,6 +97,7 @@ const KNOWN_PROVIDER_NAMES: &[&str] = &[
     "minimax",
     "moonshot",
     "venice",
+    "zaps",
     "ollama",
 ];
 

--- a/crates/gateway/src/provider_setup.rs
+++ b/crates/gateway/src/provider_setup.rs
@@ -664,6 +664,15 @@ fn known_providers() -> Vec<KnownProvider> {
             key_optional: false,
         },
         KnownProvider {
+            name: "zaps",
+            display_name: "Zaps.ai",
+            auth_type: "api-key",
+            env_key: Some("ZAPS_API_KEY"),
+            default_base_url: Some("https://zaps.ai/v1"),
+            requires_model: true,
+            key_optional: false,
+        },
+        KnownProvider {
             name: "ollama",
             display_name: "Ollama",
             auth_type: "api-key",

--- a/crates/gateway/src/server.rs
+++ b/crates/gateway/src/server.rs
@@ -2150,6 +2150,7 @@ pub async fn start_gateway(
             ("minimax", "MINIMAX_API_KEY", "https://api.minimax.chat/v1"),
             ("moonshot", "MOONSHOT_API_KEY", "https://api.moonshot.ai/v1"),
             ("venice", "VENICE_API_KEY", "https://api.venice.ai/api/v1"),
+            ("zaps", "ZAPS_API_KEY", "https://zaps.ai/v1"),
         ];
 
         for (config_name, env_key, default_base) in EMBEDDING_CANDIDATES {


### PR DESCRIPTION
feat: add Zaps.ai as native LLM provider

This PR adds **Zaps.ai** as a first-class OpenAI-compatible provider in Moltis.

### What is Zaps.ai?
Zaps.ai acts as a privacy-focused API gateway that automatically redacts Personally Identifiable Information (PII) before forwarding requests to upstream LLMs (like GPT-4o, DeepSeek, etc.). This makes it ideal for enterprise and privacy-conscious deployments where data leakage is a concern.

### Implementation Details
- **Provider Registration**: Added `OpenAiCompatDef` entry to `crates/agents/src/providers/mod.rs` with `config_name: "zaps"`.
- **Gateway UI**: Added to `known_providers()` in `crates/gateway/src/provider_setup.rs` so it appears in the provider selection dropdown.
- **RAG Support**: Added to `EMBEDDING_CANDIDATES` in `crates/gateway/src/server.rs` to enable automatic memory embedding fallback through the Zaps gateway.
- **Health Checks**: Included in `doctor_commands.rs` `PROVIDER_ENV_MAP` for `moltis doctor` verification.
- **Configuration**:
  - `env_key`: `ZAPS_API_KEY`
  - `default_base_url`: `https://zaps.ai/v1`
  - `models`: Empty list (uses dynamic model discovery based on upstream provider availability)
  - `requires_model`: `true` (like OpenRouter)

### Verification
Ran full workspace `cargo check --workspace` on Linux/x86_64 build environment.
- **Result**: `BUILD_SUCCESS`
- **Scope**: 610+ crates compiled with zero errors. All changed crates passed type checking.

### Usage
Users can enable it by adding the following to `moltis.toml` or setting `ZAPS_API_KEY`:

```toml
[providers.zaps]
enabled = true
# api_key = "gk_..."  # Optional if env var set
```
