### PR TITLE
fix(cron): document delivery fields in tool description and schema

### DIFF
--- a/crates/tools/src/cron_tool.rs
+++ b/crates/tools/src/cron_tool.rs
@@ -583,6 +583,20 @@ impl AgentTool for CronTool {
          - payload.kind: \"agentTurn\"\n\
          - payload.message: the prompt for the isolated agent run\n\
          \n\
+         To deliver the agent output to a channel (e.g. Telegram) after the run:\n\
+         - payload.deliver: true\n\
+         - payload.channel: the channel account identifier (e.g. the Telegram \
+           bot username like \"my_telegram_bot\")\n\
+         - payload.to: the recipient chat ID (e.g. \"123456789\")\n\
+         All three fields are required together. deliver=true without channel \
+         and to will be rejected. Delivery only works with agentTurn payloads.\n\
+         \n\
+         Important constraints:\n\
+         - sessionTarget \"main\" requires payload kind \"systemEvent\"\n\
+         - sessionTarget \"isolated\" requires payload kind \"agentTurn\"\n\
+         - When the user asks to send output to a channel, always use \
+           sessionTarget \"isolated\" + kind \"agentTurn\" + deliver fields\n\
+         \n\
          Optional execution controls for agent turns:\n\
          - payload.model: model id for this job\n\
          - sandbox.enabled: true for sandbox execution, false for host\n\
@@ -625,9 +639,9 @@ impl AgentTool for CronTool {
                                 "message": { "type": "string" },
                                 "model": { "type": "string" },
                                 "timeout_secs": { "type": "integer" },
-                                "deliver": { "type": "boolean" },
-                                "channel": { "type": "string" },
-                                "to": { "type": "string" }
+                                "deliver": { "type": "boolean", "description": "Set to true to deliver the agent output to a channel (e.g. Telegram) after the run. Requires channel and to." },
+                                "channel": { "type": "string", "description": "Channel account identifier for delivery (e.g. the Telegram bot username like 'my_telegram_bot'). Required when deliver=true." },
+                                "to": { "type": "string", "description": "Recipient chat ID for delivery (e.g. '123456789' for Telegram). Required when deliver=true." }
                             },
                             "required": ["kind"]
                         },


### PR DESCRIPTION
## Summary

- Add delivery documentation (deliver, channel, to) to the cron tool's `description()` method so LLM agents know how to create cron jobs that deliver output to channels (e.g. Telegram)
- Add property-level descriptions for `deliver`, `channel`, and `to` in the JSON schema
- Document the sessionTarget ↔ payload kind constraints (main→systemEvent, isolated→agentTurn)

## Problem

When a user asks the agent to create a cron job that delivers output to Telegram, the agent generates broken payloads because the tool description doesn't mention the delivery fields. Typical incorrect output:

```json
{
  "kind": "systemEvent",
  "channel": "main",
  "to": "",
  "sessionTarget": "main"
}
```

The correct payload should be:

```json
{
  "kind": "agentTurn",
  "deliver": true,
  "channel": "my_telegram_bot",
  "to": "123456789",
  "sessionTarget": "isolated"
}
```

The delivery mechanism (added in v0.9.10) works correctly when configured via the UI — this is purely a tool description gap that prevents the LLM from generating correct payloads.

## Test plan

- [ ] Verify the tool description renders correctly when the agent calls `cron` with `action: "status"`
- [ ] Test that an LLM agent creates a correct delivery payload when asked to "send a message to my Telegram channel every hour"
- [ ] Confirm existing cron functionality is unaffected (no code logic changes, only description/schema strings)

Relates to #195