### PR TITLE
fix: install rustls CryptoProvider before channel startup

### DIFF
--- a/crates/gateway/src/server.rs
+++ b/crates/gateway/src/server.rs
@@ -1434,6 +1434,14 @@ pub async fn prepare_gateway(
     let mut startup_mem_probe = StartupMemProbe::new();
     startup_mem_probe.checkpoint("prepare_gateway.start");
 
+    // Install a process-level rustls CryptoProvider early, before any channel
+    // plugin (Slack, Discord, etc.) creates outbound TLS connections via
+    // hyper-rustls.  Without this, `--no-tls` deployments skip the TLS cert
+    // setup path where `install_default()` previously lived, causing a panic
+    // the first time an outbound HTTPS request is made (see #329).
+    #[cfg(feature = "tls")]
+    let _ = rustls::crypto::ring::default_provider().install_default();
+
     // CLI --no-tls / MOLTIS_NO_TLS overrides config file TLS setting.
     if no_tls {
         config.tls.enabled = false;


### PR DESCRIPTION
## Problem

When running with `--no-tls` (e.g. behind Caddy or another reverse proxy), `rustls::crypto::ring::default_provider().install_default()` is only called inside `load_rustls_config()` in `crates/tls/src/lib.rs`. That path is skipped entirely when TLS is disabled, so no process-level `CryptoProvider` is ever installed.

When a channel plugin like Slack then creates an outbound HTTPS WebSocket connection via `SlackClientHyperConnector` (which uses `hyper-rustls`), rustls panics:

```
Could not automatically determine the process-level CryptoProvider from Rustls crate features.
```

## Fix

Move the `install_default()` call to early in `prepare_gateway()`, before any channel accounts are started. This ensures the ring `CryptoProvider` is available for all outbound TLS connections regardless of whether the gateway's own HTTPS server is enabled.

The existing call in `load_rustls_config()` is left in place as it's idempotent (`install_default()` returns `Err` if already installed, which is harmlessly ignored).

## Testing

- `install_default()` is idempotent — safe to call multiple times
- Only compiles when `feature = "tls"` is enabled (which it is by default)
- One-line surgical fix, no behavior change for TLS-enabled deployments

Fixes #329