### PR TITLE
fix(mdns): use stable host label to avoid mDNSResponder conflict and double-.local suffix

### DIFF
--- a/crates/gateway/src/mdns.rs
+++ b/crates/gateway/src/mdns.rs
@@ -38,12 +38,21 @@ pub fn register(
 ) -> anyhow::Result<ServiceDaemon> {
     let daemon = ServiceDaemon::new()?;
 
+    // Use a stable synthetic hostname instead of the system hostname to avoid
+    // two problems:
+    //   1. Double-suffix: macOS often returns a hostname already ending in
+    //      `.local`, producing `foo.local.local.` — an invalid mDNS name.
+    //   2. Conflict: mdns_sd runs its own mDNS stack on port 5353 and would
+    //      advertise A records for the system hostname, competing with macOS
+    //      mDNSResponder which already owns that name.
+    // The actual hostname is still surfaced to clients via the `hostname`
+    // property in the TXT record.
     let host = hostname::get()
         .ok()
         .and_then(|h| h.into_string().ok())
         .unwrap_or_else(|| "moltis-gateway".to_string());
 
-    let host_label = format!("{host}.local.");
+    let host_label = "moltis-gateway.local.".to_string();
 
     let port_value = port.to_string();
     let properties = [


### PR DESCRIPTION
## Summary

- **Bug 1 — double `.local.local.` suffix**: `format!("{host}.local.")` produced an invalid mDNS hostname (e.g. `my-mac.local.local.`) when `hostname::get()` returned a name already ending in `.local`, which is common on macOS after a hostname rename via System Settings.
- **Bug 2 — mDNSResponder conflict**: `mdns_sd` is a pure-Rust mDNS stack that opens its own multicast socket on port 5353 and advertises A records for `{hostname}.local.`. On macOS, `mDNSResponder` already owns that name, causing conflicts — especially visible on startup after a hostname change.

**Fix:** Use the stable synthetic hostname `moltis-gateway.local.` as the SRV target in `ServiceInfo::new()` instead of deriving it from the system hostname. The real hostname is still surfaced to clients via the `hostname` TXT record property, so discovery is unaffected.

## Validation

### Completed
- [x] Rust fmt passes
- [x] `cargo test` passes for `crates/gateway`
- [x] mDNS smoke test in `mdns.rs` still passes

### Remaining
- [ ] `./scripts/local-validate.sh` (requires CI environment)

## Manual QA

1. Rename Mac hostname via System Settings → General → Sharing.
2. Restart moltis.
3. Confirm no mDNS conflict errors in logs and that the gateway is discoverable on the LAN.
4. Confirm passkey/WebAuthn flows still work from `.local` hostname.