### PR TITLE
feat(sandbox): add GitHub runner parity packages and enable corepack

### DIFF
--- a/crates/config/src/schema.rs
+++ b/crates/config/src/schema.rs
@@ -1679,6 +1679,13 @@ fn default_sandbox_packages() -> Vec<String> {
         "ruby",
         "ruby-dev",
         "golang-go",
+        "php-cli",
+        "php-mbstring",
+        "php-xml",
+        "php-curl",
+        "default-jdk",
+        "maven",
+        "perl",
         // Build toolchain & native deps
         "build-essential",
         "clang",
@@ -1696,6 +1703,8 @@ fn default_sandbox_packages() -> Vec<String> {
         "flex",
         "dpkg-dev",
         "fakeroot",
+        "cmake",
+        "ninja-build",
         // Compression & archiving
         "zip",
         "unzip",
@@ -1719,6 +1728,11 @@ fn default_sandbox_packages() -> Vec<String> {
         "tzdata",
         "shellcheck",
         "patchelf",
+        "git-lfs",
+        "gettext",
+        "lsb-release",
+        "software-properties-common",
+        "yamllint",
         // Text processing & search
         "ripgrep",
         "fd-find",
@@ -1780,6 +1794,11 @@ fn default_sandbox_packages() -> Vec<String> {
         "dos2unix",
         "miller",
         "datamash",
+        // Database clients
+        "postgresql-client",
+        "default-mysql-client",
+        // DevOps
+        "ansible",
         // GIS / OpenStreetMap / map generation
         "gdal-bin",
         "mapnik-utils",

--- a/crates/tools/src/sandbox.rs
+++ b/crates/tools/src/sandbox.rs
@@ -703,6 +703,7 @@ fn sandbox_image_dockerfile(base: &str, packages: &[String]) -> String {
         "FROM {base}\n\
 RUN apt-get update -qq && apt-get install -y -qq {pkg_list} \
     && mkdir -p {SANDBOX_HOME_DIR}\n\
+RUN if command -v corepack >/dev/null 2>&1; then corepack enable; fi\n\
 RUN if command -v go >/dev/null 2>&1; then \
         GOBIN=/usr/local/bin go install {GOGCLI_MODULE_PATH}@{GOGCLI_VERSION} \
         && ln -sf /usr/local/bin/gog /usr/local/bin/gogcli; \


### PR DESCRIPTION
## Summary

- Add commonly-needed packages to `default_sandbox_packages()` for GitHub Actions runner parity: PHP (`php-cli`, extensions), Java (`default-jdk`, `maven`), `perl`, `cmake`, `ninja-build`, `git-lfs`, `gettext`, `lsb-release`, `software-properties-common`, `yamllint`, database clients (`postgresql-client`, `default-mysql-client`), and `ansible`
- Enable `corepack` in the sandbox Dockerfile so `yarn` and `pnpm` are available out of the box alongside `nodejs`/`npm`

## Validation

### Completed
- [x] `cargo check` passes
- [x] `cargo test -p moltis-config` — 120 tests pass
- [x] `cargo test -p moltis-tools` — 512 tests pass
- [x] `cargo +nightly-2025-11-30 fmt --all -- --check` passes

### Remaining
- [ ] `./scripts/local-validate.sh`
- [ ] Build a sandbox image and verify new packages are installed
- [ ] Verify `yarn --version` and `pnpm --version` work in sandbox

## Manual QA

1. Run `moltis sandbox build` and confirm the image builds successfully
2. Exec into the sandbox and verify: `php --version`, `java -version`, `mvn --version`, `cmake --version`, `psql --version`, `yarn --version`, `pnpm --version`