### PR TITLE
feat(tools): add send_image tool for channel image delivery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `send_image` tool for sending local image files (PNG, JPEG, GIF, WebP) to channel targets like Telegram, with optional caption support
 - GraphQL API at `/graphql` (GET serves GraphiQL playground and WebSocket subscriptions, POST handles queries/mutations) exposing all RPC methods as typed operations
 - New `moltis-graphql` crate with queries, mutations, subscriptions, custom `Json` scalar, and `ServiceCaller` trait abstraction
 - `graphql` feature flag (default on) in gateway and CLI crates for compile-time opt-out
@@ -33,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Channel image delivery now parses the actual MIME type from data URIs instead of hardcoding `image/png`
 - OpenAI TTS and Whisper STT now correctly reuse OpenAI credentials from
   voice config, `OPENAI_API_KEY`, or the LLM OpenAI provider config.
 - Voice provider parsing now accepts `openai-tts` and `google-tts` aliases

--- a/crates/chat/src/lib.rs
+++ b/crates/chat/src/lib.rs
@@ -5182,12 +5182,18 @@ async fn run_with_tools(
                     if let Some(ref err) = error {
                         payload["error"] = serde_json::json!(parse_chat_error(err, None));
                     }
-                    // Check for screenshot to send to channel (Telegram, etc.)
+                    // Check for screenshot/image to send to channel (Telegram, etc.)
                     let screenshot_to_send = result
                         .as_ref()
                         .and_then(|r| r.get("screenshot"))
                         .and_then(|s| s.as_str())
                         .filter(|s| s.starts_with("data:image/"))
+                        .map(String::from);
+
+                    let image_caption = result
+                        .as_ref()
+                        .and_then(|r| r.get("caption"))
+                        .and_then(|c| c.as_str())
                         .map(String::from);
 
                     // Extract location from show_map results for native pin
@@ -5236,13 +5242,18 @@ async fn run_with_tools(
                         });
                     }
 
-                    // Send screenshot to channel targets (Telegram) if present.
+                    // Send screenshot/image to channel targets (Telegram) if present.
                     if let Some(screenshot_data) = screenshot_to_send {
                         let state_clone = Arc::clone(&state);
                         let sk_clone = sk.clone();
                         tokio::spawn(async move {
-                            send_screenshot_to_channels(&state_clone, &sk_clone, &screenshot_data)
-                                .await;
+                            send_screenshot_to_channels(
+                                &state_clone,
+                                &sk_clone,
+                                &screenshot_data,
+                                image_caption.as_deref(),
+                            )
+                            .await;
                         });
                     }
 
@@ -6878,6 +6889,7 @@ async fn send_screenshot_to_channels(
     state: &Arc<dyn ChatRuntime>,
     session_key: &str,
     screenshot_data: &str,
+    caption: Option<&str>,
 ) {
     use moltis_common::types::{MediaAttachment, ReplyPayload};
 
@@ -6891,11 +6903,19 @@ async fn send_screenshot_to_channels(
         None => return,
     };
 
+    // Extract actual MIME from "data:image/jpeg;base64,..." instead of
+    // hardcoding PNG — supports JPEG, GIF, WebP from send_image tool.
+    let mime_type = screenshot_data
+        .strip_prefix("data:")
+        .and_then(|s| s.split(';').next())
+        .unwrap_or("image/png")
+        .to_string();
+
     let payload = ReplyPayload {
-        text: String::new(), // No caption, just the image
+        text: caption.unwrap_or_default().to_string(),
         media: Some(MediaAttachment {
             url: screenshot_data.to_string(),
-            mime_type: "image/png".to_string(),
+            mime_type,
         }),
         reply_to_id: None,
         silent: false,

--- a/crates/gateway/src/server.rs
+++ b/crates/gateway/src/server.rs
@@ -2668,6 +2668,7 @@ pub async fn start_gateway(
         tool_registry.register(Box::new(process_tool));
         tool_registry.register(Box::new(sandbox_packages_tool));
         tool_registry.register(Box::new(cron_tool));
+        tool_registry.register(Box::new(moltis_tools::send_image::SendImageTool::new()));
         if let Some(t) = moltis_tools::web_search::WebSearchTool::from_config_with_env_overrides(
             &config.tools.web.search,
             &runtime_env_overrides,

--- a/crates/tools/src/lib.rs
+++ b/crates/tools/src/lib.rs
@@ -30,6 +30,7 @@ pub mod policy;
 pub mod process;
 pub mod sandbox;
 pub mod sandbox_packages;
+pub mod send_image;
 pub mod session_state;
 pub mod skill_tools;
 pub mod spawn_agent;

--- a/crates/tools/src/send_image.rs
+++ b/crates/tools/src/send_image.rs
@@ -1,0 +1,273 @@
+//! `send_image` tool — send a local image file to the current conversation's
+//! channel (e.g. Telegram).
+//!
+//! Returns a `{ "screenshot": "data:{mime};base64,..." }` payload that the
+//! chat runner picks up and routes through `send_screenshot_to_channels`.
+
+use {
+    anyhow::{Result, bail},
+    async_trait::async_trait,
+    base64::Engine as _,
+    moltis_agents::tool_registry::AgentTool,
+    serde_json::{Value, json},
+    std::path::Path,
+    tracing::debug,
+};
+
+/// 20 MB — Telegram's maximum photo upload size.
+const MAX_FILE_SIZE: u64 = 20 * 1024 * 1024;
+
+/// Image-sending tool.
+#[derive(Default)]
+pub struct SendImageTool;
+
+impl SendImageTool {
+    #[must_use]
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+/// Map a file extension to its MIME type.
+fn mime_from_extension(ext: &str) -> Option<&'static str> {
+    match ext.to_ascii_lowercase().as_str() {
+        "png" => Some("image/png"),
+        "jpg" | "jpeg" => Some("image/jpeg"),
+        "gif" => Some("image/gif"),
+        "webp" => Some("image/webp"),
+        _ => None,
+    }
+}
+
+#[async_trait]
+impl AgentTool for SendImageTool {
+    fn name(&self) -> &str {
+        "send_image"
+    }
+
+    fn description(&self) -> &str {
+        "Send a local image file to the current conversation's channel (e.g. Telegram). \
+         Supported formats: PNG, JPEG, GIF, WebP. Maximum size: 20 MB."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "required": ["path"],
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "description": "Absolute file path to the image (e.g. /tmp/chart.png)"
+                },
+                "caption": {
+                    "type": "string",
+                    "description": "Optional text caption to send with the image"
+                }
+            }
+        })
+    }
+
+    async fn execute(&self, params: Value) -> Result<Value> {
+        let path = params
+            .get("path")
+            .and_then(Value::as_str)
+            .ok_or_else(|| anyhow::anyhow!("missing 'path' parameter"))?;
+
+        let caption = params.get("caption").and_then(Value::as_str).unwrap_or("");
+
+        // Resolve extension and validate MIME.
+        let ext = Path::new(path)
+            .extension()
+            .and_then(|e| e.to_str())
+            .ok_or_else(|| {
+                anyhow::anyhow!("file has no extension — supported: png, jpg, jpeg, gif, webp")
+            })?;
+
+        let mime = mime_from_extension(ext).ok_or_else(|| {
+            anyhow::anyhow!(
+                "unsupported image format '.{ext}' — supported: png, jpg, jpeg, gif, webp"
+            )
+        })?;
+
+        // Check file metadata before reading.
+        let meta = tokio::fs::metadata(path)
+            .await
+            .map_err(|e| anyhow::anyhow!("cannot access '{path}': {e}"))?;
+
+        if !meta.is_file() {
+            bail!("'{path}' is not a regular file");
+        }
+
+        if meta.len() > MAX_FILE_SIZE {
+            bail!(
+                "file is too large ({:.1} MB) — maximum is {:.0} MB",
+                meta.len() as f64 / (1024.0 * 1024.0),
+                MAX_FILE_SIZE as f64 / (1024.0 * 1024.0),
+            );
+        }
+
+        // Read and encode.
+        let bytes = tokio::fs::read(path)
+            .await
+            .map_err(|e| anyhow::anyhow!("failed to read '{path}': {e}"))?;
+
+        // Post-read size guard against TOCTOU races (file replaced between
+        // metadata check and read).
+        if bytes.len() as u64 > MAX_FILE_SIZE {
+            bail!(
+                "file is too large ({:.1} MB) — maximum is {:.0} MB",
+                bytes.len() as f64 / (1024.0 * 1024.0),
+                MAX_FILE_SIZE as f64 / (1024.0 * 1024.0),
+            );
+        }
+
+        debug!(
+            path,
+            mime,
+            size = bytes.len(),
+            "send_image: encoded file as data URI"
+        );
+
+        let b64 = base64::engine::general_purpose::STANDARD.encode(&bytes);
+        drop(bytes);
+        let data_uri = format!("data:{mime};base64,{b64}");
+
+        let mut result = json!({
+            "screenshot": data_uri,
+            "sent": true,
+        });
+
+        if !caption.is_empty() {
+            result["caption"] = Value::String(caption.to_string());
+        }
+
+        Ok(result)
+    }
+}
+
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+#[cfg(test)]
+mod tests {
+    use {super::*, std::io::Write};
+
+    #[test]
+    fn mime_lookup_covers_supported_formats() {
+        assert_eq!(mime_from_extension("png"), Some("image/png"));
+        assert_eq!(mime_from_extension("PNG"), Some("image/png"));
+        assert_eq!(mime_from_extension("jpg"), Some("image/jpeg"));
+        assert_eq!(mime_from_extension("jpeg"), Some("image/jpeg"));
+        assert_eq!(mime_from_extension("gif"), Some("image/gif"));
+        assert_eq!(mime_from_extension("webp"), Some("image/webp"));
+        assert_eq!(mime_from_extension("bmp"), None);
+        assert_eq!(mime_from_extension("svg"), None);
+    }
+
+    #[tokio::test]
+    async fn rejects_missing_path_parameter() {
+        let tool = SendImageTool::new();
+        let err = tool.execute(json!({})).await.unwrap_err();
+        assert!(err.to_string().contains("missing 'path'"));
+    }
+
+    #[tokio::test]
+    async fn rejects_unsupported_extension() {
+        let tool = SendImageTool::new();
+        let err = tool
+            .execute(json!({ "path": "/tmp/image.bmp" }))
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("unsupported image format"));
+    }
+
+    #[tokio::test]
+    async fn rejects_file_without_extension() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let tool = SendImageTool::new();
+        let err = tool
+            .execute(json!({ "path": tmp.path().to_str().unwrap() }))
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("has no extension"));
+    }
+
+    #[tokio::test]
+    async fn rejects_nonexistent_file() {
+        let tool = SendImageTool::new();
+        let err = tool
+            .execute(json!({ "path": "/tmp/does-not-exist-12345.png" }))
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("cannot access"));
+    }
+
+    #[tokio::test]
+    async fn rejects_directory() {
+        let dir = tempfile::tempdir().unwrap();
+        // Rename dir to have a .png extension so it passes the MIME check.
+        let png_dir = dir.path().parent().unwrap().join("test-dir.png");
+        std::fs::create_dir_all(&png_dir).unwrap();
+
+        let tool = SendImageTool::new();
+        let err = tool
+            .execute(json!({ "path": png_dir.to_str().unwrap() }))
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("not a regular file"));
+
+        std::fs::remove_dir(&png_dir).unwrap();
+    }
+
+    #[tokio::test]
+    async fn encodes_valid_png_as_data_uri() {
+        let mut tmp = tempfile::NamedTempFile::with_suffix(".png").unwrap();
+        tmp.write_all(&[0x89, b'P', b'N', b'G']).unwrap();
+
+        let tool = SendImageTool::new();
+        let result = tool
+            .execute(json!({ "path": tmp.path().to_str().unwrap() }))
+            .await
+            .unwrap();
+
+        let screenshot = result["screenshot"].as_str().unwrap();
+        assert!(screenshot.starts_with("data:image/png;base64,"));
+        assert_eq!(result["sent"], true);
+        assert!(result.get("caption").is_none());
+    }
+
+    #[tokio::test]
+    async fn includes_caption_when_provided() {
+        let mut tmp = tempfile::NamedTempFile::with_suffix(".jpg").unwrap();
+        tmp.write_all(&[0xFF, 0xD8, 0xFF]).unwrap();
+
+        let tool = SendImageTool::new();
+        let result = tool
+            .execute(json!({ "path": tmp.path().to_str().unwrap(), "caption": "Hello" }))
+            .await
+            .unwrap();
+
+        assert!(
+            result["screenshot"]
+                .as_str()
+                .unwrap()
+                .starts_with("data:image/jpeg;base64,")
+        );
+        assert_eq!(result["caption"], "Hello");
+    }
+
+    #[tokio::test]
+    async fn rejects_oversized_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("huge.png");
+
+        // Create a sparse file that reports > 20 MB without writing all bytes.
+        let file = std::fs::File::create(&path).unwrap();
+        file.set_len(MAX_FILE_SIZE + 1).unwrap();
+
+        let tool = SendImageTool::new();
+        let err = tool
+            .execute(json!({ "path": path.to_str().unwrap() }))
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("too large"));
+    }
+}


### PR DESCRIPTION
## Summary

- Add `send_image` tool that lets skills send local image files (PNG, JPEG, GIF, WebP) to channel targets like Telegram
- Reuses the existing screenshot pipeline — returns a `data:` URI in the `screenshot` key, which the chat runner picks up automatically
- Supports optional `caption` parameter sent as the media message text
- 20 MB file size guard (Telegram limit)
- Fix `send_screenshot_to_channels` to parse actual MIME type from the data URI instead of hardcoding `image/png`

## Validation

### Completed
- [x] `cargo check` passes
- [x] `cargo test` — all tests pass (7 new unit tests for `SendImageTool`)
- [x] `cargo +nightly-2025-11-30 fmt --all -- --check` passes
- [x] `cargo +nightly-2025-11-30 clippy --workspace --all-targets -- -D warnings` passes

### Remaining
- [ ] `./scripts/local-validate.sh` (requires CI environment)

## Manual QA

1. Create a skill that saves an image to `/tmp/test.png`
2. Call `send_image` with `path: "/tmp/test.png"`
3. Verify Telegram receives the image
4. Repeat with `.jpg`, `.gif`, `.webp` to confirm MIME handling
5. Test with `caption` parameter — verify caption appears in Telegram
6. Test with file > 20 MB — verify rejection
7. Test with unsupported extension (`.bmp`) — verify rejection