### PR TITLE
feat(gateway): add /autolabel command to auto-generate session titles

### DIFF
--- a/crates/gateway/src/assets/js/page-chat.js
+++ b/crates/gateway/src/assets/js/page-chat.js
@@ -34,6 +34,7 @@ var slashCommands = [
 	{ name: "compact", description: "Summarize conversation to save tokens" },
 	{ name: "context", description: "Show session context and project info" },
 	{ name: "sh", description: "Enter command mode (/sh off or Esc to exit)" },
+	{ name: "autolabel", description: "Auto-generate a title from conversation" },
 ];
 var slashMenuEl = null;
 var slashMenuIdx = 0;
@@ -775,6 +776,19 @@ function handleSlashCommand(cmdName, cmdArgs) {
 				switchSession(S.activeSessionKey);
 			} else {
 				chatAddMsg("error", res?.error?.message || "Compact failed");
+			}
+		});
+		return;
+	}
+	if (cmdName === "autolabel") {
+		chatAddMsg("system", "Generating title\u2026");
+		sendRpc("chat.autolabel", {}).then((res) => {
+			if (S.chatMsgBox?.lastChild) S.chatMsgBox.removeChild(S.chatMsgBox.lastChild);
+			if (res?.ok && res.payload?.label) {
+				chatAddMsg("system", `Title: ${res.payload.label}`, true);
+				fetchSessions();
+			} else {
+				chatAddMsg("error", res?.error?.message || "Autolabel failed");
 			}
 		});
 		return;

--- a/crates/gateway/src/channel_events.rs
+++ b/crates/gateway/src/channel_events.rs
@@ -917,6 +917,12 @@ impl ChannelEventSink for GatewayChannelEventSink {
                 chat.compact(params).await.map_err(|e| anyhow!("{e}"))?;
                 Ok("Session compacted.".to_string())
             },
+            "autolabel" => {
+                let params = serde_json::json!({ "_session_key": &session_key });
+                let res = chat.autolabel(params).await.map_err(|e| anyhow!("{e}"))?;
+                let label = res.get("label").and_then(|v| v.as_str()).unwrap_or("?");
+                Ok(format!("Title: {label}"))
+            },
             "context" => {
                 let params = serde_json::json!({ "_session_key": &session_key });
                 let res = chat.context(params).await.map_err(|e| anyhow!("{e}"))?;

--- a/crates/gateway/src/chat.rs
+++ b/crates/gateway/src/chat.rs
@@ -3933,6 +3933,75 @@ impl ChatService for LiveChatService {
         Ok(serde_json::json!(compacted))
     }
 
+    async fn autolabel(&self, params: Value) -> ServiceResult {
+        let session_key = if let Some(sk) = params.get("_session_key").and_then(|v| v.as_str()) {
+            sk.to_string()
+        } else {
+            let conn_id = params
+                .get("_conn_id")
+                .and_then(|v| v.as_str())
+                .map(String::from);
+            self.session_key_for(conn_id.as_deref()).await
+        };
+
+        let history = self
+            .session_store
+            .read(&session_key)
+            .await
+            .map_err(|e| e.to_string())?;
+
+        if history.is_empty() {
+            return Err("no messages to generate a title from".into());
+        }
+
+        // Take only the last 20 messages to keep the prompt short.
+        let recent: Vec<Value> = if history.len() > 20 {
+            history[history.len() - 20..].to_vec()
+        } else {
+            history
+        };
+
+        let provider = self.resolve_provider(&session_key, &recent).await?;
+
+        let mut messages = vec![ChatMessage::system(
+            "Generate a short, descriptive title (5 words max, no quotes, no trailing punctuation) for the following conversation.",
+        )];
+        messages.extend(values_to_chat_messages(&recent));
+        messages.push(ChatMessage::user("Generate the title now."));
+
+        info!(session = %session_key, msgs = recent.len(), "chat.autolabel: generating");
+
+        let mut stream = provider.stream(messages);
+        let mut label = String::new();
+        while let Some(event) = stream.next().await {
+            match event {
+                StreamEvent::Delta(delta) => label.push_str(&delta),
+                StreamEvent::Done(_) => break,
+                StreamEvent::Error(e) => {
+                    return Err(format!("autolabel generation failed: {e}"))
+                },
+                StreamEvent::ToolCallStart { .. }
+                | StreamEvent::ToolCallArgumentsDelta { .. }
+                | StreamEvent::ToolCallComplete { .. }
+                | StreamEvent::ProviderRaw(_)
+                | StreamEvent::ReasoningDelta(_) => {},
+            }
+        }
+
+        let label = label.trim().to_string();
+        if label.is_empty() {
+            return Err("autolabel produced empty title".into());
+        }
+
+        let _ = self
+            .session_metadata
+            .upsert(&session_key, Some(label.clone()))
+            .await;
+
+        info!(session = %session_key, label = %label, "chat.autolabel: done");
+        Ok(serde_json::json!({ "label": label, "sessionKey": session_key }))
+    }
+
     async fn context(&self, params: Value) -> ServiceResult {
         let session_key = if let Some(sk) = params.get("_session_key").and_then(|v| v.as_str()) {
             sk.to_string()

--- a/crates/gateway/src/methods.rs
+++ b/crates/gateway/src/methods.rs
@@ -123,6 +123,7 @@ const WRITE_METHODS: &[&str] = &[
     "chat.cancel_queued",
     "chat.clear",
     "chat.compact",
+    "chat.autolabel",
     "browser.request",
     "logs.ack",
     "models.detect_supported",
@@ -2131,6 +2132,22 @@ impl MethodRegistry {
                         .chat()
                         .await
                         .compact(params)
+                        .await
+                        .map_err(|e| ErrorShape::new(error_codes::UNAVAILABLE, e))
+                })
+            }),
+        );
+
+        self.register(
+            "chat.autolabel",
+            Box::new(|ctx| {
+                Box::pin(async move {
+                    let mut params = ctx.params.clone();
+                    params["_conn_id"] = serde_json::json!(ctx.client_conn_id);
+                    ctx.state
+                        .chat()
+                        .await
+                        .autolabel(params)
                         .await
                         .map_err(|e| ErrorShape::new(error_codes::UNAVAILABLE, e))
                 })

--- a/crates/gateway/src/services.rs
+++ b/crates/gateway/src/services.rs
@@ -448,6 +448,9 @@ pub trait ChatService: Send + Sync {
     async fn inject(&self, params: Value) -> ServiceResult;
     async fn clear(&self, params: Value) -> ServiceResult;
     async fn compact(&self, params: Value) -> ServiceResult;
+    async fn autolabel(&self, _params: Value) -> ServiceResult {
+        Err("autolabel not available".into())
+    }
     async fn context(&self, params: Value) -> ServiceResult;
     /// Build the complete system prompt and return it for inspection.
     async fn raw_prompt(&self, params: Value) -> ServiceResult;

--- a/crates/telegram/src/bot.rs
+++ b/crates/telegram/src/bot.rs
@@ -54,6 +54,7 @@ pub async fn start_polling(
         BotCommand::new("sh", "Enable shell command mode"),
         BotCommand::new("clear", "Clear session history"),
         BotCommand::new("compact", "Compact session (summarize)"),
+        BotCommand::new("autolabel", "Auto-generate session title"),
         BotCommand::new("context", "Show session context info"),
         BotCommand::new("help", "Show available commands"),
     ];

--- a/crates/telegram/src/handlers.rs
+++ b/crates/telegram/src/handlers.rs
@@ -636,7 +636,7 @@ pub async fn handle_message_direct(
 
 fn should_intercept_slash_command(cmd: &str, cmd_text: &str) -> bool {
     match cmd {
-        "new" | "clear" | "compact" | "context" | "model" | "sandbox" | "sessions" | "help" => true,
+        "new" | "clear" | "compact" | "autolabel" | "context" | "model" | "sandbox" | "sessions" | "help" => true,
         "sh" => {
             let args = cmd_text.strip_prefix(cmd).unwrap_or("").trim();
             args.is_empty() || matches!(args, "on" | "off" | "exit" | "status")


### PR DESCRIPTION
## Summary

- Add `/autolabel` slash command that uses LLM to generate short, descriptive session titles from recent conversation history
- Support both Web UI and Telegram bot channels
- Register `chat.autolabel` RPC method following the existing `chat.compact` pattern, with no message persistence (title generation prompt/response not saved to session history)

## Validation

### Completed

- [x] `cargo check` passes (gateway + telegram crates)
- [x] `biome check` passes (no new warnings)
- [x] Web UI: `/autolabel` generates title and updates sidebar
- [x] Telegram: `/autolabel` registered as bot command, dispatched via `dispatch_command`

### Remaining

- [x] `cargo test` — full test suite
- [ ] `cargo +nightly-2025-11-30 clippy --workspace --all-features --all-targets -- -D warnings`
- [ ] E2E test for `/autolabel` slash command

## Manual QA

1. Open Web UI → start a conversation → type `/autolabel` → verify title updates in header and sidebar
2. Type `/autolabel` in an empty session → verify error message appears
3. In Telegram → send `/autolabel` → verify bot replies with generated title