### PR TITLE
feat(gateway): support external web UI assets for distro and docker builds

### DIFF
--- a/.github/workflows/homebrew.yml
+++ b/.github/workflows/homebrew.yml
@@ -118,7 +118,9 @@ jobs:
             end
 
             def install
-              bin.install "moltis"
+              libexec.install "moltis"
+              pkgshare.install "assets"
+              (bin/"moltis").write_env_script libexec/"moltis", MOLTIS_ASSETS_DIR: "#{pkgshare}/assets"
             end
 
             test do

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -240,7 +240,8 @@ jobs:
       - name: Build release binary
         env:
           BUILD_TARGET: ${{ matrix.target }}
-        run: cargo build --release --target "$BUILD_TARGET"
+          MOLTIS_DEFAULT_ASSETS_DIR: /usr/share/moltis/assets
+        run: cargo build --release --target "$BUILD_TARGET" -p moltis --no-default-features --features "file-watcher,local-llm,metrics,prometheus,push-notifications,qmd,tailscale,tls,voice,web-ui"
 
       - name: Build .deb package
         env:
@@ -336,7 +337,8 @@ jobs:
       - name: Build release binary
         env:
           BUILD_TARGET: ${{ matrix.target }}
-        run: cargo build --release --target "$BUILD_TARGET"
+          MOLTIS_DEFAULT_ASSETS_DIR: /usr/share/moltis/assets
+        run: cargo build --release --target "$BUILD_TARGET" -p moltis --no-default-features --features "file-watcher,local-llm,metrics,prometheus,push-notifications,qmd,tailscale,tls,voice,web-ui"
 
       - name: Build .rpm package
         env:
@@ -648,7 +650,7 @@ jobs:
       - name: Build release binary
         env:
           BUILD_TARGET: ${{ matrix.target }}
-        run: cargo build --release --target "$BUILD_TARGET"
+        run: cargo build --release --target "$BUILD_TARGET" -p moltis --no-default-features --features "file-watcher,local-llm,metrics,prometheus,push-notifications,qmd,tailscale,tls,voice,web-ui"
 
       - name: Determine package version
         id: version
@@ -665,8 +667,10 @@ jobs:
           VERSION: ${{ steps.version.outputs.version }}
           BUILD_TARGET: ${{ matrix.target }}
         run: |
-          cp "target/$BUILD_TARGET/release/moltis" moltis
-          tar czf "moltis-${VERSION}-${BUILD_TARGET}.tar.gz" moltis
+          mkdir -p package
+          cp "target/$BUILD_TARGET/release/moltis" package/moltis
+          cp -R crates/gateway/src/assets package/assets
+          tar czf "moltis-${VERSION}-${BUILD_TARGET}.tar.gz" -C package moltis assets
 
       - name: Sign with Sigstore and generate checksums
         uses: ./.github/actions/sign-artifacts
@@ -1132,7 +1136,9 @@ jobs:
             end
 
             def install
-              bin.install "moltis"
+              libexec.install "moltis"
+              pkgshare.install "assets"
+              (bin/"moltis").write_env_script libexec/"moltis", MOLTIS_ASSETS_DIR: "#{pkgshare}/assets"
             end
 
             test do

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Gateway build split for web UI assets: `web-ui` now controls UI routes/templates
+  while new `web-ui-embedded-assets` controls `include_dir!` embedding. Binaries
+  can now serve assets from filesystem paths (`MOLTIS_ASSETS_DIR`) or a compiled
+  default (`MOLTIS_DEFAULT_ASSETS_DIR`) without embedding static assets.
+
 ### Changed
+
+- Docker and packaging workflows now support externalized web assets for distro
+  artifacts (Homebrew/deb/rpm), installing `crates/gateway/src/assets` alongside
+  the binary and wiring runtime asset paths.
 
 ### Deprecated
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -159,7 +159,7 @@ moltis-channels   = { path = "crates/channels" }
 moltis-common     = { path = "crates/common" }
 moltis-config     = { path = "crates/config" }
 moltis-cron       = { path = "crates/cron" }
-moltis-gateway    = { path = "crates/gateway" }
+moltis-gateway    = { default-features = false, path = "crates/gateway" }
 moltis-mcp        = { path = "crates/mcp" }
 moltis-media      = { path = "crates/media" }
 moltis-memory     = { path = "crates/memory" }

--- a/Formula/moltis.rb
+++ b/Formula/moltis.rb
@@ -10,7 +10,13 @@ class Moltis < Formula
   depends_on "rust" => :build
 
   def install
-    system "cargo", "install", *std_cargo_args(path: "crates/cli")
+    system "cargo", "build", "--release", "--manifest-path", "crates/cli/Cargo.toml",
+                    "--no-default-features",
+                    "--features",
+                    "file-watcher,local-llm,metrics,prometheus,push-notifications,qmd,tailscale,tls,voice,web-ui"
+    libexec.install "target/release/moltis"
+    pkgshare.install "crates/gateway/src/assets" => "assets"
+    (bin/"moltis").write_env_script libexec/"moltis", MOLTIS_ASSETS_DIR: "#{pkgshare}/assets"
   end
 
   test do

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -13,20 +13,34 @@ pkg-fmt = "tgz"
 pkg-url = "{ repo }/releases/download/v{ version }/moltis-{ version }-{ target }.tar.gz"
 
 [package.metadata.deb]
-assets     = [["target/release/moltis", "usr/bin/", "755"]]
-copyright  = "2025, Moltis Contributors"
-depends    = "$auto"
+assets = [
+  [
+    "target/release/moltis",
+    "usr/bin/",
+    "755",
+  ],
+  [
+    "crates/gateway/src/assets",
+    "usr/share/moltis/assets",
+    "644",
+  ],
+]
+copyright = "2025, Moltis Contributors"
+depends = "$auto"
 maintainer = "Moltis Contributors"
-name       = "moltis"
-priority   = "optional"
-section    = "net"
+name = "moltis"
+priority = "optional"
+section = "net"
 
 [package.metadata.generate-rpm]
-assets  = [{ dest = "/usr/bin/moltis", mode = "0755", source = "target/release/moltis" }]
+assets = [
+  { dest = "/usr/bin/moltis", mode = "0755", source = "target/release/moltis" },
+  { dest = "/usr/share/moltis/assets", mode = "0644", source = "crates/gateway/src/assets" },
+]
 license = "MIT"
-name    = "moltis"
+name = "moltis"
 summary = "Personal AI gateway inspired by OpenClaw"
-url     = "https://www.moltis.org/"
+url = "https://www.moltis.org/"
 
 [[bin]]
 name = "moltis"
@@ -65,11 +79,32 @@ which              = { workspace = true }
 tempfile = { workspace = true }
 
 [features]
-default            = ["push-notifications", "tailscale", "tls", "voice"]
+default = [
+  "file-watcher",
+  "local-llm",
+  "metrics",
+  "prometheus",
+  "push-notifications",
+  "qmd",
+  "tailscale",
+  "tls",
+  "voice",
+  "web-ui",
+  "web-ui-embedded-assets",
+]
+file-watcher = ["moltis-gateway/file-watcher"]
+local-llm = ["moltis-gateway/local-llm"]
+local-llm-cuda = ["moltis-gateway/local-llm-cuda"]
+local-llm-metal = ["moltis-gateway/local-llm-metal"]
+metrics = ["moltis-gateway/metrics"]
+prometheus = ["moltis-gateway/prometheus"]
 push-notifications = ["moltis-gateway/push-notifications"]
-tailscale          = ["moltis-gateway/tailscale"]
-tls                = ["moltis-gateway/tls"]
-voice              = ["moltis-gateway/voice"]
+qmd = ["moltis-gateway/qmd"]
+tailscale = ["moltis-gateway/tailscale"]
+tls = ["moltis-gateway/tls"]
+voice = ["moltis-gateway/voice"]
+web-ui = ["moltis-gateway/web-ui"]
+web-ui-embedded-assets = ["moltis-gateway/web-ui-embedded-assets"]
 
 [lints]
 workspace = true

--- a/crates/gateway/Cargo.toml
+++ b/crates/gateway/Cargo.toml
@@ -89,7 +89,7 @@ default = [
   "tailscale",
   "tls",
   "voice",
-  "web-ui",
+  "web-ui-embedded-assets",
 ]
 file-watcher = ["moltis-memory/file-watcher", "moltis-skills/file-watcher"]
 local-embeddings = ["moltis-memory/local-embeddings"]
@@ -110,7 +110,8 @@ tls = [
   "dep:tokio-rustls",
 ]
 voice = ["dep:moltis-voice"]
-web-ui = ["dep:askama", "dep:chrono", "dep:include_dir"]
+web-ui = ["dep:askama", "dep:chrono"]
+web-ui-embedded-assets = ["dep:include_dir", "web-ui"]
 
 [dev-dependencies]
 reqwest           = { workspace = true }

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -44,6 +44,7 @@
 
 - [Docker](docker.md)
 - [Cloud Deploy](cloud-deploy.md)
+- [Web UI Assets](web-ui-assets.md)
 
 ---
 

--- a/docs/src/docker.md
+++ b/docs/src/docker.md
@@ -4,6 +4,10 @@ Moltis is available as a multi-architecture Docker image supporting both
 `linux/amd64` and `linux/arm64`. The image is published to GitHub Container
 Registry on every release.
 
+```admonish info title="Web UI assets in Docker"
+Official images use filesystem assets in `/usr/share/moltis/assets` rather than embedding static assets in the binary. See [Web UI Assets](web-ui-assets.md) for build and packaging details.
+```
+
 ## Quick Start
 
 ```bash
@@ -170,6 +174,7 @@ sudo systemctl enable --now podman.socket
 |----------|-------------|
 | `MOLTIS_CONFIG_DIR` | Override config directory (default: `~/.config/moltis`) |
 | `MOLTIS_DATA_DIR` | Override data directory (default: `~/.moltis`) |
+| `MOLTIS_ASSETS_DIR` | Override web UI assets directory (optional in official images) |
 
 Example:
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -8,7 +8,7 @@ Running an AI assistant on your own machine or server is still new territory. Tr
 <strong style="font-size: 1.2em;">A personal AI gateway written in Rust.<br>One binary, no runtime, no npm.</strong>
 </div>
 
-Moltis compiles your entire AI gateway — web UI, LLM providers, tools, and all assets — into a single self-contained executable. There's no Node.js to babysit, no `node_modules` to sync, no V8 garbage collector introducing latency spikes.
+By default, Moltis compiles your entire AI gateway, web UI, LLM providers, tools, and static assets into a single self-contained executable. There's no Node.js to babysit, no `node_modules` to sync, no V8 garbage collector introducing latency spikes. For distro-style external asset layouts, see [Web UI Assets](web-ui-assets.md).
 
 ```bash
 # Quick install (macOS / Linux)

--- a/docs/src/metrics-and-tracing.md
+++ b/docs/src/metrics-and-tracing.md
@@ -39,7 +39,7 @@ moltis-cron = { version = "0.1", features = ["metrics"] }
 To build without metrics entirely:
 
 ```bash
-cargo build --release --no-default-features --features "file-watcher,tailscale,tls,web-ui"
+cargo build --release --no-default-features --features "file-watcher,tailscale,tls,web-ui,web-ui-embedded-assets"
 ```
 
 ## Prometheus Endpoint

--- a/docs/src/mobile-pwa.md
+++ b/docs/src/mobile-pwa.md
@@ -132,13 +132,13 @@ Push notifications are controlled by the `push-notifications` feature flag, whic
 ```toml
 # In your Cargo.toml or when building
 [dependencies]
-moltis-gateway = { default-features = false, features = ["web-ui", "tls"] }
+moltis-gateway = { default-features = false, features = ["web-ui", "web-ui-embedded-assets", "tls"] }
 ```
 
 Or build without the feature:
 
 ```bash
-cargo build --no-default-features --features web-ui,tls,tailscale,file-watcher
+cargo build --no-default-features --features web-ui,web-ui-embedded-assets,tls,tailscale,file-watcher
 ```
 
 ### Data Storage

--- a/docs/src/voice.md
+++ b/docs/src/voice.md
@@ -16,7 +16,7 @@ voice = ["dep:moltis-voice"]
 
 To disable voice features at compile time:
 ```bash
-cargo build --no-default-features --features "file-watcher,tailscale,tls,web-ui"
+cargo build --no-default-features --features "file-watcher,tailscale,tls,web-ui,web-ui-embedded-assets"
 ```
 
 When disabled:

--- a/docs/src/web-ui-assets.md
+++ b/docs/src/web-ui-assets.md
@@ -1,0 +1,98 @@
+# Web UI Assets
+
+Moltis supports two deployment models for the web UI static files (JS/CSS/icons/manifest/service worker):
+
+1. Embedded in the binary (`include_dir!`)
+2. External files on disk (for package-manager and container layouts)
+
+By default, Moltis keeps assets embedded for a single-binary experience.
+
+## Feature Flags
+
+`moltis-gateway` now separates UI runtime and asset embedding:
+
+- `web-ui`: enables web UI routes and templates
+- `web-ui-embedded-assets`: enables embedded static assets
+
+Default behavior includes both flags.
+
+## Runtime Asset Resolution
+
+When serving static assets, Moltis checks paths in this order:
+
+1. `MOLTIS_ASSETS_DIR` (runtime environment)
+2. `MOLTIS_DEFAULT_ASSETS_DIR` (compile-time default via `option_env!`)
+3. Auto-detected source tree path (`crates/gateway/src/assets`, for local `cargo run`)
+4. Embedded assets (only if built with `web-ui-embedded-assets`)
+
+### Required Files
+
+For non-embedded builds, the assets directory must include at least:
+
+- `style.css`
+- `js/app.js`
+- `js/onboarding-app.js`
+- `manifest.json`
+- `sw.js`
+
+If Moltis is built **without** `web-ui-embedded-assets` and assets are missing,
+startup fails fast with an actionable error.
+
+## Build Profiles
+
+### Single-Binary (Default)
+
+Embedded assets (default release behavior):
+
+```bash
+cargo build --release -p moltis
+```
+
+### External Assets (Packaging / Distro)
+
+Build without embedded assets and provide a compiled default path:
+
+```bash
+MOLTIS_DEFAULT_ASSETS_DIR=/usr/share/moltis/assets \
+cargo build --release -p moltis \
+  --no-default-features \
+  --features "file-watcher,local-llm,metrics,prometheus,push-notifications,qmd,tailscale,tls,voice,web-ui"
+```
+
+Then install/copy `crates/gateway/src/assets` to the same directory:
+
+```bash
+install -d /usr/share/moltis
+cp -R crates/gateway/src/assets /usr/share/moltis/assets
+```
+
+### Runtime Override
+
+To override assets path at runtime:
+
+```bash
+MOLTIS_ASSETS_DIR=/custom/assets/path moltis
+```
+
+## Packaging Conventions
+
+Current packaging defaults use external assets in distro/container contexts:
+
+- Docker image copies assets to `/usr/share/moltis/assets`
+- deb/rpm package metadata installs assets to `/usr/share/moltis/assets`
+- Homebrew formula installs assets under `pkgshare/assets` and sets `MOLTIS_ASSETS_DIR`
+
+## Caching Behavior
+
+- Local dev source-tree assets use no-cache behavior.
+- Packaged filesystem assets use hashed versioned asset URLs and immutable cache headers.
+- Embedded assets use hashed versioned URLs as before.
+
+## Troubleshooting
+
+If startup fails with an assets error:
+
+1. Verify the directory exists and is readable.
+2. Verify required files listed above are present.
+3. Check whether the binary was built without embedded assets.
+4. Set `MOLTIS_ASSETS_DIR` explicitly to the assets directory and restart.

--- a/pkg/homebrew/moltis.rb
+++ b/pkg/homebrew/moltis.rb
@@ -21,7 +21,9 @@ class Moltis < Formula
   end
 
   def install
-    bin.install "moltis"
+    libexec.install "moltis"
+    pkgshare.install "assets"
+    (bin/"moltis").write_env_script libexec/"moltis", MOLTIS_ASSETS_DIR: "#{pkgshare}/assets"
   end
 
   test do


### PR DESCRIPTION
## Summary

- Split gateway web UI feature wiring into `web-ui` (routes/templates) and `web-ui-embedded-assets` (static embedding).
- Add filesystem-first asset resolution with precedence: `MOLTIS_ASSETS_DIR` -> compiled `MOLTIS_DEFAULT_ASSETS_DIR` -> dev source path -> embedded fallback.
- Add startup fail-fast validation when binary is built without embedded assets and required files are missing.
- Preserve cache-busting by hashing packaged filesystem assets in production mode.
- Update Docker build/runtime to ship external assets in `/usr/share/moltis/assets`.
- Update deb/rpm/Homebrew packaging and release workflows to install/distribute assets with no-embed binaries.
- Add and update docs (`docs/src/web-ui-assets.md`, Docker/index links) and changelog entries.

## Validation

### Completed

- [x] `taplo fmt`
- [x] `just format`
- [x] `cargo test -p moltis-gateway sanitize_asset_path -- --nocapture`
- [x] `cargo check -p moltis`
- [x] `cargo check -p moltis --no-default-features --features "file-watcher,local-llm,metrics,prometheus,push-notifications,qmd,tailscale,tls,voice,web-ui"`
- [x] `cargo check -p moltis --no-default-features --features "file-watcher,tailscale,tls,web-ui,web-ui-embedded-assets"`
- [x] `cargo +nightly-2025-11-30 clippy -Z unstable-options --workspace --all-targets --timings -- -D warnings`

### Remaining

- [ ] `cargo +nightly-2025-11-30 clippy -Z unstable-options --workspace --all-features --all-targets --timings -- -D warnings`

Reason: this environment does not have CUDA (`nvcc`) available; `--all-features` pulls CUDA build paths. Used the documented macOS fallback clippy invocation above.

## Manual QA

1. Build non-embedded variant and verify startup fails when no assets dir is available.
2. Set `MOLTIS_ASSETS_DIR` to a valid assets directory and verify `/` and `/assets/style.css` load.
3. Verify Docker image serves assets from `/usr/share/moltis/assets` and UI loads at `/`.
4. Verify Homebrew-installed wrapper exports `MOLTIS_ASSETS_DIR` and UI loads.
