### PR TITLE
feat(chat): tabs to filter chats between sessions and cron

### DIFF
--- a/crates/web/src/assets/js/app.js
+++ b/crates/web/src/assets/js/app.js
@@ -485,10 +485,32 @@ function fetchBootstrap() {
 		});
 }
 
+function initSessionTabBar() {
+	var bar = S.$("sessionTabBar");
+	if (!bar) return;
+	var buttons = bar.querySelectorAll(".session-tab");
+
+	function updateActive() {
+		var current = sessionStore.sessionListTab.value;
+		for (var btn of buttons) {
+			btn.classList.toggle("active", btn.dataset.tab === current);
+		}
+	}
+
+	for (var btn of buttons) {
+		btn.addEventListener("click", function () {
+			sessionStore.setSessionListTab(this.dataset.tab);
+			updateActive();
+		});
+	}
+	updateActive();
+}
+
 function startApp() {
 	// Mount the reactive SessionList once — signals drive all re-renders.
 	var sessionListEl = S.$("sessionList");
 	if (sessionListEl) render(html`<${SessionList} />`, sessionListEl);
+	initSessionTabBar();
 
 	var path = location.pathname;
 	if (path === "/") {

--- a/crates/web/src/assets/js/components/session-list.js
+++ b/crates/web/src/assets/js/components/session-list.js
@@ -218,8 +218,14 @@ export function SessionList() {
 	var activeKey = sessionStore.activeSessionKey.value;
 	var refreshingKey = sessionStore.refreshInProgressKey.value;
 	var filterId = projectStore.projectFilterId.value;
+	var tab = sessionStore.sessionListTab.value;
 
 	var filtered = filterId ? allSessions.filter((s) => s.projectId === filterId) : allSessions;
+	if (tab === "sessions") {
+		filtered = filtered.filter((s) => !(s.key || "").startsWith("cron:"));
+	} else if (tab === "cron") {
+		filtered = filtered.filter((s) => (s.key || "").startsWith("cron:"));
+	}
 
 	// Build parent→children map for tree rendering
 	var childrenMap = {};

--- a/crates/web/src/assets/js/locales/en/sessions.js
+++ b/crates/web/src/assets/js/locales/en/sessions.js
@@ -11,6 +11,12 @@ export default {
 		},
 	},
 
+	// Session list tabs
+	tabs: {
+		sessions: "Sessions",
+		cron: "Cron",
+	},
+
 	// Session list
 	list: {
 		newSession: "New session",

--- a/crates/web/src/assets/js/locales/fr/sessions.js
+++ b/crates/web/src/assets/js/locales/fr/sessions.js
@@ -11,6 +11,12 @@ export default {
 		},
 	},
 
+	// Session list tabs
+	tabs: {
+		sessions: "Sessions",
+		cron: "Cron",
+	},
+
 	// Session list
 	list: {
 		newSession: "New session",

--- a/crates/web/src/assets/js/locales/zh/sessions.js
+++ b/crates/web/src/assets/js/locales/zh/sessions.js
@@ -11,6 +11,12 @@ export default {
 		},
 	},
 
+	// Session list tabs
+	tabs: {
+		sessions: "会话",
+		cron: "定时任务",
+	},
+
 	// Session list
 	list: {
 		newSession: "新建会话",

--- a/crates/web/src/assets/js/stores/session-store.js
+++ b/crates/web/src/assets/js/stores/session-store.js
@@ -122,6 +122,8 @@ export var sessions = signal([]);
 export var activeSessionKey = signal(localStorage.getItem("moltis-session") || "main");
 export var switchInProgress = signal(false);
 export var refreshInProgressKey = signal("");
+/** Session list tab filter: "all" | "sessions" | "cron" */
+export var sessionListTab = signal(localStorage.getItem("moltis-session-tab") || "sessions");
 
 export var activeSession = computed(() => {
 	var key = activeSessionKey.value;
@@ -222,12 +224,19 @@ export function setActive(key) {
 	localStorage.setItem("moltis-session", key);
 }
 
+/** Set the session list tab and persist it. */
+export function setSessionListTab(tab) {
+	sessionListTab.value = tab;
+	localStorage.setItem("moltis-session-tab", tab);
+}
+
 export var sessionStore = {
 	sessions,
 	activeSessionKey,
 	activeSession,
 	switchInProgress,
 	refreshInProgressKey,
+	sessionListTab,
 	Session,
 	setAll,
 	upsert,
@@ -235,5 +244,6 @@ export var sessionStore = {
 	fetch,
 	getByKey,
 	setActive,
+	setSessionListTab,
 	notify,
 };

--- a/crates/web/src/templates/index.html
+++ b/crates/web/src/templates/index.html
@@ -234,6 +234,10 @@
       </div>
       <div id="searchResults" class="hidden"></div>
     </div>
+    <div id="sessionTabBar" class="flex border-b border-[var(--border)] text-xs" role="tablist">
+      <button class="session-tab flex-1 py-1.5 text-center cursor-pointer bg-transparent border-b-2 border-transparent text-[var(--muted)] hover:text-[var(--text)] transition-colors" data-tab="sessions" role="tab">Sessions</button>
+      <button class="session-tab flex-1 py-1.5 text-center cursor-pointer bg-transparent border-b-2 border-transparent text-[var(--muted)] hover:text-[var(--text)] transition-colors" data-tab="cron" role="tab">Cron</button>
+    </div>
     <div class="flex-1 overflow-y-auto" id="sessionList"></div>
   </div>
 

--- a/crates/web/ui/input.css
+++ b/crates/web/ui/input.css
@@ -1135,6 +1135,12 @@
     color: var(--muted);
   }
 
+  /* Session tab bar */
+  .session-tab.active {
+    color: var(--text);
+    border-bottom-color: var(--accent);
+  }
+
   /* Session panel */
   .session-item {
     display: flex;


### PR DESCRIPTION
## Summary

- Add tab bar to the session list sidebar to filter between "Sessions" and "Cron" views
- Sessions tab filters out `cron:` prefixed sessions; Cron tab shows only `cron:` sessions
- Tab selection persists to `localStorage` and defaults to "Sessions"
- Adds i18n translations for tab labels (en, fr, zh)
