### PR TITLE
feat(oauth): add Anthropic OAuth provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5759,6 +5759,7 @@ dependencies = [
  "moltis-openclaw-import",
  "moltis-plugins",
  "moltis-projects",
+ "moltis-provider-setup",
  "moltis-sessions",
  "moltis-skills",
  "moltis-tools",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -43,6 +43,7 @@ moltis-onboarding      = { workspace = true }
 moltis-openclaw-import = { optional = true, workspace = true }
 moltis-plugins         = { workspace = true }
 moltis-projects        = { workspace = true }
+moltis-provider-setup  = { workspace = true }
 moltis-sessions        = { workspace = true }
 moltis-skills          = { workspace = true }
 moltis-tools           = { workspace = true }

--- a/crates/cli/src/auth_commands.rs
+++ b/crates/cli/src/auth_commands.rs
@@ -2,7 +2,8 @@ use {
     anyhow::Result,
     clap::Subcommand,
     moltis_oauth::{
-        CallbackServer, OAuthFlow, TokenStore, callback_port, device_flow, load_oauth_config,
+        CallbackServer, OAuthFlow, TokenStore, callback_port, create_api_key_from_oauth,
+        device_flow, load_oauth_config,
     },
 };
 
@@ -57,6 +58,7 @@ async fn login(provider: &str) -> Result<()> {
         return login_device_flow(provider, &config).await;
     }
 
+    let api_key_endpoint = config.api_key_endpoint.clone();
     let port = callback_port(&config);
     let flow = OAuthFlow::new(config);
     let req = flow.start()?;
@@ -72,10 +74,23 @@ async fn login(provider: &str) -> Result<()> {
     println!("Exchanging code for tokens...");
     let tokens = flow.exchange(&code, &req.pkce.verifier).await?;
 
-    let store = TokenStore::new();
-    store.save(provider, &tokens)?;
+    if let Some(endpoint) = api_key_endpoint {
+        println!("Creating API key...");
+        let api_key = create_api_key_from_oauth(&endpoint, &tokens.access_token).await?;
+        let key_store = moltis_provider_setup::KeyStore::new();
+        key_store.save_config(
+            provider,
+            Some(secrecy::ExposeSecret::expose_secret(&api_key).to_string()),
+            None,
+            None,
+        )?;
+        println!("Successfully created API key for {provider}");
+    } else {
+        let store = TokenStore::new();
+        store.save(provider, &tokens)?;
+        println!("Successfully logged in to {provider}");
+    }
 
-    println!("Successfully logged in to {provider}");
     Ok(())
 }
 

--- a/crates/mcp/src/auth.rs
+++ b/crates/mcp/src/auth.rs
@@ -196,6 +196,7 @@ impl McpOAuthProvider {
             scopes: Vec::new(),
             extra_auth_params: Vec::new(),
             device_flow: false,
+            api_key_endpoint: None,
         };
 
         let flow = OAuthFlow::new(config);
@@ -252,6 +253,7 @@ impl McpOAuthProvider {
             scopes,
             extra_auth_params: Vec::new(),
             device_flow: false,
+            api_key_endpoint: None,
         };
 
         info!(

--- a/crates/oauth/src/api_key_exchange.rs
+++ b/crates/oauth/src/api_key_exchange.rs
@@ -1,0 +1,133 @@
+use {
+    crate::error::Error,
+    secrecy::{ExposeSecret, Secret},
+};
+
+/// Response from the API key creation endpoint.
+#[derive(serde::Deserialize)]
+struct CreateApiKeyResponse {
+    raw_key: String,
+}
+
+/// Exchange a temporary OAuth access token for a permanent API key.
+///
+/// POSTs to `endpoint` with `Authorization: Bearer <token>` and parses the
+/// `raw_key` field from the JSON response.
+pub async fn create_api_key_from_oauth(
+    endpoint: &str,
+    access_token: &Secret<String>,
+) -> crate::Result<Secret<String>> {
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(endpoint)
+        .bearer_auth(access_token.expose_secret())
+        .header("Content-Type", "application/json")
+        .body("{}")
+        .send()
+        .await?;
+
+    let status = resp.status();
+    if !status.is_success() {
+        let body = resp.text().await.unwrap_or_default();
+        return Err(Error::message(format!(
+            "API key creation failed (HTTP {}): {body}",
+            status.as_u16(),
+        )));
+    }
+
+    let parsed: CreateApiKeyResponse = resp.json().await?;
+
+    if parsed.raw_key.is_empty() {
+        return Err(Error::message("API key creation returned an empty key"));
+    }
+
+    Ok(Secret::new(parsed.raw_key))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[allow(clippy::unwrap_used)]
+    #[tokio::test]
+    async fn exchange_success() {
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("POST", "/create_api_key")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"raw_key":"sk-ant-api03-test-key"}"#)
+            .create_async()
+            .await;
+
+        let token = Secret::new("oauth-access-token".to_string());
+        let result =
+            create_api_key_from_oauth(&format!("{}/create_api_key", server.url()), &token).await;
+
+        mock.assert_async().await;
+        let key = result.unwrap();
+        assert_eq!(key.expose_secret(), "sk-ant-api03-test-key");
+    }
+
+    #[allow(clippy::unwrap_used)]
+    #[tokio::test]
+    async fn exchange_empty_key() {
+        let mut server = mockito::Server::new_async().await;
+        let _mock = server
+            .mock("POST", "/create_api_key")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"raw_key":""}"#)
+            .create_async()
+            .await;
+
+        let token = Secret::new("token".to_string());
+        let result =
+            create_api_key_from_oauth(&format!("{}/create_api_key", server.url()), &token).await;
+
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("empty key"),);
+    }
+
+    #[allow(clippy::unwrap_used)]
+    #[tokio::test]
+    async fn exchange_server_error() {
+        let mut server = mockito::Server::new_async().await;
+        let _mock = server
+            .mock("POST", "/create_api_key")
+            .with_status(500)
+            .with_body("internal server error")
+            .create_async()
+            .await;
+
+        let token = Secret::new("token".to_string());
+        let result =
+            create_api_key_from_oauth(&format!("{}/create_api_key", server.url()), &token).await;
+
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("500"),
+            "error should mention status code: {err}"
+        );
+    }
+
+    #[allow(clippy::unwrap_used)]
+    #[tokio::test]
+    async fn exchange_missing_field() {
+        let mut server = mockito::Server::new_async().await;
+        let _mock = server
+            .mock("POST", "/create_api_key")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"other_field":"value"}"#)
+            .create_async()
+            .await;
+
+        let token = Secret::new("token".to_string());
+        let result =
+            create_api_key_from_oauth(&format!("{}/create_api_key", server.url()), &token).await;
+
+        assert!(result.is_err());
+    }
+}

--- a/crates/oauth/src/defaults.rs
+++ b/crates/oauth/src/defaults.rs
@@ -8,6 +8,23 @@ fn builtin_defaults() -> HashMap<String, OAuthConfig> {
     // GitHub Copilot uses device flow (handled by the provider itself),
     // but we store a config entry so `load_oauth_config` returns Some
     // and the gateway recognises it as an OAuth provider.
+    m.insert("anthropic".into(), OAuthConfig {
+        client_id: "9d1c250a-e61b-44d9-88ed-5944d1962f5e".into(),
+        auth_url: "https://console.anthropic.com/oauth/authorize".into(),
+        token_url: "https://console.anthropic.com/v1/oauth/token".into(),
+        redirect_uri: "http://localhost:1456/auth/callback".into(),
+        resource: None,
+        scopes: vec![
+            "org:create_api_key".into(),
+            "user:profile".into(),
+            "user:inference".into(),
+        ],
+        extra_auth_params: vec![],
+        device_flow: false,
+        api_key_endpoint: Some(
+            "https://api.anthropic.com/api/oauth/claude_cli/create_api_key".into(),
+        ),
+    });
     m.insert("github-copilot".into(), OAuthConfig {
         client_id: "Iv1.b507a08c87ecfe98".into(),
         auth_url: "https://github.com/login/device/code".into(),
@@ -17,6 +34,7 @@ fn builtin_defaults() -> HashMap<String, OAuthConfig> {
         scopes: vec![],
         extra_auth_params: vec![],
         device_flow: true,
+        api_key_endpoint: None,
     });
     m.insert("kimi-code".into(), OAuthConfig {
         client_id: "17e5f671-d194-4dfb-9706-5516cb48c098".into(),
@@ -27,6 +45,7 @@ fn builtin_defaults() -> HashMap<String, OAuthConfig> {
         scopes: vec![],
         extra_auth_params: vec![],
         device_flow: true,
+        api_key_endpoint: None,
     });
     m.insert("openai-codex".into(), OAuthConfig {
         client_id: "app_EMoamEEZ73f0CkXaXp7hrann".into(),
@@ -45,6 +64,7 @@ fn builtin_defaults() -> HashMap<String, OAuthConfig> {
             ("codex_cli_simplified_flow".into(), "true".into()),
         ],
         device_flow: false,
+        api_key_endpoint: None,
     });
     m
 }
@@ -88,6 +108,9 @@ pub fn load_oauth_config(provider: &str) -> Option<OAuthConfig> {
     }
     if let Ok(v) = std::env::var(format!("{env_prefix}REDIRECT_URI")) {
         config.redirect_uri = v;
+    }
+    if let Ok(v) = std::env::var(format!("{env_prefix}API_KEY_ENDPOINT")) {
+        config.api_key_endpoint = Some(v);
     }
 
     Some(config)
@@ -140,6 +163,31 @@ mod tests {
     }
 
     #[test]
+    fn load_anthropic_config() {
+        let config = load_oauth_config("anthropic").expect("should have anthropic");
+        assert_eq!(config.client_id, "9d1c250a-e61b-44d9-88ed-5944d1962f5e");
+        assert!(!config.device_flow);
+        assert_eq!(
+            config.auth_url,
+            "https://console.anthropic.com/oauth/authorize"
+        );
+        assert_eq!(
+            config.token_url,
+            "https://console.anthropic.com/v1/oauth/token"
+        );
+        assert_eq!(config.redirect_uri, "http://localhost:1456/auth/callback");
+        assert_eq!(config.scopes, vec![
+            "org:create_api_key",
+            "user:profile",
+            "user:inference"
+        ]);
+        assert_eq!(
+            config.api_key_endpoint.as_deref(),
+            Some("https://api.anthropic.com/api/oauth/claude_cli/create_api_key")
+        );
+    }
+
+    #[test]
     fn load_unknown_provider_returns_none() {
         assert!(load_oauth_config("nonexistent-provider").is_none());
     }
@@ -155,5 +203,11 @@ mod tests {
     fn callback_port_with_redirect_uri() {
         let config = load_oauth_config("openai-codex").unwrap();
         assert_eq!(callback_port(&config), 1455);
+    }
+
+    #[test]
+    fn callback_port_anthropic() {
+        let config = load_oauth_config("anthropic").unwrap();
+        assert_eq!(callback_port(&config), 1456);
     }
 }

--- a/crates/oauth/src/device_flow.rs
+++ b/crates/oauth/src/device_flow.rs
@@ -153,6 +153,7 @@ mod tests {
             scopes: vec![],
             extra_auth_params: vec![],
             device_flow: true,
+            api_key_endpoint: None,
         }
     }
 

--- a/crates/oauth/src/lib.rs
+++ b/crates/oauth/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod api_key_exchange;
 pub mod callback_server;
 mod config_dir;
 pub mod defaults;
@@ -12,6 +13,7 @@ pub mod storage;
 pub mod types;
 
 pub use {
+    api_key_exchange::create_api_key_from_oauth,
     callback_server::CallbackServer,
     defaults::{callback_port, load_oauth_config},
     device_flow::DeviceCodeResponse,

--- a/crates/oauth/src/types.rs
+++ b/crates/oauth/src/types.rs
@@ -21,6 +21,10 @@ pub struct OAuthConfig {
     /// If true, use the GitHub device-flow instead of PKCE authorization code flow.
     #[serde(default)]
     pub device_flow: bool,
+    /// If set, the temporary OAuth token is exchanged for a permanent API key
+    /// by POSTing to this endpoint. The result is stored in `KeyStore`, not `TokenStore`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub api_key_endpoint: Option<String>,
 }
 
 /// Stored OAuth tokens.

--- a/crates/oauth/tests/oauth_tests.rs
+++ b/crates/oauth/tests/oauth_tests.rs
@@ -132,6 +132,7 @@ async fn oauth_flow_exchange_sends_resource_indicator_when_configured() {
         scopes: vec![],
         extra_auth_params: vec![],
         device_flow: false,
+        api_key_endpoint: None,
     });
 
     let tokens = flow.exchange("code-123", "verifier-123").await.unwrap();

--- a/crates/provider-setup/src/lib.rs
+++ b/crates/provider-setup/src/lib.rs
@@ -1678,6 +1678,8 @@ impl ProviderSetupService for LiveProviderSetupService {
                     .unwrap_or_default();
                 let model = models.first().cloned();
 
+                let has_oauth = load_oauth_config(provider.name).is_some();
+
                 Some((
                     offered_rank.get(&normalized_name).copied(),
                     known_idx,
@@ -1692,6 +1694,7 @@ impl ProviderSetupService for LiveProviderSetupService {
                         "model": model,
                         "requiresModel": provider.requires_model,
                         "keyOptional": provider.key_optional,
+                        "hasOauth": has_oauth,
                     }),
                 ))
             })
@@ -1887,9 +1890,14 @@ impl ProviderSetupService for LiveProviderSetupService {
         set_provider_enabled_in_config(&provider_name, true)?;
         self.set_provider_enabled_in_memory(&provider_name, true);
 
-        // If tokens already exist (for example imported from the main/home config),
-        // skip launching a fresh OAuth flow and rebuild the registry immediately.
-        if self.has_oauth_tokens(&provider_name) {
+        // If credentials already exist (API key for api_key_endpoint providers,
+        // or tokens for standard OAuth), skip launching a fresh OAuth flow.
+        let already_configured = if oauth_config.api_key_endpoint.is_some() {
+            self.key_store.load(&provider_name).is_some()
+        } else {
+            self.has_oauth_tokens(&provider_name)
+        };
+        if already_configured {
             let effective = self.effective_config();
             let new_registry = self.build_registry(&effective);
             let provider_summary = new_registry.provider_summary();
@@ -1953,6 +1961,8 @@ impl ProviderSetupService for LiveProviderSetupService {
 
         // Spawn background task to wait for the callback and exchange the code
         let token_store = self.token_store.clone();
+        let key_store = self.key_store.clone();
+        let api_key_endpoint = oauth_config_for_pending.api_key_endpoint.clone();
         let registry = Arc::clone(&self.registry);
         let config = self.effective_config();
         let env_overrides = self.env_overrides.clone();
@@ -1962,7 +1972,41 @@ impl ProviderSetupService for LiveProviderSetupService {
                 Ok(code) => {
                     match flow.exchange(&code, &verifier).await {
                         Ok(tokens) => {
-                            if let Err(e) = token_store.save(&provider_name, &tokens) {
+                            if let Some(endpoint) = api_key_endpoint {
+                                // Exchange temporary token for a permanent API key.
+                                match moltis_oauth::create_api_key_from_oauth(
+                                    &endpoint,
+                                    &tokens.access_token,
+                                )
+                                .await
+                                {
+                                    Ok(api_key) => {
+                                        if let Err(e) = key_store.save_config(
+                                            &provider_name,
+                                            Some(ExposeSecret::expose_secret(&api_key).to_string()),
+                                            None,
+                                            None,
+                                        ) {
+                                            tracing::error!(
+                                                provider = %provider_name,
+                                                error = %e,
+                                                "failed to save API key from OAuth"
+                                            );
+                                            return;
+                                        }
+                                        let _ =
+                                            set_provider_enabled_in_config(&provider_name, true);
+                                    },
+                                    Err(e) => {
+                                        tracing::error!(
+                                            provider = %provider_name,
+                                            error = %e,
+                                            "OAuth API key exchange failed"
+                                        );
+                                        return;
+                                    },
+                                }
+                            } else if let Err(e) = token_store.save(&provider_name, &tokens) {
                                 tracing::error!(
                                     provider = %provider_name,
                                     error = %e,
@@ -1970,7 +2014,7 @@ impl ProviderSetupService for LiveProviderSetupService {
                                 );
                                 return;
                             }
-                            // Rebuild registry with new tokens
+                            // Rebuild registry with new tokens/key
                             let new_registry = ProviderRegistry::from_env_with_config_and_overrides(
                                 &config,
                                 &env_overrides,
@@ -2029,15 +2073,30 @@ impl ProviderSetupService for LiveProviderSetupService {
             .remove(&state)
             .ok_or_else(|| "unknown or expired OAuth state".to_string())?;
 
+        let api_key_endpoint = pending.oauth_config.api_key_endpoint.clone();
         let flow = OAuthFlow::new(pending.oauth_config);
         let tokens = flow
             .exchange(&code, &pending.verifier)
             .await
             .map_err(ServiceError::message)?;
 
-        self.token_store
-            .save(&pending.provider_name, &tokens)
-            .map_err(ServiceError::message)?;
+        if let Some(endpoint) = api_key_endpoint {
+            let api_key = moltis_oauth::create_api_key_from_oauth(&endpoint, &tokens.access_token)
+                .await
+                .map_err(|e| ServiceError::message(e.to_string()))?;
+            self.key_store
+                .save_config(
+                    &pending.provider_name,
+                    Some(ExposeSecret::expose_secret(&api_key).to_string()),
+                    None,
+                    None,
+                )
+                .map_err(ServiceError::message)?;
+        } else {
+            self.token_store
+                .save(&pending.provider_name, &tokens)
+                .map_err(ServiceError::message)?;
+        }
         set_provider_enabled_in_config(&pending.provider_name, true)?;
         self.set_provider_enabled_in_memory(&pending.provider_name, true);
 
@@ -2129,10 +2188,18 @@ impl ProviderSetupService for LiveProviderSetupService {
             .and_then(|v| v.as_str())
             .ok_or_else(|| "missing 'provider' parameter".to_string())?;
 
-        let has_tokens = self.has_oauth_tokens(provider_name);
+        // For providers with api_key_endpoint, check KeyStore instead of TokenStore.
+        let authenticated = if load_oauth_config(provider_name)
+            .as_ref()
+            .is_some_and(|c| c.api_key_endpoint.is_some())
+        {
+            self.key_store.load(provider_name).is_some()
+        } else {
+            self.has_oauth_tokens(provider_name)
+        };
         Ok(serde_json::json!({
             "provider": provider_name,
-            "authenticated": has_tokens,
+            "authenticated": authenticated,
         }))
     }
 
@@ -4428,6 +4495,65 @@ mod tests {
         assert_eq!(
             ids[2], "openrouter::gpt-4o-search-preview",
             "slow namespaced model should be last, got: {ids:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn available_includes_has_oauth_for_anthropic() {
+        let registry = Arc::new(RwLock::new(ProviderRegistry::from_env_with_config(
+            &ProvidersConfig::default(),
+        )));
+        let svc = LiveProviderSetupService::new(registry, ProvidersConfig::default(), None);
+        let result = svc.available().await.unwrap();
+        let arr = result.as_array().unwrap();
+
+        let anthropic = arr
+            .iter()
+            .find(|v| v.get("name").and_then(|n| n.as_str()) == Some("anthropic"))
+            .expect("anthropic should be in available providers");
+
+        assert_eq!(
+            anthropic.get("hasOauth").and_then(|v| v.as_bool()),
+            Some(true),
+            "anthropic should have hasOauth: true"
+        );
+        assert_eq!(
+            anthropic.get("authType").and_then(|v| v.as_str()),
+            Some("api-key"),
+            "anthropic should still have authType: api-key"
+        );
+    }
+
+    #[tokio::test]
+    async fn oauth_status_checks_key_store_for_anthropic() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let registry = Arc::new(RwLock::new(ProviderRegistry::from_env_with_config(
+            &ProvidersConfig::default(),
+        )));
+        let mut svc = LiveProviderSetupService::new(registry, ProvidersConfig::default(), None);
+        svc.key_store = KeyStore::with_path(temp.path().join("keys.json"));
+
+        // Initially not authenticated
+        let result = svc
+            .oauth_status(serde_json::json!({"provider": "anthropic"}))
+            .await
+            .unwrap();
+        assert_eq!(
+            result.get("authenticated").and_then(|v| v.as_bool()),
+            Some(false)
+        );
+
+        // Save an API key and re-check
+        svc.key_store
+            .save_config("anthropic", Some("sk-ant-test".to_string()), None, None)
+            .expect("save key");
+        let result = svc
+            .oauth_status(serde_json::json!({"provider": "anthropic"}))
+            .await
+            .unwrap();
+        assert_eq!(
+            result.get("authenticated").and_then(|v| v.as_bool()),
+            Some(true)
         );
     }
 }

--- a/crates/web/src/assets/js/onboarding-view.js
+++ b/crates/web/src/assets/js/onboarding-view.js
@@ -678,6 +678,33 @@ function ModelSelectCard({ model, selected, probe, onToggle }) {
 	</div>`;
 }
 
+function OAuthButton({ provider, onDone }) {
+	var [oauthError, setOauthError] = useState(null);
+	var [starting, setStarting] = useState(false);
+
+	function onClick() {
+		setStarting(true);
+		setOauthError(null);
+		startProviderOAuth(provider.name).then((result) => {
+			if (result.status === "browser") {
+				window.location.href = result.authUrl;
+			} else if (result.status === "already") {
+				onDone();
+			} else {
+				setStarting(false);
+				setOauthError(result.error || "OAuth failed");
+			}
+		});
+	}
+
+	return html`<div class="flex flex-col gap-1">
+		<button type="button" class="provider-btn provider-btn-secondary w-full" disabled=${starting} onClick=${onClick}>
+			${starting ? "Starting OAuth\u2026" : `Connect with ${provider.displayName} OAuth`}
+		</button>
+		${oauthError ? html`<div class="text-xs text-[var(--error)]">${oauthError}</div>` : null}
+	</div>`;
+}
+
 // ── Provider row for multi-provider onboarding ──────────────
 
 // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: provider row renders inline config forms for api-key, oauth, and local flows
@@ -762,6 +789,7 @@ function OnboardingProviderRow({
 					<span class="provider-item-badge ${provider.authType}">
 						${provider.authType === "oauth" ? "OAuth" : provider.authType === "local" ? "Local" : "API Key"}
 					</span>
+					${provider.hasOauth && provider.authType !== "oauth" ? html`<span class="provider-item-badge oauth">OAuth</span>` : null}
 				</div>
 			</div>
 			<div class="shrink-0">
@@ -799,6 +827,16 @@ function OnboardingProviderRow({
 							: null
 					}
 				</div>
+				${
+					provider.hasOauth
+						? html`<div class="flex items-center gap-2 my-2 text-xs text-[var(--muted)]">
+						<div class="flex-1 border-t border-[var(--border)]"></div>
+						<span>or</span>
+						<div class="flex-1 border-t border-[var(--border)]"></div>
+					</div>
+					<${OAuthButton} provider=${provider} onDone=${onCancelConfigure} />`
+						: null
+				}
 				${
 					supportsEndpoint
 						? html`<div>

--- a/crates/web/src/assets/js/providers.js
+++ b/crates/web/src/assets/js/providers.js
@@ -138,6 +138,12 @@ export function openProviderModal() {
 					badge.textContent = "API Key";
 				}
 				badges.appendChild(badge);
+				if (p.hasOauth && p.authType !== "oauth") {
+					var oauthBadge = document.createElement("span");
+					oauthBadge.className = "provider-item-badge oauth";
+					oauthBadge.textContent = "OAuth";
+					badges.appendChild(oauthBadge);
+				}
 			}
 			item.appendChild(badges);
 
@@ -516,6 +522,41 @@ export function showApiKeyForm(provider) {
 			keyHelpLine.textContent = keyHelp.text;
 		}
 		form.appendChild(keyHelpLine);
+	}
+
+	// OAuth alternative for API key providers with OAuth support
+	if (provider.hasOauth) {
+		var divider = document.createElement("div");
+		divider.className = "flex items-center gap-2 my-3 text-xs text-[var(--muted)]";
+		var line1 = document.createElement("div");
+		line1.className = "flex-1 border-t border-[var(--border)]";
+		var orText = document.createElement("span");
+		orText.textContent = "or";
+		var line2 = document.createElement("div");
+		line2.className = "flex-1 border-t border-[var(--border)]";
+		divider.append(line1, orText, line2);
+		form.appendChild(divider);
+
+		var oauthBtn = document.createElement("button");
+		oauthBtn.className = "provider-btn provider-btn-secondary w-full";
+		oauthBtn.textContent = `Connect with ${provider.displayName} OAuth`;
+		oauthBtn.addEventListener("click", () => {
+			oauthBtn.disabled = true;
+			oauthBtn.textContent = "Starting OAuth...";
+			startProviderOAuth(provider.name).then((result) => {
+				if (result.status === "browser") {
+					window.location.href = result.authUrl;
+				} else if (result.status === "already") {
+					closeProviderModal();
+					openProviderModal();
+				} else {
+					oauthBtn.disabled = false;
+					oauthBtn.textContent = `Connect with ${provider.displayName} OAuth`;
+					setFormError(errorPanel, result.error || "OAuth failed");
+				}
+			});
+		});
+		form.appendChild(oauthBtn);
 	}
 
 	// Endpoint field for OpenAI-compatible providers

--- a/crates/web/ui/e2e/specs/providers.spec.js
+++ b/crates/web/ui/e2e/specs/providers.spec.js
@@ -87,6 +87,47 @@ test.describe("Provider setup page", () => {
 		expect(pageErrors).toEqual([]);
 	});
 
+	test("anthropic shows api key and oauth badges", async ({ page }) => {
+		const pageErrors = watchPageErrors(page);
+		await openProvidersPage(page);
+		await page.locator("#providersAddLlmBtn").click();
+
+		const anthropicItem = page
+			.locator(".provider-modal-backdrop .provider-item")
+			.filter({ has: page.locator(".provider-item-name", { hasText: /^Anthropic$/ }) })
+			.first();
+
+		if ((await anthropicItem.count()) > 0) {
+			await expect(anthropicItem).toBeVisible();
+			const badges = anthropicItem.locator(".provider-item-badge");
+			const badgeTexts = await badges.allTextContents();
+			expect(badgeTexts).toContain("API Key");
+			expect(badgeTexts).toContain("OAuth");
+		}
+
+		expect(pageErrors).toEqual([]);
+	});
+
+	test("anthropic api key form shows oauth button", async ({ page }) => {
+		const pageErrors = watchPageErrors(page);
+		await openProvidersPage(page);
+		await page.locator("#providersAddLlmBtn").click();
+
+		const anthropicItem = page
+			.locator(".provider-modal-backdrop .provider-item")
+			.filter({ has: page.locator(".provider-item-name", { hasText: /^Anthropic$/ }) })
+			.first();
+
+		if ((await anthropicItem.count()) > 0) {
+			await anthropicItem.click();
+			await expect(
+				page.getByRole("button", { name: /Connect with Anthropic OAuth/i }),
+			).toBeVisible();
+		}
+
+		expect(pageErrors).toEqual([]);
+	});
+
 	test("provider validation errors render in danger panel", async ({ page }) => {
 		const pageErrors = watchPageErrors(page);
 		await openProvidersPage(page);


### PR DESCRIPTION
## Summary

- Add browser-based OAuth login for Anthropic (`moltis auth login --provider anthropic` and web UI button)
- Anthropic's console OAuth (PKCE) produces a temporary token, exchanged for a permanent `sk-ant-api03-*` API key via `create_api_key` endpoint
- The permanent key is stored in `KeyStore` (same as manually-entered keys) — `AnthropicProvider` unchanged
- New `api_key_endpoint` field on `OAuthConfig` enables this pattern for any future provider
- Web UI shows both "API Key" and "OAuth" badges on Anthropic, with an OAuth button in the key form

## Validation

### Completed
- [x] `cargo +nightly-2025-11-30 fmt --all -- --check`
- [x] `cargo +nightly-2025-11-30 clippy --workspace --all-targets --timings -- -D warnings`
- [x] `cargo test` (135 tests across oauth + provider-setup, 0 failures)
- [x] `taplo fmt` (TOML)
- [x] `biome check --write` (JS)
- [x] Tailwind CSS rebuilt

### Remaining
- [ ] `./scripts/local-validate.sh 309`
- [ ] Manual QA: `moltis auth login --provider anthropic` opens browser, completes OAuth, creates API key
- [ ] Manual QA: Web UI Settings > Providers > Anthropic shows both key input and OAuth button
- [ ] E2E tests: `cd crates/web/ui && npx playwright test e2e/specs/providers.spec.js`

## Manual QA

1. Start moltis, open Settings > Providers
2. Click "Add Provider" — verify Anthropic shows "API Key" + "OAuth" badges
3. Click Anthropic — verify API key form has "or" divider and "Connect with Anthropic OAuth" button
4. Click OAuth button — verify browser opens to Anthropic console OAuth page
5. Complete OAuth flow — verify API key is created and Anthropic shows as configured
6. Run `moltis auth login --provider anthropic` from CLI — verify same flow works

Closes #309

🤖 Generated with [Claude Code](https://claude.com/claude-code)