### PR TITLE
fix(chat): skip duplicate text fallback when TTS disabled and voice streamed

### DIFF
--- a/crates/chat/src/lib.rs
+++ b/crates/chat/src/lib.rs
@@ -7453,7 +7453,19 @@ async fn deliver_channel_replies_to_targets(
                         }
                     },
                     None if text_already_streamed => {
-                        // TTS disabled/failed but text was already streamed — skip.
+                        // TTS disabled/failed but text was already streamed —
+                        // only send logbook follow-up if present.
+                        if !logbook_html.is_empty()
+                            && let Err(e) = outbound
+                                .send_html(&target.account_id, &target.chat_id, &logbook_html, None)
+                                .await
+                        {
+                            warn!(
+                                account_id = target.account_id,
+                                chat_id = target.chat_id,
+                                "failed to send logbook follow-up: {e}"
+                            );
+                        }
                     },
                     None => {
                         let result = if logbook_html.is_empty() {
@@ -8805,6 +8817,104 @@ mod tests {
             0,
             "no outbound calls expected: TTS is disabled and text was already streamed"
         );
+    }
+
+    /// Regression test for #371: Telegram + Voice + NoTTS + streamed + logbook
+    /// present — the logbook follow-up must still be sent via `send_html` even
+    /// though the text fallback is skipped.
+    #[tokio::test]
+    async fn deliver_channel_replies_voice_no_tts_streamed_sends_logbook() {
+        let text_calls = Arc::new(AtomicUsize::new(0));
+        let suffix_calls = Arc::new(AtomicUsize::new(0));
+        let html_payloads = Arc::new(Mutex::new(Vec::new()));
+        let outbound_impl = Arc::new(RecordingChannelOutbound {
+            text_calls: Arc::clone(&text_calls),
+            suffix_calls: Arc::clone(&suffix_calls),
+            html_payloads: Arc::clone(&html_payloads),
+        });
+        let outbound: Arc<dyn moltis_channels::plugin::ChannelOutbound> = outbound_impl;
+        let state: Arc<dyn ChatRuntime> =
+            Arc::new(MockChatRuntime::new().with_channel_outbound(outbound));
+
+        let target = moltis_channels::ChannelReplyTarget {
+            channel_type: moltis_channels::ChannelType::Telegram,
+            account_id: "acct".to_string(),
+            chat_id: "123".to_string(),
+            message_id: Some("42".to_string()),
+        };
+        let session_key = "telegram:acct:123";
+        state.push_channel_reply(session_key, target.clone()).await;
+        state
+            .push_channel_status_log(session_key, "🔍 Searching web".to_string())
+            .await;
+
+        let mut streamed = HashSet::new();
+        streamed.insert(ChannelReplyTargetKey::from(&target));
+        deliver_channel_replies(&state, session_key, "hello", ReplyMedium::Voice, &streamed).await;
+
+        assert_eq!(
+            text_calls.load(Ordering::SeqCst),
+            0,
+            "no text sends: text was already streamed"
+        );
+        assert_eq!(
+            suffix_calls.load(Ordering::SeqCst),
+            0,
+            "no text+suffix sends: text was already streamed"
+        );
+        let payloads = html_payloads.lock().await.clone();
+        assert_eq!(payloads.len(), 1, "expected one logbook follow-up");
+        assert!(payloads[0].contains("Activity log"));
+        assert!(payloads[0].contains("Searching web"));
+    }
+
+    /// Regression test for #371: non-Telegram (Discord) + Voice + NoTTS +
+    /// streamed — the logbook follow-up must still be sent, and duplicate
+    /// text must not be delivered.
+    #[tokio::test]
+    async fn deliver_channel_replies_voice_no_tts_streamed_non_telegram_sends_logbook() {
+        let text_calls = Arc::new(AtomicUsize::new(0));
+        let suffix_calls = Arc::new(AtomicUsize::new(0));
+        let html_payloads = Arc::new(Mutex::new(Vec::new()));
+        let outbound_impl = Arc::new(RecordingChannelOutbound {
+            text_calls: Arc::clone(&text_calls),
+            suffix_calls: Arc::clone(&suffix_calls),
+            html_payloads: Arc::clone(&html_payloads),
+        });
+        let outbound: Arc<dyn moltis_channels::plugin::ChannelOutbound> = outbound_impl;
+        let state: Arc<dyn ChatRuntime> =
+            Arc::new(MockChatRuntime::new().with_channel_outbound(outbound));
+
+        let target = moltis_channels::ChannelReplyTarget {
+            channel_type: moltis_channels::ChannelType::Discord,
+            account_id: "acct".to_string(),
+            chat_id: "456".to_string(),
+            message_id: Some("99".to_string()),
+        };
+        let session_key = "discord:acct:456";
+        state.push_channel_reply(session_key, target.clone()).await;
+        state
+            .push_channel_status_log(session_key, "🌐 Browsing: https://example.com".to_string())
+            .await;
+
+        let mut streamed = HashSet::new();
+        streamed.insert(ChannelReplyTargetKey::from(&target));
+        deliver_channel_replies(&state, session_key, "hello", ReplyMedium::Voice, &streamed).await;
+
+        assert_eq!(
+            text_calls.load(Ordering::SeqCst),
+            0,
+            "no text sends: text was already streamed"
+        );
+        assert_eq!(
+            suffix_calls.load(Ordering::SeqCst),
+            0,
+            "no text+suffix sends: text was already streamed"
+        );
+        let payloads = html_payloads.lock().await.clone();
+        assert_eq!(payloads.len(), 1, "expected one logbook follow-up");
+        assert!(payloads[0].contains("Activity log"));
+        assert!(payloads[0].contains("Browsing: https://example.com"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- Fixes #371 — when a voice message is received with TTS disabled, the bot sent two identical text replies on Telegram
- The root cause: `deliver_channel_replies` skips stream dedup for `ReplyMedium::Voice` (to allow TTS audio delivery), but when `build_tts_payload` returns `None` (TTS disabled), the `None` branch falls through to `send_text()` — duplicating the already-streamed text
- Added `None if text_already_streamed` guard arms in both the Telegram and generic channel branches of `deliver_channel_replies_to_targets` to skip the text fallback when text was already delivered via streaming
- For Telegram, the guarded branch still sends the logbook follow-up if present

## Validation

### Completed
- [x] `cargo +nightly-2025-11-30 fmt --all -- --check`
- [x] All `deliver_channel_replies*` tests pass (4/4)
- [x] New regression test: `deliver_channel_replies_voice_no_tts_skips_streamed_text_fallback`

### Remaining
- [ ] `cargo +nightly-2025-11-30 clippy -Z unstable-options --workspace --all-features --all-targets --timings -- -D warnings`
- [ ] `cargo test` (full suite)
- [ ] `./scripts/local-validate.sh 372`

## Manual QA

1. Configure Telegram channel with STT enabled, TTS disabled, streaming default (EditInPlace)
2. Send a voice message from Telegram
3. Verify only **one** text reply appears (not two)
4. Re-enable TTS and send a voice message — verify TTS audio is still delivered correctly