### PR TITLE
fix(memory): normalize embeddings base_url and add disable_rag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Memory config: add `memory.disable_rag` to force keyword-only memory search while keeping markdown indexing and memory tools enabled
+
 ### Changed
 
 ### Deprecated
@@ -16,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Fixed
+
+- Memory embeddings endpoint composition now avoids duplicated path segments like `/v1/v1/embeddings` and accepts base URLs ending in host-only, `/v1`, versioned paths (for example `/v4`), or `/embeddings`
 
 ### Security
 

--- a/crates/config/src/schema.rs
+++ b/crates/config/src/schema.rs
@@ -787,6 +787,9 @@ pub struct MemoryEmbeddingConfig {
     pub backend: Option<String>,
     /// Embedding provider: "local", "ollama", "openai", "custom", or None for auto-detect.
     pub provider: Option<String>,
+    /// Disable RAG embeddings and force keyword-only memory search.
+    #[serde(default)]
+    pub disable_rag: bool,
     /// Base URL for the embedding API (e.g. "http://localhost:11434/v1" for Ollama).
     pub base_url: Option<String>,
     /// Model name (e.g. "nomic-embed-text" for Ollama, "text-embedding-3-small" for OpenAI).

--- a/crates/config/src/template.rs
+++ b/crates/config/src/template.rs
@@ -518,7 +518,8 @@ reset_on_exit = true              # Reset serve/funnel when gateway shuts down
                                   #   "openai"  - OpenAI API
                                   #   "custom"  - Custom endpoint
                                   #   (none)    - Auto-detect from available providers
-# base_url = "http://localhost:11434/v1"  # API endpoint for embeddings
+# disable_rag = false             # true => keyword-only search (no embeddings)
+# base_url = "http://localhost:11434/v1"  # Embedding API base (host, /v1, or /embeddings)
 # model = "nomic-embed-text"      # Embedding model name
 # api_key = "..."                 # API key (optional for local endpoints like Ollama)
 

--- a/crates/config/src/validate.rs
+++ b/crates/config/src/validate.rs
@@ -354,6 +354,7 @@ fn build_schema_map() -> KnownKeys {
             Struct(HashMap::from([
                 ("backend", Leaf),
                 ("provider", Leaf),
+                ("disable_rag", Leaf),
                 ("base_url", Leaf),
                 ("model", Leaf),
                 ("api_key", Leaf),
@@ -1411,6 +1412,23 @@ provider = "pinecone"
         assert!(
             warning.is_some(),
             "expected warning for unknown memory provider"
+        );
+    }
+
+    #[test]
+    fn memory_disable_rag_is_valid_field() {
+        let toml = r#"
+[memory]
+disable_rag = true
+"#;
+        let result = validate_toml_str(toml);
+        let unknown = result
+            .diagnostics
+            .iter()
+            .find(|d| d.category == "unknown-field" && d.path == "memory.disable_rag");
+        assert!(
+            unknown.is_none(),
+            "memory.disable_rag should be accepted as a known field"
         );
     }
 

--- a/crates/gateway/src/chat.rs
+++ b/crates/gateway/src/chat.rs
@@ -2676,10 +2676,7 @@ impl ChatService for LiveChatService {
                 .write()
                 .await
                 .remove(&session_key_clone);
-            active_reply_medium
-                .write()
-                .await
-                .remove(&session_key_clone);
+            active_reply_medium.write().await.remove(&session_key_clone);
 
             // Release the semaphore *before* draining so replayed sends can
             // acquire it. Without this, every replayed `chat.send()` would

--- a/docs/src/memory.md
+++ b/docs/src/memory.md
@@ -87,6 +87,12 @@ backend = "builtin"
 # Embedding provider: "local", "ollama", "openai", "custom", or auto-detect
 provider = "local"
 
+# Disable RAG embeddings and force keyword-only search
+disable_rag = false
+
+# Embedding API base URL (host, /v1, or full /embeddings endpoint)
+base_url = "http://localhost:11434/v1"
+
 # Citation mode: "on", "off", or "auto"
 citations = "auto"
 


### PR DESCRIPTION
## Summary

Closes #137.

- Fix memory embedding endpoint URL composition so `memory.base_url` works for:
  - host-only URLs (e.g. `https://api.openai.com`)
  - versioned URLs (e.g. `.../v1`, `.../v4`)
  - explicit embedding URLs (e.g. `.../v1/embeddings`)
- Add `memory.disable_rag` config to force keyword-only memory search while keeping markdown indexing and memory tools active.
- Wire `disable_rag` through gateway startup and memory config RPCs (`memory.config.get`/`memory.config.update`).
- Update config template, memory docs, and changelog.
- Add focused tests for endpoint normalization and config validation.

## Validation

### Completed

- [x] `cargo +nightly-2025-11-30 fmt --all -- --check`
- [x] `cargo test -p moltis-memory embeddings_openai::tests`
- [x] `cargo test -p moltis-config memory_disable_rag_is_valid_field`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`

### Remaining

- [ ] `cargo clippy --all --benches --tests --examples --all-features` (blocked in this environment: CUDA toolkit / `nvcc` missing for `llama-cpp-sys` all-features path)

## Manual QA

- Set `[memory] provider = "custom"` with `base_url` ending in `/v1` and verify `memory_search` no longer fails with duplicated `/v1/v1/embeddings`.
- Set `[memory] disable_rag = true`, restart gateway, and verify:
  - `memory.status` reports `has_embeddings: false`
  - memory search still returns keyword results from local markdown memory files.
