### PR TITLE
fix(auth): allow local API/WS requests during onboarding setup

### DIFF
--- a/crates/gateway/src/auth_middleware.rs
+++ b/crates/gateway/src/auth_middleware.rs
@@ -119,7 +119,7 @@ pub async fn auth_gate(
             next.run(request).await
         },
         AuthResult::SetupRequired => {
-            if path.starts_with("/api/") || path.starts_with("/ws/") {
+            if (path.starts_with("/api/") || path.starts_with("/ws/")) && !is_local {
                 if path.starts_with("/ws/") {
                     warn!(
                         path,


### PR DESCRIPTION
The auth middleware blocks all /api/ and /ws/ requests when setup is required, but the onboarding page itself makes API calls (e.g. STT test via /api/sessions/main/upload). This causes a 401 AUTH_NOT_AUTHENTICATED error when testing whisper during onboarding.

Allow local connections through during SetupRequired, consistent with the existing page-level exemption for /onboarding.