### PR TITLE
fix(ci): only tag Docker image as latest for highest semver release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -901,6 +901,23 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Check if this is the highest release tag
+        id: check_latest
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          CURRENT="${GITHUB_REF#refs/tags/v}"
+          LATEST=$(gh api "repos/${{ github.repository }}/tags" --paginate --jq '.[].name' \
+            | sed 's/^v//' \
+            | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' \
+            | sort -V | tail -1)
+          if [ "$CURRENT" = "$LATEST" ]; then
+            echo "is_latest=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_latest=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Skipping floating tags: ${CURRENT} is not the highest version (${LATEST} is)"
+          fi
+
       - name: Extract metadata
         id: meta
         uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5
@@ -908,9 +925,9 @@ jobs:
           images: ghcr.io/${{ github.repository }}
           tags: |
             type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}.{{minor}},enable=${{ steps.check_latest.outputs.is_latest }}
             type=sha
-            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/') }}
+            type=raw,value=latest,enable=${{ steps.check_latest.outputs.is_latest }}
 
       - name: Create multi-arch manifest and push
         env:


### PR DESCRIPTION
## Summary

- When multiple version tags are pushed simultaneously (e.g. v0.9.9 and v0.9.10 at the same second), concurrent `merge-docker` jobs race to set `latest` and `major.minor` Docker tags. The last job to finish wins regardless of version ordering — this caused `latest` to point at 0.9.9 instead of 0.9.10.
- Adds a `check_latest` step that queries the GitHub tags API for the highest semver tag. Floating tags (`latest`, `{{major}}.{{minor}}`) are only applied when the current tag matches it. Per-version and SHA tags are always applied.

## Validation

### Completed
- [x] Verified root cause: v0.9.9 `merge-docker` finished 2min after v0.9.10 (04:59:07 vs 04:56:59 UTC)
- [x] Confirmed both tags created at same second (`2026-02-20 20:16:33 -0800`)
- [x] GHCR shows `latest`/`0.9` pointing to 0.9.9 digest, 0.9.10 has separate digest

### Remaining
- [ ] Re-run v0.9.10 workflow (or `docker buildx imagetools create` with auth) to fix current GHCR state

## Manual QA

Trigger the release workflow for a new tag and verify `latest` points to the correct version on GHCR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)