### PR TITLE
feat(skills): gate installer behind install feature

### DIFF
--- a/crates/skills/Cargo.toml
+++ b/crates/skills/Cargo.toml
@@ -10,7 +10,7 @@ flate2                = { workspace = true }
 moltis-config         = { workspace = true }
 moltis-metrics        = { optional = true, workspace = true }
 notify-debouncer-full = { optional = true, workspace = true }
-reqwest               = { workspace = true }
+reqwest               = { optional = true, workspace = true }
 serde                 = { workspace = true }
 serde_json            = { workspace = true }
 serde_yaml            = { workspace = true }
@@ -19,7 +19,8 @@ tokio                 = { workspace = true }
 tracing               = { workspace = true }
 
 [features]
-default      = []
+default      = ["install"]
+install      = ["dep:reqwest"]
 file-watcher = ["dep:notify-debouncer-full"]
 metrics      = ["dep:moltis-metrics"]
 

--- a/crates/skills/src/lib.rs
+++ b/crates/skills/src/lib.rs
@@ -5,6 +5,7 @@
 
 pub mod discover;
 pub mod formats;
+#[cfg(feature = "install")]
 pub mod install;
 pub mod manifest;
 pub mod migration;


### PR DESCRIPTION
## Background / Motivation
We are targeting a minimal moltis agent build for edge-device environments. The HTTP/TLS stack pulled by `reqwest` has a significant binary-size impact, so installer-related networking should be feature-gated and only enabled when needed.

In our local minimal-path validation (`cerebellum` release), binary size dropped from **8,167,936 bytes** to **5,128,192 bytes** (**-37.22%**). This PR is the first foundational step: make the skills installer an explicit feature.

## Changes
- `crates/skills/Cargo.toml`
  - Make `reqwest` optional.
  - Add `install = ["dep:reqwest"]`.
  - Keep `default = ["install"]` to preserve existing behavior.
- `crates/skills/src/lib.rs`
  - Gate `install` module behind `#[cfg(feature = "install")]`.

## Compatibility
- Default behavior remains unchanged.
- Consumers can now disable install/http dependencies by turning off default features.

## Validation
- `cargo check -p moltis-skills`
- `cargo check -p moltis-skills --no-default-features`
- `cargo check -p moltis-skills --no-default-features --features install`