### PR TITLE
feat(agents,providers): Support reasoning_details for tool_calls

### DIFF
--- a/crates/agents/src/model.rs
+++ b/crates/agents/src/model.rs
@@ -22,6 +22,7 @@ pub enum ChatMessage {
     Assistant {
         content: Option<String>,
         tool_calls: Vec<ToolCall>,
+        reasoning: Option<Reasoning>,
     },
     Tool {
         tool_call_id: String,
@@ -34,6 +35,14 @@ pub enum ChatMessage {
 pub enum UserContent {
     Text(String),
     Multimodal(Vec<ContentPart>),
+}
+
+/// Reasoning content from the assistant, can be either a simple string
+/// (Moonshot API) or structured details (Kimi through OpenAI-compatible APIs).
+#[derive(Debug, Clone)]
+pub enum Reasoning {
+    Content(String),
+    Details(serde_json::Value),
 }
 
 impl UserContent {
@@ -77,14 +86,20 @@ impl ChatMessage {
         Self::Assistant {
             content: Some(content.into()),
             tool_calls: vec![],
+            reasoning: None,
         }
     }
 
     /// Create an assistant message with tool calls (and optional text).
-    pub fn assistant_with_tools(content: Option<String>, tool_calls: Vec<ToolCall>) -> Self {
+    pub fn assistant_with_tools(
+        content: Option<String>,
+        tool_calls: Vec<ToolCall>,
+        reasoning: Option<Reasoning>,
+    ) -> Self {
         Self::Assistant {
             content,
             tool_calls,
+            reasoning,
         }
     }
 
@@ -132,12 +147,24 @@ impl ChatMessage {
             ChatMessage::Assistant {
                 content,
                 tool_calls,
+                reasoning,
             } => {
                 if tool_calls.is_empty() {
-                    serde_json::json!({
+                    let mut msg = serde_json::json!({
                         "role": "assistant",
                         "content": content.as_deref().unwrap_or(""),
-                    })
+                    });
+                    if let Some(r) = reasoning {
+                        match r {
+                            Reasoning::Content(rc) => {
+                                msg["reasoning_content"] = serde_json::Value::String(rc.clone());
+                            },
+                            Reasoning::Details(rd) => {
+                                msg["reasoning_details"] = rd.clone();
+                            },
+                        }
+                    }
+                    msg
                 } else {
                     let tc_json: Vec<serde_json::Value> = tool_calls
                         .iter()
@@ -158,6 +185,16 @@ impl ChatMessage {
                     });
                     if let Some(text) = content {
                         msg["content"] = serde_json::Value::String(text.clone());
+                    }
+                    if let Some(r) = reasoning {
+                        match r {
+                            Reasoning::Content(rc) => {
+                                msg["reasoning_content"] = serde_json::Value::String(rc.clone());
+                            },
+                            Reasoning::Details(rd) => {
+                                msg["reasoning_details"] = rd.clone();
+                            },
+                        }
                     }
                     msg
                 }
@@ -246,9 +283,19 @@ pub fn values_to_chat_messages(values: &[serde_json::Value]) -> Vec<ChatMessage>
                             .collect()
                     })
                     .unwrap_or_default();
+                let reasoning = val
+                    .get("reasoning_details")
+                    .cloned()
+                    .map(Reasoning::Details)
+                    .or_else(|| {
+                        val["reasoning_content"]
+                            .as_str()
+                            .map(|s| Reasoning::Content(s.to_string()))
+                    });
                 messages.push(ChatMessage::Assistant {
                     content,
                     tool_calls,
+                    reasoning,
                 });
             },
             "tool" => {
@@ -288,6 +335,8 @@ pub enum StreamEvent {
     ProviderRaw(serde_json::Value),
     /// Reasoning/planning text delta (not user-visible final answer text).
     ReasoningDelta(String),
+    /// Structured reasoning details (e.g. Kimi reasoning_details array).
+    ReasoningDetailsDelta(serde_json::Value),
     /// A tool call has started (content_block_start with tool_use).
     ToolCallStart {
         /// Tool call ID from the provider.
@@ -398,6 +447,7 @@ pub struct CompletionResponse {
     pub text: Option<String>,
     pub tool_calls: Vec<ToolCall>,
     pub usage: Usage,
+    pub reasoning: Option<Reasoning>,
 }
 
 #[derive(Debug, Clone)]
@@ -445,7 +495,7 @@ mod tests {
     fn assistant_message_text() {
         let msg = ChatMessage::assistant("Hi there");
         assert!(
-            matches!(msg, ChatMessage::Assistant { content: Some(t), tool_calls } if t == "Hi there" && tool_calls.is_empty())
+            matches!(msg, ChatMessage::Assistant { content: Some(t), tool_calls, .. } if t == "Hi there" && tool_calls.is_empty())
         );
     }
 
@@ -506,11 +556,15 @@ mod tests {
 
     #[test]
     fn to_openai_assistant_with_tools() {
-        let msg = ChatMessage::assistant_with_tools(Some("thinking".into()), vec![ToolCall {
-            id: "call_1".into(),
-            name: "exec".into(),
-            arguments: serde_json::json!({"cmd": "ls"}),
-        }]);
+        let msg = ChatMessage::assistant_with_tools(
+            Some("thinking".into()),
+            vec![ToolCall {
+                id: "call_1".into(),
+                name: "exec".into(),
+                arguments: serde_json::json!({"cmd": "ls"}),
+            }],
+            None,
+        );
         let val = msg.to_openai_value();
         assert_eq!(val["role"], "assistant");
         assert_eq!(val["content"], "thinking");
@@ -592,6 +646,7 @@ mod tests {
             ChatMessage::Assistant {
                 content,
                 tool_calls,
+                ..
             } => {
                 assert_eq!(content.as_deref(), Some("thinking"));
                 assert_eq!(tool_calls.len(), 1);

--- a/crates/agents/src/provider_chain.rs
+++ b/crates/agents/src/provider_chain.rs
@@ -395,6 +395,7 @@ mod tests {
             Ok(CompletionResponse {
                 text: Some("ok".into()),
                 tool_calls: vec![],
+                reasoning: None,
                 usage: Usage {
                     input_tokens: 1,
                     output_tokens: 1,
@@ -696,6 +697,7 @@ mod tests {
             Ok(CompletionResponse {
                 text: Some("ok".into()),
                 tool_calls: vec![],
+                reasoning: None,
                 usage: Usage {
                     input_tokens: 1,
                     output_tokens: 1,

--- a/crates/agents/src/runner.rs
+++ b/crates/agents/src/runner.rs
@@ -12,7 +12,8 @@ use moltis_common::hooks::{HookAction, HookPayload, HookRegistry};
 
 use crate::{
     model::{
-        ChatMessage, CompletionResponse, LlmProvider, StreamEvent, ToolCall, Usage, UserContent,
+        ChatMessage, CompletionResponse, LlmProvider, Reasoning, StreamEvent, ToolCall, Usage,
+        UserContent,
     },
     response_sanitizer::{clean_response, recover_tool_calls_from_content},
     tool_parsing::{
@@ -269,6 +270,7 @@ pub enum RunnerEvent {
     /// LLM returned reasoning/status text alongside tool calls.
     ThinkingText(String),
     TextDelta(String),
+    ReasoningDetails(serde_json::Value),
     Iteration(usize),
     SubAgentStart {
         task: String,
@@ -920,6 +922,7 @@ pub async fn run_agent_loop_with_context(
         messages.push(ChatMessage::assistant_with_tools(
             response.text.clone(),
             response.tool_calls.clone(),
+            response.reasoning.clone(),
         ));
 
         // Execute tool calls concurrently.
@@ -1097,6 +1100,47 @@ pub async fn run_agent_loop_with_context(
     }
 }
 
+/// Accumulate Kimi-style `reasoning_details` into the provided map.
+fn accumulate_reasoning_details(
+    details_map: &mut std::collections::HashMap<usize, serde_json::Map<String, serde_json::Value>>,
+    delta_details: &serde_json::Value,
+) {
+    let Some(arr) = delta_details.as_array() else {
+        return;
+    };
+    for item in arr {
+        let Some(obj) = item.as_object() else {
+            continue;
+        };
+        let Some(index) = obj
+            .get("index")
+            .and_then(|v| v.as_u64())
+            .map(|v| v as usize)
+        else {
+            continue;
+        };
+
+        let entry = details_map.entry(index).or_insert_with(|| {
+            let mut new_obj = serde_json::Map::new();
+            // Copy non-text fields from first occurrence
+            for (key, value) in obj.iter() {
+                if key != "text" {
+                    new_obj.insert(key.clone(), value.clone());
+                }
+            }
+            new_obj
+        });
+
+        if let Some(text) = obj.get("text").and_then(|v| v.as_str()) {
+            let current = entry.get("text").and_then(|v| v.as_str()).unwrap_or("");
+            entry.insert(
+                "text".to_string(),
+                serde_json::Value::String(current.to_string() + text),
+            );
+        }
+    }
+}
+
 /// Convenience wrapper matching the old stub signature.
 pub async fn run_agent(_agent_id: &str, _session_key: &str, _message: &str) -> Result<String> {
     bail!("run_agent requires a configured provider and tool registry; use run_agent_loop instead")
@@ -1247,6 +1291,10 @@ pub async fn run_agent_loop_streaming(
         // Accumulate answer text, reasoning text, and tool calls from the stream.
         let mut accumulated_text = String::new();
         let mut accumulated_reasoning = String::new();
+        let mut reasoning_details_map: std::collections::HashMap<
+            usize,
+            serde_json::Map<String, serde_json::Value>,
+        > = std::collections::HashMap::new();
         let mut tool_calls: Vec<ToolCall> = Vec::new();
         // Map streaming index → accumulated JSON args string.
         let mut tool_call_args: std::collections::HashMap<usize, String> =
@@ -1271,7 +1319,26 @@ pub async fn run_agent_loop_streaming(
                 },
                 StreamEvent::ProviderRaw(raw) => {
                     if raw_llm_responses.len() < 256 {
-                        raw_llm_responses.push(raw);
+                        raw_llm_responses.push(raw.clone());
+                    }
+                },
+                StreamEvent::ReasoningDetailsDelta(details) => {
+                    accumulate_reasoning_details(&mut reasoning_details_map, &details);
+                    if let Some(cb) = on_event {
+                        let mut indices: Vec<usize> =
+                            reasoning_details_map.keys().cloned().collect();
+                        indices.sort();
+                        let merged_array: Vec<serde_json::Value> = indices
+                            .into_iter()
+                            .filter_map(|idx| {
+                                reasoning_details_map
+                                    .get(&idx)
+                                    .map(|obj| serde_json::Value::Object(obj.clone()))
+                            })
+                            .collect();
+                        cb(RunnerEvent::ReasoningDetails(serde_json::Value::Array(
+                            merged_array,
+                        )));
                     }
                 },
                 StreamEvent::ReasoningDelta(text) => {
@@ -1566,7 +1633,7 @@ pub async fn run_agent_loop_streaming(
         // likely the actual answer (e.g. a search result table produced
         // before a `browser close` cleanup call).
         let (text_for_msg, is_actual_reasoning) = if !accumulated_reasoning.is_empty() {
-            (Some(accumulated_reasoning), true)
+            (Some(accumulated_reasoning.clone()), true)
         } else if !accumulated_text.is_empty() {
             last_answer_text.clone_from(&accumulated_text);
             (Some(accumulated_text), false)
@@ -1579,9 +1646,27 @@ pub async fn run_agent_loop_streaming(
         {
             cb(RunnerEvent::ThinkingText(text.clone()));
         }
+        let reasoning = if !reasoning_details_map.is_empty() {
+            let mut indices: Vec<usize> = reasoning_details_map.keys().cloned().collect();
+            indices.sort();
+            let merged_array: Vec<serde_json::Value> = indices
+                .into_iter()
+                .filter_map(|idx| {
+                    reasoning_details_map
+                        .get(&idx)
+                        .map(|obj| serde_json::Value::Object(obj.clone()))
+                })
+                .collect();
+            Some(Reasoning::Details(serde_json::Value::Array(merged_array)))
+        } else if !accumulated_reasoning.is_empty() {
+            Some(Reasoning::Content(accumulated_reasoning.clone()))
+        } else {
+            None
+        };
         messages.push(ChatMessage::assistant_with_tools(
             text_for_msg,
             tool_calls.clone(),
+            reasoning,
         ));
 
         // Execute tool calls concurrently.
@@ -1895,6 +1980,7 @@ mod tests {
             Ok(CompletionResponse {
                 text: Some(self.response_text.clone()),
                 tool_calls: vec![],
+                reasoning: None,
                 usage: Usage {
                     input_tokens: 10,
                     output_tokens: 5,
@@ -1946,6 +2032,7 @@ mod tests {
                         name: "echo_tool".into(),
                         arguments: serde_json::json!({"text": "hi"}),
                     }],
+                    reasoning: None,
                     usage: Usage {
                         input_tokens: 10,
                         output_tokens: 5,
@@ -1956,6 +2043,7 @@ mod tests {
                 Ok(CompletionResponse {
                     text: Some("Done!".into()),
                     tool_calls: vec![],
+                    reasoning: None,
                     usage: Usage {
                         input_tokens: 20,
                         output_tokens: 10,
@@ -2005,6 +2093,7 @@ mod tests {
                 Ok(CompletionResponse {
                     text: Some("```tool_call\n{\"tool\": \"exec\", \"arguments\": {\"command\": \"echo hello\"}}\n```".into()),
                     tool_calls: vec![],
+                    reasoning: None,
                     usage: Usage { input_tokens: 10, output_tokens: 20, ..Default::default() },
                 })
             } else {
@@ -2026,6 +2115,7 @@ mod tests {
                 Ok(CompletionResponse {
                     text: Some("The command output: hello".into()),
                     tool_calls: vec![],
+                    reasoning: None,
                     usage: Usage {
                         input_tokens: 30,
                         output_tokens: 10,
@@ -2203,6 +2293,7 @@ mod tests {
                         name: "exec".into(),
                         arguments: serde_json::json!({"command": "echo hello"}),
                     }],
+                    reasoning: None,
                     usage: Usage {
                         input_tokens: 10,
                         output_tokens: 5,
@@ -2227,6 +2318,7 @@ mod tests {
                 Ok(CompletionResponse {
                     text: Some(format!("The output was: {}", stdout.trim())),
                     tool_calls: vec![],
+                    reasoning: None,
                     usage: Usage {
                         input_tokens: 20,
                         output_tokens: 10,
@@ -2375,6 +2467,7 @@ mod tests {
                 Ok(CompletionResponse {
                     text: Some("I'll summarize the command output for you.".into()),
                     tool_calls: vec![],
+                    reasoning: None,
                     usage: Usage {
                         input_tokens: 10,
                         output_tokens: 10,
@@ -2388,6 +2481,7 @@ mod tests {
                         if let ChatMessage::Assistant {
                             content,
                             tool_calls,
+                            ..
                         } = m
                         {
                             if tool_calls.is_empty() {
@@ -2419,6 +2513,7 @@ mod tests {
                 Ok(CompletionResponse {
                     text: Some("done".into()),
                     tool_calls: vec![],
+                    reasoning: None,
                     usage: Usage {
                         input_tokens: 10,
                         output_tokens: 5,
@@ -2559,6 +2654,7 @@ mod tests {
                             .into(),
                     ),
                     tool_calls: vec![],
+                    reasoning: None,
                     usage: Usage {
                         input_tokens: 10,
                         output_tokens: 20,
@@ -2588,6 +2684,7 @@ mod tests {
                 Ok(CompletionResponse {
                     text: Some("Process started for pwd".into()),
                     tool_calls: vec![],
+                    reasoning: None,
                     usage: Usage {
                         input_tokens: 30,
                         output_tokens: 10,
@@ -2736,6 +2833,7 @@ mod tests {
                 Ok(CompletionResponse {
                     text: None,
                     tool_calls: self.tool_calls.clone(),
+                    reasoning: None,
                     usage: Usage {
                         input_tokens: 10,
                         output_tokens: 5,
@@ -2746,6 +2844,7 @@ mod tests {
                 Ok(CompletionResponse {
                     text: Some("All done".into()),
                     tool_calls: vec![],
+                    reasoning: None,
                     usage: Usage {
                         input_tokens: 20,
                         output_tokens: 10,
@@ -3189,6 +3288,7 @@ mod tests {
                         name: "screenshot_tool".into(),
                         arguments: serde_json::json!({}),
                     }],
+                    reasoning: None,
                     usage: Usage {
                         input_tokens: 10,
                         output_tokens: 5,
@@ -3222,6 +3322,7 @@ mod tests {
                 Ok(CompletionResponse {
                     text: Some("Screenshot processed successfully".into()),
                     tool_calls: vec![],
+                    reasoning: None,
                     usage: Usage {
                         input_tokens: 20,
                         output_tokens: 10,
@@ -3481,6 +3582,7 @@ mod tests {
             Ok(CompletionResponse {
                 text: Some("fallback".into()),
                 tool_calls: vec![],
+                reasoning: None,
                 usage: Usage::default(),
             })
         }
@@ -3626,6 +3728,7 @@ mod tests {
             Ok(CompletionResponse {
                 text: Some("fallback".into()),
                 tool_calls: vec![],
+                reasoning: None,
                 usage: Usage::default(),
             })
         }
@@ -3661,6 +3764,7 @@ mod tests {
                         if let ChatMessage::Assistant {
                             content,
                             tool_calls,
+                            ..
                         } = m
                         {
                             if tool_calls.is_empty() {
@@ -3775,6 +3879,7 @@ mod tests {
             Ok(CompletionResponse {
                 text: Some("fallback".into()),
                 tool_calls: vec![],
+                reasoning: None,
                 usage: Usage::default(),
             })
         }
@@ -3862,6 +3967,7 @@ mod tests {
             Ok(CompletionResponse {
                 text: Some("fallback".into()),
                 tool_calls: vec![],
+                reasoning: None,
                 usage: Usage::default(),
             })
         }
@@ -3982,6 +4088,7 @@ mod tests {
             Ok(CompletionResponse {
                 text: Some("fallback".into()),
                 tool_calls: vec![],
+                reasoning: None,
                 usage: Usage::default(),
             })
         }
@@ -4135,6 +4242,7 @@ mod tests {
             Ok(CompletionResponse {
                 text: Some("fallback".into()),
                 tool_calls: vec![],
+                reasoning: None,
                 usage: Usage::default(),
             })
         }
@@ -4374,6 +4482,7 @@ mod tests {
                 Ok(CompletionResponse {
                     text: Some("Recovered!".into()),
                     tool_calls: vec![],
+                    reasoning: None,
                     usage: Usage::default(),
                 })
             }
@@ -4427,6 +4536,7 @@ mod tests {
                 Ok(CompletionResponse {
                     text: Some("Recovered from rate limit".into()),
                     tool_calls: vec![],
+                    reasoning: None,
                     usage: Usage::default(),
                 })
             }

--- a/crates/agents/src/silent_turn.rs
+++ b/crates/agents/src/silent_turn.rs
@@ -255,6 +255,7 @@ mod tests {
                             "content": "# Memories\n\nUser prefers Rust over Python."
                         }),
                     }],
+                    reasoning: None,
                     usage: Usage {
                         input_tokens: 100,
                         output_tokens: 50,
@@ -265,6 +266,7 @@ mod tests {
                 Ok(CompletionResponse {
                     text: Some("NO_REPLY".into()),
                     tool_calls: vec![],
+                    reasoning: None,
                     usage: Usage {
                         input_tokens: 50,
                         output_tokens: 5,

--- a/crates/chat/src/lib.rs
+++ b/crates/chat/src/lib.rs
@@ -4072,7 +4072,8 @@ impl ChatService for LiveChatService {
                 | StreamEvent::ProviderRaw(_)
                 // Ignore provider reasoning blocks; summary body should only
                 // include final answer text.
-                | StreamEvent::ReasoningDelta(_) => {},
+                | StreamEvent::ReasoningDelta(_)
+                | StreamEvent::ReasoningDetailsDelta(_) => {},
             }
         }
 
@@ -6024,6 +6025,16 @@ async fn run_with_tools(
                         "seq": seq,
                     })
                 },
+                RunnerEvent::ReasoningDetails(details) => {
+                    latest_reasoning = serde_json::to_string(&details).unwrap_or_default();
+                    serde_json::json!({
+                        "runId": run_id,
+                        "sessionKey": sk,
+                        "state": "thinking_details",
+                        "details": details,
+                        "seq": seq,
+                    })
+                },
                 RunnerEvent::Iteration(n) => serde_json::json!({
                     "runId": run_id,
                     "sessionKey": sk,
@@ -6442,7 +6453,8 @@ async fn compact_session(
             | StreamEvent::ProviderRaw(_)
             // Ignore provider reasoning blocks; summary body should only
             // include final answer text.
-            | StreamEvent::ReasoningDelta(_) => {},
+            | StreamEvent::ReasoningDelta(_)
+            | StreamEvent::ReasoningDetailsDelta(_) => {},
         }
     }
 
@@ -6910,7 +6922,8 @@ async fn run_streaming(
                 // Tool events not expected in stream-only mode.
                 StreamEvent::ToolCallStart { .. }
                 | StreamEvent::ToolCallArgumentsDelta { .. }
-                | StreamEvent::ToolCallComplete { .. } => {},
+                | StreamEvent::ToolCallComplete { .. }
+                | StreamEvent::ReasoningDetailsDelta(_) => {},
             }
         }
 

--- a/crates/providers/src/anthropic.rs
+++ b/crates/providers/src/anthropic.rs
@@ -133,6 +133,7 @@ fn to_anthropic_messages(messages: &[ChatMessage]) -> (Option<String>, Vec<serde
             ChatMessage::Assistant {
                 content,
                 tool_calls,
+                ..
             } => {
                 if tool_calls.is_empty() {
                     out.push(serde_json::json!({
@@ -284,6 +285,7 @@ impl LlmProvider for AnthropicProvider {
         Ok(CompletionResponse {
             text,
             tool_calls,
+            reasoning: None,
             usage,
         })
     }

--- a/crates/providers/src/async_openai_provider.rs
+++ b/crates/providers/src/async_openai_provider.rs
@@ -180,6 +180,7 @@ impl LlmProvider for AsyncOpenAiProvider {
         Ok(CompletionResponse {
             text,
             tool_calls: vec![],
+            reasoning: None,
             usage,
         })
     }

--- a/crates/providers/src/contract.rs
+++ b/crates/providers/src/contract.rs
@@ -69,6 +69,7 @@ impl LlmProvider for MockLlmProvider {
             None => Ok(CompletionResponse {
                 text: Some("Hello from mock provider".into()),
                 tool_calls: vec![],
+                reasoning: None,
                 usage: Usage {
                     input_tokens: 10,
                     output_tokens: 5,

--- a/crates/providers/src/genai_provider.rs
+++ b/crates/providers/src/genai_provider.rs
@@ -106,6 +106,7 @@ impl LlmProvider for GenaiProvider {
         Ok(CompletionResponse {
             text,
             tool_calls: vec![],
+            reasoning: None,
             usage,
         })
     }

--- a/crates/providers/src/github_copilot.rs
+++ b/crates/providers/src/github_copilot.rs
@@ -513,6 +513,7 @@ impl LlmProvider for GitHubCopilotProvider {
         Ok(CompletionResponse {
             text,
             tool_calls,
+            reasoning: None,
             usage,
         })
     }
@@ -801,6 +802,7 @@ mod tests {
             Ok(CompletionResponse {
                 text,
                 tool_calls,
+                reasoning: None,
                 usage,
             })
         }

--- a/crates/providers/src/kimi_code.rs
+++ b/crates/providers/src/kimi_code.rs
@@ -272,6 +272,7 @@ impl LlmProvider for KimiCodeProvider {
         Ok(CompletionResponse {
             text,
             tool_calls,
+            reasoning: None,
             usage,
         })
     }
@@ -557,6 +558,7 @@ mod tests {
             Ok(CompletionResponse {
                 text,
                 tool_calls,
+                reasoning: None,
                 usage,
             })
         }

--- a/crates/providers/src/local_gguf/mod.rs
+++ b/crates/providers/src/local_gguf/mod.rs
@@ -460,6 +460,7 @@ impl LlmProvider for LocalGgufProvider {
         Ok(CompletionResponse {
             text: display_text,
             tool_calls,
+            reasoning: None,
             usage: Usage {
                 input_tokens,
                 output_tokens,

--- a/crates/providers/src/local_llm/backend.rs
+++ b/crates/providers/src/local_llm/backend.rs
@@ -532,6 +532,7 @@ pub mod gguf {
             Ok(CompletionResponse {
                 text: display_text,
                 tool_calls,
+                reasoning: None,
                 usage: Usage {
                     input_tokens,
                     output_tokens,
@@ -946,6 +947,7 @@ print(json.dumps({{"text": response, "input_tokens": input_tokens, "output_token
             Ok(CompletionResponse {
                 text: Some(text),
                 tool_calls: vec![],
+                reasoning: None,
                 usage: Usage {
                     input_tokens,
                     output_tokens,

--- a/crates/providers/src/openai.rs
+++ b/crates/providers/src/openai.rs
@@ -255,7 +255,7 @@ fn base_openai_tool_call_id(raw: &str) -> String {
     let mut cleaned: String = raw
         .chars()
         .map(|ch| {
-            if ch.is_ascii_alphanumeric() || matches!(ch, '_' | '-') {
+            if ch.is_ascii_alphanumeric() || matches!(ch, '_' | '-' | ':') {
                 ch
             } else {
                 '_'
@@ -553,18 +553,8 @@ impl OpenAiProvider {
                     .is_some_and(|calls| !calls.is_empty());
 
                 if is_assistant && has_tool_calls {
-                    let reasoning_content = value
-                        .get("content")
-                        .and_then(serde_json::Value::as_str)
-                        .unwrap_or("")
-                        .to_string();
-
                     if value.get("content").is_none() {
                         value["content"] = serde_json::Value::String(String::new());
-                    }
-
-                    if value.get("reasoning_content").is_none() {
-                        value["reasoning_content"] = serde_json::Value::String(reasoning_content);
                     }
                 }
             }
@@ -1144,6 +1134,15 @@ impl LlmProvider for OpenAiProvider {
             }
         });
         let tool_calls = parse_tool_calls(message);
+        let reasoning = message
+            .get("reasoning_details")
+            .cloned()
+            .map(moltis_agents::model::Reasoning::Details)
+            .or_else(|| {
+                message["reasoning_content"]
+                    .as_str()
+                    .map(|s| moltis_agents::model::Reasoning::Content(s.to_string()))
+            });
 
         let usage = parse_openai_compat_usage_from_payload(&resp).unwrap_or_default();
 
@@ -1151,6 +1150,7 @@ impl LlmProvider for OpenAiProvider {
             text,
             tool_calls,
             usage,
+            reasoning,
         })
     }
 
@@ -1266,17 +1266,59 @@ mod tests {
             "https://api.moonshot.ai/v1".to_string(),
             "moonshot".to_string(),
         );
-        let messages = vec![ChatMessage::assistant_with_tools(None, vec![ToolCall {
-            id: "call_1".into(),
-            name: "exec".into(),
-            arguments: serde_json::json!({ "command": "uname -a" }),
-        }])];
+        // Message with reasoning_content (Moonshot API style)
+        let messages = vec![ChatMessage::assistant_with_tools(
+            None,
+            vec![ToolCall {
+                id: "call_1".into(),
+                name: "exec".into(),
+                arguments: serde_json::json!({ "command": "uname -a" }),
+            }],
+            Some(moltis_agents::model::Reasoning::Content(
+                "Thinking about the command".into(),
+            )),
+        )];
 
         let serialized = provider.serialize_messages_for_request(&messages);
         assert_eq!(serialized.len(), 1);
         assert_eq!(serialized[0]["role"], "assistant");
         assert_eq!(serialized[0]["content"], "");
-        assert_eq!(serialized[0]["reasoning_content"], "");
+        assert_eq!(
+            serialized[0]["reasoning_content"],
+            "Thinking about the command"
+        );
+    }
+
+    #[test]
+    fn moonshot_serialization_preserves_reasoning_details_when_present() {
+        let provider = OpenAiProvider::new_with_name(
+            Secret::new("test-key".to_string()),
+            "kimi-k2.5".to_string(),
+            "https://api.moonshot.ai/v1".to_string(),
+            "moonshot".to_string(),
+        );
+        // Message with reasoning_details (Kimi through OpenAI-compatible API style)
+        let reasoning_details = serde_json::json!([{
+            "format": "unknown",
+            "index": 0,
+            "type": "reasoning.text",
+            "text": "The user wants me to check my memory"
+        }]);
+        let messages = vec![ChatMessage::assistant_with_tools(
+            Some("Let me check that".into()),
+            vec![ToolCall {
+                id: "call_1".into(),
+                name: "exec".into(),
+                arguments: serde_json::json!({ "command": "uname -a" }),
+            }],
+            Some(moltis_agents::model::Reasoning::Details(reasoning_details)),
+        )];
+
+        let serialized = provider.serialize_messages_for_request(&messages);
+        assert_eq!(serialized.len(), 1);
+        assert_eq!(serialized[0]["role"], "assistant");
+        assert_eq!(serialized[0]["content"], "Let me check that");
+        assert!(serialized[0]["reasoning_details"].is_array());
     }
 
     #[test]
@@ -1286,11 +1328,15 @@ mod tests {
             "gpt-4o".to_string(),
             "https://api.openai.com/v1".to_string(),
         );
-        let messages = vec![ChatMessage::assistant_with_tools(None, vec![ToolCall {
-            id: "call_1".into(),
-            name: "exec".into(),
-            arguments: serde_json::json!({ "command": "uname -a" }),
-        }])];
+        let messages = vec![ChatMessage::assistant_with_tools(
+            None,
+            vec![ToolCall {
+                id: "call_1".into(),
+                name: "exec".into(),
+                arguments: serde_json::json!({ "command": "uname -a" }),
+            }],
+            None,
+        )];
 
         let serialized = provider.serialize_messages_for_request(&messages);
         assert_eq!(serialized.len(), 1);
@@ -1325,13 +1371,15 @@ mod tests {
         );
         let long_id = "forced-123e4567-e89b-12d3-a456-426614174000";
         let messages = vec![
-            ChatMessage::assistant_with_tools(Some("running command".to_string()), vec![
-                ToolCall {
+            ChatMessage::assistant_with_tools(
+                Some("running command".to_string()),
+                vec![ToolCall {
                     id: long_id.to_string(),
                     name: "exec".to_string(),
                     arguments: serde_json::json!({ "command": "pwd" }),
-                },
-            ]),
+                }],
+                None,
+            ),
             ChatMessage::tool(long_id, "ok"),
         ];
 
@@ -1356,13 +1404,15 @@ mod tests {
         );
         let short_id = "call_abc";
         let messages = vec![
-            ChatMessage::assistant_with_tools(Some("running command".to_string()), vec![
-                ToolCall {
+            ChatMessage::assistant_with_tools(
+                Some("running command".to_string()),
+                vec![ToolCall {
                     id: short_id.to_string(),
                     name: "exec".to_string(),
                     arguments: serde_json::json!({ "command": "pwd" }),
-                },
-            ]),
+                }],
+                None,
+            ),
             ChatMessage::tool(short_id, "ok"),
         ];
 
@@ -1387,11 +1437,15 @@ mod tests {
         );
         let messages = vec![
             ChatMessage::user("run uname"),
-            ChatMessage::assistant_with_tools(None, vec![ToolCall {
-                id: "exec:0".into(),
-                name: "exec".into(),
-                arguments: serde_json::json!({ "command": "uname -a" }),
-            }]),
+            ChatMessage::assistant_with_tools(
+                None,
+                vec![ToolCall {
+                    id: "exec:0".into(),
+                    name: "exec".into(),
+                    arguments: serde_json::json!({ "command": "uname -a" }),
+                }],
+                None,
+            ),
             ChatMessage::tool("exec:0", "Linux host 6.0"),
         ];
 
@@ -1406,7 +1460,7 @@ mod tests {
             .expect("messages should be an array");
         assert_eq!(history[1]["role"], "assistant");
         assert_eq!(history[1]["content"], "");
-        assert_eq!(history[1]["reasoning_content"], "");
+        assert!(history[1].get("reasoning_content").is_none());
         assert!(history[1]["tool_calls"].is_array());
     }
 

--- a/crates/providers/src/openai_codex.rs
+++ b/crates/providers/src/openai_codex.rs
@@ -229,6 +229,7 @@ impl OpenAiCodexProvider {
                     ChatMessage::Assistant {
                         content,
                         tool_calls,
+                        ..
                     } => {
                         if !tool_calls.is_empty() {
                             let mut items: Vec<serde_json::Value> = vec![];
@@ -750,6 +751,7 @@ impl LlmProvider for OpenAiCodexProvider {
         Ok(CompletionResponse {
             text,
             tool_calls,
+            reasoning: None,
             usage: Usage {
                 input_tokens,
                 output_tokens,
@@ -1091,11 +1093,15 @@ mod tests {
     #[test]
     fn convert_messages_tool_call_and_result() {
         let messages = vec![
-            ChatMessage::assistant_with_tools(None, vec![ToolCall {
-                id: "call_1".to_string(),
-                name: "get_time".to_string(),
-                arguments: serde_json::json!({}),
-            }]),
+            ChatMessage::assistant_with_tools(
+                None,
+                vec![ToolCall {
+                    id: "call_1".to_string(),
+                    name: "get_time".to_string(),
+                    arguments: serde_json::json!({}),
+                }],
+                None,
+            ),
             ChatMessage::tool("call_1", "12:00"),
         ];
         let converted = OpenAiCodexProvider::convert_messages(&messages);
@@ -1220,11 +1226,15 @@ mod tests {
         .to_string();
         let messages = vec![
             ChatMessage::user("Take a screenshot"),
-            ChatMessage::assistant_with_tools(None, vec![ToolCall {
-                id: "call_screenshot".to_string(),
-                name: "browser_screenshot".to_string(),
-                arguments: serde_json::json!({}),
-            }]),
+            ChatMessage::assistant_with_tools(
+                None,
+                vec![ToolCall {
+                    id: "call_screenshot".to_string(),
+                    name: "browser_screenshot".to_string(),
+                    arguments: serde_json::json!({}),
+                }],
+                None,
+            ),
             ChatMessage::tool("call_screenshot", &tool_output),
             ChatMessage::assistant("Here is the screenshot."),
         ];

--- a/crates/providers/src/openai_compat.rs
+++ b/crates/providers/src/openai_compat.rs
@@ -341,6 +341,7 @@ pub fn to_responses_input(messages: &[ChatMessage]) -> Vec<serde_json::Value> {
             ChatMessage::Assistant {
                 content,
                 tool_calls,
+                ..
             } => {
                 if !tool_calls.is_empty() {
                     let mut items: Vec<serde_json::Value> = tool_calls
@@ -776,6 +777,15 @@ pub fn process_openai_sse_line(data: &str, state: &mut StreamingToolState) -> Ss
         && !content.is_empty()
     {
         process_content_think_tags(content, state, &mut events);
+    }
+
+    // Handle Kimi-style structured reasoning details.
+    if let Some(reasoning_details) = delta["reasoning_details"].as_array()
+        && !reasoning_details.is_empty()
+    {
+        events.push(StreamEvent::ReasoningDetailsDelta(
+            serde_json::Value::Array(reasoning_details.clone()),
+        ));
     }
 
     // Some OpenAI-compatible backends stream planning text in


### PR DESCRIPTION
This got a little bigger than I intended, but supports Kimi models when used with providers other than Moonshot. Tested with Opencode Go but should apply to Openrouter, etc.

### `reasoning_content`

Started in https://github.com/moltis-org/moltis/issues/281#issuecomment-3986124136 where I kept running into this using kimi-k2.5 through a [custom provider](https://opencode.ai/docs/go/#endpoints):

    thinking is enabled but reasoning_content is missing in assistant tool call message

Digging through the [moonshot](https://platform.moonshot.ai/docs/guide/use-kimi-k2-thinking-model) and openrouter docs I eventually realized that while the error mentions `reasoning_content`,  that's specific to Moonshot's API.  With [openrouter](https://openrouter.ai/docs/guides/best-practices/reasoning-tokens#preserving-reasoning) a `reasoning_details` array is returned instead.

This handles both cases and passes through all context that came from the model.  Mostly written through opencode of course, and since it changes some fundamental pieces like `ChatMessage` I'm open to any feedback.  If you'd rather scrap this and take it as a detailed feature request I'm good with that too. :)