### PR TITLE
feat(system-prompt): add prompt profiles with CRUD, section options, and model overrides

### DIFF
--- a/apps/ios/GraphQL/Schema/schema.graphqls
+++ b/apps/ios/GraphQL/Schema/schema.graphqls
@@ -547,6 +547,10 @@ type MemoryStats {
 	"""
 	process: Int!
 	"""
+	Approximate bytes held by loaded local llama.cpp model tensors.
+	"""
+	localLlamaCpp: Int!
+	"""
 	System available memory in bytes.
 	"""
 	available: Int!

--- a/crates/web/ui/e2e/specs/agents.spec.js
+++ b/crates/web/ui/e2e/specs/agents.spec.js
@@ -159,13 +159,14 @@ test.describe("Agents settings page", () => {
 		await waitForWsConnected(page);
 		await createSession(page);
 
-		const agentSelect = page.locator('select[title="Session agent"]');
-		await expect(agentSelect).toBeEnabled({ timeout: 10_000 });
-		await expect(agentSelect.locator('option[value="selector-test"]')).toBeAttached({ timeout: 10_000 });
-		await agentSelect.selectOption("selector-test");
-		// The controlled Preact select resets value on re-render; wait for
-		// the session store to reflect the agent switch (RPC round-trip)
-		// before asserting the DOM value.
+		const agentPicker = page.locator("#sessionHeaderToolbarMount .model-combo .model-combo-btn").first();
+		await expect(agentPicker).toBeEnabled({ timeout: 10_000 });
+		await agentPicker.click();
+		const selectorOption = page.locator(".model-dropdown-item").filter({ hasText: "Selector Test Agent" }).first();
+		await expect(selectorOption).toBeVisible({ timeout: 10_000 });
+		await selectorOption.click();
+
+		// Wait for the session store to reflect the agent switch (RPC round-trip).
 		await expect
 			.poll(
 				async () =>

--- a/crates/web/ui/e2e/specs/chat-input.spec.js
+++ b/crates/web/ui/e2e/specs/chat-input.spec.js
@@ -64,8 +64,31 @@ async function getChatSeq(page) {
 	});
 }
 
+async function openChatMoreControls(page) {
+	const moreBtn = page.locator("#chatMoreBtn");
+	const moreModal = page.locator("#chatMoreModal");
+	await expect(moreBtn).toBeVisible();
+	const alreadyOpen = await moreModal.isVisible().catch(() => false);
+	if (!alreadyOpen) {
+		await moreBtn.click();
+		await expect(moreModal).toBeVisible();
+	}
+	return moreModal;
+}
+
+async function ensureFullContextModalOpen(page) {
+	const fullContextModal = page.locator("#fullContextModal");
+	const alreadyOpen = await fullContextModal.isVisible().catch(() => false);
+	if (alreadyOpen) return fullContextModal;
+	await openChatMoreControls(page);
+	await expect(page.locator("#fullContextBtn")).toBeVisible();
+	await page.locator("#fullContextBtn").click();
+	await expect(fullContextModal).toBeVisible();
+	return fullContextModal;
+}
+
 async function openFullContextWithRetry(page) {
-	const toggleBtn = page.locator("#fullContextBtn");
+	const fullContextModal = page.locator("#fullContextModal");
 	const panel = page.locator("#fullContextPanel");
 	const copyBtn = panel.getByRole("button", { name: "Copy", exact: true });
 	const failedMsg = panel.getByText("Failed to build context", { exact: true });
@@ -80,10 +103,11 @@ async function openFullContextWithRetry(page) {
 
 		const panelVisible = await panel.isVisible().catch(() => false);
 		if (panelVisible) {
-			await toggleBtn.click();
+			await page.locator("#fullContextModalCloseBtn").click();
+			await expect(fullContextModal).toBeHidden();
 		}
 
-		await toggleBtn.click();
+		await ensureFullContextModalOpen(page);
 		await expect(panel).toBeVisible();
 
 		const result = await expect

--- a/crates/web/ui/e2e/specs/sessions.spec.js
+++ b/crates/web/ui/e2e/specs/sessions.spec.js
@@ -86,6 +86,22 @@ async function setSwitchRpcSendMode(page, mode, delayMs = 0) {
 	);
 }
 
+async function openChatMoreControls(page) {
+	const moreBtn = page.locator("#chatMoreBtn");
+	const moreModal = page.locator("#chatMoreModal");
+	await expect(moreBtn).toBeVisible();
+	const alreadyOpen = await moreModal.isVisible().catch(() => false);
+	if (!alreadyOpen) {
+		await moreBtn.click();
+		await expect(moreModal).toBeVisible();
+	}
+	return moreModal;
+}
+
+function activeModalBackdrops(page) {
+	return page.locator(".provider-modal-backdrop:not(.hidden)");
+}
+
 test.describe("Session management", () => {
 	test("session list renders on load", async ({ page }) => {
 		await navigateAndWait(page, "/");
@@ -233,19 +249,23 @@ test.describe("Session management", () => {
 		expect(pageErrors).toEqual([]);
 	});
 
-	test("main session shows clear action while non-main sessions show delete", async ({ page }) => {
+	test("main session hides clear/delete actions while non-main sessions show delete", async ({ page }) => {
 		const pageErrors = watchPageErrors(page);
 		await page.goto("/");
 		await waitForWsConnected(page);
 		await expectPageContentMounted(page);
 
-		await expect(page.locator('button[title="Clear session"]')).toBeVisible();
-		await expect(page.locator('button[title="Delete session"]')).toHaveCount(0);
+		await openChatMoreControls(page);
+		await expect(page.locator('#chatMoreModal button[title="Clear session"]')).toBeHidden();
+		await expect(page.locator('#chatMoreModal button[title="Delete session"]')).toHaveCount(0);
+		await page.keyboard.press("Escape");
+		await expect(page.locator("#chatMoreModal")).toBeHidden();
 
 		await createSession(page);
 
-		await expect(page.locator('button[title="Clear session"]')).toHaveCount(0);
-		await expect(page.locator('button[title="Delete session"]')).toBeVisible();
+		await openChatMoreControls(page);
+		await expect(page.locator('#chatMoreModal button[title="Clear session"]')).toHaveCount(0);
+		await expect(page.locator('#chatMoreModal button[title="Delete session"]')).toBeVisible();
 
 		expect(pageErrors).toEqual([]);
 	});
@@ -260,9 +280,12 @@ test.describe("Session management", () => {
 		const sessionPath = new URL(page.url()).pathname;
 		const sessionKey = sessionPath.replace(/^\/chats\//, "").replace(/\//g, ":");
 
-		const stopBtn = page.locator('#sessionHeaderMount button[title="Stop generation"]');
+		await openChatMoreControls(page);
+		const stopBtn = page.locator('.chat-toolbar button[title="Stop generation"]');
 		await expect(stopBtn).toHaveCount(0);
-		await expect(page.locator('button[title="Delete session"]')).toBeVisible();
+		await expect(page.locator('#chatMoreModal button[title="Delete session"]')).toBeVisible();
+		await page.keyboard.press("Escape");
+		await expect(page.locator("#chatMoreModal")).toBeHidden();
 
 		await expectRpcOk(page, "system-event", {
 			event: "chat",
@@ -276,7 +299,8 @@ test.describe("Session management", () => {
 		await expect(stopBtn).toBeVisible();
 		await stopBtn.click();
 		await expect(stopBtn).toHaveCount(0);
-		await expect(page.locator('button[title="Delete session"]')).toBeVisible();
+		await openChatMoreControls(page);
+		await expect(page.locator('#chatMoreModal button[title="Delete session"]')).toBeVisible();
 
 		expect(pageErrors).toEqual([]);
 	});
@@ -306,8 +330,9 @@ test.describe("Session management", () => {
 			}
 		});
 
-		await page.locator('button[title="Share snapshot"]').click();
-		await expect(page.locator(".provider-modal-backdrop")).toBeVisible();
+		await openChatMoreControls(page);
+		await page.locator('#chatMoreModal button[title="Share snapshot"]').click();
+		await expect(activeModalBackdrops(page)).toBeVisible();
 		await expect(
 			page.getByText(
 				"We do best-effort redaction for API keys and tokens in shared tool output, but always review before sharing.",
@@ -348,8 +373,9 @@ test.describe("Session management", () => {
 		const pageErrors = await navigateAndWait(page, "/");
 		await waitForWsConnected(page);
 
-		await page.locator('button[title="Share snapshot"]').click();
-		await expect(page.locator(".provider-modal-backdrop")).toBeVisible();
+		await openChatMoreControls(page);
+		await page.locator('#chatMoreModal button[title="Share snapshot"]').click();
+		await expect(activeModalBackdrops(page)).toBeVisible();
 		await page.locator('[data-share-visibility="public"]').click();
 
 		const linkModal = page.locator('[data-share-link-modal="true"]');
@@ -519,20 +545,21 @@ test.describe("Session management", () => {
 					page.evaluate(() => {
 						const store = window.__moltis_stores?.sessionStore;
 						const session = store?.activeSession?.value;
-						const deleteBtn = document.querySelector('button[title="Delete session"]');
-						if (!(session && deleteBtn)) return false;
+						if (!session) return false;
 						session.forkPoint = 5;
 						session.messageCount = 5;
 						session.dataVersion.value++;
-						deleteBtn.click();
 						return true;
 					}),
 				{ timeout: 10_000 },
 			)
 			.toBe(true);
 
+		await openChatMoreControls(page);
+		await page.locator('#chatMoreModal button[title="Delete session"]').click();
+
 		// The confirmation dialog should NOT be visible.
-		await expect(page.locator(".provider-modal-backdrop")).toHaveCount(0);
+		await expect(activeModalBackdrops(page)).toHaveCount(0);
 
 		// The session should be deleted immediately (no dialog appeared)
 		// so we should navigate away from the current session URL.
@@ -568,16 +595,17 @@ test.describe("Session management", () => {
 			)
 			.toBe(true);
 
-		const deleteBtn = page.locator('button[title="Delete session"]');
+		await openChatMoreControls(page);
+		const deleteBtn = page.locator('#chatMoreModal button[title="Delete session"]');
 		await expect(deleteBtn).toBeVisible();
 		await deleteBtn.click();
 
 		// The confirmation dialog SHOULD appear
-		await expect(page.locator(".provider-modal-backdrop")).toBeVisible();
+		await expect(activeModalBackdrops(page)).toBeVisible();
 
 		// Dismiss the dialog by clicking Cancel
-		await page.locator(".provider-modal-backdrop .provider-btn-secondary").click();
-		await expect(page.locator(".provider-modal-backdrop")).toHaveCount(0);
+		await activeModalBackdrops(page).locator(".provider-btn-secondary").click();
+		await expect(activeModalBackdrops(page)).toHaveCount(0);
 
 		expect(pageErrors).toEqual([]);
 	});


### PR DESCRIPTION
## Summary

- Add configurable system prompt profiles with full CRUD lifecycle (create, delete, set-default) via 6 new `system_prompt.config.*` RPC methods
- Per-profile section options (runtime, user details, memory bootstrap, datetime tail), enabled sections toggle grid, template variables with insertion, and live preview with token estimation
- Model overrides UI with glob-based provider/model routing to different prompt profiles, backed by flattened `[[prompt_profiles.overrides]]` TOML schema
- New typed config (`PromptProfilesConfig`, `PromptSectionId`, `PromptSectionOptions`, etc.) in `moltis-config`, profile-aware prompt building in `moltis-agents`, profile resolution and RPC handlers in `moltis-chat`

## Validation

### Completed

- [x] `cargo +nightly-2025-11-30 fmt --all -- --check` passes
- [x] `cargo +nightly-2025-11-30 clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo check --workspace` passes
- [x] `cargo test -p moltis-chat -p moltis-config -p moltis-agents -p moltis-gateway` passes (128+ tests, 0 failures)
- [x] `biome check` passes on all JS files
- [x] `taplo fmt` passes
- [x] Tailwind CSS rebuilt (`crates/web/ui`)

### Remaining

- [ ] `./scripts/local-validate.sh 190`
- [ ] E2E tests: `cd crates/web/ui && npx playwright test e2e/specs/settings-nav.spec.js`

## Manual QA

1. Navigate to Settings > System Prompt
2. Verify default profile loads with template editor and live preview
3. Create a new profile ("test-profile"), verify it appears in the dropdown
4. Toggle section options (Show/Hide Section Options) and verify checkboxes
5. Toggle enabled sections grid, verify required sections are locked
6. Insert a template variable from the collapsible variables list
7. Set the new profile as default, then restore original default
8. Open model overrides panel, add/remove override rows
9. Delete the test profile
10. Verify no JS console errors throughout