### PR TITLE
fix(mcp): make optional MCP tool params nullable to prevent empty string errors

### DIFF
--- a/crates/mcp/src/tool_bridge.rs
+++ b/crates/mcp/src/tool_bridge.rs
@@ -10,6 +10,30 @@ use crate::{
     types::{McpToolDef, ToolContent},
 };
 
+/// Recursively strip null values from nested objects and arrays.
+///
+/// Top-level null stripping is handled by the caller; this recurses into
+/// values that are themselves objects or arrays.
+fn strip_nulls_recursive(map: &mut serde_json::Map<String, serde_json::Value>) {
+    for value in map.values_mut() {
+        match value {
+            serde_json::Value::Object(inner) => {
+                inner.retain(|_, v| !v.is_null());
+                strip_nulls_recursive(inner);
+            },
+            serde_json::Value::Array(arr) => {
+                for item in arr.iter_mut() {
+                    if let serde_json::Value::Object(inner) = item {
+                        inner.retain(|_, v| !v.is_null());
+                        strip_nulls_recursive(inner);
+                    }
+                }
+            },
+            _ => {},
+        }
+    }
+}
+
 /// An `AgentTool` implementation that delegates to an MCP server via `McpClient`.
 pub struct McpToolBridge {
     /// Prefixed tool name: `mcp__<server>__<tool>`.
@@ -92,12 +116,16 @@ impl McpAgentTool for McpToolBridge {
     }
 
     async fn execute(&self, params: serde_json::Value) -> Result<serde_json::Value> {
-        // Strip internal metadata keys (e.g. _session_key, _accept_language,
-        // _conn_id) injected by the agent runner — these are not part of the
-        // MCP tool schema and break servers with strict validation.
+        // Clean up arguments before forwarding to the MCP server:
+        // 1. Strip internal metadata keys (e.g. _session_key) injected by the
+        //    agent runner — these break servers with strict validation.
+        // 2. Strip null values — these arise from strict-mode schema patching
+        //    that makes optional properties nullable.  MCP servers expect
+        //    optional fields to be absent, not null.
         let params = match params {
             serde_json::Value::Object(mut map) => {
-                map.retain(|k, _| !k.starts_with('_'));
+                map.retain(|k, v| !k.starts_with('_') && !v.is_null());
+                strip_nulls_recursive(&mut map);
                 serde_json::Value::Object(map)
             },
             other => other,
@@ -274,5 +302,100 @@ mod tests {
 
         let forwarded = received.lock().await.take().expect("call_tool was called");
         assert_eq!(forwarded, serde_json::json!("hello"));
+    }
+
+    #[tokio::test]
+    async fn test_execute_strips_null_values() {
+        let received = Arc::new(tokio::sync::Mutex::new(None));
+        let client = MockMcpClient {
+            received_args: Arc::clone(&received),
+        };
+        let client: Arc<RwLock<dyn McpClientTrait>> = Arc::new(RwLock::new(client));
+
+        let tool_def = McpToolDef {
+            name: "add_task".to_string(),
+            description: Some("Add a task".to_string()),
+            input_schema: serde_json::json!({"type": "object"}),
+        };
+        let bridge = McpToolBridge::new("todoist", &tool_def, client);
+
+        // Simulate what the LLM sends when optional fields are nullable:
+        // real values for used fields, null for unused optional fields.
+        let params = serde_json::json!({
+            "content": "Buy milk",
+            "due_string": "today",
+            "description": null,
+            "deadline_date": null,
+            "parent_id": null
+        });
+
+        let result = bridge.execute(params).await;
+        assert!(result.is_ok());
+
+        let forwarded = received.lock().await.take().expect("call_tool was called");
+        let map = forwarded.as_object().expect("args should be an object");
+
+        // Real values are forwarded.
+        assert_eq!(
+            map.get("content").and_then(|v| v.as_str()),
+            Some("Buy milk")
+        );
+        assert_eq!(
+            map.get("due_string").and_then(|v| v.as_str()),
+            Some("today")
+        );
+
+        // Null values are stripped.
+        assert!(!map.contains_key("description"));
+        assert!(!map.contains_key("deadline_date"));
+        assert!(!map.contains_key("parent_id"));
+    }
+
+    #[tokio::test]
+    async fn test_execute_strips_nulls_in_nested_objects() {
+        let received = Arc::new(tokio::sync::Mutex::new(None));
+        let client = MockMcpClient {
+            received_args: Arc::clone(&received),
+        };
+        let client: Arc<RwLock<dyn McpClientTrait>> = Arc::new(RwLock::new(client));
+
+        let tool_def = McpToolDef {
+            name: "create".to_string(),
+            description: Some("Create".to_string()),
+            input_schema: serde_json::json!({"type": "object"}),
+        };
+        let bridge = McpToolBridge::new("svc", &tool_def, client);
+
+        let params = serde_json::json!({
+            "tasks": [
+                {
+                    "content": "Test",
+                    "due": "today",
+                    "parent_id": null,
+                    "section_id": null
+                }
+            ],
+            "project": {
+                "name": "Inbox",
+                "color": null
+            }
+        });
+
+        let result = bridge.execute(params).await;
+        assert!(result.is_ok());
+
+        let forwarded = received.lock().await.take().expect("call_tool was called");
+
+        // Array item nulls stripped
+        let task = &forwarded["tasks"][0];
+        assert_eq!(task["content"], "Test");
+        assert_eq!(task["due"], "today");
+        assert!(task.get("parent_id").is_none());
+        assert!(task.get("section_id").is_none());
+
+        // Nested object nulls stripped
+        let project = &forwarded["project"];
+        assert_eq!(project["name"], "Inbox");
+        assert!(project.get("color").is_none());
     }
 }

--- a/crates/providers/src/openai_compat.rs
+++ b/crates/providers/src/openai_compat.rs
@@ -56,11 +56,63 @@ pub struct ResponsesApiTool {
     pub strict: bool,
 }
 
+/// Make a JSON Schema node nullable by adding `"null"` to its type.
+///
+/// For schemas using `"type": "string"` (or any single type), this converts to
+/// `"type": ["string", "null"]`.  For schemas using `anyOf`/`oneOf`, it appends
+/// a `{"type": "null"}` variant.  Already-nullable schemas are left unchanged.
+fn make_nullable(schema: &mut serde_json::Value) {
+    let Some(obj) = schema.as_object_mut() else {
+        return;
+    };
+
+    // If it already has a "null" type, nothing to do.
+    if let Some(ty) = obj.get("type") {
+        if ty.as_str() == Some("null") {
+            return;
+        }
+        if let Some(arr) = ty.as_array()
+            && arr.iter().any(|v| v.as_str() == Some("null"))
+        {
+            return;
+        }
+    }
+
+    // Case 1: has a `type` field — convert to array form with "null".
+    if let Some(ty) = obj.get("type").cloned() {
+        if let Some(s) = ty.as_str() {
+            obj.insert("type".to_string(), serde_json::json!([s, "null"]));
+        } else if let Some(arr) = ty.as_array() {
+            let mut new_arr = arr.clone();
+            new_arr.push(serde_json::json!("null"));
+            obj.insert("type".to_string(), serde_json::Value::Array(new_arr));
+        }
+        return;
+    }
+
+    // Case 2: uses anyOf/oneOf — append a null variant.
+    for key in ["anyOf", "oneOf"] {
+        if let Some(variants) = obj.get_mut(key).and_then(|v| v.as_array_mut()) {
+            let has_null = variants
+                .iter()
+                .any(|v| v.get("type").and_then(|t| t.as_str()) == Some("null"));
+            if !has_null {
+                variants.push(serde_json::json!({"type": "null"}));
+            }
+            return;
+        }
+    }
+}
+
 /// Recursively patch schema for OpenAI strict mode compliance.
 ///
 /// OpenAI's strict mode requires:
 /// 1. `additionalProperties: false` on every object in the schema tree
 /// 2. All properties must be listed in the `required` array
+///
+/// Properties not in the original `required` array are made nullable so the
+/// model can send `null` for unused optional fields instead of fabricating
+/// placeholder values.
 ///
 /// This function recursively patches nested objects in `properties`, array
 /// `items`, `anyOf`/`oneOf`/`allOf` variants, etc.
@@ -69,17 +121,38 @@ pub fn patch_schema_for_strict_mode(schema: &mut serde_json::Value) {
         return;
     };
 
+    // Collect originally-optional property names so we can make them nullable
+    // AFTER recursion (otherwise changing "type":"object" to ["object","null"]
+    // would prevent the recursive pass from recognising nested objects).
+    let mut optional_props: Vec<String> = Vec::new();
+
     // If this is an object type, apply strict mode requirements
     if obj.get("type").and_then(|t| t.as_str()) == Some("object") {
         // Add additionalProperties: false
         obj.insert("additionalProperties".to_string(), serde_json::json!(false));
 
-        // Ensure all properties are in required array
-        // Objects without properties need empty properties + empty required
-        if let Some(props) = obj.get("properties").and_then(|p| p.as_object()) {
+        // Ensure all properties are in required array.
+        if let Some(props) = obj.get("properties").and_then(|p| p.as_object()).cloned() {
+            let originally_required: std::collections::HashSet<String> = obj
+                .get("required")
+                .and_then(|r| r.as_array())
+                .map(|arr| {
+                    arr.iter()
+                        .filter_map(|v| v.as_str().map(String::from))
+                        .collect()
+                })
+                .unwrap_or_default();
+
             let all_prop_names: Vec<serde_json::Value> =
                 props.keys().map(|k| serde_json::json!(k)).collect();
             obj.insert("required".to_string(), serde_json::json!(all_prop_names));
+
+            // Remember which properties need to be made nullable (deferred).
+            for key in props.keys() {
+                if !originally_required.contains(key) {
+                    optional_props.push(key.clone());
+                }
+            }
         } else {
             // Object without properties - add empty properties and required
             obj.insert("properties".to_string(), serde_json::json!({}));
@@ -113,6 +186,19 @@ pub fn patch_schema_for_strict_mode(schema: &mut serde_json::Value) {
         && additional.is_object()
     {
         patch_schema_for_strict_mode(additional);
+    }
+
+    // Now that recursion is done, make originally-optional properties nullable
+    // so the model can send `null` instead of fabricating placeholder values
+    // (e.g. empty strings) that downstream MCP servers reject.
+    if !optional_props.is_empty()
+        && let Some(props) = obj.get_mut("properties").and_then(|p| p.as_object_mut())
+    {
+        for key in &optional_props {
+            if let Some(prop_schema) = props.get_mut(key) {
+                make_nullable(prop_schema);
+            }
+        }
     }
 }
 
@@ -903,12 +989,16 @@ mod tests {
         // First variant is string, no additionalProperties needed
         // Second variant is object, should have additionalProperties: false
         assert_eq!(any_of[1]["additionalProperties"], false);
+
+        // "value" is not in original required, so a null variant is appended
+        assert_eq!(any_of.len(), 3);
+        assert_eq!(any_of[2], serde_json::json!({"type": "null"}));
     }
 
     #[test]
-    fn test_to_openai_tools_all_properties_required() {
-        // Test that all properties are added to the required array
-        // This is the case that was failing for web_fetch with extract_mode
+    fn test_to_openai_tools_all_properties_required_and_optional_nullable() {
+        // All properties are in `required`, but originally-optional ones
+        // become nullable so the model can send null instead of empty strings.
         let tools = vec![serde_json::json!({
             "name": "web_fetch",
             "description": "Fetch a URL",
@@ -931,6 +1021,71 @@ mod tests {
         assert!(required.contains(&serde_json::json!("url")));
         assert!(required.contains(&serde_json::json!("extract_mode")));
         assert!(required.contains(&serde_json::json!("max_chars")));
+
+        // Originally-required "url" keeps its original type
+        assert_eq!(params["properties"]["url"]["type"], "string");
+
+        // Originally-optional properties become nullable
+        let em_type = params["properties"]["extract_mode"]["type"]
+            .as_array()
+            .unwrap();
+        assert!(em_type.contains(&serde_json::json!("string")));
+        assert!(em_type.contains(&serde_json::json!("null")));
+
+        let mc_type = params["properties"]["max_chars"]["type"]
+            .as_array()
+            .unwrap();
+        assert!(mc_type.contains(&serde_json::json!("integer")));
+        assert!(mc_type.contains(&serde_json::json!("null")));
+    }
+
+    #[test]
+    fn test_strict_mode_no_required_field_all_become_nullable() {
+        // When the schema has no `required` field at all, every property is
+        // optional and should become nullable.
+        let tools = vec![serde_json::json!({
+            "name": "add_task",
+            "description": "Add a task",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "content": {"type": "string"},
+                    "description": {"type": "string"},
+                    "due_date": {"type": "string"}
+                }
+            }
+        })];
+        let converted = to_openai_tools(&tools);
+        let params = &converted[0]["function"]["parameters"];
+
+        for key in ["content", "description", "due_date"] {
+            let ty = params["properties"][key]["type"].as_array().unwrap();
+            assert!(
+                ty.contains(&serde_json::json!("null")),
+                "{key} should be nullable"
+            );
+        }
+    }
+
+    #[test]
+    fn test_strict_mode_already_nullable_not_doubled() {
+        let tools = vec![serde_json::json!({
+            "name": "test",
+            "description": "test",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "opt": {"type": ["string", "null"]}
+                },
+                "required": []
+            }
+        })];
+        let converted = to_openai_tools(&tools);
+        let ty = converted[0]["function"]["parameters"]["properties"]["opt"]["type"]
+            .as_array()
+            .unwrap();
+        // Should still be exactly ["string", "null"], not ["string", "null", "null"]
+        assert_eq!(ty.len(), 2);
     }
 
     #[test]
@@ -1309,9 +1464,12 @@ mod tests {
         assert!(required.contains(&serde_json::json!("action")));
         assert!(required.contains(&serde_json::json!("patch")));
 
-        // The "patch" object should have empty properties and empty required
+        // The "patch" object should have empty properties and empty required.
+        // Because "patch" was not in the original `required`, it is also nullable.
         let patch = &params["properties"]["patch"];
-        assert_eq!(patch["type"], "object");
+        let patch_type = patch["type"].as_array().unwrap();
+        assert!(patch_type.contains(&serde_json::json!("object")));
+        assert!(patch_type.contains(&serde_json::json!("null")));
         assert_eq!(patch["additionalProperties"], false);
         assert_eq!(patch["properties"], serde_json::json!({}));
         assert_eq!(patch["required"], serde_json::json!([]));


### PR DESCRIPTION
## Summary

- OpenAI strict mode requires all properties in the `required` array, which caused LLMs to fill in empty strings (`""`) for optional MCP tool parameters. Downstream MCP servers (e.g. Todoist) reject these with 400 errors.
- Fix schema patching to make originally-optional properties **nullable**, so the model sends `null` instead of fabricating empty strings.
- Strip `null` values (recursively, including nested objects/arrays) in the MCP tool bridge before forwarding to the server, since MCP servers expect optional fields to be absent rather than null.

## Validation

- [x] `cargo +nightly-2025-11-30 fmt --all -- --check` passes
- [x] `cargo +nightly-2025-11-30 clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test -p moltis-providers -p moltis-mcp -p moltis-agents` — all 432 tests pass
- [x] 6 new/updated tests covering nullable schema patching, idempotency, null stripping (top-level + nested)

## Manual QA

1. Configure a Todoist MCP server
2. Ask the agent to create a task (e.g. "add a task to buy milk due today")
3. Verify the MCP call succeeds (no 400 errors) and optional fields like `deadlineDate`, `parentId` are absent from the forwarded arguments rather than sent as empty strings