### PR TITLE
refactor(httpd): extract moltis-httpd crate as HTTP transport facade

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -477,11 +477,6 @@ jobs:
           cargo build --target wasm32-wasip2 -p moltis-wasm-calc -p moltis-wasm-web-fetch -p moltis-wasm-web-search --release
           cargo run -p moltis-wasm-precompile --release
 
-      - name: Build release binary
-        env:
-          BUILD_TARGET: ${{ matrix.target }}
-        run: cargo build --release --target "$BUILD_TARGET"
-
       - name: Determine package version
         id: version
         run: |
@@ -589,11 +584,6 @@ jobs:
         run: |
           cargo build --target wasm32-wasip2 -p moltis-wasm-calc -p moltis-wasm-web-fetch -p moltis-wasm-web-search --release
           cargo run -p moltis-wasm-precompile --release
-
-      - name: Build release binary
-        env:
-          BUILD_TARGET: ${{ matrix.target }}
-        run: cargo build --release --target "$BUILD_TARGET"
 
       - name: Determine package version
         id: version
@@ -787,11 +777,6 @@ jobs:
           cargo build --target wasm32-wasip2 -p moltis-wasm-calc -p moltis-wasm-web-fetch -p moltis-wasm-web-search --release
           cargo run -p moltis-wasm-precompile --release
 
-      - name: Build release binary
-        env:
-          BUILD_TARGET: ${{ matrix.target }}
-        run: cargo build --release --target "$BUILD_TARGET"
-
       - name: Determine package version
         id: version
         run: |
@@ -975,10 +960,6 @@ jobs:
         run: |
           cargo build --target wasm32-wasip2 -p moltis-wasm-calc -p moltis-wasm-web-fetch -p moltis-wasm-web-search --release
           cargo run -p moltis-wasm-precompile --release
-
-      - name: Build release binary
-        shell: bash
-        run: cargo build --release --target "$BUILD_TARGET" --features embedded-assets,embedded-wasm
 
       - name: Determine package version
         id: version

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6206,6 +6206,7 @@ dependencies = [
  "dashmap 6.1.0",
  "futures",
  "hostname",
+ "moltis-agents",
  "moltis-auth",
  "moltis-browser",
  "moltis-channels",

--- a/crates/gateway/src/server.rs
+++ b/crates/gateway/src/server.rs
@@ -816,8 +816,9 @@ fn spawn_post_listener_warmups(
 /// Start browser warmup after the transport listener is ready.
 pub fn start_browser_warmup_after_listener(
     browser_service: Arc<dyn crate::services::BrowserService>,
+    browser_tool: Option<Arc<dyn moltis_agents::tool_registry::AgentTool>>,
 ) {
-    spawn_post_listener_warmups(browser_service, None);
+    spawn_post_listener_warmups(browser_service, browser_tool);
 }
 
 #[cfg(feature = "tailscale")]

--- a/crates/httpd/Cargo.toml
+++ b/crates/httpd/Cargo.toml
@@ -18,6 +18,7 @@ chrono-tz             = { workspace = true }
 dashmap               = { workspace = true }
 futures               = { workspace = true }
 hostname              = { workspace = true }
+moltis-agents         = { workspace = true }
 moltis-auth           = { workspace = true }
 moltis-browser        = { workspace = true }
 moltis-channels       = { workspace = true }

--- a/crates/httpd/src/server.rs
+++ b/crates/httpd/src/server.rs
@@ -466,6 +466,7 @@ pub struct BannerMeta {
     pub setup_code_display: Option<String>,
     pub webauthn_registry: Option<SharedWebAuthnRegistry>,
     pub browser_for_lifecycle: Arc<dyn moltis_gateway::services::BrowserService>,
+    pub browser_tool_for_warmup: Option<Arc<dyn moltis_agents::tool_registry::AgentTool>>,
     pub config: moltis_config::schema::MoltisConfig,
     #[cfg(feature = "tailscale")]
     pub tailscale_mode: TailscaleMode,
@@ -493,6 +494,14 @@ pub async fn prepare_gateway(
     extra_routes: Option<RouteEnhancer>,
     session_event_bus: Option<SessionEventBus>,
 ) -> anyhow::Result<PreparedGateway> {
+    // Install a process-level rustls CryptoProvider early, before any channel
+    // plugin (Slack, Discord, etc.) creates outbound TLS connections via
+    // hyper-rustls.  Without this, `--no-tls` deployments skip the TLS cert
+    // setup path where `install_default()` previously lived, causing a panic
+    // the first time an outbound HTTPS request is made (see #329).
+    #[cfg(feature = "tls")]
+    let _ = rustls::crypto::ring::default_provider().install_default();
+
     #[cfg(feature = "tailscale")]
     let tailscale_mode_override = tailscale_opts.as_ref().map(|opts| opts.mode.clone());
     #[cfg(feature = "tailscale")]
@@ -528,6 +537,7 @@ pub async fn prepare_gateway(
             audit_buffer: audit_buffer_for_broadcast,
         sandbox_router,
         browser_for_lifecycle,
+        browser_tool_for_warmup,
         cron_service,
         log_buffer,
         config,
@@ -1486,6 +1496,7 @@ pub async fn prepare_gateway(
             setup_code_display,
             webauthn_registry,
             browser_for_lifecycle,
+            browser_tool_for_warmup,
             config,
             #[cfg(feature = "tailscale")]
             tailscale_mode,
@@ -1553,14 +1564,6 @@ pub async fn start_gateway(
     #[cfg(feature = "tailscale")] tailscale_opts: Option<TailscaleOpts>,
     extra_routes: Option<RouteEnhancer>,
 ) -> anyhow::Result<()> {
-    // Install a process-level rustls CryptoProvider early, before any channel
-    // plugin (Slack, Discord, etc.) creates outbound TLS connections via
-    // hyper-rustls.  Without this, `--no-tls` deployments skip the TLS cert
-    // setup path where `install_default()` previously lived, causing a panic
-    // the first time an outbound HTTPS request is made (see #329).
-    #[cfg(feature = "tls")]
-    let _ = rustls::crypto::ring::default_provider().install_default();
-
     let prepared = prepare_gateway(
         bind,
         port,
@@ -1622,6 +1625,7 @@ pub async fn start_gateway(
 
     let app = prepared.app;
     let browser_for_warmup = Arc::clone(&banner.browser_for_lifecycle);
+    let browser_tool_for_warmup = banner.browser_tool_for_warmup.clone();
 
     #[cfg(feature = "tls")]
     if tls_active {
@@ -1893,9 +1897,10 @@ pub async fn start_gateway(
         let tls_cfg = rustls_config.expect("rustls config must be set when TLS is active");
         let tcp_listener = tokio::net::TcpListener::bind(addr).await?;
         moltis_gateway::server::start_openclaw_background_tasks(banner.data_dir.clone());
-        moltis_gateway::server::start_browser_warmup_after_listener(Arc::clone(
-            &browser_for_warmup,
-        ));
+        moltis_gateway::server::start_browser_warmup_after_listener(
+            Arc::clone(&browser_for_warmup),
+            browser_tool_for_warmup.clone(),
+        );
         moltis_tls::serve_tls_with_http_redirect(tcp_listener, Arc::new(tls_cfg), app, port, bind)
             .await?;
         return Ok(());
@@ -1904,7 +1909,10 @@ pub async fn start_gateway(
     // Plain HTTP server (existing behavior, or TLS feature disabled).
     let listener = tokio::net::TcpListener::bind(addr).await?;
     moltis_gateway::server::start_openclaw_background_tasks(banner.data_dir.clone());
-    moltis_gateway::server::start_browser_warmup_after_listener(Arc::clone(&browser_for_warmup));
+    moltis_gateway::server::start_browser_warmup_after_listener(
+        Arc::clone(&browser_for_warmup),
+        browser_tool_for_warmup,
+    );
     axum::serve(
         listener,
         app.into_make_service_with_connect_info::<SocketAddr>(),


### PR DESCRIPTION
## Summary

- Introduce `moltis-httpd` crate to decouple the HTTP/WS transport layer from `moltis-gateway` core business logic, so non-HTTP consumers (TUI, tests) can depend on `moltis-gateway` without pulling in the full HTTP stack
- Extract `PreparedGatewayCore` struct and `prepare_gateway_core()` in gateway to cleanly separate transport-agnostic initialization from HTTP-specific setup
- Update CLI, web, and swift-bridge crates to import HTTP types (`AppState`, `RouteEnhancer`, route modules, middleware) from `moltis_httpd` instead of `moltis_gateway::server`

This is **Phase 1** (re-export facade): HTTP modules remain in gateway while httpd re-exports them, giving consumers a stable import path. The actual file migration will follow in a future step.

## Validation

### Completed
- [x] `cargo check --workspace` — clean, no warnings
- [x] `cargo test --workspace` — all tests pass (0 failures)
- [x] `cargo test -p moltis-gateway` — 283 tests pass
- [x] `cargo +nightly-2025-11-30 fmt --all -- --check` — clean
- [x] `taplo fmt --check` — clean

### Remaining
- [ ] `cargo +nightly-2025-11-30 clippy -Z unstable-options --workspace --all-features --all-targets --timings -- -D warnings`
- [ ] `./scripts/local-validate.sh <PR_NUMBER>`
- [ ] E2E tests: `cd crates/web/ui && npx playwright test`
- [ ] Manual QA: start server, verify WebSocket + web UI work
- [ ] macOS swift-bridge build: `./scripts/build-swift-bridge.sh`

## Manual QA

1. `cargo run` — verify server starts, banner prints correctly
2. Open web UI in browser — verify pages load
3. Check WebSocket connection establishes
4. Verify TLS works (if enabled)