### PR TITLE
feat(web): add push-to-talk, VAD continuous listening, and voice settings

### DIFF
--- a/crates/web/src/assets/css/components.css
+++ b/crates/web/src/assets/css/components.css
@@ -1593,6 +1593,30 @@
   50% { transform: scale(1.05); }
 }
 
+/* -- VAD Button States -- */
+.vad-btn.vad-active {
+  border-color: var(--accent) !important;
+  color: var(--accent) !important;
+}
+
+.vad-btn.vad-listening {
+  border-color: var(--accent) !important;
+  color: var(--accent) !important;
+  animation: vad-glow 2s ease-in-out infinite;
+}
+
+.vad-btn.vad-speech {
+  background: var(--error) !important;
+  border-color: var(--error) !important;
+  color: #fff !important;
+  animation: mic-pulse 1s infinite;
+}
+
+@keyframes vad-glow {
+  0%, 100% { opacity: 0.7; }
+  50% { opacity: 1; }
+}
+
 /* ── Toggle Switch ── */
 
 .toggle-switch {

--- a/crates/web/src/assets/css/style.css
+++ b/crates/web/src/assets/css/style.css
@@ -3437,6 +3437,10 @@
     -webkit-mask-image: url("./icons/masks/mask-0162291303f5d971.svg");
     mask-image: url("./icons/masks/mask-0162291303f5d971.svg");
   }
+  .icon-waveform {
+    -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24'%3E%3Cpath stroke='black' stroke-width='1.5' stroke-linecap='round' d='M3 12h1M7 8v8M11 5v14M15 8v8M19 10v4M23 12h-1'%2F%3E%3C/svg%3E");
+    mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24'%3E%3Cpath stroke='black' stroke-width='1.5' stroke-linecap='round' d='M3 12h1M7 8v8M11 5v14M15 8v8M19 10v4M23 12h-1'%2F%3E%3C/svg%3E");
+  }
   .icon-checkmark {
     -webkit-mask-image: url("./icons/masks/mask-48b7d531f003fdb1.svg");
     mask-image: url("./icons/masks/mask-48b7d531f003fdb1.svg");

--- a/crates/web/src/assets/dist/chunks/chat.js
+++ b/crates/web/src/assets/dist/chunks/chat.js
@@ -7,6 +7,8 @@ const chat = {
   micStopAndSend: "Click to stop and send",
   voiceTranscribing: "Transcribing...",
   voiceTranscribingMessage: "Transcribing voice...",
+  vadTooltip: "Conversation mode (VAD)",
+  vadStopTooltip: "Click to stop conversation mode",
   // ── Slash commands ───────────────────────────────────────
   slashClear: "Clear conversation history",
   slashCompact: "Summarize conversation to save tokens",

--- a/crates/web/src/assets/dist/chunks/chat.js
+++ b/crates/web/src/assets/dist/chunks/chat.js
@@ -9,6 +9,10 @@ const chat = {
   voiceTranscribingMessage: "Transcribing voice...",
   vadTooltip: "Conversation mode (VAD)",
   vadStopTooltip: "Click to stop conversation mode",
+  voiceNoSpeech: "No speech detected",
+  voiceTranscriptionError: "Transcription error",
+  voiceTranscriptionFailed: "Transcription failed: {{error}}",
+  voiceUploadFailed: "Upload failed: {{error}}",
   // ── Slash commands ───────────────────────────────────────
   slashClear: "Clear conversation history",
   slashCompact: "Summarize conversation to save tokens",

--- a/crates/web/src/assets/dist/chunks/chat2.js
+++ b/crates/web/src/assets/dist/chunks/chat2.js
@@ -7,6 +7,8 @@ const chat = {
   micStopAndSend: "Cliquez pour arrêter et envoyer",
   voiceTranscribing: "Transcription...",
   voiceTranscribingMessage: "Transcription de la voix...",
+  vadTooltip: "Mode conversation (VAD)",
+  vadStopTooltip: "Cliquer pour quitter le mode conversation",
   // ── Slash commands ───────────────────────────────────────
   slashClear: "Clear conversation history",
   slashCompact: "Summarize conversation to save tokens",

--- a/crates/web/src/assets/dist/chunks/chat2.js
+++ b/crates/web/src/assets/dist/chunks/chat2.js
@@ -9,6 +9,10 @@ const chat = {
   voiceTranscribingMessage: "Transcription de la voix...",
   vadTooltip: "Mode conversation (VAD)",
   vadStopTooltip: "Cliquer pour quitter le mode conversation",
+  voiceNoSpeech: "Aucune parole détectée",
+  voiceTranscriptionError: "Erreur de transcription",
+  voiceTranscriptionFailed: "Échec de la transcription : {{error}}",
+  voiceUploadFailed: "Échec du téléversement : {{error}}",
   // ── Slash commands ───────────────────────────────────────
   slashClear: "Clear conversation history",
   slashCompact: "Summarize conversation to save tokens",

--- a/crates/web/src/assets/dist/chunks/chat3.js
+++ b/crates/web/src/assets/dist/chunks/chat3.js
@@ -9,6 +9,10 @@ const chat = {
   voiceTranscribingMessage: "正在转录语音...",
   vadTooltip: "对话模式 (VAD)",
   vadStopTooltip: "点击停止对话模式",
+  voiceNoSpeech: "未检测到语音",
+  voiceTranscriptionError: "转录错误",
+  voiceTranscriptionFailed: "转录失败：{{error}}",
+  voiceUploadFailed: "上传失败：{{error}}",
   // ── Slash commands ───────────────────────────────────────
   slashClear: "清除对话历史",
   slashCompact: "压缩对话以节省 token",

--- a/crates/web/src/assets/dist/chunks/chat3.js
+++ b/crates/web/src/assets/dist/chunks/chat3.js
@@ -7,6 +7,8 @@ const chat = {
   micStopAndSend: "点击停止并发送",
   voiceTranscribing: "转录中...",
   voiceTranscribingMessage: "正在转录语音...",
+  vadTooltip: "对话模式 (VAD)",
+  vadStopTooltip: "点击停止对话模式",
   // ── Slash commands ───────────────────────────────────────
   slashClear: "清除对话历史",
   slashCompact: "压缩对话以节省 token",

--- a/crates/web/src/assets/dist/chunks/projects2.js
+++ b/crates/web/src/assets/dist/chunks/projects2.js
@@ -21,7 +21,8 @@ const projects = {
     worktree: "worktree",
     setup: "setup",
     teardown: "teardown",
-    image: "image"
+    image: "image",
+    indexed: "indexed"
   },
   card: {
     systemPromptPrefix: "System prompt: ",
@@ -44,7 +45,8 @@ const projects = {
     branchPrefixPlaceholder: "default: moltis",
     sandboxImage: "Sandbox image",
     sandboxImagePlaceholder: "Default (ubuntu:25.10)",
-    autoWorktree: "Auto-create git worktree per session"
+    autoWorktree: "Auto-create git worktree per session",
+    codeIndex: "Enable code indexing (semantic search)"
   }
 };
 export {

--- a/crates/web/src/assets/dist/chunks/projects3.js
+++ b/crates/web/src/assets/dist/chunks/projects3.js
@@ -21,7 +21,8 @@ const projects = {
     worktree: "工作树",
     setup: "初始化",
     teardown: "清理",
-    image: "镜像"
+    image: "镜像",
+    indexed: "已索引"
   },
   card: {
     systemPromptPrefix: "系统提示：",
@@ -44,7 +45,8 @@ const projects = {
     branchPrefixPlaceholder: "默认：moltis",
     sandboxImage: "沙盒镜像",
     sandboxImagePlaceholder: "默认 (ubuntu:25.10)",
-    autoWorktree: "每个会话自动创建 git 工作树"
+    autoWorktree: "每个会话自动创建 git 工作树",
+    codeIndex: "启用代码索引（语义搜索）"
   }
 };
 export {

--- a/crates/web/src/assets/dist/main.js
+++ b/crates/web/src/assets/dist/main.js
@@ -4852,6 +4852,7 @@ function isVoiceEnabled() {
 async function checkSttStatus() {
   if (!isVoiceEnabled()) {
     sttConfigured = false;
+    if (vadActive) stopVad();
     updateMicButton();
     updateVadButton();
     return;
@@ -4862,6 +4863,7 @@ async function checkSttStatus() {
   } else {
     sttConfigured = false;
   }
+  if (!sttConfigured && vadActive) stopVad();
   updateMicButton();
   updateVadButton();
 }
@@ -5124,20 +5126,20 @@ async function transcribeAudio() {
         cleanupTranscribingState();
         sendTranscribedMessage(text, audioFilename || null);
       } else {
-        showTemporaryMessage("No speech detected", false, 2e3);
+        showTemporaryMessage(t("chat:voiceNoSpeech"), false, 2e3);
       }
     } else if (res.transcriptionError) {
       console.error("Transcription failed:", res.transcriptionError);
-      showTemporaryMessage(`Transcription failed: ${res.transcriptionError}`, true, 4e3);
+      showTemporaryMessage(t("chat:voiceTranscriptionFailed", { error: res.transcriptionError }), true, 4e3);
     } else if (!res.ok) {
       console.error("Upload failed:", res.error);
-      showTemporaryMessage(`Upload failed: ${res.error || "Unknown error"}`, true, 4e3);
+      showTemporaryMessage(t("chat:voiceUploadFailed", { error: res.error || t("chat:unknownError") }), true, 4e3);
     }
   } catch (err) {
     console.error("Transcription error:", err);
     micBtn == null ? void 0 : micBtn.classList.remove("transcribing");
     if (micBtn) micBtn.title = t("chat:micTooltip");
-    showTemporaryMessage("Transcription error", true, 4e3);
+    showTemporaryMessage(t("chat:voiceTranscriptionError"), true, 4e3);
   }
 }
 function onMicClick(e) {
@@ -5250,6 +5252,9 @@ async function vadReacquireStream() {
     const newStream = await navigator.mediaDevices.getUserMedia({
       audio: { echoCancellation: true, noiseSuppression: true, autoGainControl: true }
     });
+    if (vadStream) {
+      for (const track of vadStream.getTracks()) track.stop();
+    }
     vadStream = newStream;
     if (vadAudioCtx && vadAnalyser) {
       const source = vadAudioCtx.createMediaStreamSource(newStream);

--- a/crates/web/src/assets/dist/main.js
+++ b/crates/web/src/assets/dist/main.js
@@ -4847,6 +4847,7 @@ let vadRecordingStart = 0;
 let vadMediaRecorder = null;
 let vadTranscribing = false;
 let vadReacquiring = false;
+let vadSourceNode = null;
 let vadMonitorMuteStart = 0;
 function isVoiceEnabled() {
   return get("voice_enabled") === true;
@@ -4927,6 +4928,19 @@ async function startRecording(opts) {
       stream = await navigator.mediaDevices.getUserMedia({
         audio: { echoCancellation: true, noiseSuppression: true, autoGainControl: true }
       });
+    }
+    if (recordingCancelled) {
+      isStarting = false;
+      recordingCancelled = false;
+      if (!fromVad) {
+        for (const track of stream.getTracks()) track.stop();
+      }
+      if (micBtn) {
+        micBtn.classList.remove("starting");
+        micBtn.removeAttribute("aria-busy");
+        micBtn.title = t("chat:micTooltip");
+      }
+      return;
     }
     audioChunks = [];
     let recordingUiShown = false;
@@ -5182,6 +5196,9 @@ function onPttKeyUp(e) {
   e.preventDefault();
   pttActive = false;
   releaseVoiceLock();
+  if (isStarting) {
+    recordingCancelled = true;
+  }
   console.debug("[voice] PTT release — sending");
   stopRecording();
 }
@@ -5210,11 +5227,11 @@ async function startVad() {
     vadBtn.title = t("chat:vadStopTooltip");
   }
   vadAudioCtx = new AudioContext();
-  const source = vadAudioCtx.createMediaStreamSource(vadStream);
+  vadSourceNode = vadAudioCtx.createMediaStreamSource(vadStream);
   vadAnalyser = vadAudioCtx.createAnalyser();
   vadAnalyser.fftSize = 512;
   vadAnalyser.smoothingTimeConstant = 0.3;
-  source.connect(vadAnalyser);
+  vadSourceNode.connect(vadAnalyser);
   vadDataArray = new Uint8Array(vadAnalyser.fftSize);
   vadStartContinuousRecorder();
   vadMonitorLoop();
@@ -5262,8 +5279,11 @@ async function vadReacquireStream() {
     }
     vadStream = newStream;
     if (vadAudioCtx && vadAnalyser) {
-      const source = vadAudioCtx.createMediaStreamSource(newStream);
-      source.connect(vadAnalyser);
+      if (vadSourceNode) {
+        vadSourceNode.disconnect();
+      }
+      vadSourceNode = vadAudioCtx.createMediaStreamSource(newStream);
+      vadSourceNode.connect(vadAnalyser);
     }
     if (vadMediaRecorder && vadMediaRecorder.state === "recording") {
       vadMediaRecorder.stop();
@@ -5295,6 +5315,10 @@ function stopVad() {
   if (vadRafId) {
     cancelAnimationFrame(vadRafId);
     vadRafId = null;
+  }
+  if (vadSourceNode) {
+    vadSourceNode.disconnect();
+    vadSourceNode = null;
   }
   if (vadAudioCtx) {
     vadAudioCtx.close().catch(() => {

--- a/crates/web/src/assets/dist/main.js
+++ b/crates/web/src/assets/dist/main.js
@@ -4846,7 +4846,6 @@ let vadRecordingStart = 0;
 let vadMediaRecorder = null;
 let vadTranscribing = false;
 let vadMonitorMuteStart = 0;
-let vadMonitorLastLog = 0;
 function isVoiceEnabled() {
   return get("voice_enabled") === true;
 }
@@ -5104,14 +5103,18 @@ async function transcribeAudio() {
     }
     const abortCtrl = new AbortController();
     const fetchTimeout = setTimeout(() => abortCtrl.abort(), 15e3);
-    const resp = await fetch(`/api/sessions/${encodeURIComponent(activeSessionKey)}/upload?transcribe=true`, {
-      method: "POST",
-      headers: { "Content-Type": blob.type || "audio/webm" },
-      body: blob,
-      signal: abortCtrl.signal
-    });
-    clearTimeout(fetchTimeout);
-    const res = await resp.json();
+    let res;
+    try {
+      const resp = await fetch(`/api/sessions/${encodeURIComponent(activeSessionKey)}/upload?transcribe=true`, {
+        method: "POST",
+        headers: { "Content-Type": blob.type || "audio/webm" },
+        body: blob,
+        signal: abortCtrl.signal
+      });
+      res = await resp.json();
+    } finally {
+      clearTimeout(fetchTimeout);
+    }
     micBtn == null ? void 0 : micBtn.classList.remove("transcribing");
     if (micBtn) micBtn.title = t("chat:micTooltip");
     if (res.ok && ((_a2 = res.transcription) == null ? void 0 : _a2.text)) {
@@ -5307,7 +5310,8 @@ function vadMonitorLoop() {
   if (!(vadActive && vadAnalyser && vadDataArray)) return;
   if (vadAudioCtx && vadAudioCtx.state === "suspended") {
     console.debug("[voice] VAD: AudioContext suspended, resuming");
-    vadAudioCtx.resume();
+    vadAudioCtx.resume().catch(() => {
+    });
   }
   if (vadStream) {
     const track = vadStream.getAudioTracks()[0];
@@ -5346,21 +5350,6 @@ function vadMonitorLoop() {
   }
   const rms = getRMS(vadAnalyser, vadDataArray);
   const now = Date.now();
-  if (!vadMonitorLastLog || now - vadMonitorLastLog > 1e3) {
-    vadMonitorLastLog = now;
-    console.debug(
-      "[voice] VAD rms:",
-      rms.toFixed(4),
-      "speech:",
-      vadSpeechDetected,
-      "muted:",
-      vadMutedForTts,
-      "transcribing:",
-      vadTranscribing,
-      "ctx:",
-      vadAudioCtx == null ? void 0 : vadAudioCtx.state
-    );
-  }
   if (rms > vadSpeechThreshold) {
     vadSilenceStart = 0;
     if (vadSpeechDetected && vadRecordingStart && now - vadRecordingStart > 3e4) {
@@ -31539,6 +31528,43 @@ function VaultSection() {
 const voiceShowAddModal = y(false);
 const voiceSelectedProvider = y(null);
 const voiceSelectedProviderData = y(null);
+function PttKeyPicker({ pttListening, setPttListening, pttKeyValue, setPttKeyValue }) {
+  const handlerRef = A(null);
+  y$1(() => {
+    return () => {
+      if (handlerRef.current) {
+        document.removeEventListener("keydown", handlerRef.current, true);
+        handlerRef.current = null;
+      }
+    };
+  }, []);
+  return /* @__PURE__ */ u(
+    "button",
+    {
+      type: "button",
+      className: "provider-key-input",
+      style: { minWidth: "120px", textAlign: "center", cursor: "pointer" },
+      onClick: () => {
+        if (pttListening) return;
+        setPttListening(true);
+        const handler = (ev) => {
+          ev.preventDefault();
+          ev.stopPropagation();
+          setPttKeyValue(ev.key);
+          setPttKey(ev.key);
+          setPttListening(false);
+          document.removeEventListener("keydown", handler, true);
+          handlerRef.current = null;
+          rerender$1();
+        };
+        handlerRef.current = handler;
+        document.addEventListener("keydown", handler, true);
+        rerender$1();
+      },
+      children: pttListening ? "Press any key..." : pttKeyValue
+    }
+  );
+}
 function VoiceSection() {
   const [allProviders, setAllProviders] = d({ tts: [], stt: [] });
   const [voiceLoading, setVoiceLoading] = d(true);
@@ -31810,27 +31836,12 @@ function VoiceSection() {
       /* @__PURE__ */ u("div", { className: "flex items-center gap-3", children: [
         /* @__PURE__ */ u("span", { className: "text-xs text-[var(--muted)]", children: "PTT Key:" }),
         /* @__PURE__ */ u(
-          "button",
+          PttKeyPicker,
           {
-            type: "button",
-            className: "provider-key-input",
-            style: { minWidth: "120px", textAlign: "center", cursor: "pointer" },
-            onClick: () => {
-              if (pttListening) return;
-              setPttListening(true);
-              const handler = (ev) => {
-                ev.preventDefault();
-                ev.stopPropagation();
-                setPttKeyValue(ev.key);
-                setPttKey(ev.key);
-                setPttListening(false);
-                document.removeEventListener("keydown", handler, true);
-                rerender$1();
-              };
-              document.addEventListener("keydown", handler, true);
-              rerender$1();
-            },
-            children: pttListening ? "Press any key..." : pttKeyValue
+            pttListening,
+            setPttListening,
+            pttKeyValue,
+            setPttKeyValue
           }
         )
       ] })

--- a/crates/web/src/assets/dist/main.js
+++ b/crates/web/src/assets/dist/main.js
@@ -5242,6 +5242,7 @@ async function startVad() {
 function vadStartContinuousRecorder() {
   if (!(vadActive && vadStream)) return;
   if (vadTranscribing) return;
+  if (vadMediaRecorder && vadMediaRecorder.state === "recording") return;
   audioChunks = [];
   const mimeType = MediaRecorder.isTypeSupported("audio/webm;codecs=opus") ? "audio/webm;codecs=opus" : "audio/webm";
   vadMediaRecorder = new MediaRecorder(vadStream, { mimeType });
@@ -5448,8 +5449,9 @@ function onTtsPlay(e) {
   if (vadMediaRecorder && vadMediaRecorder.state === "recording") {
     vadSpeechDetected = false;
     audioChunks = [];
-    vadMediaRecorder.stop();
+    const mr = vadMediaRecorder;
     vadMediaRecorder = null;
+    mr.stop();
   }
 }
 function resumeVadAfterTts() {

--- a/crates/web/src/assets/dist/main.js
+++ b/crates/web/src/assets/dist/main.js
@@ -4800,6 +4800,7 @@ let audioChunks = [];
 let sttConfigured = false;
 let isRecording = false;
 let isStarting = false;
+let recordingCancelled = false;
 let transcribingEl = null;
 let pttKey = localStorage.getItem("moltis_ptt_key") || "F13";
 let pttActive = false;
@@ -4845,6 +4846,7 @@ let vadSpeechStart = 0;
 let vadRecordingStart = 0;
 let vadMediaRecorder = null;
 let vadTranscribing = false;
+let vadReacquiring = false;
 let vadMonitorMuteStart = 0;
 function isVoiceEnabled() {
   return get("voice_enabled") === true;
@@ -4989,6 +4991,7 @@ function stopRecording() {
 function cancelRecording() {
   if (!(isRecording && mediaRecorder)) return;
   console.debug("[voice] recording cancelled via Escape");
+  recordingCancelled = true;
   audioChunks = [];
   isStarting = false;
   isRecording = false;
@@ -5080,10 +5083,12 @@ function sendTranscribedMessage(text, audioFilename) {
 }
 async function transcribeAudio() {
   var _a2;
-  if (audioChunks.length === 0) {
+  if (recordingCancelled || audioChunks.length === 0) {
+    recordingCancelled = false;
     cleanupTranscribingState();
     return;
   }
+  recordingCancelled = false;
   if (chatMsgBox) {
     transcribingEl = createTranscribingIndicator(t("chat:voiceTranscribingMessage"));
     chatMsgBox.appendChild(transcribingEl);
@@ -5321,8 +5326,13 @@ function vadMonitorLoop() {
   if (vadStream) {
     const track = vadStream.getAudioTracks()[0];
     if (!track || track.readyState !== "live") {
-      console.warn("[voice] VAD: mic track died, reacquiring");
-      vadReacquireStream();
+      if (!vadReacquiring) {
+        vadReacquiring = true;
+        console.warn("[voice] VAD: mic track died, reacquiring");
+        vadReacquireStream().finally(() => {
+          vadReacquiring = false;
+        });
+      }
       vadRafId = requestAnimationFrame(vadMonitorLoop);
       return;
     }

--- a/crates/web/src/assets/dist/main.js
+++ b/crates/web/src/assets/dist/main.js
@@ -4794,12 +4794,59 @@ window.addEventListener("moltis:locale-changed", () => {
   }
 });
 let micBtn = null;
+let vadBtn = null;
 let mediaRecorder = null;
 let audioChunks = [];
 let sttConfigured = false;
 let isRecording = false;
 let isStarting = false;
 let transcribingEl = null;
+let pttKey = localStorage.getItem("moltis_ptt_key") || "F13";
+let pttActive = false;
+const voiceLockChannel = typeof BroadcastChannel !== "undefined" ? new BroadcastChannel("moltis_voice_lock") : null;
+let voiceLockedByOtherTab = false;
+if (voiceLockChannel) {
+  voiceLockChannel.onmessage = (e) => {
+    var _a2, _b2;
+    if (((_a2 = e.data) == null ? void 0 : _a2.type) === "voice_lock") {
+      voiceLockedByOtherTab = true;
+      console.debug("[voice] another tab claimed voice lock");
+    } else if (((_b2 = e.data) == null ? void 0 : _b2.type) === "voice_unlock") {
+      voiceLockedByOtherTab = false;
+      console.debug("[voice] another tab released voice lock");
+    }
+  };
+}
+function claimVoiceLock() {
+  voiceLockedByOtherTab = false;
+  voiceLockChannel == null ? void 0 : voiceLockChannel.postMessage({ type: "voice_lock" });
+}
+function releaseVoiceLock() {
+  voiceLockChannel == null ? void 0 : voiceLockChannel.postMessage({ type: "voice_unlock" });
+}
+let vadActive = false;
+let vadStream = null;
+let vadAudioCtx = null;
+let vadAnalyser = null;
+let vadDataArray = null;
+let vadRafId = null;
+let vadSpeechDetected = false;
+let vadSilenceStart = 0;
+let vadMutedForTts = false;
+let vadSensitivity = parseInt(localStorage.getItem("moltis_vad_sensitivity") || "50", 10);
+let vadSpeechThreshold = sensitivityToThreshold(vadSensitivity);
+function sensitivityToThreshold(pct) {
+  const clamped = Math.max(0, Math.min(100, pct));
+  return 0.08 * (5e-3 / 0.08) ** (clamped / 100);
+}
+const VAD_SILENCE_DURATION = 2500;
+const VAD_DEBOUNCE_SPEECH = 250;
+let vadSpeechStart = 0;
+let vadRecordingStart = 0;
+let vadMediaRecorder = null;
+let vadTranscribing = false;
+let vadMonitorMuteStart = 0;
+let vadMonitorLastLog = 0;
 function isVoiceEnabled() {
   return get("voice_enabled") === true;
 }
@@ -4807,6 +4854,7 @@ async function checkSttStatus() {
   if (!isVoiceEnabled()) {
     sttConfigured = false;
     updateMicButton();
+    updateVadButton();
     return;
   }
   const res = await sendRpc("stt.status", {});
@@ -4816,12 +4864,19 @@ async function checkSttStatus() {
     sttConfigured = false;
   }
   updateMicButton();
+  updateVadButton();
 }
 function updateMicButton() {
   if (!micBtn) return;
   micBtn.style.display = sttConfigured && isVoiceEnabled() ? "" : "none";
   micBtn.disabled = !connected;
   micBtn.title = isStarting ? t("chat:micStarting") : isRecording ? t("chat:micStopAndSend") : t("chat:micTooltip");
+}
+function updateVadButton() {
+  if (!vadBtn) return;
+  vadBtn.style.display = sttConfigured && isVoiceEnabled() ? "" : "none";
+  vadBtn.disabled = !connected;
+  vadBtn.title = vadActive ? t("chat:vadStopTooltip") : t("chat:vadTooltip");
 }
 function stopAllAudio() {
   for (const audio of document.querySelectorAll("audio")) {
@@ -4831,25 +4886,45 @@ function stopAllAudio() {
     }
   }
 }
-async function startRecording() {
+function getRMS(analyser, dataArray) {
+  analyser.getByteTimeDomainData(dataArray);
+  let sum = 0;
+  for (const sample of dataArray) {
+    const val = (sample - 128) / 128;
+    sum += val * val;
+  }
+  return Math.sqrt(sum / dataArray.length);
+}
+async function startRecording(opts) {
   if (isRecording || isStarting || !sttConfigured) return;
+  const fromVad = (opts == null ? void 0 : opts.fromVad) === true;
+  let stream = null;
   stopAllAudio();
   isStarting = true;
-  micBtn == null ? void 0 : micBtn.classList.add("starting");
-  micBtn == null ? void 0 : micBtn.setAttribute("aria-busy", "true");
-  micBtn.title = t("chat:micStarting");
+  if (micBtn && !fromVad) {
+    micBtn.classList.add("starting");
+    micBtn.setAttribute("aria-busy", "true");
+    micBtn.title = t("chat:micStarting");
+  }
   try {
     let showRecordingUi = function() {
-      if (recordingUiShown || !micBtn) return;
+      if (recordingUiShown) return;
       recordingUiShown = true;
       isStarting = false;
-      micBtn.classList.remove("starting");
-      micBtn.removeAttribute("aria-busy");
-      micBtn.classList.add("recording");
-      micBtn.setAttribute("aria-pressed", "true");
-      micBtn.title = t("chat:micStopAndSend");
+      if (fromVad) ;
+      else if (micBtn) {
+        micBtn.classList.remove("starting");
+        micBtn.removeAttribute("aria-busy");
+        micBtn.classList.add("recording");
+        micBtn.setAttribute("aria-pressed", "true");
+        micBtn.title = t("chat:micStopAndSend");
+      }
     };
-    const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+    if (!stream) {
+      stream = await navigator.mediaDevices.getUserMedia({
+        audio: { echoCancellation: true, noiseSuppression: true, autoGainControl: true }
+      });
+    }
     audioChunks = [];
     let recordingUiShown = false;
     const mimeType = MediaRecorder.isTypeSupported("audio/webm;codecs=opus") ? "audio/webm;codecs=opus" : "audio/webm";
@@ -4870,16 +4945,19 @@ async function startRecording() {
       audioTrack.addEventListener("unmute", showRecordingUi, { once: true });
     }
     mediaRecorder.onstop = async () => {
-      for (const track of stream.getTracks()) {
-        track.stop();
+      if (!fromVad) {
+        for (const track of stream.getTracks()) {
+          track.stop();
+        }
       }
+      if (fromVad) ;
       await transcribeAudio();
     };
     mediaRecorder.start(250);
   } catch (err) {
     isStarting = false;
     isRecording = false;
-    if (micBtn) {
+    if (micBtn && !fromVad) {
       micBtn.classList.remove("starting");
       micBtn.removeAttribute("aria-busy");
       micBtn.setAttribute("aria-pressed", "false");
@@ -4897,12 +4975,14 @@ function stopRecording() {
   if (!(isRecording && mediaRecorder)) return;
   isStarting = false;
   isRecording = false;
-  micBtn == null ? void 0 : micBtn.classList.remove("starting");
-  micBtn == null ? void 0 : micBtn.removeAttribute("aria-busy");
-  micBtn == null ? void 0 : micBtn.classList.remove("recording");
-  micBtn == null ? void 0 : micBtn.setAttribute("aria-pressed", "false");
-  micBtn == null ? void 0 : micBtn.classList.add("transcribing");
-  micBtn.title = t("chat:voiceTranscribing");
+  if (micBtn) {
+    micBtn.classList.remove("starting");
+    micBtn.removeAttribute("aria-busy");
+    micBtn.classList.remove("recording");
+    micBtn.setAttribute("aria-pressed", "false");
+    micBtn.classList.add("transcribing");
+    micBtn.title = t("chat:voiceTranscribing");
+  }
   mediaRecorder.stop();
 }
 function cancelRecording() {
@@ -4911,10 +4991,13 @@ function cancelRecording() {
   audioChunks = [];
   isStarting = false;
   isRecording = false;
-  micBtn == null ? void 0 : micBtn.classList.remove("starting", "recording");
-  micBtn == null ? void 0 : micBtn.removeAttribute("aria-busy");
-  micBtn == null ? void 0 : micBtn.setAttribute("aria-pressed", "false");
-  micBtn.title = t("chat:micTooltip");
+  if (micBtn) {
+    micBtn.classList.remove("starting", "recording");
+    micBtn.removeAttribute("aria-busy");
+    micBtn.setAttribute("aria-pressed", "false");
+    micBtn.title = t("chat:micTooltip");
+  }
+  vadBtn == null ? void 0 : vadBtn.classList.remove("vad-speech");
   mediaRecorder.stop();
 }
 function createTranscribingIndicator(message, isError) {
@@ -4952,7 +5035,7 @@ function cleanupTranscribingState() {
   micBtn == null ? void 0 : micBtn.classList.remove("starting");
   micBtn == null ? void 0 : micBtn.removeAttribute("aria-busy");
   micBtn == null ? void 0 : micBtn.classList.remove("transcribing");
-  micBtn.title = t("chat:micTooltip");
+  if (micBtn) micBtn.title = t("chat:micTooltip");
   if (transcribingEl) {
     transcribingEl.remove();
     transcribingEl = null;
@@ -4968,7 +5051,6 @@ function sendTranscribedMessage(text, audioFilename) {
       if (text) {
         const textWrap = document.createElement("div");
         textWrap.className = "mt-2";
-        textWrap.textContent = "";
         const rendered = renderMarkdown(text);
         const fragment = document.createRange().createContextualFragment(rendered);
         textWrap.appendChild(fragment);
@@ -4982,13 +5064,9 @@ function sendTranscribedMessage(text, audioFilename) {
     text,
     _input_medium: "voice"
   };
-  if (audioFilename) {
-    chatParams._audio_filename = audioFilename;
-  }
+  if (audioFilename) chatParams._audio_filename = audioFilename;
   const selectedModel = selectedModelId;
-  if (selectedModel) {
-    chatParams.model = selectedModel;
-  }
+  if (selectedModel) chatParams.model = selectedModel;
   bumpSessionCount(activeSessionKey, 1);
   seedSessionPreviewFromUserText(activeSessionKey, text);
   setSessionReplying(activeSessionKey, true);
@@ -5013,14 +5091,29 @@ async function transcribeAudio() {
   try {
     const blob = new Blob(audioChunks, { type: "audio/webm" });
     audioChunks = [];
+    if (blob.size < 2e3) {
+      console.debug("[voice] skipping tiny blob:", blob.size, "bytes");
+      cleanupTranscribingState();
+      return;
+    }
+    const headerBytes = new Uint8Array(await blob.slice(0, 4).arrayBuffer());
+    if (headerBytes[0] !== 26 || headerBytes[1] !== 69 || headerBytes[2] !== 223 || headerBytes[3] !== 163) {
+      console.warn("[voice] corrupt WebM blob (bad EBML header), discarding. size:", blob.size);
+      cleanupTranscribingState();
+      return;
+    }
+    const abortCtrl = new AbortController();
+    const fetchTimeout = setTimeout(() => abortCtrl.abort(), 15e3);
     const resp = await fetch(`/api/sessions/${encodeURIComponent(activeSessionKey)}/upload?transcribe=true`, {
       method: "POST",
       headers: { "Content-Type": blob.type || "audio/webm" },
-      body: blob
+      body: blob,
+      signal: abortCtrl.signal
     });
+    clearTimeout(fetchTimeout);
     const res = await resp.json();
     micBtn == null ? void 0 : micBtn.classList.remove("transcribing");
-    micBtn.title = t("chat:micTooltip");
+    if (micBtn) micBtn.title = t("chat:micTooltip");
     if (res.ok && ((_a2 = res.transcription) == null ? void 0 : _a2.text)) {
       const text = String(res.transcription.text).trim();
       const audioFilename = typeof res.filename === "string" ? res.filename.trim() : "";
@@ -5040,16 +5133,339 @@ async function transcribeAudio() {
   } catch (err) {
     console.error("Transcription error:", err);
     micBtn == null ? void 0 : micBtn.classList.remove("transcribing");
-    micBtn.title = t("chat:micTooltip");
+    if (micBtn) micBtn.title = t("chat:micTooltip");
     showTemporaryMessage("Transcription error", true, 4e3);
   }
 }
 function onMicClick(e) {
   e.preventDefault();
+  if (vadActive) return;
   if (isRecording) {
+    releaseVoiceLock();
     stopRecording();
   } else {
+    if (voiceLockedByOtherTab) return;
+    claimVoiceLock();
     startRecording();
+  }
+}
+function onPttKeyDown(e) {
+  var _a2;
+  if (e.key !== pttKey) return;
+  if (vadActive || pttActive || isRecording) return;
+  const isFunctionKey = /^F\d{1,2}$/.test(e.key);
+  if (!isFunctionKey) {
+    const tag = (_a2 = document.activeElement) == null ? void 0 : _a2.tagName;
+    if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") return;
+  }
+  e.preventDefault();
+  if (voiceLockedByOtherTab) return;
+  pttActive = true;
+  claimVoiceLock();
+  console.debug("[voice] PTT start:", pttKey);
+  stopAllAudio();
+  startRecording();
+}
+function onPttKeyUp(e) {
+  if (e.key !== pttKey) return;
+  if (!pttActive) return;
+  e.preventDefault();
+  pttActive = false;
+  releaseVoiceLock();
+  console.debug("[voice] PTT release — sending");
+  stopRecording();
+}
+async function startVad() {
+  if (vadActive) return;
+  console.debug("[voice] VAD starting");
+  try {
+    vadStream = await navigator.mediaDevices.getUserMedia({
+      audio: { echoCancellation: true, noiseSuppression: true, autoGainControl: true }
+    });
+  } catch (err) {
+    console.error("[voice] VAD mic access failed:", err);
+    if (err.name === "NotAllowedError") {
+      alert(t("settings:voice.micDenied"));
+    }
+    return;
+  }
+  vadActive = true;
+  vadSpeechDetected = false;
+  vadSilenceStart = 0;
+  vadSpeechStart = 0;
+  vadMutedForTts = false;
+  claimVoiceLock();
+  if (vadBtn) {
+    vadBtn.classList.add("vad-active");
+    vadBtn.title = t("chat:vadStopTooltip");
+  }
+  vadAudioCtx = new AudioContext();
+  const source = vadAudioCtx.createMediaStreamSource(vadStream);
+  vadAnalyser = vadAudioCtx.createAnalyser();
+  vadAnalyser.fftSize = 512;
+  vadAnalyser.smoothingTimeConstant = 0.3;
+  source.connect(vadAnalyser);
+  vadDataArray = new Uint8Array(vadAnalyser.fftSize);
+  vadStartContinuousRecorder();
+  vadMonitorLoop();
+  document.addEventListener("play", onTtsPlay, true);
+  document.addEventListener("ended", onTtsEnded, true);
+  document.addEventListener("pause", onTtsPause, true);
+}
+function vadStartContinuousRecorder() {
+  if (!(vadActive && vadStream)) return;
+  if (vadTranscribing) return;
+  audioChunks = [];
+  const mimeType = MediaRecorder.isTypeSupported("audio/webm;codecs=opus") ? "audio/webm;codecs=opus" : "audio/webm";
+  vadMediaRecorder = new MediaRecorder(vadStream, { mimeType });
+  vadMediaRecorder.ondataavailable = (e) => {
+    if (e.data.size > 0) audioChunks.push(e.data);
+  };
+  vadMediaRecorder.onstop = async () => {
+    vadBtn == null ? void 0 : vadBtn.classList.remove("vad-speech");
+    if (audioChunks.length > 0 && vadSpeechDetected) {
+      vadSpeechDetected = false;
+      vadTranscribing = true;
+      try {
+        await transcribeAudio();
+      } finally {
+        vadTranscribing = false;
+      }
+    } else {
+      audioChunks = [];
+      vadSpeechDetected = false;
+    }
+    if (vadActive && !vadMutedForTts) {
+      vadStartContinuousRecorder();
+    }
+  };
+  vadMediaRecorder.start(250);
+  console.debug("[voice] VAD continuous recorder started");
+}
+async function vadReacquireStream() {
+  try {
+    const newStream = await navigator.mediaDevices.getUserMedia({
+      audio: { echoCancellation: true, noiseSuppression: true, autoGainControl: true }
+    });
+    vadStream = newStream;
+    if (vadAudioCtx && vadAnalyser) {
+      const source = vadAudioCtx.createMediaStreamSource(newStream);
+      source.connect(vadAnalyser);
+    }
+    if (vadMediaRecorder && vadMediaRecorder.state === "recording") {
+      vadMediaRecorder.stop();
+    } else {
+      vadStartContinuousRecorder();
+    }
+    console.debug("[voice] VAD: stream reacquired successfully");
+  } catch (err) {
+    console.error("[voice] VAD: failed to reacquire stream:", err);
+    stopVad();
+  }
+}
+function stopVad() {
+  if (!vadActive) return;
+  console.debug("[voice] VAD stopping");
+  vadActive = false;
+  vadSpeechDetected = false;
+  vadTranscribing = false;
+  if (vadMediaRecorder && vadMediaRecorder.state !== "inactive") {
+    audioChunks = [];
+    vadMediaRecorder.stop();
+  }
+  vadMediaRecorder = null;
+  if (isRecording && mediaRecorder) {
+    audioChunks = [];
+    isRecording = false;
+    mediaRecorder.stop();
+  }
+  if (vadRafId) {
+    cancelAnimationFrame(vadRafId);
+    vadRafId = null;
+  }
+  if (vadAudioCtx) {
+    vadAudioCtx.close().catch(() => {
+    });
+    vadAudioCtx = null;
+    vadAnalyser = null;
+    vadDataArray = null;
+  }
+  if (vadStream) {
+    for (const track of vadStream.getTracks()) track.stop();
+    vadStream = null;
+  }
+  if (vadBtn) {
+    vadBtn.classList.remove("vad-active", "vad-speech", "vad-listening");
+    vadBtn.title = t("chat:vadTooltip");
+  }
+  releaseVoiceLock();
+  document.removeEventListener("play", onTtsPlay, true);
+  document.removeEventListener("ended", onTtsEnded, true);
+  document.removeEventListener("pause", onTtsPause, true);
+}
+function vadMonitorLoop() {
+  if (!(vadActive && vadAnalyser && vadDataArray)) return;
+  if (vadAudioCtx && vadAudioCtx.state === "suspended") {
+    console.debug("[voice] VAD: AudioContext suspended, resuming");
+    vadAudioCtx.resume();
+  }
+  if (vadStream) {
+    const track = vadStream.getAudioTracks()[0];
+    if (!track || track.readyState !== "live") {
+      console.warn("[voice] VAD: mic track died, reacquiring");
+      vadReacquireStream();
+      vadRafId = requestAnimationFrame(vadMonitorLoop);
+      return;
+    }
+  }
+  if (vadMutedForTts || (micBtn == null ? void 0 : micBtn.classList.contains("transcribing"))) {
+    if (vadMutedForTts && !vadMonitorMuteStart) {
+      vadMonitorMuteStart = Date.now();
+    } else if (vadMutedForTts && Date.now() - vadMonitorMuteStart > 1e4) {
+      console.debug("[voice] VAD: TTS mute timeout, force-resuming");
+      vadMutedForTts = false;
+      vadMonitorMuteStart = 0;
+      vadSpeechDetected = false;
+      vadStartContinuousRecorder();
+      vadBtn == null ? void 0 : vadBtn.classList.add("vad-listening");
+    }
+    vadRafId = requestAnimationFrame(vadMonitorLoop);
+    return;
+  }
+  vadMonitorMuteStart = 0;
+  const activeSession = sessionStore.getByKey(activeSessionKey);
+  if (activeSession == null ? void 0 : activeSession.replying.value) {
+    vadRafId = requestAnimationFrame(vadMonitorLoop);
+    return;
+  }
+  if (vadMediaRecorder && vadMediaRecorder.state === "recording" && vadBtn && !vadBtn.classList.contains("vad-listening") && !vadBtn.classList.contains("vad-speech")) {
+    vadBtn.classList.add("vad-listening");
+  }
+  if (!vadTranscribing && (!vadMediaRecorder || vadMediaRecorder.state === "inactive")) {
+    vadStartContinuousRecorder();
+  }
+  const rms = getRMS(vadAnalyser, vadDataArray);
+  const now = Date.now();
+  if (!vadMonitorLastLog || now - vadMonitorLastLog > 1e3) {
+    vadMonitorLastLog = now;
+    console.debug(
+      "[voice] VAD rms:",
+      rms.toFixed(4),
+      "speech:",
+      vadSpeechDetected,
+      "muted:",
+      vadMutedForTts,
+      "transcribing:",
+      vadTranscribing,
+      "ctx:",
+      vadAudioCtx == null ? void 0 : vadAudioCtx.state
+    );
+  }
+  if (rms > vadSpeechThreshold) {
+    vadSilenceStart = 0;
+    if (vadSpeechDetected && vadRecordingStart && now - vadRecordingStart > 3e4) {
+      console.debug("[voice] VAD: max duration reached, auto-sending");
+      vadSilenceStart = 0;
+      vadRecordingStart = 0;
+      vadBtn == null ? void 0 : vadBtn.classList.remove("vad-speech", "vad-listening");
+      if (vadMediaRecorder && vadMediaRecorder.state === "recording") {
+        vadMediaRecorder.stop();
+      }
+      vadRafId = requestAnimationFrame(vadMonitorLoop);
+      return;
+    }
+    if (!vadSpeechDetected) {
+      if (!vadSpeechStart) {
+        vadSpeechStart = now;
+      } else if (now - vadSpeechStart >= VAD_DEBOUNCE_SPEECH) {
+        vadSpeechDetected = true;
+        vadSpeechStart = 0;
+        vadRecordingStart = now;
+        console.debug("[voice] VAD: speech detected (recorder already running)");
+        stopAllAudio();
+        vadBtn == null ? void 0 : vadBtn.classList.add("vad-speech");
+      }
+    }
+  } else {
+    vadSpeechStart = 0;
+    if (vadSpeechDetected) {
+      if (!vadSilenceStart) {
+        vadSilenceStart = now;
+      } else if (now - vadSilenceStart >= VAD_SILENCE_DURATION) {
+        console.debug("[voice] VAD: silence detected, stopping & sending");
+        vadRecordingStart = 0;
+        vadSilenceStart = 0;
+        vadBtn == null ? void 0 : vadBtn.classList.remove("vad-speech", "vad-listening");
+        if (vadMediaRecorder && vadMediaRecorder.state === "recording") {
+          vadMediaRecorder.stop();
+        } else {
+          vadSpeechDetected = false;
+          audioChunks = [];
+        }
+      }
+    }
+  }
+  vadRafId = requestAnimationFrame(vadMonitorLoop);
+}
+function isAnyAudioPlaying() {
+  return Array.from(document.querySelectorAll("audio")).some((a) => !(a.paused || a.ended));
+}
+function onTtsPlay(e) {
+  var _a2;
+  if (!vadActive) return;
+  if (((_a2 = e.target) == null ? void 0 : _a2.tagName) !== "AUDIO") return;
+  console.debug("[voice] VAD: TTS playing, muting VAD + stopping recorder");
+  vadMutedForTts = true;
+  vadBtn == null ? void 0 : vadBtn.classList.remove("vad-listening", "vad-speech");
+  if (vadMediaRecorder && vadMediaRecorder.state === "recording") {
+    vadSpeechDetected = false;
+    audioChunks = [];
+    vadMediaRecorder.stop();
+    vadMediaRecorder = null;
+  }
+}
+function resumeVadAfterTts() {
+  vadSpeechDetected = false;
+  vadSilenceStart = 0;
+  vadSpeechStart = 0;
+  setTimeout(() => {
+    if (!vadActive) return;
+    if (isAnyAudioPlaying()) {
+      console.debug("[voice] VAD: another audio still playing, staying muted");
+      return;
+    }
+    vadMutedForTts = false;
+    if (!vadTranscribing) {
+      vadStartContinuousRecorder();
+      vadBtn == null ? void 0 : vadBtn.classList.add("vad-listening");
+    }
+  }, 400);
+}
+function onTtsEnded(e) {
+  var _a2;
+  if (!vadActive) return;
+  if (((_a2 = e.target) == null ? void 0 : _a2.tagName) !== "AUDIO") return;
+  console.debug("[voice] VAD: TTS ended, resuming VAD after delay");
+  resumeVadAfterTts();
+}
+function onTtsPause(e) {
+  var _a2;
+  if (!vadActive) return;
+  if (((_a2 = e.target) == null ? void 0 : _a2.tagName) !== "AUDIO") return;
+  const audio = e.target;
+  if (audio.ended || audio.duration && audio.currentTime >= audio.duration - 0.1) {
+    console.debug("[voice] VAD: TTS paused at end, treating as ended");
+    resumeVadAfterTts();
+  } else if (!isAnyAudioPlaying()) {
+    vadMutedForTts = false;
+  }
+}
+function onVadClick(e) {
+  e.preventDefault();
+  if (vadActive) {
+    stopVad();
+  } else {
+    startVad();
   }
 }
 function initVoiceInput(btn2) {
@@ -5067,19 +5483,52 @@ function initVoiceInput(btn2) {
     if (e.key === "Escape" && isRecording) {
       e.preventDefault();
       cancelRecording();
+      if (vadActive) stopVad();
     }
   });
+  document.addEventListener("keydown", onPttKeyDown);
+  document.addEventListener("keyup", onPttKeyUp);
   window.addEventListener("voice-config-changed", checkSttStatus);
 }
+function initVadButton(btn2) {
+  if (!btn2) return;
+  vadBtn = btn2;
+  updateVadButton();
+  vadBtn.addEventListener("click", onVadClick);
+}
 function teardownVoiceInput() {
+  if (vadActive) stopVad();
   if (isRecording && mediaRecorder) {
     mediaRecorder.stop();
   }
+  document.removeEventListener("keydown", onPttKeyDown);
+  document.removeEventListener("keyup", onPttKeyUp);
   window.removeEventListener("voice-config-changed", checkSttStatus);
+  releaseVoiceLock();
   micBtn = null;
+  vadBtn = null;
   mediaRecorder = null;
+  vadMediaRecorder = null;
+  vadTranscribing = false;
   audioChunks = [];
   isRecording = false;
+}
+function setPttKey(key) {
+  pttKey = key;
+  localStorage.setItem("moltis_ptt_key", key);
+  console.debug("[voice] PTT key set to:", key);
+}
+function getPttKey() {
+  return pttKey;
+}
+function setVadSensitivity(pct) {
+  vadSensitivity = Math.max(0, Math.min(100, pct));
+  vadSpeechThreshold = sensitivityToThreshold(vadSensitivity);
+  localStorage.setItem("moltis_vad_sensitivity", String(vadSensitivity));
+  console.debug("[voice] VAD sensitivity set to:", vadSensitivity, "threshold:", vadSpeechThreshold.toFixed(4));
+}
+function getVadSensitivity() {
+  return vadSensitivity;
 }
 function ctxEl(tag, cls, text) {
   const el = document.createElement(tag);
@@ -6374,7 +6823,7 @@ function initializeChatMediaDrop() {
   const inputArea = (_a2 = chatInput) == null ? void 0 : _a2.closest(".px-4.py-3");
   initMediaDrop(chatMsgBox, inputArea);
 }
-const chatPageHTML = '<div style="position:absolute;inset:0;display:grid;grid-template-rows:auto auto 1fr auto auto auto;overflow:hidden"><div class="chat-toolbar h-12 px-4 border-b border-[var(--border)] bg-[var(--surface)] flex items-center gap-2" style="grid-row:1;"><div id="modelCombo" class="model-combo"><button id="modelComboBtn" class="model-combo-btn" type="button"><span id="modelComboLabel">loading…</span><span class="icon icon-sm icon-chevron-down model-combo-chevron"></span></button><div id="modelDropdown" class="model-dropdown hidden"><input id="modelSearchInput" type="text" placeholder="Search models…" class="model-search-input" autocomplete="off" /><div id="modelDropdownList" class="model-dropdown-list"></div></div></div><div id="reasoningCombo" class="model-combo hidden"><button id="reasoningComboBtn" class="model-combo-btn" type="button" title="Reasoning effort"><span class="icon icon-sm icon-brain" style="flex-shrink:0;"></span><span id="reasoningComboLabel">Off</span><span class="icon icon-sm icon-chevron-down model-combo-chevron"></span></button><div id="reasoningDropdown" class="model-dropdown hidden"><div id="reasoningDropdownList" class="model-dropdown-list"></div></div></div><div id="nodeCombo" class="model-combo hidden"><button id="nodeComboBtn" class="model-combo-btn" type="button"><span class="icon icon-sm icon-server" style="flex-shrink:0;"></span><span id="nodeComboLabel">Local</span><span class="icon icon-sm icon-chevron-down model-combo-chevron"></span></button><div id="nodeDropdown" class="model-dropdown hidden" tabindex="-1"><div id="nodeDropdownList" class="model-dropdown-list"></div></div></div><div id="projectCombo" class="model-combo hidden"><button id="projectComboBtn" class="model-combo-btn" type="button"><span class="icon icon-sm icon-folder" style="flex-shrink:0;"></span><span id="projectComboLabel">No project</span><span class="icon icon-sm icon-chevron-down model-combo-chevron"></span></button><div id="projectDropdown" class="model-dropdown hidden"><div id="projectDropdownList" class="model-dropdown-list"></div></div></div><div id="sessionHeaderToolbarMount" class="ml-auto flex items-center gap-1.5"></div><button id="chatMoreBtn" type="button" class="model-combo-btn" title="More controls" aria-label="More controls"><span class="icon icon-lg icon-menu-dots-horizontal"></span></button></div><div id="chatMoreModal" class="provider-modal-backdrop hidden"><div class="provider-modal" style="width:560px;max-width:92vw;"><div class="provider-modal-header"><div class="flex items-center gap-2"><button id="chatMoreDeleteAllBtn" type="button" class="provider-btn provider-btn-sm chat-session-btn-danger inline-flex items-center gap-1.5" style="background:var(--error);border-color:var(--error);color:#fff;"><span class="icon icon-sm icon-x-circle shrink-0"></span><span id="chatMoreDeleteAllLabel">Delete all sessions</span></button></div><div id="sessionHeaderModalTopMount" class="flex items-center gap-2"></div></div><div class="provider-modal-body flex flex-col gap-3"><div class="flex flex-wrap items-center gap-2"><button id="sandboxToggle" class="sandbox-toggle text-xs border border-[var(--border)] px-2 py-1 rounded-md transition-colors cursor-pointer bg-transparent font-[var(--font-body)] inline-flex items-center gap-1" title="Toggle sandbox mode"><span class="icon icon-md icon-lock shrink-0"></span><span id="sandboxLabel">sandboxed</span></button><div style="position:relative;display:inline-block"><button id="sandboxImageBtn" class="text-xs border border-[var(--border)] px-2 py-1 rounded-md transition-colors cursor-pointer bg-transparent font-[var(--font-body)] inline-flex items-center gap-1 text-[var(--muted)]" title="Sandbox image"><span class="icon icon-md icon-cube shrink-0"></span><span id="sandboxImageLabel" class="max-w-[120px] truncate">ubuntu:25.10</span></button><div id="sandboxImageDropdown" class="hidden" style="position:absolute;top:100%;left:0;z-index:50;margin-top:4px;min-width:200px;max-height:300px;overflow-y:auto;background:var(--surface);border:1px solid var(--border);border-radius:8px;box-shadow:0 4px 12px rgba(0,0,0,.15);"></div></div><button id="mcpToggleBtn" class="text-xs border border-[var(--border)] px-2 py-1 rounded-md transition-colors cursor-pointer bg-transparent font-[var(--font-body)] inline-flex items-center gap-1" title="Toggle MCP tools for this session"><span class="icon icon-md icon-link shrink-0"></span><span id="mcpToggleLabel">MCP</span></button><button id="debugPanelBtn" class="text-xs border border-[var(--border)] px-2 py-1 rounded-md transition-colors cursor-pointer bg-transparent font-[var(--font-body)] inline-flex items-center gap-1 text-[var(--muted)]" title="Show context debug info"><span class="icon icon-md icon-wrench shrink-0"></span><span id="debugPanelLabel">Debug</span></button><button id="fullContextBtn" class="text-xs border border-[var(--border)] px-2 py-1 rounded-md transition-colors cursor-pointer bg-transparent font-[var(--font-body)] inline-flex items-center gap-1 text-[var(--muted)]" title="Show full LLM context (system prompt + history)"><span class="icon icon-md icon-document shrink-0"></span><span id="fullContextLabel">Context</span></button></div><div id="sessionControlsSection" class="border-t border-[var(--border)] pt-3"><div id="sessionHeaderModalMount" class="w-full"></div></div></div></div></div><div id="debugModal" class="provider-modal-backdrop hidden"><div class="provider-modal" style="width:min(980px,96vw);max-width:96vw;max-height:88vh;"><div class="provider-modal-header"><div class="provider-item-name">Debug context</div><button id="debugModalCloseBtn" type="button" class="provider-btn provider-btn-secondary provider-btn-sm">Close</button></div><div class="provider-modal-body" style="padding:0;overflow:hidden;"><div id="debugPanel" class="px-4 py-3 overflow-y-auto" style="max-height:72vh;"></div></div></div></div><div id="fullContextModal" class="provider-modal-backdrop hidden"><div class="provider-modal" style="width:min(1080px,96vw);max-width:96vw;max-height:88vh;"><div class="provider-modal-header"><div class="provider-item-name">Full context</div><button id="fullContextModalCloseBtn" type="button" class="provider-btn provider-btn-secondary provider-btn-sm">Close</button></div><div class="provider-modal-body" style="padding:0;overflow:hidden;"><div id="fullContextPanel" class="px-4 py-3 overflow-y-auto" style="max-height:72vh;"></div></div></div></div><div class="p-4 flex flex-col gap-2" id="messages" style="grid-row:3;overflow-y:auto;min-height:0"></div><div id="queuedMessages" class="queued-tray hidden" style="grid-row:4;"></div><div id="tokenBar" class="token-bar" style="grid-row:5;"></div><div class="chat-input-row px-4 py-3 border-t border-[var(--border)] bg-[var(--surface)] flex gap-2 items-end" style="grid-row:6;"><span id="chatCommandPrompt" class="chat-command-prompt chat-command-prompt-hidden" title="Command prompt symbol" aria-hidden="true">$</span><textarea id="chatInput" placeholder="Type a message..." rows="1" enterkeyhint="send" class="flex-1 bg-[var(--surface2)] border border-[var(--border)] text-[var(--text)] px-3 py-2 rounded-lg text-sm resize-none min-h-[40px] max-h-[120px] leading-relaxed focus:outline-none focus:border-[var(--border-strong)] focus:ring-1 focus:ring-[var(--accent-subtle)] transition-colors font-[var(--font-body)]"></textarea><button id="micBtn" disabled title="Click to start recording" class="mic-btn min-h-[40px] px-3 bg-[var(--surface2)] border border-[var(--border)] rounded-lg text-[var(--muted)] cursor-pointer disabled:opacity-40 disabled:cursor-default transition-colors hover:border-[var(--border-strong)] hover:text-[var(--text)]"><span class="icon icon-lg icon-microphone"></span></button><button id="sendBtn" disabled class="provider-btn min-h-[40px] disabled:opacity-40 disabled:cursor-default">Send</button></div></div>';
+const chatPageHTML = '<div style="position:absolute;inset:0;display:grid;grid-template-rows:auto auto 1fr auto auto auto;overflow:hidden"><div class="chat-toolbar h-12 px-4 border-b border-[var(--border)] bg-[var(--surface)] flex items-center gap-2" style="grid-row:1;"><div id="modelCombo" class="model-combo"><button id="modelComboBtn" class="model-combo-btn" type="button"><span id="modelComboLabel">loading…</span><span class="icon icon-sm icon-chevron-down model-combo-chevron"></span></button><div id="modelDropdown" class="model-dropdown hidden"><input id="modelSearchInput" type="text" placeholder="Search models…" class="model-search-input" autocomplete="off" /><div id="modelDropdownList" class="model-dropdown-list"></div></div></div><div id="reasoningCombo" class="model-combo hidden"><button id="reasoningComboBtn" class="model-combo-btn" type="button" title="Reasoning effort"><span class="icon icon-sm icon-brain" style="flex-shrink:0;"></span><span id="reasoningComboLabel">Off</span><span class="icon icon-sm icon-chevron-down model-combo-chevron"></span></button><div id="reasoningDropdown" class="model-dropdown hidden"><div id="reasoningDropdownList" class="model-dropdown-list"></div></div></div><div id="nodeCombo" class="model-combo hidden"><button id="nodeComboBtn" class="model-combo-btn" type="button"><span class="icon icon-sm icon-server" style="flex-shrink:0;"></span><span id="nodeComboLabel">Local</span><span class="icon icon-sm icon-chevron-down model-combo-chevron"></span></button><div id="nodeDropdown" class="model-dropdown hidden" tabindex="-1"><div id="nodeDropdownList" class="model-dropdown-list"></div></div></div><div id="projectCombo" class="model-combo hidden"><button id="projectComboBtn" class="model-combo-btn" type="button"><span class="icon icon-sm icon-folder" style="flex-shrink:0;"></span><span id="projectComboLabel">No project</span><span class="icon icon-sm icon-chevron-down model-combo-chevron"></span></button><div id="projectDropdown" class="model-dropdown hidden"><div id="projectDropdownList" class="model-dropdown-list"></div></div></div><div id="sessionHeaderToolbarMount" class="ml-auto flex items-center gap-1.5"></div><button id="chatMoreBtn" type="button" class="model-combo-btn" title="More controls" aria-label="More controls"><span class="icon icon-lg icon-menu-dots-horizontal"></span></button></div><div id="chatMoreModal" class="provider-modal-backdrop hidden"><div class="provider-modal" style="width:560px;max-width:92vw;"><div class="provider-modal-header"><div class="flex items-center gap-2"><button id="chatMoreDeleteAllBtn" type="button" class="provider-btn provider-btn-sm chat-session-btn-danger inline-flex items-center gap-1.5" style="background:var(--error);border-color:var(--error);color:#fff;"><span class="icon icon-sm icon-x-circle shrink-0"></span><span id="chatMoreDeleteAllLabel">Delete all sessions</span></button></div><div id="sessionHeaderModalTopMount" class="flex items-center gap-2"></div></div><div class="provider-modal-body flex flex-col gap-3"><div class="flex flex-wrap items-center gap-2"><button id="sandboxToggle" class="sandbox-toggle text-xs border border-[var(--border)] px-2 py-1 rounded-md transition-colors cursor-pointer bg-transparent font-[var(--font-body)] inline-flex items-center gap-1" title="Toggle sandbox mode"><span class="icon icon-md icon-lock shrink-0"></span><span id="sandboxLabel">sandboxed</span></button><div style="position:relative;display:inline-block"><button id="sandboxImageBtn" class="text-xs border border-[var(--border)] px-2 py-1 rounded-md transition-colors cursor-pointer bg-transparent font-[var(--font-body)] inline-flex items-center gap-1 text-[var(--muted)]" title="Sandbox image"><span class="icon icon-md icon-cube shrink-0"></span><span id="sandboxImageLabel" class="max-w-[120px] truncate">ubuntu:25.10</span></button><div id="sandboxImageDropdown" class="hidden" style="position:absolute;top:100%;left:0;z-index:50;margin-top:4px;min-width:200px;max-height:300px;overflow-y:auto;background:var(--surface);border:1px solid var(--border);border-radius:8px;box-shadow:0 4px 12px rgba(0,0,0,.15);"></div></div><button id="mcpToggleBtn" class="text-xs border border-[var(--border)] px-2 py-1 rounded-md transition-colors cursor-pointer bg-transparent font-[var(--font-body)] inline-flex items-center gap-1" title="Toggle MCP tools for this session"><span class="icon icon-md icon-link shrink-0"></span><span id="mcpToggleLabel">MCP</span></button><button id="debugPanelBtn" class="text-xs border border-[var(--border)] px-2 py-1 rounded-md transition-colors cursor-pointer bg-transparent font-[var(--font-body)] inline-flex items-center gap-1 text-[var(--muted)]" title="Show context debug info"><span class="icon icon-md icon-wrench shrink-0"></span><span id="debugPanelLabel">Debug</span></button><button id="fullContextBtn" class="text-xs border border-[var(--border)] px-2 py-1 rounded-md transition-colors cursor-pointer bg-transparent font-[var(--font-body)] inline-flex items-center gap-1 text-[var(--muted)]" title="Show full LLM context (system prompt + history)"><span class="icon icon-md icon-document shrink-0"></span><span id="fullContextLabel">Context</span></button></div><div id="sessionControlsSection" class="border-t border-[var(--border)] pt-3"><div id="sessionHeaderModalMount" class="w-full"></div></div></div></div></div><div id="debugModal" class="provider-modal-backdrop hidden"><div class="provider-modal" style="width:min(980px,96vw);max-width:96vw;max-height:88vh;"><div class="provider-modal-header"><div class="provider-item-name">Debug context</div><button id="debugModalCloseBtn" type="button" class="provider-btn provider-btn-secondary provider-btn-sm">Close</button></div><div class="provider-modal-body" style="padding:0;overflow:hidden;"><div id="debugPanel" class="px-4 py-3 overflow-y-auto" style="max-height:72vh;"></div></div></div></div><div id="fullContextModal" class="provider-modal-backdrop hidden"><div class="provider-modal" style="width:min(1080px,96vw);max-width:96vw;max-height:88vh;"><div class="provider-modal-header"><div class="provider-item-name">Full context</div><button id="fullContextModalCloseBtn" type="button" class="provider-btn provider-btn-secondary provider-btn-sm">Close</button></div><div class="provider-modal-body" style="padding:0;overflow:hidden;"><div id="fullContextPanel" class="px-4 py-3 overflow-y-auto" style="max-height:72vh;"></div></div></div></div><div class="p-4 flex flex-col gap-2" id="messages" style="grid-row:3;overflow-y:auto;min-height:0"></div><div id="queuedMessages" class="queued-tray hidden" style="grid-row:4;"></div><div id="tokenBar" class="token-bar" style="grid-row:5;"></div><div class="chat-input-row px-4 py-3 border-t border-[var(--border)] bg-[var(--surface)] flex gap-2 items-end" style="grid-row:6;"><span id="chatCommandPrompt" class="chat-command-prompt chat-command-prompt-hidden" title="Command prompt symbol" aria-hidden="true">$</span><textarea id="chatInput" placeholder="Type a message..." rows="1" enterkeyhint="send" class="flex-1 bg-[var(--surface2)] border border-[var(--border)] text-[var(--text)] px-3 py-2 rounded-lg text-sm resize-none min-h-[40px] max-h-[120px] leading-relaxed focus:outline-none focus:border-[var(--border-strong)] focus:ring-1 focus:ring-[var(--accent-subtle)] transition-colors font-[var(--font-body)]"></textarea><button id="micBtn" disabled title="Click to start recording" class="mic-btn min-h-[40px] px-3 bg-[var(--surface2)] border border-[var(--border)] rounded-lg text-[var(--muted)] cursor-pointer disabled:opacity-40 disabled:cursor-default transition-colors hover:border-[var(--border-strong)] hover:text-[var(--text)]"><span class="icon icon-lg icon-microphone"></span></button><button id="vadBtn" disabled title="Conversation mode (VAD)" class="vad-btn min-h-[40px] px-3 bg-[var(--surface2)] border border-[var(--border)] rounded-lg text-[var(--muted)] cursor-pointer disabled:opacity-40 disabled:cursor-default transition-colors hover:border-[var(--border-strong)] hover:text-[var(--text)]"><span class="icon icon-lg icon-waveform"></span></button><button id="sendBtn" disabled class="provider-btn min-h-[40px] disabled:opacity-40 disabled:cursor-default">Send</button></div></div>';
 let chatScrollHandler = null;
 registerPrefix(
   routes.chats,
@@ -6411,6 +6860,7 @@ registerPrefix(
     };
     (_c = chatMsgBox) == null ? void 0 : _c.addEventListener("scroll", chatScrollHandler, { passive: true });
     initVoiceInput($("micBtn"));
+    initVadButton($("vadBtn"));
     initializeChatMediaDrop();
     (_d = chatInput) == null ? void 0 : _d.focus();
   },
@@ -31099,6 +31549,9 @@ function VoiceSection() {
   const [voiceTesting, setVoiceTesting] = d(null);
   const [activeRecorder, setActiveRecorder] = d(null);
   const [voiceTestResults, setVoiceTestResults] = d({});
+  const [pttKeyValue, setPttKeyValue] = d(getPttKey());
+  const [pttListening, setPttListening] = d(false);
+  const [vadSens, setVadSens] = d(getVadSensitivity());
   function fetchVoiceStatus(options) {
     if (!(options == null ? void 0 : options.silent)) {
       setVoiceLoading(true);
@@ -31349,6 +31802,65 @@ function VoiceSection() {
             prov.id
           );
         }) })
+      ] })
+    ] }),
+    /* @__PURE__ */ u("div", { style: { maxWidth: "700px", display: "flex", flexDirection: "column", gap: "12px" }, children: [
+      /* @__PURE__ */ u("h3", { className: "text-sm font-medium text-[var(--text-strong)]", children: "Push-to-Talk" }),
+      /* @__PURE__ */ u("p", { className: "text-xs text-[var(--muted)] leading-relaxed", style: { margin: 0 }, children: "Hold a keyboard key to record voice input. Release to send. Function keys (F1–F24) work even when focused in an input field." }),
+      /* @__PURE__ */ u("div", { className: "flex items-center gap-3", children: [
+        /* @__PURE__ */ u("span", { className: "text-xs text-[var(--muted)]", children: "PTT Key:" }),
+        /* @__PURE__ */ u(
+          "button",
+          {
+            type: "button",
+            className: "provider-key-input",
+            style: { minWidth: "120px", textAlign: "center", cursor: "pointer" },
+            onClick: () => {
+              if (pttListening) return;
+              setPttListening(true);
+              const handler = (ev) => {
+                ev.preventDefault();
+                ev.stopPropagation();
+                setPttKeyValue(ev.key);
+                setPttKey(ev.key);
+                setPttListening(false);
+                document.removeEventListener("keydown", handler, true);
+                rerender$1();
+              };
+              document.addEventListener("keydown", handler, true);
+              rerender$1();
+            },
+            children: pttListening ? "Press any key..." : pttKeyValue
+          }
+        )
+      ] })
+    ] }),
+    /* @__PURE__ */ u("div", { style: { maxWidth: "700px", display: "flex", flexDirection: "column", gap: "12px" }, children: [
+      /* @__PURE__ */ u("h3", { className: "text-sm font-medium text-[var(--text-strong)]", children: "Conversation Mode (VAD)" }),
+      /* @__PURE__ */ u("p", { className: "text-xs text-[var(--muted)] leading-relaxed", style: { margin: 0 }, children: "Adjust how sensitive the voice activity detection is. Higher values pick up softer speech but may trigger on background noise." }),
+      /* @__PURE__ */ u("div", { className: "flex items-center gap-3", children: [
+        /* @__PURE__ */ u("span", { className: "text-xs text-[var(--muted)]", style: { minWidth: "80px" }, children: "Sensitivity:" }),
+        /* @__PURE__ */ u(
+          "input",
+          {
+            type: "range",
+            min: "0",
+            max: "100",
+            step: "5",
+            value: vadSens,
+            style: { flex: 1, maxWidth: "200px", accentColor: "var(--accent)" },
+            onInput: (e) => {
+              const val = parseInt(targetValue(e), 10);
+              setVadSens(val);
+              setVadSensitivity(val);
+              rerender$1();
+            }
+          }
+        ),
+        /* @__PURE__ */ u("span", { className: "text-xs text-[var(--muted)]", style: { minWidth: "35px", textAlign: "right" }, children: [
+          vadSens,
+          "%"
+        ] })
       ] })
     ] }),
     /* @__PURE__ */ u(

--- a/crates/web/src/assets/dist/main.js
+++ b/crates/web/src/assets/dist/main.js
@@ -5204,7 +5204,7 @@ function onPttKeyUp(e) {
   stopRecording();
 }
 async function startVad() {
-  if (vadActive || vadStarting) return;
+  if (vadActive || vadStarting || isRecording || isStarting) return;
   vadStarting = true;
   console.debug("[voice] VAD starting");
   try {
@@ -5502,24 +5502,26 @@ function onVadClick(e) {
     startVad();
   }
 }
+function onMicKeydown(e) {
+  if (e.key === " " || e.key === "Enter") {
+    e.preventDefault();
+    onMicClick(e);
+  }
+}
+function onEscapeKeydown(e) {
+  if (e.key === "Escape" && isRecording) {
+    e.preventDefault();
+    cancelRecording();
+    if (vadActive) stopVad();
+  }
+}
 function initVoiceInput(btn2) {
   if (!btn2) return;
   micBtn = btn2;
   checkSttStatus();
   micBtn.addEventListener("click", onMicClick);
-  micBtn.addEventListener("keydown", (e) => {
-    if (e.key === " " || e.key === "Enter") {
-      e.preventDefault();
-      onMicClick(e);
-    }
-  });
-  document.addEventListener("keydown", (e) => {
-    if (e.key === "Escape" && isRecording) {
-      e.preventDefault();
-      cancelRecording();
-      if (vadActive) stopVad();
-    }
-  });
+  micBtn.addEventListener("keydown", onMicKeydown);
+  document.addEventListener("keydown", onEscapeKeydown);
   document.addEventListener("keydown", onPttKeyDown);
   document.addEventListener("keyup", onPttKeyUp);
   window.addEventListener("voice-config-changed", checkSttStatus);
@@ -5535,8 +5537,10 @@ function teardownVoiceInput() {
   if (isRecording && mediaRecorder) {
     mediaRecorder.stop();
   }
+  document.removeEventListener("keydown", onEscapeKeydown);
   document.removeEventListener("keydown", onPttKeyDown);
   document.removeEventListener("keyup", onPttKeyUp);
+  micBtn == null ? void 0 : micBtn.removeEventListener("keydown", onMicKeydown);
   window.removeEventListener("voice-config-changed", checkSttStatus);
   releaseVoiceLock();
   micBtn = null;

--- a/crates/web/src/assets/dist/main.js
+++ b/crates/web/src/assets/dist/main.js
@@ -4847,6 +4847,7 @@ let vadRecordingStart = 0;
 let vadMediaRecorder = null;
 let vadTranscribing = false;
 let vadReacquiring = false;
+let vadStarting = false;
 let vadSourceNode = null;
 let vadMonitorMuteStart = 0;
 function isVoiceEnabled() {
@@ -5203,19 +5204,22 @@ function onPttKeyUp(e) {
   stopRecording();
 }
 async function startVad() {
-  if (vadActive) return;
+  if (vadActive || vadStarting) return;
+  vadStarting = true;
   console.debug("[voice] VAD starting");
   try {
     vadStream = await navigator.mediaDevices.getUserMedia({
       audio: { echoCancellation: true, noiseSuppression: true, autoGainControl: true }
     });
   } catch (err) {
+    vadStarting = false;
     console.error("[voice] VAD mic access failed:", err);
     if (err.name === "NotAllowedError") {
       alert(t("settings:voice.micDenied"));
     }
     return;
   }
+  vadStarting = false;
   vadActive = true;
   vadSpeechDetected = false;
   vadSilenceStart = 0;

--- a/crates/web/ui/input.css
+++ b/crates/web/ui/input.css
@@ -2022,6 +2022,11 @@
     mask-image: url("./icons/masks/mask-0162291303f5d971.svg");
   }
 
+  .icon-waveform {
+    -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24'%3E%3Cpath stroke='black' stroke-width='1.5' stroke-linecap='round' d='M3 12h1M7 8v8M11 5v14M15 8v8M19 10v4M23 12h-1'%2F%3E%3C/svg%3E");
+    mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24'%3E%3Cpath stroke='black' stroke-width='1.5' stroke-linecap='round' d='M3 12h1M7 8v8M11 5v14M15 8v8M19 10v4M23 12h-1'%2F%3E%3C/svg%3E");
+  }
+
   /* Status icons */
   .icon-checkmark {
     -webkit-mask-image: url("./icons/masks/mask-48b7d531f003fdb1.svg");

--- a/crates/web/ui/src/locales/en/chat.ts
+++ b/crates/web/ui/src/locales/en/chat.ts
@@ -9,6 +9,8 @@ export default {
 	micStopAndSend: "Click to stop and send",
 	voiceTranscribing: "Transcribing...",
 	voiceTranscribingMessage: "Transcribing voice...",
+	vadTooltip: "Conversation mode (VAD)",
+	vadStopTooltip: "Click to stop conversation mode",
 
 	// ── Slash commands ───────────────────────────────────────
 	slashClear: "Clear conversation history",

--- a/crates/web/ui/src/locales/en/chat.ts
+++ b/crates/web/ui/src/locales/en/chat.ts
@@ -11,6 +11,10 @@ export default {
 	voiceTranscribingMessage: "Transcribing voice...",
 	vadTooltip: "Conversation mode (VAD)",
 	vadStopTooltip: "Click to stop conversation mode",
+	voiceNoSpeech: "No speech detected",
+	voiceTranscriptionError: "Transcription error",
+	voiceTranscriptionFailed: "Transcription failed: {{error}}",
+	voiceUploadFailed: "Upload failed: {{error}}",
 
 	// ── Slash commands ───────────────────────────────────────
 	slashClear: "Clear conversation history",

--- a/crates/web/ui/src/locales/fr/chat.ts
+++ b/crates/web/ui/src/locales/fr/chat.ts
@@ -11,6 +11,10 @@ export default {
 	voiceTranscribingMessage: "Transcription de la voix...",
 	vadTooltip: "Mode conversation (VAD)",
 	vadStopTooltip: "Cliquer pour quitter le mode conversation",
+	voiceNoSpeech: "Aucune parole détectée",
+	voiceTranscriptionError: "Erreur de transcription",
+	voiceTranscriptionFailed: "Échec de la transcription : {{error}}",
+	voiceUploadFailed: "Échec du téléversement : {{error}}",
 
 	// ── Slash commands ───────────────────────────────────────
 	slashClear: "Clear conversation history",

--- a/crates/web/ui/src/locales/fr/chat.ts
+++ b/crates/web/ui/src/locales/fr/chat.ts
@@ -9,6 +9,8 @@ export default {
 	micStopAndSend: "Cliquez pour arrêter et envoyer",
 	voiceTranscribing: "Transcription...",
 	voiceTranscribingMessage: "Transcription de la voix...",
+	vadTooltip: "Mode conversation (VAD)",
+	vadStopTooltip: "Cliquer pour quitter le mode conversation",
 
 	// ── Slash commands ───────────────────────────────────────
 	slashClear: "Clear conversation history",

--- a/crates/web/ui/src/locales/zh/chat.ts
+++ b/crates/web/ui/src/locales/zh/chat.ts
@@ -9,6 +9,8 @@ export default {
 	micStopAndSend: "点击停止并发送",
 	voiceTranscribing: "转录中...",
 	voiceTranscribingMessage: "正在转录语音...",
+	vadTooltip: "对话模式 (VAD)",
+	vadStopTooltip: "点击停止对话模式",
 
 	// ── Slash commands ───────────────────────────────────────
 	slashClear: "清除对话历史",

--- a/crates/web/ui/src/locales/zh/chat.ts
+++ b/crates/web/ui/src/locales/zh/chat.ts
@@ -11,6 +11,10 @@ export default {
 	voiceTranscribingMessage: "正在转录语音...",
 	vadTooltip: "对话模式 (VAD)",
 	vadStopTooltip: "点击停止对话模式",
+	voiceNoSpeech: "未检测到语音",
+	voiceTranscriptionError: "转录错误",
+	voiceTranscriptionFailed: "转录失败：{{error}}",
+	voiceUploadFailed: "上传失败：{{error}}",
 
 	// ── Slash commands ───────────────────────────────────────
 	slashClear: "清除对话历史",

--- a/crates/web/ui/src/pages/ChatPage.tsx
+++ b/crates/web/ui/src/pages/ChatPage.tsx
@@ -25,7 +25,7 @@ import { bindSandboxImageEvents, bindSandboxToggleEvents, updateSandboxImageUI, 
 import { clearAllSessions, switchSession } from "../sessions";
 import * as S from "../state";
 import { sessionStore } from "../stores/session-store";
-import { initVoiceInput, teardownVoiceInput } from "../voice-input";
+import { initVadButton, initVoiceInput, teardownVoiceInput } from "../voice-input";
 import {
 	chatAutoResize,
 	handleHistoryDown,
@@ -892,7 +892,7 @@ const chatPageHTML =
 	'<div class="p-4 flex flex-col gap-2" id="messages" style="grid-row:3;overflow-y:auto;min-height:0"></div>' +
 	'<div id="queuedMessages" class="queued-tray hidden" style="grid-row:4;"></div>' +
 	'<div id="tokenBar" class="token-bar" style="grid-row:5;"></div>' +
-	'<div class="chat-input-row px-4 py-3 border-t border-[var(--border)] bg-[var(--surface)] flex gap-2 items-end" style="grid-row:6;"><span id="chatCommandPrompt" class="chat-command-prompt chat-command-prompt-hidden" title="Command prompt symbol" aria-hidden="true">$</span><textarea id="chatInput" placeholder="Type a message..." rows="1" enterkeyhint="send" class="flex-1 bg-[var(--surface2)] border border-[var(--border)] text-[var(--text)] px-3 py-2 rounded-lg text-sm resize-none min-h-[40px] max-h-[120px] leading-relaxed focus:outline-none focus:border-[var(--border-strong)] focus:ring-1 focus:ring-[var(--accent-subtle)] transition-colors font-[var(--font-body)]"></textarea><button id="micBtn" disabled title="Click to start recording" class="mic-btn min-h-[40px] px-3 bg-[var(--surface2)] border border-[var(--border)] rounded-lg text-[var(--muted)] cursor-pointer disabled:opacity-40 disabled:cursor-default transition-colors hover:border-[var(--border-strong)] hover:text-[var(--text)]"><span class="icon icon-lg icon-microphone"></span></button><button id="sendBtn" disabled class="provider-btn min-h-[40px] disabled:opacity-40 disabled:cursor-default">Send</button></div></div>';
+	'<div class="chat-input-row px-4 py-3 border-t border-[var(--border)] bg-[var(--surface)] flex gap-2 items-end" style="grid-row:6;"><span id="chatCommandPrompt" class="chat-command-prompt chat-command-prompt-hidden" title="Command prompt symbol" aria-hidden="true">$</span><textarea id="chatInput" placeholder="Type a message..." rows="1" enterkeyhint="send" class="flex-1 bg-[var(--surface2)] border border-[var(--border)] text-[var(--text)] px-3 py-2 rounded-lg text-sm resize-none min-h-[40px] max-h-[120px] leading-relaxed focus:outline-none focus:border-[var(--border-strong)] focus:ring-1 focus:ring-[var(--accent-subtle)] transition-colors font-[var(--font-body)]"></textarea><button id="micBtn" disabled title="Click to start recording" class="mic-btn min-h-[40px] px-3 bg-[var(--surface2)] border border-[var(--border)] rounded-lg text-[var(--muted)] cursor-pointer disabled:opacity-40 disabled:cursor-default transition-colors hover:border-[var(--border-strong)] hover:text-[var(--text)]"><span class="icon icon-lg icon-microphone"></span></button><button id="vadBtn" disabled title="Conversation mode (VAD)" class="vad-btn min-h-[40px] px-3 bg-[var(--surface2)] border border-[var(--border)] rounded-lg text-[var(--muted)] cursor-pointer disabled:opacity-40 disabled:cursor-default transition-colors hover:border-[var(--border-strong)] hover:text-[var(--text)]"><span class="icon icon-lg icon-waveform"></span></button><button id="sendBtn" disabled class="provider-btn min-h-[40px] disabled:opacity-40 disabled:cursor-default">Send</button></div></div>';
 
 // ── Page registration ────────────────────────────────────────
 
@@ -947,6 +947,7 @@ registerPrefix(
 		S.chatMsgBox?.addEventListener("scroll", chatScrollHandler, { passive: true });
 
 		initVoiceInput(S.$("micBtn") as HTMLButtonElement | null);
+		initVadButton(S.$("vadBtn") as HTMLButtonElement | null);
 		initializeChatMediaDrop();
 		S.chatInput?.focus();
 	},

--- a/crates/web/ui/src/pages/sections/VoiceSection.tsx
+++ b/crates/web/ui/src/pages/sections/VoiceSection.tsx
@@ -75,6 +75,53 @@ interface VoxtralRequirements {
 	cuda?: { available?: boolean; gpu_name?: string; memory_mb?: number };
 }
 
+interface PttKeyPickerProps {
+	pttListening: boolean;
+	setPttListening: (v: boolean) => void;
+	pttKeyValue: string;
+	setPttKeyValue: (v: string) => void;
+}
+
+function PttKeyPicker({ pttListening, setPttListening, pttKeyValue, setPttKeyValue }: PttKeyPickerProps): VNode {
+	const handlerRef = useRef<((ev: KeyboardEvent) => void) | null>(null);
+
+	useEffect(() => {
+		return () => {
+			if (handlerRef.current) {
+				document.removeEventListener("keydown", handlerRef.current, true);
+				handlerRef.current = null;
+			}
+		};
+	}, []);
+
+	return (
+		<button
+			type="button"
+			className="provider-key-input"
+			style={{ minWidth: "120px", textAlign: "center", cursor: "pointer" }}
+			onClick={() => {
+				if (pttListening) return;
+				setPttListening(true);
+				const handler = (ev: KeyboardEvent): void => {
+					ev.preventDefault();
+					ev.stopPropagation();
+					setPttKeyValue(ev.key);
+					setPttKey(ev.key);
+					setPttListening(false);
+					document.removeEventListener("keydown", handler, true);
+					handlerRef.current = null;
+					rerender();
+				};
+				handlerRef.current = handler;
+				document.addEventListener("keydown", handler, true);
+				rerender();
+			}}
+		>
+			{pttListening ? "Press any key..." : pttKeyValue}
+		</button>
+	);
+}
+
 export function VoiceSection(): VNode {
 	const [allProviders, setAllProviders] = useState<VoiceProviders>({ tts: [], stt: [] });
 	const [voiceLoading, setVoiceLoading] = useState(true);
@@ -389,28 +436,12 @@ export function VoiceSection(): VNode {
 				</p>
 				<div className="flex items-center gap-3">
 					<span className="text-xs text-[var(--muted)]">PTT Key:</span>
-					<button
-						type="button"
-						className="provider-key-input"
-						style={{ minWidth: "120px", textAlign: "center", cursor: "pointer" }}
-						onClick={() => {
-							if (pttListening) return;
-							setPttListening(true);
-							const handler = (ev: KeyboardEvent): void => {
-								ev.preventDefault();
-								ev.stopPropagation();
-								setPttKeyValue(ev.key);
-								setPttKey(ev.key);
-								setPttListening(false);
-								document.removeEventListener("keydown", handler, true);
-								rerender();
-							};
-							document.addEventListener("keydown", handler, true);
-							rerender();
-						}}
-					>
-						{pttListening ? "Press any key..." : pttKeyValue}
-					</button>
+					<PttKeyPicker
+						pttListening={pttListening}
+						setPttListening={setPttListening}
+						pttKeyValue={pttKeyValue}
+						setPttKeyValue={setPttKeyValue}
+					/>
 				</div>
 			</div>
 

--- a/crates/web/ui/src/pages/sections/VoiceSection.tsx
+++ b/crates/web/ui/src/pages/sections/VoiceSection.tsx
@@ -10,6 +10,7 @@ import * as S from "../../state";
 import { fetchPhrase } from "../../tts-phrases";
 import { targetChecked, targetValue } from "../../typed-events";
 import { Modal } from "../../ui";
+import { getPttKey, getVadSensitivity, setPttKey, setVadSensitivity } from "../../voice-input";
 import {
 	decodeBase64Safe,
 	fetchVoiceProviders,
@@ -84,6 +85,13 @@ export function VoiceSection(): VNode {
 	const [voiceTesting, setVoiceTesting] = useState<VoiceTesting | null>(null);
 	const [activeRecorder, setActiveRecorder] = useState<MediaRecorder | null>(null);
 	const [voiceTestResults, setVoiceTestResults] = useState<Record<string, VoiceTestResult>>({});
+
+	// PTT key configuration
+	const [pttKeyValue, setPttKeyValue] = useState(getPttKey());
+	const [pttListening, setPttListening] = useState(false);
+
+	// VAD sensitivity
+	const [vadSens, setVadSens] = useState(getVadSensitivity());
 
 	function fetchVoiceStatus(options?: { silent?: boolean }): void {
 		if (!options?.silent) {
@@ -369,6 +377,71 @@ export function VoiceSection(): VNode {
 							);
 						})}
 					</div>
+				</div>
+			</div>
+
+			{/* Push-to-Talk Configuration */}
+			<div style={{ maxWidth: "700px", display: "flex", flexDirection: "column", gap: "12px" }}>
+				<h3 className="text-sm font-medium text-[var(--text-strong)]">Push-to-Talk</h3>
+				<p className="text-xs text-[var(--muted)] leading-relaxed" style={{ margin: 0 }}>
+					Hold a keyboard key to record voice input. Release to send. Function keys (F1–F24) work even when focused in
+					an input field.
+				</p>
+				<div className="flex items-center gap-3">
+					<span className="text-xs text-[var(--muted)]">PTT Key:</span>
+					<button
+						type="button"
+						className="provider-key-input"
+						style={{ minWidth: "120px", textAlign: "center", cursor: "pointer" }}
+						onClick={() => {
+							if (pttListening) return;
+							setPttListening(true);
+							const handler = (ev: KeyboardEvent): void => {
+								ev.preventDefault();
+								ev.stopPropagation();
+								setPttKeyValue(ev.key);
+								setPttKey(ev.key);
+								setPttListening(false);
+								document.removeEventListener("keydown", handler, true);
+								rerender();
+							};
+							document.addEventListener("keydown", handler, true);
+							rerender();
+						}}
+					>
+						{pttListening ? "Press any key..." : pttKeyValue}
+					</button>
+				</div>
+			</div>
+
+			{/* VAD Sensitivity */}
+			<div style={{ maxWidth: "700px", display: "flex", flexDirection: "column", gap: "12px" }}>
+				<h3 className="text-sm font-medium text-[var(--text-strong)]">Conversation Mode (VAD)</h3>
+				<p className="text-xs text-[var(--muted)] leading-relaxed" style={{ margin: 0 }}>
+					Adjust how sensitive the voice activity detection is. Higher values pick up softer speech but may trigger on
+					background noise.
+				</p>
+				<div className="flex items-center gap-3">
+					<span className="text-xs text-[var(--muted)]" style={{ minWidth: "80px" }}>
+						Sensitivity:
+					</span>
+					<input
+						type="range"
+						min="0"
+						max="100"
+						step="5"
+						value={vadSens}
+						style={{ flex: 1, maxWidth: "200px", accentColor: "var(--accent)" }}
+						onInput={(e) => {
+							const val = parseInt(targetValue(e), 10);
+							setVadSens(val);
+							setVadSensitivity(val);
+							rerender();
+						}}
+					/>
+					<span className="text-xs text-[var(--muted)]" style={{ minWidth: "35px", textAlign: "right" }}>
+						{vadSens}%
+					</span>
 				</div>
 			</div>
 

--- a/crates/web/ui/src/voice-input.ts
+++ b/crates/web/ui/src/voice-input.ts
@@ -23,6 +23,7 @@ let audioChunks: Blob[] = [];
 let sttConfigured = false;
 let isRecording = false;
 let isStarting = false;
+let recordingCancelled = false;
 let transcribingEl: HTMLElement | null = null;
 
 // ── PTT state ────────────────────────────────────────────────
@@ -77,6 +78,7 @@ let vadSpeechStart = 0;
 let vadRecordingStart = 0;
 let vadMediaRecorder: MediaRecorder | null = null;
 let vadTranscribing = false;
+let vadReacquiring = false;
 
 // VAD monitor loop mutable state (avoids static properties on function)
 let vadMonitorMuteStart = 0;
@@ -262,6 +264,7 @@ function cancelRecording(): void {
 	if (!(isRecording && mediaRecorder)) return;
 
 	console.debug("[voice] recording cancelled via Escape");
+	recordingCancelled = true;
 	audioChunks = [];
 	isStarting = false;
 	isRecording = false;
@@ -378,10 +381,12 @@ interface TranscriptionUploadResponse {
 }
 
 async function transcribeAudio(): Promise<void> {
-	if (audioChunks.length === 0) {
+	if (recordingCancelled || audioChunks.length === 0) {
+		recordingCancelled = false;
 		cleanupTranscribingState();
 		return;
 	}
+	recordingCancelled = false;
 
 	if (S.chatMsgBox) {
 		transcribingEl = createTranscribingIndicator(t("chat:voiceTranscribingMessage"), false);
@@ -654,12 +659,17 @@ function vadMonitorLoop(): void {
 		vadAudioCtx.resume().catch(() => {});
 	}
 
-	// Health check: if the mic stream track ended, reacquire it
+	// Health check: if the mic stream track ended, reacquire it (guarded to prevent concurrent calls)
 	if (vadStream) {
 		const track = vadStream.getAudioTracks()[0];
 		if (!track || track.readyState !== "live") {
-			console.warn("[voice] VAD: mic track died, reacquiring");
-			vadReacquireStream();
+			if (!vadReacquiring) {
+				vadReacquiring = true;
+				console.warn("[voice] VAD: mic track died, reacquiring");
+				vadReacquireStream().finally(() => {
+					vadReacquiring = false;
+				});
+			}
 			vadRafId = requestAnimationFrame(vadMonitorLoop);
 			return;
 		}

--- a/crates/web/ui/src/voice-input.ts
+++ b/crates/web/ui/src/voice-input.ts
@@ -567,6 +567,7 @@ async function startVad(): Promise<void> {
 function vadStartContinuousRecorder(): void {
 	if (!(vadActive && vadStream)) return;
 	if (vadTranscribing) return;
+	if (vadMediaRecorder && vadMediaRecorder.state === "recording") return;
 	audioChunks = [];
 	const mimeType = MediaRecorder.isTypeSupported("audio/webm;codecs=opus") ? "audio/webm;codecs=opus" : "audio/webm";
 	vadMediaRecorder = new MediaRecorder(vadStream, { mimeType });
@@ -811,8 +812,9 @@ function onTtsPlay(e: Event): void {
 	if (vadMediaRecorder && vadMediaRecorder.state === "recording") {
 		vadSpeechDetected = false;
 		audioChunks = [];
-		vadMediaRecorder.stop();
+		const mr = vadMediaRecorder;
 		vadMediaRecorder = null;
+		mr.stop();
 	}
 }
 

--- a/crates/web/ui/src/voice-input.ts
+++ b/crates/web/ui/src/voice-input.ts
@@ -80,7 +80,6 @@ let vadTranscribing = false;
 
 // VAD monitor loop mutable state (avoids static properties on function)
 let vadMonitorMuteStart = 0;
-let vadMonitorLastLog = 0;
 
 /** Check if voice feature is enabled. */
 function isVoiceEnabled(): boolean {
@@ -409,14 +408,18 @@ async function transcribeAudio(): Promise<void> {
 
 		const abortCtrl = new AbortController();
 		const fetchTimeout = setTimeout(() => abortCtrl.abort(), 15000);
-		const resp = await fetch(`/api/sessions/${encodeURIComponent(S.activeSessionKey)}/upload?transcribe=true`, {
-			method: "POST",
-			headers: { "Content-Type": blob.type || "audio/webm" },
-			body: blob,
-			signal: abortCtrl.signal,
-		});
-		clearTimeout(fetchTimeout);
-		const res: TranscriptionUploadResponse = await resp.json();
+		let res: TranscriptionUploadResponse;
+		try {
+			const resp = await fetch(`/api/sessions/${encodeURIComponent(S.activeSessionKey)}/upload?transcribe=true`, {
+				method: "POST",
+				headers: { "Content-Type": blob.type || "audio/webm" },
+				body: blob,
+				signal: abortCtrl.signal,
+			});
+			res = await resp.json();
+		} finally {
+			clearTimeout(fetchTimeout);
+		}
 
 		micBtn?.classList.remove("transcribing");
 		if (micBtn) micBtn.title = t("chat:micTooltip");
@@ -643,7 +646,7 @@ function vadMonitorLoop(): void {
 	// Health check: resume AudioContext if browser suspended it
 	if (vadAudioCtx && vadAudioCtx.state === "suspended") {
 		console.debug("[voice] VAD: AudioContext suspended, resuming");
-		vadAudioCtx.resume();
+		vadAudioCtx.resume().catch(() => {});
 	}
 
 	// Health check: if the mic stream track ended, reacquire it
@@ -699,22 +702,6 @@ function vadMonitorLoop(): void {
 
 	const rms = getRMS(vadAnalyser, vadDataArray);
 	const now = Date.now();
-
-	if (!vadMonitorLastLog || now - vadMonitorLastLog > 1000) {
-		vadMonitorLastLog = now;
-		console.debug(
-			"[voice] VAD rms:",
-			rms.toFixed(4),
-			"speech:",
-			vadSpeechDetected,
-			"muted:",
-			vadMutedForTts,
-			"transcribing:",
-			vadTranscribing,
-			"ctx:",
-			vadAudioCtx?.state,
-		);
-	}
 
 	if (rms > vadSpeechThreshold) {
 		vadSilenceStart = 0;

--- a/crates/web/ui/src/voice-input.ts
+++ b/crates/web/ui/src/voice-input.ts
@@ -90,6 +90,7 @@ function isVoiceEnabled(): boolean {
 async function checkSttStatus(): Promise<void> {
 	if (!isVoiceEnabled()) {
 		sttConfigured = false;
+		if (vadActive) stopVad();
 		updateMicButton();
 		updateVadButton();
 		return;
@@ -100,6 +101,7 @@ async function checkSttStatus(): Promise<void> {
 	} else {
 		sttConfigured = false;
 	}
+	if (!sttConfigured && vadActive) stopVad();
 	updateMicButton();
 	updateVadButton();
 }
@@ -431,20 +433,20 @@ async function transcribeAudio(): Promise<void> {
 				cleanupTranscribingState();
 				sendTranscribedMessage(text, audioFilename || null);
 			} else {
-				showTemporaryMessage("No speech detected", false, 2000);
+				showTemporaryMessage(t("chat:voiceNoSpeech"), false, 2000);
 			}
 		} else if (res.transcriptionError) {
 			console.error("Transcription failed:", res.transcriptionError);
-			showTemporaryMessage(`Transcription failed: ${res.transcriptionError}`, true, 4000);
+			showTemporaryMessage(t("chat:voiceTranscriptionFailed", { error: res.transcriptionError }), true, 4000);
 		} else if (!res.ok) {
 			console.error("Upload failed:", res.error);
-			showTemporaryMessage(`Upload failed: ${res.error || "Unknown error"}`, true, 4000);
+			showTemporaryMessage(t("chat:voiceUploadFailed", { error: res.error || t("chat:unknownError") }), true, 4000);
 		}
 	} catch (err) {
 		console.error("Transcription error:", err);
 		micBtn?.classList.remove("transcribing");
 		if (micBtn) micBtn.title = t("chat:micTooltip");
-		showTemporaryMessage("Transcription error", true, 4000);
+		showTemporaryMessage(t("chat:voiceTranscriptionError"), true, 4000);
 	}
 }
 
@@ -574,6 +576,9 @@ async function vadReacquireStream(): Promise<void> {
 		const newStream = await navigator.mediaDevices.getUserMedia({
 			audio: { echoCancellation: true, noiseSuppression: true, autoGainControl: true },
 		});
+		if (vadStream) {
+			for (const track of vadStream.getTracks()) track.stop();
+		}
 		vadStream = newStream;
 		if (vadAudioCtx && vadAnalyser) {
 			const source = vadAudioCtx.createMediaStreamSource(newStream);

--- a/crates/web/ui/src/voice-input.ts
+++ b/crates/web/ui/src/voice-input.ts
@@ -79,6 +79,7 @@ let vadRecordingStart = 0;
 let vadMediaRecorder: MediaRecorder | null = null;
 let vadTranscribing = false;
 let vadReacquiring = false;
+let vadSourceNode: MediaStreamAudioSourceNode | null = null;
 
 // VAD monitor loop mutable state (avoids static properties on function)
 let vadMonitorMuteStart = 0;
@@ -174,6 +175,20 @@ async function startRecording(opts?: StartRecordingOpts): Promise<void> {
 			stream = await navigator.mediaDevices.getUserMedia({
 				audio: { echoCancellation: true, noiseSuppression: true, autoGainControl: true },
 			});
+		}
+		// If recording was cancelled while getUserMedia was in-flight (e.g. quick PTT tap), bail out
+		if (recordingCancelled) {
+			isStarting = false;
+			recordingCancelled = false;
+			if (!fromVad) {
+				for (const track of stream.getTracks()) track.stop();
+			}
+			if (micBtn) {
+				micBtn.classList.remove("starting");
+				micBtn.removeAttribute("aria-busy");
+				micBtn.title = t("chat:micTooltip");
+			}
+			return;
 		}
 		audioChunks = [];
 		let recordingUiShown = false;
@@ -495,6 +510,10 @@ function onPttKeyUp(e: KeyboardEvent): void {
 	e.preventDefault();
 	pttActive = false;
 	releaseVoiceLock();
+	if (isStarting) {
+		// getUserMedia still in-flight; cancel so it doesn't start an orphaned recording
+		recordingCancelled = true;
+	}
 	console.debug("[voice] PTT release — sending");
 	stopRecording();
 }
@@ -530,11 +549,11 @@ async function startVad(): Promise<void> {
 	}
 
 	vadAudioCtx = new AudioContext();
-	const source = vadAudioCtx.createMediaStreamSource(vadStream);
+	vadSourceNode = vadAudioCtx.createMediaStreamSource(vadStream);
 	vadAnalyser = vadAudioCtx.createAnalyser();
 	vadAnalyser.fftSize = 512;
 	vadAnalyser.smoothingTimeConstant = 0.3;
-	source.connect(vadAnalyser);
+	vadSourceNode.connect(vadAnalyser);
 	vadDataArray = new Uint8Array(vadAnalyser.fftSize);
 
 	vadStartContinuousRecorder();
@@ -586,8 +605,11 @@ async function vadReacquireStream(): Promise<void> {
 		}
 		vadStream = newStream;
 		if (vadAudioCtx && vadAnalyser) {
-			const source = vadAudioCtx.createMediaStreamSource(newStream);
-			source.connect(vadAnalyser);
+			if (vadSourceNode) {
+				vadSourceNode.disconnect();
+			}
+			vadSourceNode = vadAudioCtx.createMediaStreamSource(newStream);
+			vadSourceNode.connect(vadAnalyser);
 		}
 		if (vadMediaRecorder && vadMediaRecorder.state === "recording") {
 			vadMediaRecorder.stop();
@@ -626,6 +648,10 @@ function stopVad(): void {
 		vadRafId = null;
 	}
 
+	if (vadSourceNode) {
+		vadSourceNode.disconnect();
+		vadSourceNode = null;
+	}
 	if (vadAudioCtx) {
 		vadAudioCtx.close().catch(() => {});
 		vadAudioCtx = null;

--- a/crates/web/ui/src/voice-input.ts
+++ b/crates/web/ui/src/voice-input.ts
@@ -522,7 +522,7 @@ function onPttKeyUp(e: KeyboardEvent): void {
 // ── VAD (voice activity detection) ───────────────────────────
 
 async function startVad(): Promise<void> {
-	if (vadActive || vadStarting) return;
+	if (vadActive || vadStarting || isRecording || isStarting) return;
 	vadStarting = true;
 
 	console.debug("[voice] VAD starting");
@@ -870,6 +870,21 @@ function onVadClick(e: Event): void {
 	}
 }
 
+function onMicKeydown(e: KeyboardEvent): void {
+	if (e.key === " " || e.key === "Enter") {
+		e.preventDefault();
+		onMicClick(e);
+	}
+}
+
+function onEscapeKeydown(e: KeyboardEvent): void {
+	if (e.key === "Escape" && isRecording) {
+		e.preventDefault();
+		cancelRecording();
+		if (vadActive) stopVad();
+	}
+}
+
 // ── Init / teardown ──────────────────────────────────────────
 
 /** Initialize voice input with the mic button element. */
@@ -881,20 +896,8 @@ export function initVoiceInput(btn: HTMLButtonElement | null): void {
 
 	micBtn.addEventListener("click", onMicClick);
 
-	micBtn.addEventListener("keydown", (e: KeyboardEvent): void => {
-		if (e.key === " " || e.key === "Enter") {
-			e.preventDefault();
-			onMicClick(e);
-		}
-	});
-
-	document.addEventListener("keydown", (e: KeyboardEvent): void => {
-		if (e.key === "Escape" && isRecording) {
-			e.preventDefault();
-			cancelRecording();
-			if (vadActive) stopVad();
-		}
-	});
+	micBtn.addEventListener("keydown", onMicKeydown);
+	document.addEventListener("keydown", onEscapeKeydown);
 
 	// PTT: global key handlers
 	document.addEventListener("keydown", onPttKeyDown);
@@ -917,8 +920,10 @@ export function teardownVoiceInput(): void {
 	if (isRecording && mediaRecorder) {
 		mediaRecorder.stop();
 	}
+	document.removeEventListener("keydown", onEscapeKeydown);
 	document.removeEventListener("keydown", onPttKeyDown);
 	document.removeEventListener("keyup", onPttKeyUp);
+	micBtn?.removeEventListener("keydown", onMicKeydown);
 	window.removeEventListener("voice-config-changed", checkSttStatus);
 	releaseVoiceLock();
 	micBtn = null;

--- a/crates/web/ui/src/voice-input.ts
+++ b/crates/web/ui/src/voice-input.ts
@@ -79,6 +79,7 @@ let vadRecordingStart = 0;
 let vadMediaRecorder: MediaRecorder | null = null;
 let vadTranscribing = false;
 let vadReacquiring = false;
+let vadStarting = false;
 let vadSourceNode: MediaStreamAudioSourceNode | null = null;
 
 // VAD monitor loop mutable state (avoids static properties on function)
@@ -521,7 +522,8 @@ function onPttKeyUp(e: KeyboardEvent): void {
 // ── VAD (voice activity detection) ───────────────────────────
 
 async function startVad(): Promise<void> {
-	if (vadActive) return;
+	if (vadActive || vadStarting) return;
+	vadStarting = true;
 
 	console.debug("[voice] VAD starting");
 	try {
@@ -529,6 +531,7 @@ async function startVad(): Promise<void> {
 			audio: { echoCancellation: true, noiseSuppression: true, autoGainControl: true },
 		});
 	} catch (err) {
+		vadStarting = false;
 		console.error("[voice] VAD mic access failed:", err);
 		if ((err as DOMException).name === "NotAllowedError") {
 			alert(t("settings:voice.micDenied"));
@@ -536,6 +539,7 @@ async function startVad(): Promise<void> {
 		return;
 	}
 
+	vadStarting = false;
 	vadActive = true;
 	vadSpeechDetected = false;
 	vadSilenceStart = 0;

--- a/crates/web/ui/src/voice-input.ts
+++ b/crates/web/ui/src/voice-input.ts
@@ -1,5 +1,11 @@
 // ── Voice input module ───────────────────────────────────────
 // Handles microphone recording and speech-to-text transcription.
+// Supports three input modes:
+//   1. Toggle (default): click mic to start, click again to stop & send
+//   2. Push-to-talk (PTT): hold a hotkey to record, release to send
+//   3. VAD (continuous): click waveform button to enter hands-free mode;
+//      auto-detects speech via energy-based VAD, auto-sends on silence,
+//      auto-re-listens after TTS playback finishes.
 
 import { chatAddMsg, smartScrollToBottom } from "./chat-ui";
 import * as gon from "./gon";
@@ -7,8 +13,11 @@ import { renderAudioPlayer, renderMarkdown, sendRpc, warmAudioPlayback } from ".
 import { t } from "./i18n";
 import { bumpSessionCount, seedSessionPreviewFromUserText, setSessionReplying } from "./sessions";
 import * as S from "./state";
+import { sessionStore } from "./stores/session-store";
 
+// ── Shared state ─────────────────────────────────────────────
 let micBtn: HTMLButtonElement | null = null;
+let vadBtn: HTMLButtonElement | null = null;
 let mediaRecorder: MediaRecorder | null = null;
 let audioChunks: Blob[] = [];
 let sttConfigured = false;
@@ -16,17 +25,74 @@ let isRecording = false;
 let isStarting = false;
 let transcribingEl: HTMLElement | null = null;
 
+// ── PTT state ────────────────────────────────────────────────
+let pttKey = localStorage.getItem("moltis_ptt_key") || "F13";
+let pttActive = false;
+
+// ── Tab coordination (prevent dual-tab recording) ────────────
+const voiceLockChannel = typeof BroadcastChannel !== "undefined" ? new BroadcastChannel("moltis_voice_lock") : null;
+let voiceLockedByOtherTab = false;
+if (voiceLockChannel) {
+	voiceLockChannel.onmessage = (e: MessageEvent): void => {
+		if (e.data?.type === "voice_lock") {
+			voiceLockedByOtherTab = true;
+			console.debug("[voice] another tab claimed voice lock");
+		} else if (e.data?.type === "voice_unlock") {
+			voiceLockedByOtherTab = false;
+			console.debug("[voice] another tab released voice lock");
+		}
+	};
+}
+function claimVoiceLock(): void {
+	voiceLockedByOtherTab = false;
+	voiceLockChannel?.postMessage({ type: "voice_lock" });
+}
+function releaseVoiceLock(): void {
+	voiceLockChannel?.postMessage({ type: "voice_unlock" });
+}
+
+// ── VAD state ────────────────────────────────────────────────
+let vadActive = false;
+let vadStream: MediaStream | null = null;
+let vadAudioCtx: AudioContext | null = null;
+let vadAnalyser: AnalyserNode | null = null;
+let vadDataArray: Uint8Array<ArrayBuffer> | null = null;
+let vadRafId: number | null = null;
+let vadSpeechDetected = false;
+let vadSilenceStart = 0;
+let vadMutedForTts = false;
+let vadSensitivity = parseInt(localStorage.getItem("moltis_vad_sensitivity") || "50", 10);
+let vadSpeechThreshold = sensitivityToThreshold(vadSensitivity);
+
+/** Map sensitivity percentage (0-100) to RMS threshold.
+ *  0% = least sensitive (threshold 0.08), 100% = most sensitive (threshold 0.005). */
+function sensitivityToThreshold(pct: number): number {
+	const clamped = Math.max(0, Math.min(100, pct));
+	return 0.08 * (0.005 / 0.08) ** (clamped / 100);
+}
+
+const VAD_SILENCE_DURATION = 2500;
+const VAD_DEBOUNCE_SPEECH = 250;
+let vadSpeechStart = 0;
+let vadRecordingStart = 0;
+let vadMediaRecorder: MediaRecorder | null = null;
+let vadTranscribing = false;
+
+// VAD monitor loop mutable state (avoids static properties on function)
+let vadMonitorMuteStart = 0;
+let vadMonitorLastLog = 0;
+
 /** Check if voice feature is enabled. */
 function isVoiceEnabled(): boolean {
 	return gon.get("voice_enabled") === true;
 }
 
-/** Check if STT is available and enable/disable mic button. */
+/** Check if STT is available and enable/disable buttons. */
 async function checkSttStatus(): Promise<void> {
-	// If voice feature is disabled, always hide the button
 	if (!isVoiceEnabled()) {
 		sttConfigured = false;
 		updateMicButton();
+		updateVadButton();
 		return;
 	}
 	const res = await sendRpc<{ configured?: boolean }>("stt.status", {});
@@ -36,19 +102,29 @@ async function checkSttStatus(): Promise<void> {
 		sttConfigured = false;
 	}
 	updateMicButton();
+	updateVadButton();
 }
 
-/** Update mic button visibility based on STT configuration. */
+// ── Mic button (toggle mode) ─────────────────────────────────
+
 function updateMicButton(): void {
 	if (!micBtn) return;
-	// Hide button when voice feature is disabled or STT is not configured
 	micBtn.style.display = sttConfigured && isVoiceEnabled() ? "" : "none";
-	// Disable only when not connected (button is only visible when STT configured)
 	micBtn.disabled = !S.connected;
 	micBtn.title = isStarting ? t("chat:micStarting") : isRecording ? t("chat:micStopAndSend") : t("chat:micTooltip");
 }
 
-/** Pause all currently playing audio elements on the page. */
+// ── VAD button ───────────────────────────────────────────────
+
+function updateVadButton(): void {
+	if (!vadBtn) return;
+	vadBtn.style.display = sttConfigured && isVoiceEnabled() ? "" : "none";
+	vadBtn.disabled = !S.connected;
+	vadBtn.title = vadActive ? t("chat:vadStopTooltip") : t("chat:vadTooltip");
+}
+
+// ── Audio helpers ────────────────────────────────────────────
+
 function stopAllAudio(): void {
 	for (const audio of document.querySelectorAll("audio")) {
 		if (!audio.paused) {
@@ -58,35 +134,62 @@ function stopAllAudio(): void {
 	}
 }
 
-/** Start recording audio from the microphone. */
-async function startRecording(): Promise<void> {
+function getRMS(analyser: AnalyserNode, dataArray: Uint8Array<ArrayBuffer>): number {
+	analyser.getByteTimeDomainData(dataArray);
+	let sum = 0;
+	for (const sample of dataArray) {
+		const val = (sample - 128) / 128;
+		sum += val * val;
+	}
+	return Math.sqrt(sum / dataArray.length);
+}
+
+// ── Recording (shared by toggle + PTT + VAD) ─────────────────
+
+interface StartRecordingOpts {
+	fromVad?: boolean;
+	stream?: MediaStream | null;
+}
+
+async function startRecording(opts?: StartRecordingOpts): Promise<void> {
 	if (isRecording || isStarting || !sttConfigured) return;
 
-	// Stop any playing audio so the mic doesn't pick up speaker output.
-	stopAllAudio();
+	const fromVad = opts?.fromVad === true;
+	let stream = opts?.stream ?? null;
+
+	if (!fromVad) stopAllAudio();
 
 	isStarting = true;
-	micBtn?.classList.add("starting");
-	micBtn?.setAttribute("aria-busy", "true");
-	micBtn!.title = t("chat:micStarting");
+	if (micBtn && !fromVad) {
+		micBtn.classList.add("starting");
+		micBtn.setAttribute("aria-busy", "true");
+		micBtn.title = t("chat:micStarting");
+	}
 
 	try {
-		const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+		if (!stream) {
+			stream = await navigator.mediaDevices.getUserMedia({
+				audio: { echoCancellation: true, noiseSuppression: true, autoGainControl: true },
+			});
+		}
 		audioChunks = [];
 		let recordingUiShown = false;
 
 		function showRecordingUi(): void {
-			if (recordingUiShown || !micBtn) return;
+			if (recordingUiShown) return;
 			recordingUiShown = true;
 			isStarting = false;
-			micBtn.classList.remove("starting");
-			micBtn.removeAttribute("aria-busy");
-			micBtn.classList.add("recording");
-			micBtn.setAttribute("aria-pressed", "true");
-			micBtn.title = t("chat:micStopAndSend");
+			if (fromVad) {
+				vadBtn?.classList.add("vad-speech");
+			} else if (micBtn) {
+				micBtn.classList.remove("starting");
+				micBtn.removeAttribute("aria-busy");
+				micBtn.classList.add("recording");
+				micBtn.setAttribute("aria-pressed", "true");
+				micBtn.title = t("chat:micStopAndSend");
+			}
 		}
 
-		// Use webm/opus if available, fall back to audio/webm
 		const mimeType = MediaRecorder.isTypeSupported("audio/webm;codecs=opus") ? "audio/webm;codecs=opus" : "audio/webm";
 
 		mediaRecorder = new MediaRecorder(stream, { mimeType });
@@ -98,7 +201,6 @@ async function startRecording(): Promise<void> {
 			}
 		};
 
-		// Recorder start means stop is now valid; visual indicator waits for actual audio data.
 		mediaRecorder.onstart = (): void => {
 			isRecording = true;
 		};
@@ -111,10 +213,12 @@ async function startRecording(): Promise<void> {
 		}
 
 		mediaRecorder.onstop = async (): Promise<void> => {
-			// Stop all tracks to release the microphone
-			for (const track of stream.getTracks()) {
-				track.stop();
+			if (!fromVad) {
+				for (const track of stream!.getTracks()) {
+					track.stop();
+				}
 			}
+			if (fromVad) vadBtn?.classList.remove("vad-speech");
 			await transcribeAudio();
 		};
 
@@ -122,14 +226,13 @@ async function startRecording(): Promise<void> {
 	} catch (err) {
 		isStarting = false;
 		isRecording = false;
-		if (micBtn) {
+		if (micBtn && !fromVad) {
 			micBtn.classList.remove("starting");
 			micBtn.removeAttribute("aria-busy");
 			micBtn.setAttribute("aria-pressed", "false");
 			micBtn.title = t("chat:micTooltip");
 		}
 		console.error("Failed to start recording:", err);
-		// Show user-friendly error
 		if ((err as DOMException).name === "NotAllowedError") {
 			alert(t("settings:voice.micDenied"));
 		} else if ((err as DOMException).name === "NotFoundError") {
@@ -138,44 +241,41 @@ async function startRecording(): Promise<void> {
 	}
 }
 
-/** Stop recording and trigger transcription. */
 function stopRecording(): void {
 	if (!(isRecording && mediaRecorder)) return;
 
 	isStarting = false;
 	isRecording = false;
-	micBtn?.classList.remove("starting");
-	micBtn?.removeAttribute("aria-busy");
-	micBtn?.classList.remove("recording");
-	micBtn?.setAttribute("aria-pressed", "false");
-	micBtn?.classList.add("transcribing");
-	micBtn!.title = t("chat:voiceTranscribing");
-
-	// Stop the recorder, which triggers onstop -> transcribeAudio
+	if (micBtn) {
+		micBtn.classList.remove("starting");
+		micBtn.removeAttribute("aria-busy");
+		micBtn.classList.remove("recording");
+		micBtn.setAttribute("aria-pressed", "false");
+		micBtn.classList.add("transcribing");
+		micBtn.title = t("chat:voiceTranscribing");
+	}
 	mediaRecorder.stop();
 }
 
-/** Cancel recording without sending -- discards audio chunks. */
 function cancelRecording(): void {
 	if (!(isRecording && mediaRecorder)) return;
 
 	console.debug("[voice] recording cancelled via Escape");
-
-	// Prevent onstop from transcribing by clearing chunks first.
 	audioChunks = [];
-
 	isStarting = false;
 	isRecording = false;
-	micBtn?.classList.remove("starting", "recording");
-	micBtn?.removeAttribute("aria-busy");
-	micBtn?.setAttribute("aria-pressed", "false");
-	micBtn!.title = t("chat:micTooltip");
-
-	// Stop the recorder -- onstop will see empty chunks and bail out.
+	if (micBtn) {
+		micBtn.classList.remove("starting", "recording");
+		micBtn.removeAttribute("aria-busy");
+		micBtn.setAttribute("aria-pressed", "false");
+		micBtn.title = t("chat:micTooltip");
+	}
+	vadBtn?.classList.remove("vad-speech");
 	mediaRecorder.stop();
 }
 
-/** Create transcribing indicator element. */
+// ── Transcription UI helpers ─────────────────────────────────
+
 function createTranscribingIndicator(message: string, isError: boolean): HTMLElement {
 	const el = document.createElement("div");
 	el.className = "msg voice-transcribing";
@@ -193,7 +293,6 @@ function createTranscribingIndicator(message: string, isError: boolean): HTMLEle
 	return el;
 }
 
-/** Update transcribing element with a message. */
 function updateTranscribingMessage(message: string, isError: boolean): void {
 	if (!transcribingEl) return;
 	transcribingEl.textContent = "";
@@ -204,7 +303,6 @@ function updateTranscribingMessage(message: string, isError: boolean): void {
 	transcribingEl.appendChild(text);
 }
 
-/** Show a temporary message then remove the transcribing element. */
 function showTemporaryMessage(message: string, isError: boolean, delayMs: number): void {
 	updateTranscribingMessage(message, isError);
 	setTimeout(() => {
@@ -215,26 +313,23 @@ function showTemporaryMessage(message: string, isError: boolean, delayMs: number
 	}, delayMs);
 }
 
-/** Remove transcribing indicator and reset mic button state. */
 function cleanupTranscribingState(): void {
 	isStarting = false;
 	micBtn?.classList.remove("starting");
 	micBtn?.removeAttribute("aria-busy");
 	micBtn?.classList.remove("transcribing");
-	micBtn!.title = t("chat:micTooltip");
+	if (micBtn) micBtn.title = t("chat:micTooltip");
 	if (transcribingEl) {
 		transcribingEl.remove();
 		transcribingEl = null;
 	}
 }
 
-/** Send transcribed text as a chat message. */
+// ── Send transcribed message ─────────────────────────────────
+
 function sendTranscribedMessage(text: string, audioFilename: string | null): void {
-	// Unlock audio playback while we still have user-gesture context.
 	warmAudioPlayback();
 
-	// Add user message to chat (like sendChat does), including the recorded
-	// audio player when we have a saved filename from the upload endpoint.
 	if (audioFilename) {
 		const userEl = chatAddMsg("user", "", true);
 		if (userEl) {
@@ -243,8 +338,6 @@ function sendTranscribedMessage(text: string, audioFilename: string | null): voi
 			if (text) {
 				const textWrap = document.createElement("div");
 				textWrap.className = "mt-2";
-				// Safe: renderMarkdown escapes untrusted content before formatting tags.
-				textWrap.textContent = "";
 				const rendered = renderMarkdown(text);
 				const fragment = document.createRange().createContextualFragment(rendered);
 				textWrap.appendChild(fragment);
@@ -255,18 +348,14 @@ function sendTranscribedMessage(text: string, audioFilename: string | null): voi
 		chatAddMsg("user", renderMarkdown(text), true);
 	}
 
-	// Send the message
 	const chatParams: { text: string; _input_medium: string; _audio_filename?: string; model?: string } = {
-		text: text,
+		text,
 		_input_medium: "voice",
 	};
-	if (audioFilename) {
-		chatParams._audio_filename = audioFilename;
-	}
+	if (audioFilename) chatParams._audio_filename = audioFilename;
 	const selectedModel = S.selectedModelId;
-	if (selectedModel) {
-		chatParams.model = selectedModel;
-	}
+	if (selectedModel) chatParams.model = selectedModel;
+
 	bumpSessionCount(S.activeSessionKey, 1);
 	seedSessionPreviewFromUserText(S.activeSessionKey, text);
 	setSessionReplying(S.activeSessionKey, true);
@@ -277,14 +366,22 @@ function sendTranscribedMessage(text: string, audioFilename: string | null): voi
 	});
 }
 
-/** Send recorded audio to STT service for transcription via upload endpoint. */
+// ── Transcription ────────────────────────────────────────────
+
+interface TranscriptionUploadResponse {
+	ok?: boolean;
+	transcription?: { text?: string };
+	filename?: string;
+	transcriptionError?: string;
+	error?: string;
+}
+
 async function transcribeAudio(): Promise<void> {
 	if (audioChunks.length === 0) {
 		cleanupTranscribingState();
 		return;
 	}
 
-	// Show transcribing indicator in chat immediately
 	if (S.chatMsgBox) {
 		transcribingEl = createTranscribingIndicator(t("chat:voiceTranscribingMessage"), false);
 		(S.chatMsgBox as HTMLElement).appendChild(transcribingEl);
@@ -295,23 +392,34 @@ async function transcribeAudio(): Promise<void> {
 		const blob = new Blob(audioChunks, { type: "audio/webm" });
 		audioChunks = [];
 
+		// Skip tiny blobs that are just WebM headers with no real audio
+		if (blob.size < 2000) {
+			console.debug("[voice] skipping tiny blob:", blob.size, "bytes");
+			cleanupTranscribingState();
+			return;
+		}
+
+		// Validate EBML header (WebM magic bytes: 1A 45 DF A3)
+		const headerBytes = new Uint8Array(await blob.slice(0, 4).arrayBuffer());
+		if (headerBytes[0] !== 0x1a || headerBytes[1] !== 0x45 || headerBytes[2] !== 0xdf || headerBytes[3] !== 0xa3) {
+			console.warn("[voice] corrupt WebM blob (bad EBML header), discarding. size:", blob.size);
+			cleanupTranscribingState();
+			return;
+		}
+
+		const abortCtrl = new AbortController();
+		const fetchTimeout = setTimeout(() => abortCtrl.abort(), 15000);
 		const resp = await fetch(`/api/sessions/${encodeURIComponent(S.activeSessionKey)}/upload?transcribe=true`, {
 			method: "POST",
 			headers: { "Content-Type": blob.type || "audio/webm" },
 			body: blob,
+			signal: abortCtrl.signal,
 		});
-		interface TranscriptionUploadResponse {
-			ok?: boolean;
-			transcription?: { text?: string };
-			filename?: string;
-			transcriptionError?: string;
-			error?: string;
-		}
-
+		clearTimeout(fetchTimeout);
 		const res: TranscriptionUploadResponse = await resp.json();
 
 		micBtn?.classList.remove("transcribing");
-		micBtn!.title = t("chat:micTooltip");
+		if (micBtn) micBtn.title = t("chat:micTooltip");
 
 		if (res.ok && res.transcription?.text) {
 			const text = String(res.transcription.text).trim();
@@ -332,34 +440,413 @@ async function transcribeAudio(): Promise<void> {
 	} catch (err) {
 		console.error("Transcription error:", err);
 		micBtn?.classList.remove("transcribing");
-		micBtn!.title = t("chat:micTooltip");
+		if (micBtn) micBtn.title = t("chat:micTooltip");
 		showTemporaryMessage("Transcription error", true, 4000);
 	}
 }
 
-/** Handle click on mic button - toggle recording. */
+// ── Toggle mode (mic button click) ───────────────────────────
+
 function onMicClick(e: Event): void {
 	e.preventDefault();
+	if (vadActive) return;
 	if (isRecording) {
+		releaseVoiceLock();
 		stopRecording();
 	} else {
+		if (voiceLockedByOtherTab) return;
+		claimVoiceLock();
 		startRecording();
 	}
 }
+
+// ── PTT (push-to-talk via hotkey) ────────────────────────────
+
+function onPttKeyDown(e: KeyboardEvent): void {
+	if (e.key !== pttKey) return;
+	if (vadActive || pttActive || isRecording) return;
+	const isFunctionKey = /^F\d{1,2}$/.test(e.key);
+	if (!isFunctionKey) {
+		const tag = document.activeElement?.tagName;
+		if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") return;
+	}
+	e.preventDefault();
+	if (voiceLockedByOtherTab) return;
+	pttActive = true;
+	claimVoiceLock();
+	console.debug("[voice] PTT start:", pttKey);
+	stopAllAudio();
+	startRecording();
+}
+
+function onPttKeyUp(e: KeyboardEvent): void {
+	if (e.key !== pttKey) return;
+	if (!pttActive) return;
+	e.preventDefault();
+	pttActive = false;
+	releaseVoiceLock();
+	console.debug("[voice] PTT release — sending");
+	stopRecording();
+}
+
+// ── VAD (voice activity detection) ───────────────────────────
+
+async function startVad(): Promise<void> {
+	if (vadActive) return;
+
+	console.debug("[voice] VAD starting");
+	try {
+		vadStream = await navigator.mediaDevices.getUserMedia({
+			audio: { echoCancellation: true, noiseSuppression: true, autoGainControl: true },
+		});
+	} catch (err) {
+		console.error("[voice] VAD mic access failed:", err);
+		if ((err as DOMException).name === "NotAllowedError") {
+			alert(t("settings:voice.micDenied"));
+		}
+		return;
+	}
+
+	vadActive = true;
+	vadSpeechDetected = false;
+	vadSilenceStart = 0;
+	vadSpeechStart = 0;
+	vadMutedForTts = false;
+	claimVoiceLock();
+
+	if (vadBtn) {
+		vadBtn.classList.add("vad-active");
+		vadBtn.title = t("chat:vadStopTooltip");
+	}
+
+	vadAudioCtx = new AudioContext();
+	const source = vadAudioCtx.createMediaStreamSource(vadStream);
+	vadAnalyser = vadAudioCtx.createAnalyser();
+	vadAnalyser.fftSize = 512;
+	vadAnalyser.smoothingTimeConstant = 0.3;
+	source.connect(vadAnalyser);
+	vadDataArray = new Uint8Array(vadAnalyser.fftSize);
+
+	vadStartContinuousRecorder();
+	vadMonitorLoop();
+
+	document.addEventListener("play", onTtsPlay, true);
+	document.addEventListener("ended", onTtsEnded, true);
+	document.addEventListener("pause", onTtsPause, true);
+}
+
+function vadStartContinuousRecorder(): void {
+	if (!(vadActive && vadStream)) return;
+	if (vadTranscribing) return;
+	audioChunks = [];
+	const mimeType = MediaRecorder.isTypeSupported("audio/webm;codecs=opus") ? "audio/webm;codecs=opus" : "audio/webm";
+	vadMediaRecorder = new MediaRecorder(vadStream, { mimeType });
+	vadMediaRecorder.ondataavailable = (e: BlobEvent): void => {
+		if (e.data.size > 0) audioChunks.push(e.data);
+	};
+	vadMediaRecorder.onstop = async (): Promise<void> => {
+		vadBtn?.classList.remove("vad-speech");
+		if (audioChunks.length > 0 && vadSpeechDetected) {
+			vadSpeechDetected = false;
+			vadTranscribing = true;
+			try {
+				await transcribeAudio();
+			} finally {
+				vadTranscribing = false;
+			}
+		} else {
+			audioChunks = [];
+			vadSpeechDetected = false;
+		}
+		if (vadActive && !vadMutedForTts) {
+			vadStartContinuousRecorder();
+		}
+	};
+	vadMediaRecorder.start(250);
+	console.debug("[voice] VAD continuous recorder started");
+}
+
+async function vadReacquireStream(): Promise<void> {
+	try {
+		const newStream = await navigator.mediaDevices.getUserMedia({
+			audio: { echoCancellation: true, noiseSuppression: true, autoGainControl: true },
+		});
+		vadStream = newStream;
+		if (vadAudioCtx && vadAnalyser) {
+			const source = vadAudioCtx.createMediaStreamSource(newStream);
+			source.connect(vadAnalyser);
+		}
+		if (vadMediaRecorder && vadMediaRecorder.state === "recording") {
+			vadMediaRecorder.stop();
+		} else {
+			vadStartContinuousRecorder();
+		}
+		console.debug("[voice] VAD: stream reacquired successfully");
+	} catch (err) {
+		console.error("[voice] VAD: failed to reacquire stream:", err);
+		stopVad();
+	}
+}
+
+function stopVad(): void {
+	if (!vadActive) return;
+	console.debug("[voice] VAD stopping");
+
+	vadActive = false;
+	vadSpeechDetected = false;
+	vadTranscribing = false;
+
+	if (vadMediaRecorder && vadMediaRecorder.state !== "inactive") {
+		audioChunks = [];
+		vadMediaRecorder.stop();
+	}
+	vadMediaRecorder = null;
+
+	if (isRecording && mediaRecorder) {
+		audioChunks = [];
+		isRecording = false;
+		mediaRecorder.stop();
+	}
+
+	if (vadRafId) {
+		cancelAnimationFrame(vadRafId);
+		vadRafId = null;
+	}
+
+	if (vadAudioCtx) {
+		vadAudioCtx.close().catch(() => {});
+		vadAudioCtx = null;
+		vadAnalyser = null;
+		vadDataArray = null;
+	}
+
+	if (vadStream) {
+		for (const track of vadStream.getTracks()) track.stop();
+		vadStream = null;
+	}
+
+	if (vadBtn) {
+		vadBtn.classList.remove("vad-active", "vad-speech", "vad-listening");
+		vadBtn.title = t("chat:vadTooltip");
+	}
+
+	releaseVoiceLock();
+
+	document.removeEventListener("play", onTtsPlay, true);
+	document.removeEventListener("ended", onTtsEnded, true);
+	document.removeEventListener("pause", onTtsPause, true);
+}
+
+function vadMonitorLoop(): void {
+	if (!(vadActive && vadAnalyser && vadDataArray)) return;
+
+	// Health check: resume AudioContext if browser suspended it
+	if (vadAudioCtx && vadAudioCtx.state === "suspended") {
+		console.debug("[voice] VAD: AudioContext suspended, resuming");
+		vadAudioCtx.resume();
+	}
+
+	// Health check: if the mic stream track ended, reacquire it
+	if (vadStream) {
+		const track = vadStream.getAudioTracks()[0];
+		if (!track || track.readyState !== "live") {
+			console.warn("[voice] VAD: mic track died, reacquiring");
+			vadReacquireStream();
+			vadRafId = requestAnimationFrame(vadMonitorLoop);
+			return;
+		}
+	}
+
+	// Skip monitoring while TTS is playing or while transcribing
+	if (vadMutedForTts || micBtn?.classList.contains("transcribing")) {
+		if (vadMutedForTts && !vadMonitorMuteStart) {
+			vadMonitorMuteStart = Date.now();
+		} else if (vadMutedForTts && Date.now() - vadMonitorMuteStart > 10000) {
+			console.debug("[voice] VAD: TTS mute timeout, force-resuming");
+			vadMutedForTts = false;
+			vadMonitorMuteStart = 0;
+			vadSpeechDetected = false;
+			vadStartContinuousRecorder();
+			vadBtn?.classList.add("vad-listening");
+		}
+		vadRafId = requestAnimationFrame(vadMonitorLoop);
+		return;
+	}
+	vadMonitorMuteStart = 0;
+
+	// Skip if the session is still replying (waiting for AI response)
+	const activeSession = sessionStore.getByKey(S.activeSessionKey);
+	if (activeSession?.replying.value) {
+		vadRafId = requestAnimationFrame(vadMonitorLoop);
+		return;
+	}
+
+	// Show listening state when recorder is running
+	if (
+		vadMediaRecorder &&
+		vadMediaRecorder.state === "recording" &&
+		vadBtn &&
+		!vadBtn.classList.contains("vad-listening") &&
+		!vadBtn.classList.contains("vad-speech")
+	) {
+		vadBtn.classList.add("vad-listening");
+	}
+
+	// Restart recorder if it died
+	if (!vadTranscribing && (!vadMediaRecorder || vadMediaRecorder.state === "inactive")) {
+		vadStartContinuousRecorder();
+	}
+
+	const rms = getRMS(vadAnalyser, vadDataArray);
+	const now = Date.now();
+
+	if (!vadMonitorLastLog || now - vadMonitorLastLog > 1000) {
+		vadMonitorLastLog = now;
+		console.debug(
+			"[voice] VAD rms:",
+			rms.toFixed(4),
+			"speech:",
+			vadSpeechDetected,
+			"muted:",
+			vadMutedForTts,
+			"transcribing:",
+			vadTranscribing,
+			"ctx:",
+			vadAudioCtx?.state,
+		);
+	}
+
+	if (rms > vadSpeechThreshold) {
+		vadSilenceStart = 0;
+
+		// Safety valve: auto-stop after 30s of continuous speech
+		if (vadSpeechDetected && vadRecordingStart && now - vadRecordingStart > 30000) {
+			console.debug("[voice] VAD: max duration reached, auto-sending");
+			vadSilenceStart = 0;
+			vadRecordingStart = 0;
+			vadBtn?.classList.remove("vad-speech", "vad-listening");
+			if (vadMediaRecorder && vadMediaRecorder.state === "recording") {
+				vadMediaRecorder.stop();
+			}
+			vadRafId = requestAnimationFrame(vadMonitorLoop);
+			return;
+		}
+
+		if (!vadSpeechDetected) {
+			if (!vadSpeechStart) {
+				vadSpeechStart = now;
+			} else if (now - vadSpeechStart >= VAD_DEBOUNCE_SPEECH) {
+				vadSpeechDetected = true;
+				vadSpeechStart = 0;
+				vadRecordingStart = now;
+				console.debug("[voice] VAD: speech detected (recorder already running)");
+				stopAllAudio();
+				vadBtn?.classList.add("vad-speech");
+			}
+		}
+	} else {
+		vadSpeechStart = 0;
+
+		if (vadSpeechDetected) {
+			if (!vadSilenceStart) {
+				vadSilenceStart = now;
+			} else if (now - vadSilenceStart >= VAD_SILENCE_DURATION) {
+				console.debug("[voice] VAD: silence detected, stopping & sending");
+				vadRecordingStart = 0;
+				vadSilenceStart = 0;
+				vadBtn?.classList.remove("vad-speech", "vad-listening");
+				if (vadMediaRecorder && vadMediaRecorder.state === "recording") {
+					vadMediaRecorder.stop();
+				} else {
+					vadSpeechDetected = false;
+					audioChunks = [];
+				}
+			}
+		}
+	}
+
+	vadRafId = requestAnimationFrame(vadMonitorLoop);
+}
+
+// ── TTS mute/unmute for VAD ──────────────────────────────────
+
+function isAnyAudioPlaying(): boolean {
+	return Array.from(document.querySelectorAll("audio")).some((a) => !(a.paused || a.ended));
+}
+
+function onTtsPlay(e: Event): void {
+	if (!vadActive) return;
+	if ((e.target as HTMLElement)?.tagName !== "AUDIO") return;
+	console.debug("[voice] VAD: TTS playing, muting VAD + stopping recorder");
+	vadMutedForTts = true;
+	vadBtn?.classList.remove("vad-listening", "vad-speech");
+	if (vadMediaRecorder && vadMediaRecorder.state === "recording") {
+		vadSpeechDetected = false;
+		audioChunks = [];
+		vadMediaRecorder.stop();
+		vadMediaRecorder = null;
+	}
+}
+
+function resumeVadAfterTts(): void {
+	vadSpeechDetected = false;
+	vadSilenceStart = 0;
+	vadSpeechStart = 0;
+	setTimeout(() => {
+		if (!vadActive) return;
+		if (isAnyAudioPlaying()) {
+			console.debug("[voice] VAD: another audio still playing, staying muted");
+			return;
+		}
+		vadMutedForTts = false;
+		if (!vadTranscribing) {
+			vadStartContinuousRecorder();
+			vadBtn?.classList.add("vad-listening");
+		}
+	}, 400);
+}
+
+function onTtsEnded(e: Event): void {
+	if (!vadActive) return;
+	if ((e.target as HTMLElement)?.tagName !== "AUDIO") return;
+	console.debug("[voice] VAD: TTS ended, resuming VAD after delay");
+	resumeVadAfterTts();
+}
+
+function onTtsPause(e: Event): void {
+	if (!vadActive) return;
+	if ((e.target as HTMLElement)?.tagName !== "AUDIO") return;
+	const audio = e.target as HTMLAudioElement;
+	if (audio.ended || (audio.duration && audio.currentTime >= audio.duration - 0.1)) {
+		console.debug("[voice] VAD: TTS paused at end, treating as ended");
+		resumeVadAfterTts();
+	} else if (!isAnyAudioPlaying()) {
+		vadMutedForTts = false;
+	}
+}
+
+// ── VAD button click ─────────────────────────────────────────
+
+function onVadClick(e: Event): void {
+	e.preventDefault();
+	if (vadActive) {
+		stopVad();
+	} else {
+		startVad();
+	}
+}
+
+// ── Init / teardown ──────────────────────────────────────────
 
 /** Initialize voice input with the mic button element. */
 export function initVoiceInput(btn: HTMLButtonElement | null): void {
 	if (!btn) return;
 
 	micBtn = btn;
-
-	// Check STT status on init
 	checkSttStatus();
 
-	// Click to toggle recording (start on first click, stop on second)
 	micBtn.addEventListener("click", onMicClick);
 
-	// Keyboard accessibility: Space/Enter to toggle
 	micBtn.addEventListener("keydown", (e: KeyboardEvent): void => {
 		if (e.key === " " || e.key === "Enter") {
 			e.preventDefault();
@@ -367,26 +854,44 @@ export function initVoiceInput(btn: HTMLButtonElement | null): void {
 		}
 	});
 
-	// Escape cancels recording without sending.
 	document.addEventListener("keydown", (e: KeyboardEvent): void => {
 		if (e.key === "Escape" && isRecording) {
 			e.preventDefault();
 			cancelRecording();
+			if (vadActive) stopVad();
 		}
 	});
 
-	// Re-check STT status when voice config changes
+	// PTT: global key handlers
+	document.addEventListener("keydown", onPttKeyDown);
+	document.addEventListener("keyup", onPttKeyUp);
+
 	window.addEventListener("voice-config-changed", checkSttStatus);
+}
+
+/** Initialize VAD (conversation mode) button. */
+export function initVadButton(btn: HTMLButtonElement | null): void {
+	if (!btn) return;
+	vadBtn = btn;
+	updateVadButton();
+	vadBtn.addEventListener("click", onVadClick);
 }
 
 /** Teardown voice input module. */
 export function teardownVoiceInput(): void {
+	if (vadActive) stopVad();
 	if (isRecording && mediaRecorder) {
 		mediaRecorder.stop();
 	}
+	document.removeEventListener("keydown", onPttKeyDown);
+	document.removeEventListener("keyup", onPttKeyUp);
 	window.removeEventListener("voice-config-changed", checkSttStatus);
+	releaseVoiceLock();
 	micBtn = null;
+	vadBtn = null;
 	mediaRecorder = null;
+	vadMediaRecorder = null;
+	vadTranscribing = false;
 	audioChunks = [];
 	isRecording = false;
 }
@@ -394,4 +899,34 @@ export function teardownVoiceInput(): void {
 /** Re-check STT status (can be called externally). */
 export function refreshVoiceStatus(): void {
 	checkSttStatus();
+}
+
+/** Update PTT key at runtime. */
+export function setPttKey(key: string): void {
+	pttKey = key;
+	localStorage.setItem("moltis_ptt_key", key);
+	console.debug("[voice] PTT key set to:", key);
+}
+
+/** Get current PTT key. */
+export function getPttKey(): string {
+	return pttKey;
+}
+
+/** Check if VAD is currently active. */
+export function isVadModeActive(): boolean {
+	return vadActive;
+}
+
+/** Update VAD sensitivity at runtime (0-100). */
+export function setVadSensitivity(pct: number): void {
+	vadSensitivity = Math.max(0, Math.min(100, pct));
+	vadSpeechThreshold = sensitivityToThreshold(vadSensitivity);
+	localStorage.setItem("moltis_vad_sensitivity", String(vadSensitivity));
+	console.debug("[voice] VAD sensitivity set to:", vadSensitivity, "threshold:", vadSpeechThreshold.toFixed(4));
+}
+
+/** Get current VAD sensitivity (0-100). */
+export function getVadSensitivity(): number {
+	return vadSensitivity;
 }


### PR DESCRIPTION
Add two new voice input modes alongside the existing toggle:

## Push-to-Talk (PTT)
- Configurable hotkey (default F13, stored in localStorage)
- Hold to record, release to send
- Function keys work even when focused in text inputs
- BroadcastChannel tab coordination prevents dual-tab recording

## Voice Activity Detection (VAD)
- Energy-based continuous listening with conversation mode button
- Exponential sensitivity curve (0–100%) configurable in settings
- Auto-sends after 2.5s silence, 30s max recording safety valve
- Mutes during TTS playback, auto-resumes after with echo settle delay
- AudioContext health monitoring with auto-resume on browser suspension
- MediaStream track health check with automatic reacquisition
- Race condition guards (`vadTranscribing` flag) prevent recorder restart storms during async transcription fetches
- EBML header validation catches corrupt WebM blobs before API submission
- 15s fetch timeout prevents stuck transcription state

## Voice Settings UI
- PTT key picker (click to listen, press any key to rebind)
- VAD sensitivity slider with real-time threshold preview
- Waveform icon button with CSS states (listening glow, speech pulse)

Also adds i18n keys for en/fr/zh locales.

## Notes
- The `.github/workflows/local-ci.yml` file is fork-specific CI infrastructure (sets `local/*` commit statuses for the upstream local-validation polling jobs, since upstream `ci.yml` skips checks on fork PRs). Happy to drop it if you prefer.