### PR TITLE
docs: fix QMD repository link

### DIFF
--- a/crates/qmd/src/lib.rs
+++ b/crates/qmd/src/lib.rs
@@ -3,7 +3,7 @@
 //! This crate provides an alternative memory backend that uses the QMD sidecar process
 //! for hybrid search (BM25 + vector + LLM reranking).
 //!
-//! QMD must be installed separately. See: https://github.com/qmd/qmd
+//! QMD must be installed separately. See: https://github.com/tobi/qmd
 
 mod manager;
 mod store;

--- a/docs/src/memory.md
+++ b/docs/src/memory.md
@@ -37,7 +37,7 @@ QMD is an optional external sidecar that provides enhanced search capabilities:
 - **Hybrid search with LLM reranking**: Combines both methods with an LLM pass for optimal relevance
 
 To use QMD:
-1. Install QMD separately from [github.com/qmd/qmd](https://github.com/qmd/qmd)
+1. Install QMD separately from [github.com/tobi/qmd](https://github.com/tobi/qmd)
 2. Enable it in Settings > Memory > Backend
 
 ## Features


### PR DESCRIPTION
Update QMD repository reference from github.com/qmd/qmd to github.com/tobi/qmd.