### PR TITLE
fix(providers): strip stop tokens from MLX streaming output

### DIFF
--- a/crates/providers/src/local_llm/backend.rs
+++ b/crates/providers/src/local_llm/backend.rs
@@ -1132,9 +1132,7 @@ print(f"\n__TOKENS__:{{input_tokens}}:{{output_tokens}}", flush=True)
             } else {
                 // Strip any chat template stop tokens that slipped through
                 let cleaned = strip_chat_template_tokens(&line);
-                if !cleaned.is_empty()
-                    && tx.blocking_send(StreamEvent::Delta(cleaned)).is_err()
-                {
+                if !cleaned.is_empty() && tx.blocking_send(StreamEvent::Delta(cleaned)).is_err() {
                     break;
                 }
             }


### PR DESCRIPTION
## Summary

- Strip chat template stop tokens (`<|im_end|>`, `<|eot_id|>`, `</s>`, `<|end|>`, `<|endoftext|>`) from MLX streaming responses
- Two-layer fix: Python-side early break on stop tokens + Rust-side `strip_chat_template_tokens()` safety net on each delta
- The non-streaming paths already stripped these tokens; only the streaming path was missing it

Closes #306

## Validation

### Completed
- [x] `cargo test -p moltis-providers --features local-llm` — all 21 backend tests pass (9 new for `strip_chat_template_tokens`)
- [x] `cargo +nightly-2025-11-30 fmt --all -- --check` — clean

### Remaining
- [ ] `cargo +nightly-2025-11-30 clippy -Z unstable-options --workspace --all-features --all-targets --timings -- -D warnings`
- [ ] `./scripts/local-validate.sh 395`
- [ ] Manual QA with MLX model

## Manual QA

1. Configure `[providers.local-llm]` with an MLX model (e.g. `mlx-qwen2.5-coder-7b-4bit`)
2. Send a message via web UI or Telegram
3. Verify response does **not** contain raw `<|im_end|>` or other stop tokens

🤖 Generated with [Claude Code](https://claude.com/claude-code)