### PR TITLE
fix(web): prevent Enter key from triggering actions during IME composition

### DIFF
--- a/crates/web/src/assets/js/components/session-header.js
+++ b/crates/web/src/assets/js/components/session-header.js
@@ -154,7 +154,7 @@ export function SessionHeader({
 
 	var onKeyDown = useCallback(
 		(e) => {
-			if (e.key === "Enter") {
+			if (e.key === "Enter" && !e.isComposing) {
 				e.preventDefault();
 				commitRename();
 			}

--- a/crates/web/src/assets/js/page-channels.js
+++ b/crates/web/src/assets/js/page-channels.js
@@ -346,7 +346,7 @@ function AllowlistInput({ value, onChange }) {
 	}
 
 	function onKeyDown(e) {
-		if (e.key === "Enter" || e.key === ",") {
+		if ((e.key === "Enter" || e.key === ",") && !e.isComposing) {
 			e.preventDefault();
 			if (input.value.trim()) addTag(input.value);
 		} else if (e.key === "Backspace" && !input.value && value.length > 0) {

--- a/crates/web/src/assets/js/page-chat.js
+++ b/crates/web/src/assets/js/page-chat.js
@@ -1348,7 +1348,7 @@ registerPrefix(
 				setCommandMode(false);
 				return;
 			}
-			if (e.key === "Enter" && !e.shiftKey) {
+			if (e.key === "Enter" && !e.shiftKey && !e.isComposing) {
 				e.preventDefault();
 				sendChat();
 				return;

--- a/crates/web/src/assets/js/providers.js
+++ b/crates/web/src/assets/js/providers.js
@@ -1505,7 +1505,7 @@ function renderLocalModelSelection(provider, sysInfo, modelsData) {
 
 	searchBtn.addEventListener("click", doSearch);
 	searchInput.addEventListener("keydown", (e) => {
-		if (e.key === "Enter") doSearch();
+		if (e.key === "Enter" && !e.isComposing) doSearch();
 	});
 
 	// Auto-search with debounce when user stops typing


### PR DESCRIPTION
## Summary

Fixes IME (Input Method Editor) conflict where pressing Enter while using input methods for CJK languages (Chinese, Japanese, Korean) would incorrectly trigger actions instead of confirming the IME composition.

## Problem

When users type with IME enabled:
1. User types pinyin/hiragana/hangul
2. User presses Enter to select the suggested character/word
3. **Bug**: The Enter key also triggers the form action (sends message, submits form, etc.)
4. **Expected**: Enter should only confirm IME selection, not trigger the action

This is a common UX issue in web applications that don't properly handle IME events.

## Solution

Added `!e.isComposing` check to all Enter key event handlers. The `isComposing` property is `true` when the user is in the middle of IME composition, allowing us to distinguish between:
- IME confirmation Enter (ignore action)
- Regular Enter (trigger action)

## Changes

Modified Enter key handlers in:
- `crates/web/src/assets/js/page-chat.js` - Chat message input
- `crates/web/src/assets/js/components/session-header.js` - Session rename input
- `crates/web/src/assets/js/page-channels.js` - Channel tags input
- `crates/web/src/assets/js/providers.js` - Provider search input

## Validation

### Completed
- [x] Code changes implemented
- [x] Biome formatting applied: `npx biome check --write` on modified files
- [x] Conventional commit message used

### Manual QA

Test with IME enabled (Chinese/Japanese/Korean input):

1. **Chat input**:
   - Enable IME (e.g., Chinese Pinyin)
   - Type "nihao" and press Enter to select "你好"
   - Verify: Message is NOT sent, IME selection is confirmed
   - Press Enter again
   - Verify: Message IS sent

2. **Session rename**:
   - Click to rename a session
   - Enable IME and type with composition
   - Press Enter during composition
   - Verify: Rename is NOT committed, IME selection is confirmed
   - Press Enter again
   - Verify: Rename IS committed

3. **Channel tags**:
   - Add channel tag with IME
   - Press Enter during composition
   - Verify: Tag is NOT added, IME selection is confirmed
   - Press Enter again
   - Verify: Tag IS added

4. **Provider search**:
   - Search providers with IME
   - Press Enter during composition
   - Verify: Search is NOT triggered, IME selection is confirmed
   - Press Enter again
   - Verify: Search IS triggered

### Remaining
- [ ] Manual QA with actual IME input (requires testing by maintainer or contributor with CJK input method)

## References

- [MDN: KeyboardEvent.isComposing](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/isComposing)
- Standard practice for handling IME in web applications
