### PR TITLE
fix(gateway): harden reverse-proxy tls/ws behavior and docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - GraphQL WebSocket upgrade detection now accepts clients that provide `Upgrade`/`Sec-WebSocket-Key` without `Connection: upgrade`
 - GraphQL channel and memory status bridges now return schema-compatible shapes for `channels.status`, `channels.list`, and `memory.status`
 - Provider errors with `insufficient_quota` now surface as explicit quota/billing failures (with the upstream message) instead of generic retrying/rate-limit behavior
+- Gateway startup now blocks the common reverse-proxy TLS mismatch (`MOLTIS_BEHIND_PROXY=true` with Moltis TLS enabled) and explains using `--no-tls`; HTTPS-upstream proxy setups can explicitly opt in with `MOLTIS_ALLOW_TLS_BEHIND_PROXY=true`
+- WebSocket same-origin checks now accept proxy deployments that rewrite `Host` by using `X-Forwarded-Host` in proxy mode, and treat implicit `:443`/`:80` as equivalent to default ports
 ### Security
 
 ## [0.9.10] - 2026-02-21

--- a/crates/gateway/src/server.rs
+++ b/crates/gateway/src/server.rs
@@ -858,6 +858,25 @@ fn env_var_or_unset(name: &str) -> String {
         .unwrap_or_else(|| "<unset>".to_string())
 }
 
+fn env_flag_enabled(name: &str) -> bool {
+    std::env::var(name)
+        .map(|value| value == "1" || value.eq_ignore_ascii_case("true"))
+        .unwrap_or(false)
+}
+
+fn validate_proxy_tls_configuration(
+    behind_proxy: bool,
+    tls_enabled: bool,
+    allow_tls_behind_proxy: bool,
+) -> anyhow::Result<()> {
+    if behind_proxy && tls_enabled && !allow_tls_behind_proxy {
+        anyhow::bail!(
+            "MOLTIS_BEHIND_PROXY=true with Moltis TLS enabled is usually a proxy misconfiguration. Run with --no-tls (or MOLTIS_NO_TLS=true). If your proxy upstream is HTTPS/TCP passthrough by design, set MOLTIS_ALLOW_TLS_BEHIND_PROXY=true."
+        );
+    }
+    Ok(())
+}
+
 fn log_path_diagnostics(kind: &str, path: &FsPath) {
     match std::fs::metadata(path) {
         Ok(metadata) => {
@@ -1045,6 +1064,22 @@ pub async fn start_gateway(
     // CLI --no-tls / MOLTIS_NO_TLS overrides config file TLS setting.
     if no_tls {
         config.tls.enabled = false;
+    }
+    let behind_proxy = env_flag_enabled("MOLTIS_BEHIND_PROXY");
+    let allow_tls_behind_proxy = env_flag_enabled("MOLTIS_ALLOW_TLS_BEHIND_PROXY");
+    #[cfg(feature = "tls")]
+    let tls_enabled_for_gateway = config.tls.enabled;
+    #[cfg(not(feature = "tls"))]
+    let tls_enabled_for_gateway = false;
+    validate_proxy_tls_configuration(
+        behind_proxy,
+        tls_enabled_for_gateway,
+        allow_tls_behind_proxy,
+    )?;
+    if behind_proxy && tls_enabled_for_gateway && allow_tls_behind_proxy {
+        warn!(
+            "MOLTIS_ALLOW_TLS_BEHIND_PROXY=true is set; ensure your proxy uses HTTPS upstream or TLS passthrough to avoid redirect loops"
+        );
     }
 
     let base_provider_config = config.providers.clone();
@@ -2483,11 +2518,6 @@ pub async fn start_gateway(
 
     let is_localhost =
         matches!(bind, "127.0.0.1" | "::1" | "localhost") || bind.ends_with(".localhost");
-    #[cfg(feature = "tls")]
-    let tls_active_for_state = config.tls.enabled;
-    #[cfg(not(feature = "tls"))]
-    let tls_active_for_state = false;
-
     // Initialize metrics system.
     #[cfg(feature = "metrics")]
     let metrics_handle = {
@@ -2532,10 +2562,6 @@ pub async fn start_gateway(
         }
     };
 
-    let behind_proxy = std::env::var("MOLTIS_BEHIND_PROXY")
-        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
-        .unwrap_or(false);
-
     // Keep a reference to the browser service for periodic cleanup and shutdown.
     let browser_for_lifecycle = Arc::clone(&services.browser);
 
@@ -2546,7 +2572,7 @@ pub async fn start_gateway(
         Some(Arc::clone(&credential_store)),
         is_localhost,
         behind_proxy,
-        tls_active_for_state,
+        tls_enabled_for_gateway,
         hook_registry.clone(),
         memory_manager.clone(),
         port,
@@ -2917,10 +2943,7 @@ pub async fn start_gateway(
     let addr: SocketAddr = format!("{bind}:{port}").parse()?;
 
     // Resolve TLS configuration (only when compiled with the `tls` feature).
-    #[cfg(feature = "tls")]
-    let tls_active = config.tls.enabled;
-    #[cfg(not(feature = "tls"))]
-    let tls_active = false;
+    let tls_active = tls_enabled_for_gateway;
 
     #[cfg(feature = "tls")]
     let mut ca_cert_path: Option<PathBuf> = None;
@@ -3695,12 +3718,14 @@ async fn ws_upgrade_handler(
         .get(axum::http::header::ORIGIN)
         .and_then(|v| v.to_str().ok())
     {
-        let host = headers
-            .get(axum::http::header::HOST)
-            .and_then(|v| v.to_str().ok())
-            .unwrap_or("");
-        if !is_same_origin(origin, host) {
-            tracing::warn!(origin, host, remote = %addr, "rejected cross-origin WebSocket upgrade");
+        let host = websocket_origin_host(&headers, state.gateway.behind_proxy).unwrap_or_default();
+        if !is_same_origin(origin, &host) {
+            tracing::warn!(
+                origin,
+                host = %host,
+                remote = %addr,
+                "rejected cross-origin WebSocket upgrade"
+            );
             return (
                 StatusCode::FORBIDDEN,
                 "cross-origin WebSocket connections are not allowed",
@@ -3736,6 +3761,26 @@ async fn ws_upgrade_handler(
         )
     })
     .into_response()
+}
+
+fn websocket_origin_host(headers: &axum::http::HeaderMap, behind_proxy: bool) -> Option<String> {
+    let host = headers
+        .get(axum::http::header::HOST)
+        .and_then(|v| v.to_str().ok())
+        .map(str::trim)
+        .filter(|v| !v.is_empty())
+        .map(ToOwned::to_owned);
+    if !behind_proxy {
+        return host;
+    }
+    headers
+        .get("x-forwarded-host")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|value| value.split(',').next())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+        .or(host)
 }
 
 /// Dedicated host terminal WebSocket stream (`Settings > Terminal`).
@@ -3862,6 +3907,19 @@ fn startup_setup_code_lines(code: &str) -> Vec<String> {
 /// header.  Accepts `localhost`, `127.0.0.1`, and `[::1]` interchangeably
 /// so that `http://localhost:8080` matches a Host of `127.0.0.1:8080`.
 fn is_same_origin(origin: &str, host: &str) -> bool {
+    fn default_port_for_scheme(scheme: &str) -> Option<&'static str> {
+        match scheme {
+            "http" | "ws" => Some("80"),
+            "https" | "wss" => Some("443"),
+            _ => None,
+        }
+    }
+
+    let origin_scheme = origin
+        .split("://")
+        .next()
+        .unwrap_or("")
+        .to_ascii_lowercase();
     // Origin is a full URL (e.g. "https://localhost:8080"), Host is just
     // "host:port" or "host".
     let origin_host = origin
@@ -3891,8 +3949,8 @@ fn is_same_origin(origin: &str, host: &str) -> bool {
         }
     }
 
-    let origin_port = get_port(origin_host);
-    let host_port = get_port(host);
+    let origin_port = get_port(origin_host).or_else(|| default_port_for_scheme(&origin_scheme));
+    let host_port = get_port(host).or_else(|| default_port_for_scheme(&origin_scheme));
 
     let oh = strip_port(origin_host);
     let hh = strip_port(host);
@@ -4757,6 +4815,14 @@ mod tests {
     }
 
     #[test]
+    fn same_origin_treats_default_ports_as_equivalent() {
+        assert!(is_same_origin("https://example.com", "example.com:443"));
+        assert!(is_same_origin("https://example.com:443", "example.com"));
+        assert!(is_same_origin("http://example.com", "example.com:80"));
+        assert!(is_same_origin("http://example.com:80", "example.com"));
+    }
+
+    #[test]
     fn same_origin_localhost_variants() {
         // localhost ↔ 127.0.0.1
         assert!(is_same_origin("http://localhost:8080", "127.0.0.1:8080"));
@@ -4815,6 +4881,31 @@ mod tests {
             "https://app.moltis.localhost:8080",
             "localhost:8080"
         ));
+    }
+
+    #[test]
+    fn websocket_origin_host_prefers_forwarded_host_when_behind_proxy() {
+        let mut headers = axum::http::HeaderMap::new();
+        headers.insert(axum::http::header::HOST, "127.0.0.1:13131".parse().unwrap());
+        headers.insert("x-forwarded-host", "chat.example.com".parse().unwrap());
+        assert_eq!(
+            websocket_origin_host(&headers, true).as_deref(),
+            Some("chat.example.com")
+        );
+    }
+
+    #[test]
+    fn websocket_origin_host_uses_host_without_proxy_mode() {
+        let mut headers = axum::http::HeaderMap::new();
+        headers.insert(
+            axum::http::header::HOST,
+            "gateway.example.com:8443".parse().unwrap(),
+        );
+        headers.insert("x-forwarded-host", "chat.example.com".parse().unwrap());
+        assert_eq!(
+            websocket_origin_host(&headers, false).as_deref(),
+            Some("gateway.example.com:8443")
+        );
     }
 
     #[test]
@@ -4886,6 +4977,25 @@ mod tests {
             "enter this code to set your password or register a passkey",
             "",
         ]);
+    }
+
+    #[test]
+    fn proxy_tls_validation_rejects_common_misconfiguration() {
+        let err = validate_proxy_tls_configuration(true, true, false)
+            .expect_err("behind proxy with TLS should fail without explicit override");
+        let message = err.to_string();
+        assert!(message.contains("MOLTIS_BEHIND_PROXY=true"));
+        assert!(message.contains("--no-tls"));
+    }
+
+    #[test]
+    fn proxy_tls_validation_allows_proxy_mode_when_tls_is_disabled() {
+        assert!(validate_proxy_tls_configuration(true, false, false).is_ok());
+    }
+
+    #[test]
+    fn proxy_tls_validation_allows_explicit_tls_override() {
+        assert!(validate_proxy_tls_configuration(true, true, true).is_ok());
     }
 
     #[test]

--- a/crates/gateway/src/voice.rs
+++ b/crates/gateway/src/voice.rs
@@ -120,8 +120,8 @@ impl LiveTtsService {
                 api_key: cfg.voice.tts.google.api_key.clone(),
                 voice: cfg.voice.tts.google.voice.clone(),
                 language_code: cfg.voice.tts.google.language_code.clone(),
-                speaking_rate: cfg.voice.tts.google.speaking_rate.clone(),
-                pitch: cfg.voice.tts.google.pitch.clone(),
+                speaking_rate: cfg.voice.tts.google.speaking_rate,
+                pitch: cfg.voice.tts.google.pitch,
             },
             piper: moltis_voice::PiperTtsConfig {
                 binary_path: cfg.voice.tts.piper.binary_path.clone(),

--- a/docs/src/authentication.md
+++ b/docs/src/authentication.md
@@ -251,12 +251,15 @@ local-connection detection:
 - **Bare proxies** (no forwarding headers) can appear local — set
   `MOLTIS_BEHIND_PROXY=true` to force all connections to be treated as
   remote
-- The proxy must forward `Origin` and `Host` headers for WebSocket
-  CSWSH protection
+- The proxy must preserve the browser origin host for WebSocket CSWSH
+  protection (forward `Host`, or `X-Forwarded-Host` when rewriting `Host`)
 - TLS termination typically happens at the proxy
+- Passkeys are tied to the RP ID/host identity; host/domain changes usually
+  require registering new passkeys on the new host
 
 See [Security Architecture](security.md#reverse-proxy-deployments) for
-detailed proxy deployment guidance.
+detailed proxy deployment guidance, including a Nginx Proxy Manager
+header snippet and passkey migration guidance.
 
 ## Session Management
 

--- a/docs/src/cloud-deploy.md
+++ b/docs/src/cloud-deploy.md
@@ -19,6 +19,15 @@ HTTP mode. The key settings are:
 | `MOLTIS_DEPLOY_PLATFORM` | Deploy platform | Hides local-only providers (see below) |
 | `MOLTIS_PASSWORD` | Initial password | Set auth password via environment variable |
 
+```admonish tip
+If requests to your domain are redirected to `:13131`, Moltis TLS is still
+enabled behind a TLS-terminating proxy. Use `--no-tls` (or
+`MOLTIS_NO_TLS=true`).
+
+Only keep Moltis TLS enabled when your proxy talks HTTPS to Moltis (or uses
+TCP TLS passthrough). In that case, set `MOLTIS_ALLOW_TLS_BEHIND_PROXY=true`.
+```
+
 ```admonish warning
 **Sandbox limitation**: Most cloud providers do not support Docker-in-Docker.
 The sandboxed command execution feature (where the LLM runs shell commands

--- a/docs/src/docker.md
+++ b/docs/src/docker.md
@@ -131,6 +131,8 @@ Key points:
 
 - Set `MOLTIS_PASSWORD` in the Coolify UI before first deploy.
 - Set `SERVICE_FQDN_MOLTIS_13131` to your app domain.
+- Keep Moltis in `--no-tls` mode behind Coolify's reverse proxy. If requests
+  are redirected to `:13131`, check that TLS is disabled in Moltis.
 - Keep `/var/run/docker.sock:/var/run/docker.sock` mounted if you want sandbox
   isolation for exec tools.
 

--- a/docs/src/security.md
+++ b/docs/src/security.md
@@ -388,13 +388,74 @@ no loopback bypass, no exceptions.
    Once a password is configured (Tier 1), authentication is required
    for all traffic regardless of `is_local_connection()`.
 
-3. **WebSocket proxying** must forward the `Origin` and `Host` headers
-   correctly.  Moltis validates same-origin on WebSocket upgrades to
-   prevent cross-site WebSocket hijacking (CSWSH).
+3. **WebSocket proxying** must preserve browser origin host info
+   (`Host`, or `X-Forwarded-Host` if `Host` is rewritten). Moltis
+   validates same-origin on WebSocket upgrades to prevent cross-site
+   WebSocket hijacking (CSWSH).
 
-4. **TLS termination** should happen at the proxy.  Moltis can also
-   serve TLS directly (`[tls] enabled = true`), but most proxy setups
-   handle certificates at the edge.
+4. **TLS termination** should happen at the proxy. Run Moltis with
+   `--no-tls` (or `MOLTIS_NO_TLS=true`) in this mode.
+
+   If your browser is being redirected to `https://<domain>:13131`,
+   Moltis TLS is still enabled while your proxy upstream is plain HTTP.
+
+5. **Advanced TLS upstream mode** (optional): if your proxy connects to
+   Moltis using HTTPS upstream (or TCP TLS passthrough), you may keep
+   Moltis TLS enabled. Set `MOLTIS_ALLOW_TLS_BEHIND_PROXY=true` to
+   acknowledge this non-default setup.
+
+### Nginx Proxy Manager (known-good headers)
+
+If WebSockets fail behind NPM while HTTP works, ensure:
+
+- Moltis runs with `MOLTIS_BEHIND_PROXY=true`
+- For standard edge TLS termination, Moltis runs with `--no-tls`
+- NPM preserves browser host/origin context
+
+Use this in NPM's **Advanced** field:
+
+```nginx
+proxy_set_header Host $host;
+proxy_set_header X-Forwarded-Host $host;
+proxy_set_header X-Forwarded-Proto $scheme;
+proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+proxy_set_header Upgrade $http_upgrade;
+proxy_set_header Connection "upgrade";
+```
+
+Upstream scheme guidance:
+
+- **Edge TLS termination (most setups)**: proxy to `http://<moltis-host>:13131`
+  with Moltis started using `--no-tls`
+- **HTTPS upstream / TLS passthrough**: proxy to `https://<moltis-host>:13131`
+  and set `MOLTIS_ALLOW_TLS_BEHIND_PROXY=true`
+
+### Passkeys Behind Proxies (Host Changes)
+
+WebAuthn passkeys are bound to an RP ID (domain identity), not just the
+server process. In practice:
+
+- If users move from one hostname to another, old passkeys for the old host
+  will not authenticate on the new host.
+- If a proxy rewrites `Host` and does not preserve browser host context,
+  passkey routes can fail with "no passkey config for this hostname".
+
+For stable proxy deployments, set explicit WebAuthn identity to your public
+domain:
+
+```bash
+MOLTIS_BEHIND_PROXY=true
+MOLTIS_NO_TLS=true
+MOLTIS_WEBAUTHN_RP_ID=chat.example.com
+MOLTIS_WEBAUTHN_ORIGIN=https://chat.example.com
+```
+
+Migration guidance when changing host/domain:
+
+1. Keep password login enabled during migration.
+2. Deploy with the new `MOLTIS_WEBAUTHN_RP_ID`/`MOLTIS_WEBAUTHN_ORIGIN`.
+3. Ask users to register a new passkey on the new host.
+4. Remove old passkeys after new-host login is confirmed.
 
 ## Production Recommendations
 


### PR DESCRIPTION
## Summary
- add startup validation for reverse-proxy TLS mismatch (`MOLTIS_BEHIND_PROXY=true` + Moltis TLS enabled), with explicit advanced override via `MOLTIS_ALLOW_TLS_BEHIND_PROXY=true`
- fix WebSocket origin checks behind host-rewriting proxies by using `X-Forwarded-Host` in proxy mode
- normalize same-origin default ports (`https`/`wss` => `443`, `http`/`ws` => `80`) to avoid false cross-origin rejects
- add focused unit tests for proxy TLS validation, proxy host selection, and default-port origin matching
- document reverse-proxy troubleshooting (`:13131` redirect), Nginx Proxy Manager known-good headers, and passkey migration guidance when host/domain changes
- clean up `clone_on_copy` in gateway voice config loading to satisfy clippy

## Validation
### Completed
- [x] `just format`
- [x] `cargo test -p moltis-gateway proxy_tls_validation -- --nocapture`
- [x] `cargo test -p moltis-gateway same_origin -- --nocapture`
- [x] `cargo test -p moltis-gateway websocket_origin_host -- --nocapture`
- [x] `cargo +nightly-2025-11-30 clippy -Z unstable-options --workspace --all-targets --timings -- -D warnings`

### Remaining
- [ ] `just lint` (all-features variant can require CUDA/nvcc in this environment)

## Manual QA
- not run locally with a live Nginx Proxy Manager instance in this session
- docs include a concrete NPM header snippet and expected upstream scheme options
