### PR TITLE
fix(gateway): retain proxy shutdown sender to prevent immediate proxy exit

### DIFF
--- a/crates/gateway/src/server.rs
+++ b/crates/gateway/src/server.rs
@@ -1366,6 +1366,11 @@ pub struct PreparedGateway {
     /// the `trusted-network` feature is enabled and the proxy is active).
     #[cfg(feature = "trusted-network")]
     pub audit_buffer: Option<crate::network_audit::NetworkAuditBuffer>,
+    /// Shutdown sender for the trusted-network proxy.  Retained here so the
+    /// proxy task is not cancelled when `prepare_gateway` returns (dropping
+    /// the sender closes the watch channel and triggers immediate shutdown).
+    #[cfg(feature = "trusted-network")]
+    _proxy_shutdown_tx: Option<tokio::sync::watch::Sender<bool>>,
 }
 
 /// Internal metadata for the startup banner printed by [`start_gateway`].
@@ -2335,6 +2340,8 @@ pub async fn prepare_gateway(
     #[cfg(feature = "trusted-network")]
     let proxy_url_for_tools: Option<String>;
     #[cfg(feature = "trusted-network")]
+    let proxy_shutdown_tx: Option<tokio::sync::watch::Sender<bool>>;
+    #[cfg(feature = "trusted-network")]
     {
         let (audit_tx, audit_rx) =
             tokio::sync::mpsc::channel::<moltis_network_filter::NetworkAuditEntry>(1024);
@@ -2359,7 +2366,7 @@ pub async fn prepare_gateway(
                 Arc::clone(&domain_mgr),
                 Some(audit_tx.clone()),
             );
-            let (_proxy_shutdown_tx, proxy_shutdown_rx) = tokio::sync::watch::channel(false);
+            let (shutdown_tx, proxy_shutdown_rx) = tokio::sync::watch::channel(false);
             tokio::spawn(async move {
                 if let Err(e) = proxy.run(proxy_shutdown_rx).await {
                     tracing::warn!("network proxy exited: {e}");
@@ -2375,12 +2382,14 @@ pub async fn prepare_gateway(
             );
             moltis_tools::init_shared_http_client(Some(&url));
             proxy_url_for_tools = Some(url);
+            proxy_shutdown_tx = Some(shutdown_tx);
         } else {
             info!(
                 network_policy = ?sandbox_config.network,
                 "trusted-network proxy not started (policy is not Trusted)"
             );
             proxy_url_for_tools = None;
+            proxy_shutdown_tx = None;
         }
 
         // Create the live network audit service from the receiver channel.
@@ -4948,6 +4957,8 @@ pub async fn prepare_gateway(
         },
         #[cfg(feature = "trusted-network")]
         audit_buffer: audit_buffer_for_broadcast,
+        #[cfg(feature = "trusted-network")]
+        _proxy_shutdown_tx: proxy_shutdown_tx,
     })
 }
 


### PR DESCRIPTION
## Summary

Fixes #367 — The trusted-network proxy shuts down immediately after starting because the `watch::Sender` (`_proxy_shutdown_tx`) is dropped when it goes out of scope, causing the proxy's shutdown signal to fire.

## Root Cause

In `crates/gateway/src/server.rs`, the shutdown channel sender is created inside the `if sandbox_config.network == Trusted` block:

```rust
let (_proxy_shutdown_tx, proxy_shutdown_rx) = tokio::sync::watch::channel(false);
tokio::spawn(async move {
    if let Err(e) = proxy.run(proxy_shutdown_rx).await { ... }
});
```

When the `if` block ends, `_proxy_shutdown_tx` is dropped. The proxy's `shutdown_signal()` in `crates/network-filter/src/proxy.rs` detects this via `rx.changed().await.is_err()` and breaks out of the accept loop, shutting down the proxy before any requests are served.

**Note**: The `_` prefix on `_proxy_shutdown_tx` suppresses the unused-variable warning but does NOT prevent the value from being dropped at end of scope (only bare `_` drops immediately; named `_foo` bindings drop normally at scope exit).

## Fix

Store the sender in `PreparedGateway` so it lives as long as the server:

1. Add `_proxy_shutdown_tx: Option<watch::Sender<bool>>` field to `PreparedGateway` (behind `#[cfg(feature = "trusted-network")]`)
2. Declare an outer-scope staging variable in `prepare_gateway()`, following the existing pattern used for `audit_buffer_for_broadcast` and `proxy_url_for_tools`
3. Assign `Some(shutdown_tx)` in the Trusted branch, `None` in the else branch
4. Pass through to `PreparedGateway` construction

## Impact

- Affects all users on v0.10.17+ with `network = "trusted"` in sandbox config
- `web_fetch`, `sandbox` HTTP tools, and any proxy-routed requests fail because the proxy exits before they arrive
- `network = "open"` is unaffected (proxy is never started)

## Testing

This is a lifetime/ownership fix — the proxy task receives the `watch::Receiver` via `tokio::spawn` and the sender must simply outlive it. No behavioral change other than the proxy staying alive as intended.