### PR TITLE
fix(whatsapp): sled persistence + graceful shutdown + account state l…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6706,6 +6706,7 @@ dependencies = [
  "moltis-config",
  "moltis-media",
  "moltis-metrics",
+ "postcard",
  "rand 0.9.2",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,6 +125,7 @@ askama     = "0.15"
 axum       = { features = ["ws"], version = "0.8" }
 axum-extra = "0.10"
 # Serialization
+postcard   = { features = ["alloc"], version = "1.1" }
 serde      = { features = ["derive"], version = "1" }
 serde_json = "1"
 # Error handling

--- a/crates/gateway/src/channel.rs
+++ b/crates/gateway/src/channel.rs
@@ -537,9 +537,20 @@ impl ChannelService for LiveChannelService {
             channel_type = channel_type.as_str(),
             "updating channel account"
         );
-        self.stop_plugin_account(channel_type, account_id).await?;
-        self.start_plugin_account(channel_type, account_id, config.clone())
-            .await?;
+        match channel_type {
+            ChannelType::Whatsapp => {
+                // WhatsApp keeps a persistent sled DB lock while running; for
+                // policy/config-only changes, apply hot updates in-place to
+                // avoid stop/start lock races.
+                self.hot_update_config(channel_type, account_id, config.clone())
+                    .await;
+            },
+            _ => {
+                self.stop_plugin_account(channel_type, account_id).await?;
+                self.start_plugin_account(channel_type, account_id, config.clone())
+                    .await?;
+            },
+        }
 
         let created_at = self
             .store

--- a/crates/whatsapp/Cargo.toml
+++ b/crates/whatsapp/Cargo.toml
@@ -11,6 +11,7 @@ moltis-common   = { workspace = true }
 moltis-config   = { workspace = true }
 moltis-media    = { workspace = true }
 moltis-metrics  = { optional = true, workspace = true }
+postcard        = { workspace = true }
 rand            = { workspace = true }
 serde           = { workspace = true }
 serde_json      = { workspace = true }

--- a/crates/whatsapp/src/connection.rs
+++ b/crates/whatsapp/src/connection.rs
@@ -10,7 +10,7 @@ use moltis_channels::{ChannelEventSink, message_log::MessageLog};
 use crate::{
     config::WhatsAppAccountConfig,
     handlers,
-    state::{AccountState, AccountStateMap},
+    state::{AccountState, AccountStateMap, ShutdownState},
 };
 
 /// Start a WhatsApp connection for the given account.
@@ -42,6 +42,8 @@ pub async fn start_connection(
 
     let cancel = CancellationToken::new();
     let cancel_clone = cancel.clone();
+    let shutdown = Arc::new(ShutdownState::new());
+    let shutdown_clone = Arc::clone(&shutdown);
 
     // Build the bot.
     let account_id_clone = account_id.clone();
@@ -85,6 +87,7 @@ pub async fn start_connection(
         account_id: account_id_clone.clone(),
         config,
         cancel: cancel_clone,
+        shutdown: Arc::clone(&shutdown),
         message_log: message_log_clone,
         event_sink: event_sink_clone,
         latest_qr: std::sync::RwLock::new(None),
@@ -104,6 +107,7 @@ pub async fn start_connection(
             account_id: account_id.clone(),
             config: account_state.config.clone(),
             cancel: cancel.clone(),
+            shutdown: Arc::clone(&shutdown),
             message_log: account_state.message_log.clone(),
             event_sink: account_state.event_sink.clone(),
             latest_qr: std::sync::RwLock::new(None),
@@ -138,6 +142,7 @@ pub async fn start_connection(
                 info!(account_id = %account_id_task, "WhatsApp account cancelled before start");
             },
         }
+        shutdown_clone.mark_done();
     });
 
     Ok(())

--- a/crates/whatsapp/src/handlers.rs
+++ b/crates/whatsapp/src/handlers.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::sync::{Arc, atomic::Ordering};
 
 use {
     tracing::{debug, info, warn},
@@ -15,9 +15,39 @@ use moltis_channels::{
 
 use crate::{
     access::{self, AccessDenied},
+    config::WhatsAppAccountConfig,
     otp::{OTP_CHALLENGE_MSG, OtpInitResult, OtpVerifyResult},
     state::{AccountState, AccountStateMap, has_bot_watermark},
 };
+
+fn mirror_connected(accounts: &AccountStateMap, account_id: &str, connected: bool) {
+    let mut map = accounts.write().unwrap_or_else(|e| e.into_inner());
+    if let Some(state) = map.get_mut(account_id) {
+        state
+            .connected
+            .store(connected, Ordering::Relaxed);
+    }
+}
+
+fn mirror_latest_qr(accounts: &AccountStateMap, account_id: &str, qr: Option<String>) {
+    let mut map = accounts.write().unwrap_or_else(|e| e.into_inner());
+    if let Some(state) = map.get_mut(account_id)
+        && let Ok(mut latest_qr) = state.latest_qr.write()
+    {
+        *latest_qr = qr;
+    }
+}
+
+fn current_config(
+    accounts: &AccountStateMap,
+    account_id: &str,
+    fallback: &WhatsAppAccountConfig,
+) -> WhatsAppAccountConfig {
+    let map = accounts.read().unwrap_or_else(|e| e.into_inner());
+    map.get(account_id)
+        .map(|s| s.config.clone())
+        .unwrap_or_else(|| fallback.clone())
+}
 
 /// Process an incoming whatsapp-rust event for the given account.
 pub async fn handle_event(
@@ -34,6 +64,7 @@ pub async fn handle_event(
             if let Ok(mut qr) = state.latest_qr.write() {
                 *qr = Some(code.clone());
             }
+            mirror_latest_qr(&accounts, &state.account_id, Some(code.clone()));
 
             if let Some(ref sink) = state.event_sink {
                 sink.emit(ChannelEvent::PairingQrCode {
@@ -48,12 +79,14 @@ pub async fn handle_event(
             info!(account_id = %state.account_id, "WhatsApp connected");
             state
                 .connected
-                .store(true, std::sync::atomic::Ordering::Relaxed);
+                .store(true, Ordering::Relaxed);
+            mirror_connected(&accounts, &state.account_id, true);
 
             // Clear QR data once connected.
             if let Ok(mut qr) = state.latest_qr.write() {
                 *qr = None;
             }
+            mirror_latest_qr(&accounts, &state.account_id, None);
 
             let display_name = state.client.get_push_name().await;
             let display = if display_name.is_empty() {
@@ -86,13 +119,15 @@ pub async fn handle_event(
             info!(account_id = %state.account_id, "WhatsApp disconnected");
             state
                 .connected
-                .store(false, std::sync::atomic::Ordering::Relaxed);
+                .store(false, Ordering::Relaxed);
+            mirror_connected(&accounts, &state.account_id, false);
         },
         Event::LoggedOut(_) => {
             warn!(account_id = %state.account_id, "WhatsApp logged out");
             state
                 .connected
-                .store(false, std::sync::atomic::Ordering::Relaxed);
+                .store(false, Ordering::Relaxed);
+            mirror_connected(&accounts, &state.account_id, false);
             if let Some(ref sink) = state.event_sink {
                 sink.emit(ChannelEvent::AccountDisabled {
                     channel_type: ChannelType::Whatsapp,
@@ -188,6 +223,7 @@ async fn handle_message(
         .unwrap_or("");
 
     let message_kind = classify_message(&msg, text);
+    let effective_config = current_config(accounts, &state.account_id, &state.config);
 
     // Access control. Self-chat messages from the account owner always bypass
     // access control — the owner is inherently authorized.
@@ -200,7 +236,7 @@ async fn handle_message(
     let access_result = if is_owner_self_chat {
         Ok(())
     } else {
-        access::check_access(&state.config, is_group, &peer_id, Some(&username), group_id)
+        access::check_access(&effective_config, is_group, &peer_id, Some(&username), group_id)
     };
     let access_granted = access_result.is_ok();
 
@@ -258,7 +294,8 @@ async fn handle_message(
         );
 
         // OTP self-approval for non-allowlisted DM users.
-        if reason == AccessDenied::NotOnAllowlist && !is_group && state.config.otp_self_approval {
+        if reason == AccessDenied::NotOnAllowlist && !is_group && effective_config.otp_self_approval
+        {
             handle_otp_flow(
                 accounts,
                 &state.account_id,
@@ -317,7 +354,7 @@ async fn handle_message(
         sender_name,
         username: Some(username),
         message_kind: Some(message_kind),
-        model: state.config.model.clone(),
+        model: effective_config.model.clone(),
         audio_filename: None,
     };
 

--- a/crates/whatsapp/src/plugin.rs
+++ b/crates/whatsapp/src/plugin.rs
@@ -1,12 +1,13 @@
 use std::{
     collections::HashMap,
     path::PathBuf,
-    sync::{Arc, RwLock},
+    sync::{Arc, RwLock, atomic::Ordering},
     time::Instant,
 };
 
 use {
     async_trait::async_trait,
+    tokio::time::{Duration, timeout},
     tracing::{info, warn},
 };
 
@@ -23,7 +24,7 @@ use crate::{
 };
 
 /// Cache TTL for probe results (30 seconds).
-const PROBE_CACHE_TTL: std::time::Duration = std::time::Duration::from_secs(30);
+const PROBE_CACHE_TTL: Duration = Duration::from_secs(30);
 
 /// WhatsApp channel plugin.
 pub struct WhatsAppPlugin {
@@ -167,14 +168,25 @@ impl ChannelPlugin for WhatsAppPlugin {
     }
 
     async fn stop_account(&mut self, account_id: &str) -> ChannelResult<()> {
-        let cancel = {
+        let stop_ctx = {
             let accounts = self.accounts.read().unwrap_or_else(|e| e.into_inner());
-            accounts.get(account_id).map(|s| s.cancel.clone())
+            accounts
+                .get(account_id)
+                .map(|s| (s.cancel.clone(), Arc::clone(&s.shutdown)))
         };
 
-        if let Some(cancel) = cancel {
+        if let Some((cancel, shutdown)) = stop_ctx {
             info!(account_id, "stopping WhatsApp account");
             cancel.cancel();
+
+            if !shutdown.is_done()
+                && timeout(Duration::from_secs(10), shutdown.wait())
+                    .await
+                    .is_err()
+            {
+                warn!(account_id, "timeout waiting for WhatsApp account shutdown");
+            }
+
             let mut accounts = self.accounts.write().unwrap_or_else(|e| e.into_inner());
             accounts.remove(account_id);
         } else {
@@ -208,7 +220,7 @@ impl ChannelStatus for WhatsAppPlugin {
             let accounts = self.accounts.read().unwrap_or_else(|e| e.into_inner());
             match accounts.get(account_id) {
                 Some(state) => {
-                    let connected = state.connected.load(std::sync::atomic::Ordering::Relaxed);
+                    let connected = state.connected.load(Ordering::Relaxed);
                     let details = if connected {
                         state
                             .config

--- a/crates/whatsapp/src/sled_store.rs
+++ b/crates/whatsapp/src/sled_store.rs
@@ -9,6 +9,7 @@ use std::{fmt::Write, path::Path, sync::atomic::AtomicI32};
 
 use {
     async_trait::async_trait,
+    serde::{Serialize, de::DeserializeOwned},
     wacore::{
         appstate::{hash::HashState, processor::AppStateMutationMAC},
         store::{
@@ -52,6 +53,21 @@ pub struct SledStore {
 
 fn json_err(e: serde_json::Error) -> StoreError {
     StoreError::Serialization(e.to_string())
+}
+
+fn postcard_err(e: postcard::Error) -> StoreError {
+    StoreError::Serialization(e.to_string())
+}
+
+fn encode_persistent<T: Serialize>(value: &T) -> Result<Vec<u8>> {
+    postcard::to_allocvec(value).map_err(postcard_err)
+}
+
+fn decode_persistent<T: DeserializeOwned>(bytes: &[u8]) -> Result<T> {
+    match postcard::from_bytes::<T>(bytes) {
+        Ok(value) => Ok(value),
+        Err(_) => serde_json::from_slice(bytes).map_err(json_err),
+    }
 }
 
 impl SledStore {
@@ -226,13 +242,13 @@ impl SignalStore for SledStore {
 impl AppSyncStore for SledStore {
     async fn get_sync_key(&self, key_id: &[u8]) -> Result<Option<AppStateSyncKey>> {
         match self.sync_keys.get(key_id).map_err(db_err)? {
-            Some(v) => Ok(Some(serde_json::from_slice(&v).map_err(json_err)?)),
+            Some(v) => Ok(Some(decode_persistent(&v)?)),
             None => Ok(None),
         }
     }
 
     async fn set_sync_key(&self, key_id: &[u8], key: AppStateSyncKey) -> Result<()> {
-        let val = serde_json::to_vec(&key).map_err(json_err)?;
+        let val = encode_persistent(&key)?;
         self.sync_keys
             .insert(key_id, val.as_slice())
             .map_err(db_err)?;
@@ -245,13 +261,13 @@ impl AppSyncStore for SledStore {
             .get(name.as_bytes())
             .map_err(db_err)?
         {
-            Some(v) => Ok(serde_json::from_slice(&v).map_err(json_err)?),
+            Some(v) => decode_persistent(&v),
             None => Ok(HashState::default()),
         }
     }
 
     async fn set_version(&self, name: &str, state: HashState) -> Result<()> {
-        let val = serde_json::to_vec(&state).map_err(json_err)?;
+        let val = encode_persistent(&state)?;
         self.app_state_versions
             .insert(name.as_bytes(), val.as_slice())
             .map_err(db_err)?;
@@ -273,7 +289,7 @@ impl AppSyncStore for SledStore {
                 .map_err(db_err)?;
             indexes.push(mac.index_mac.clone());
         }
-        let idx_val = serde_json::to_vec(&indexes).map_err(json_err)?;
+        let idx_val = encode_persistent(&indexes)?;
         self.mutation_mac_indexes
             .insert(version_key.as_bytes(), idx_val.as_slice())
             .map_err(db_err)?;
@@ -330,7 +346,7 @@ impl ProtocolStore for SledStore {
             .get(group_jid.as_bytes())
             .map_err(db_err)?
         {
-            Some(v) => Ok(serde_json::from_slice(&v).map_err(json_err)?),
+            Some(v) => decode_persistent(&v),
             None => Ok(Vec::new()),
         }
     }
@@ -338,7 +354,7 @@ impl ProtocolStore for SledStore {
     async fn add_skdm_recipients(&self, group_jid: &str, device_jids: &[String]) -> Result<()> {
         let mut current = self.get_skdm_recipients(group_jid).await?;
         current.extend(device_jids.iter().cloned());
-        let val = serde_json::to_vec(&current).map_err(json_err)?;
+        let val = encode_persistent(&current)?;
         self.skdm_recipients
             .insert(group_jid.as_bytes(), val.as_slice())
             .map_err(db_err)?;
@@ -354,7 +370,7 @@ impl ProtocolStore for SledStore {
 
     async fn get_lid_mapping(&self, lid: &str) -> Result<Option<LidPnMappingEntry>> {
         match self.lid_mappings.get(lid.as_bytes()).map_err(db_err)? {
-            Some(v) => Ok(Some(serde_json::from_slice(&v).map_err(json_err)?)),
+            Some(v) => Ok(Some(decode_persistent(&v)?)),
             None => Ok(None),
         }
     }
@@ -371,7 +387,7 @@ impl ProtocolStore for SledStore {
         self.pn_mappings
             .insert(entry.phone_number.as_bytes(), entry.lid.as_bytes())
             .map_err(db_err)?;
-        let val = serde_json::to_vec(entry).map_err(json_err)?;
+        let val = encode_persistent(entry)?;
         self.lid_mappings
             .insert(entry.lid.as_bytes(), val.as_slice())
             .map_err(db_err)?;
@@ -382,7 +398,7 @@ impl ProtocolStore for SledStore {
         let mut result = Vec::new();
         for entry in self.lid_mappings.iter() {
             let (_, v) = entry.map_err(db_err)?;
-            let mapping: LidPnMappingEntry = serde_json::from_slice(&v).map_err(json_err)?;
+            let mapping: LidPnMappingEntry = decode_persistent(&v)?;
             result.push(mapping);
         }
         Ok(result)
@@ -417,7 +433,7 @@ impl ProtocolStore for SledStore {
     }
 
     async fn update_device_list(&self, record: DeviceListRecord) -> Result<()> {
-        let val = serde_json::to_vec(&record).map_err(json_err)?;
+        let val = encode_persistent(&record)?;
         self.device_list_records
             .insert(record.user.as_bytes(), val.as_slice())
             .map_err(db_err)?;
@@ -430,7 +446,7 @@ impl ProtocolStore for SledStore {
             .get(user.as_bytes())
             .map_err(db_err)?
         {
-            Some(v) => Ok(Some(serde_json::from_slice(&v).map_err(json_err)?)),
+            Some(v) => Ok(Some(decode_persistent(&v)?)),
             None => Ok(None),
         }
     }
@@ -470,7 +486,7 @@ impl ProtocolStore for SledStore {
 #[async_trait]
 impl DeviceStore for SledStore {
     async fn save(&self, device: &wacore::store::Device) -> Result<()> {
-        let val = serde_json::to_vec(device).map_err(json_err)?;
+        let val = encode_persistent(device)?;
         self.device_data
             .insert(b"device", val.as_slice())
             .map_err(db_err)?;
@@ -479,7 +495,7 @@ impl DeviceStore for SledStore {
 
     async fn load(&self) -> Result<Option<wacore::store::Device>> {
         match self.device_data.get(b"device").map_err(db_err)? {
-            Some(v) => Ok(Some(serde_json::from_slice(&v).map_err(json_err)?)),
+            Some(v) => Ok(Some(decode_persistent(&v)?)),
             None => Ok(None),
         }
     }
@@ -616,6 +632,41 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn app_state_persistence_survives_reopen() {
+        let dir = tempfile::tempdir().unwrap();
+
+        {
+            let store = SledStore::open(dir.path()).unwrap();
+            let key = AppStateSyncKey {
+                key_data: vec![10, 20, 30],
+                fingerprint: vec![40, 50],
+                timestamp: 98765,
+            };
+            store.set_sync_key(b"persist-key", key).await.unwrap();
+            store
+                .set_version(
+                    "regular_high",
+                    HashState {
+                        version: 9,
+                        ..Default::default()
+                    },
+                )
+                .await
+                .unwrap();
+        }
+
+        {
+            let store = SledStore::open(dir.path()).unwrap();
+            let loaded_key = store.get_sync_key(b"persist-key").await.unwrap();
+            assert!(loaded_key.is_some());
+            assert_eq!(loaded_key.unwrap().timestamp, 98765);
+
+            let loaded_state = store.get_version("regular_high").await.unwrap();
+            assert_eq!(loaded_state.version, 9);
+        }
+    }
+
+    #[tokio::test]
     async fn skdm_recipients() {
         let store = temp_store();
         let recips = store.get_skdm_recipients("group1").await.unwrap();
@@ -693,6 +744,37 @@ mod tests {
         let loaded = store.get_devices("user1").await.unwrap();
         assert!(loaded.is_some());
         assert_eq!(loaded.unwrap().devices.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn device_list_persistence_survives_reopen() {
+        let dir = tempfile::tempdir().unwrap();
+
+        {
+            let store = SledStore::open(dir.path()).unwrap();
+            store
+                .update_device_list(DeviceListRecord {
+                    user: "persist-user".into(),
+                    devices: vec![DeviceInfo {
+                        device_id: 7,
+                        key_index: Some(2),
+                    }],
+                    timestamp: 1234,
+                    phash: None,
+                })
+                .await
+                .unwrap();
+        }
+
+        {
+            let store = SledStore::open(dir.path()).unwrap();
+            let loaded = store.get_devices("persist-user").await.unwrap();
+            assert!(loaded.is_some());
+            let loaded = loaded.unwrap();
+            assert_eq!(loaded.devices.len(), 1);
+            assert_eq!(loaded.devices[0].device_id, 7);
+            assert_eq!(loaded.timestamp, 1234);
+        }
     }
 
     #[tokio::test]

--- a/crates/whatsapp/src/state.rs
+++ b/crates/whatsapp/src/state.rs
@@ -1,9 +1,16 @@
 use std::{
     collections::{HashMap, VecDeque},
-    sync::{Arc, Mutex, RwLock},
+    sync::{
+        Arc, Mutex, RwLock,
+        atomic::{AtomicBool, Ordering},
+    },
 };
 
-use {tokio_util::sync::CancellationToken, whatsapp_rust::client::Client};
+use {
+    tokio::sync::Notify,
+    tokio_util::sync::CancellationToken,
+    whatsapp_rust::client::Client,
+};
 
 use moltis_channels::{ChannelEventSink, message_log::MessageLog};
 
@@ -25,18 +32,55 @@ pub(crate) const BOT_WATERMARK: &str = "\u{200D}\u{200C}\u{200D}\u{200C}";
 /// Shared account state map.
 pub type AccountStateMap = Arc<RwLock<HashMap<String, AccountState>>>;
 
+/// Synchronization primitive for graceful bot shutdown.
+pub struct ShutdownState {
+    done: AtomicBool,
+    notify: Notify,
+}
+
+impl Default for ShutdownState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ShutdownState {
+    pub fn new() -> Self {
+        Self {
+            done: AtomicBool::new(false),
+            notify: Notify::new(),
+        }
+    }
+
+    pub fn is_done(&self) -> bool {
+        self.done.load(Ordering::Acquire)
+    }
+
+    pub fn mark_done(&self) {
+        self.done.store(true, Ordering::Release);
+        self.notify.notify_waiters();
+    }
+
+    pub async fn wait(&self) {
+        while !self.is_done() {
+            self.notify.notified().await;
+        }
+    }
+}
+
 /// Per-account runtime state.
 pub struct AccountState {
     pub client: Arc<Client>,
     pub account_id: String,
     pub config: WhatsAppAccountConfig,
     pub cancel: CancellationToken,
+    pub shutdown: Arc<ShutdownState>,
     pub message_log: Option<Arc<dyn MessageLog>>,
     pub event_sink: Option<Arc<dyn ChannelEventSink>>,
     /// Latest QR code data for the pairing flow (updated every ~20s).
     pub latest_qr: RwLock<Option<String>>,
     /// Whether the client is currently connected.
-    pub connected: std::sync::atomic::AtomicBool,
+    pub connected: AtomicBool,
     /// In-memory OTP challenges for self-approval (std::sync::Mutex because
     /// all OTP operations are synchronous HashMap lookups, never held across
     /// `.await` points).
@@ -209,5 +253,21 @@ mod tests {
         watermark_message(&mut msg);
         assert!(msg.conversation.is_none());
         assert!(msg.extended_text_message.is_none());
+    }
+
+    #[tokio::test]
+    async fn shutdown_state_waits_for_completion() {
+        let shutdown = Arc::new(ShutdownState::new());
+        let wait_state = Arc::clone(&shutdown);
+
+        let waiter = tokio::spawn(async move {
+            wait_state.wait().await;
+        });
+
+        tokio::task::yield_now().await;
+        assert!(!shutdown.is_done());
+        shutdown.mark_done();
+        waiter.await.unwrap();
+        assert!(shutdown.is_done());
     }
 }


### PR DESCRIPTION
## Summary

Fix WhatsApp account lifecycle around Sled persistence to avoid lock contention during update/restart.
- Ensure account shutdown completes before reopening the same Sled store path.
- Prevent Resource temporarily unavailable lock errors when updating channel config.
- Keep in-memory account state consistent across stop/start so channels recover cleanly.

This specifically fixes:
- failed to open sled store ... could not acquire lock ... WouldBlock

### Validation

#### Completed

- [X] Reproduced failure by updating WhatsApp channel config after an active paired session.
- [X] Verified update/restart flow no longer hits Sled lock error.
- [X] Confirmed channel starts correctly after stop/start cycle.
- [X] cargo test -p moltis-whatsapp (Docker flow) — passed.
- [X] Commit message follows conventional commit style.
- [X] Reviewed diff for secrets/sensitive data — none found.

#### Remaining

- just format-check
- just release-preflight
- just test
- ./scripts/local-validate.sh (recommended CI-parity check)

### Session / Context Sharing

- Full implementation context is available from this development session (issue reproduction, lock contention diagnosis, lifecycle fix, and verification flow).
- If maintainers need the complete raw transcript export, it can be attached in follow-up.


### Redaction / Security

- Shared logs/transcript are redacted for credentials and sensitive values.
- No API keys, tokens, passwords, or private keys are included in this PR.

### Manual QA

1. Start server with an existing paired WhatsApp account.
2. Update WhatsApp channel config (e.g. allowlist) and save.
3. Confirm logs do not show Sled lock errors.
4. Restart server and verify account starts normally.

