### PR TITLE
fix(gateway): use last turn input tokens for auto-compact threshold

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Auto-compact threshold**: use the last turn's input tokens instead of the
+  cumulative sum across all turns when deciding whether to compact. The previous
+  logic summed `inputTokens` from every persisted message, which double-counts
+  the system prompt and tool schemas on every API round-trip, triggering
+  compaction far too early.
+
 ### Security
 
 ## [0.8.30] - 2026-02-15

--- a/crates/gateway/src/chat.rs
+++ b/crates/gateway/src/chat.rs
@@ -2371,16 +2371,27 @@ impl ChatService for LiveChatService {
             .get("_accept_language")
             .and_then(|v| v.as_str())
             .map(String::from);
-        // Auto-compact: if conversation input tokens exceed 95% of context window, compact first.
+        // Auto-compact: if the most recent turn's input tokens exceed 95% of the
+        // context window, compact before sending the next request.  We use the
+        // *last* assistant message's `inputTokens` — that value reflects the
+        // actual payload size the API received (system prompt + tools + full
+        // history + user message).  Summing `inputTokens` across all turns is
+        // wrong because each turn re-sends the entire context, so the sum
+        // grows ~N× faster than the real context usage.
         let context_window = provider.context_window() as u64;
-        let total_input: u64 = history
+        let last_input: u64 = history
             .iter()
-            .filter_map(|m| m.get("inputTokens").and_then(|v| v.as_u64()))
-            .sum();
+            .rev()
+            .find_map(|m| m.get("inputTokens").and_then(|v| v.as_u64()))
+            .unwrap_or(0);
         let compact_threshold = (context_window * 95) / 100;
 
-        if total_input >= compact_threshold {
+        if last_input >= compact_threshold {
             let pre_compact_msg_count = history.len();
+            let total_input: u64 = history
+                .iter()
+                .filter_map(|m| m.get("inputTokens").and_then(|v| v.as_u64()))
+                .sum();
             let total_output: u64 = history
                 .iter()
                 .filter_map(|m| m.get("outputTokens").and_then(|v| v.as_u64()))
@@ -2389,9 +2400,9 @@ impl ChatService for LiveChatService {
 
             info!(
                 session = %session_key,
-                total_input,
+                last_input,
                 context_window,
-                "auto-compact triggered (95% threshold reached)"
+                "auto-compact triggered (last turn at 95% of context window)"
             );
             broadcast(
                 &self.state,
@@ -2402,6 +2413,7 @@ impl ChatService for LiveChatService {
                     "phase": "start",
                     "messageCount": pre_compact_msg_count,
                     "totalTokens": pre_compact_total,
+                    "lastTurnInput": last_input,
                     "inputTokens": total_input,
                     "outputTokens": total_output,
                     "contextWindow": context_window,


### PR DESCRIPTION
## Summary

The auto-compact logic was summing `inputTokens` from every persisted assistant message to decide when to compact. Because each LLM API call re-sends the full context (system prompt + tool schemas + history), per-turn `inputTokens` already includes the full payload. Summing across turns N-counts the base context.

A 3-message casual conversation accumulated 42K "input tokens" in the sum while actual context usage was only ~9K per call. On a 200K window this would trigger compaction after ~25 short exchanges instead of when context is genuinely full.

**Fix:** Use the last assistant message's `inputTokens` instead of the sum.

## Validation

### Completed
- [x] `just format-check` — passed
- [x] clippy (macOS, no nvcc, no `--all-features`) — passed
- [x] zizmor — passed
- [x] lockfile — passed
- [x] `cargo check --package moltis-gateway` — passed
- [x] CHANGELOG.md updated under `[Unreleased] > Fixed`

### Not completed
- [ ] `cargo nextest run` — link failure (pre-existing: OpenMP/llama-cpp under Rosetta x86_64)
- [ ] `biome ci` — pre-existing schema version mismatch on main
- [ ] E2E — not applicable (Rust-only change)

## Manual QA

I wasn't able to manual QA. I'm on macOS and had some issues trying to get a release build to deploy on my server. I'm not really a rust guy, sorry.

## Context

Should fix #134 
