### PR TITLE
fix(chat): compact the active channel session

### DIFF
--- a/crates/chat/src/lib.rs
+++ b/crates/chat/src/lib.rs
@@ -3280,7 +3280,7 @@ impl ChatService for LiveChatService {
             )
             .await;
 
-            let compact_params = serde_json::json!({ "_conn_id": conn_id });
+            let compact_params = serde_json::json!({ "_session_key": &session_key });
             match self.compact(compact_params).await {
                 Ok(_) => {
                     // Reload history after compaction.
@@ -7978,6 +7978,10 @@ mod tests {
         id: String,
     }
 
+    struct AutoCompactRegressionProvider {
+        context_window: u32,
+    }
+
     #[async_trait]
     impl LlmProvider for StaticProvider {
         fn name(&self) -> &str {
@@ -8001,6 +8005,48 @@ mod tests {
             _messages: Vec<ChatMessage>,
         ) -> Pin<Box<dyn Stream<Item = StreamEvent> + Send + '_>> {
             Box::pin(tokio_stream::empty())
+        }
+    }
+
+    #[async_trait]
+    impl LlmProvider for AutoCompactRegressionProvider {
+        fn name(&self) -> &str {
+            "test"
+        }
+
+        fn id(&self) -> &str {
+            "test::auto-compact"
+        }
+
+        async fn complete(
+            &self,
+            _messages: &[ChatMessage],
+            _tools: &[Value],
+        ) -> Result<moltis_agents::model::CompletionResponse> {
+            anyhow::bail!("not implemented for test")
+        }
+
+        fn context_window(&self) -> u32 {
+            self.context_window
+        }
+
+        fn stream(
+            &self,
+            messages: Vec<ChatMessage>,
+        ) -> Pin<Box<dyn Stream<Item = StreamEvent> + Send + '_>> {
+            let response = match messages.first() {
+                Some(ChatMessage::System { content })
+                    if content.contains("conversation summarizer") =>
+                {
+                    "summary"
+                },
+                _ => "final reply",
+            };
+
+            Box::pin(tokio_stream::iter(vec![
+                StreamEvent::Delta(response.to_string()),
+                StreamEvent::Done(moltis_agents::model::Usage::default()),
+            ]))
         }
     }
 
@@ -9185,6 +9231,103 @@ mod tests {
                 .iter()
                 .any(|msg| msg.get("role").and_then(Value::as_str) == Some("assistant")),
             "explicit /sh should persist an assistant turn for history coherence"
+        );
+    }
+
+    #[tokio::test]
+    async fn auto_compact_uses_explicit_session_key_for_channel_sessions() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = Arc::new(SessionStore::new(dir.path().to_path_buf()));
+        let pool = sqlite_pool().await;
+        let metadata = Arc::new(SqliteSessionMetadata::new(pool));
+
+        let state: Arc<dyn ChatRuntime> = Arc::new(MockChatRuntime::new());
+        let mut providers = ProviderRegistry::empty();
+        providers.register(
+            moltis_providers::ModelInfo {
+                id: "test::auto-compact".to_string(),
+                provider: "test".to_string(),
+                display_name: "Auto Compact Test".to_string(),
+                created_at: None,
+            },
+            Arc::new(AutoCompactRegressionProvider {
+                context_window: 100,
+            }),
+        );
+
+        let chat = LiveChatService::new(
+            Arc::new(RwLock::new(providers)),
+            Arc::new(RwLock::new(DisabledModelsStore::default())),
+            state,
+            Arc::clone(&store),
+            metadata,
+        );
+
+        let session_key = "discord:acct:123";
+        store
+            .append(
+                session_key,
+                &serde_json::json!({
+                    "role": "assistant",
+                    "content": "existing response",
+                    "requestInputTokens": 94_u64,
+                    "requestOutputTokens": 1_u64
+                }),
+            )
+            .await
+            .expect("seed channel session history");
+
+        let send_result = chat
+            .send(serde_json::json!({
+                "text": "ping",
+                "_session_key": session_key
+            }))
+            .await
+            .expect("chat.send should succeed");
+        assert!(
+            send_result
+                .get("runId")
+                .and_then(Value::as_str)
+                .is_some_and(|id| !id.is_empty())
+        );
+
+        let history = tokio::time::timeout(Duration::from_secs(2), async {
+            loop {
+                let messages = store.read(session_key).await.unwrap_or_default();
+                let has_final_reply = messages.last().is_some_and(|message| {
+                    message.get("role").and_then(Value::as_str) == Some("assistant")
+                        && message.get("content").and_then(Value::as_str) == Some("final reply")
+                });
+                if has_final_reply {
+                    return messages;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("assistant reply should be persisted");
+
+        assert_eq!(history.len(), 3);
+        assert_eq!(
+            history[0].get("role").and_then(Value::as_str),
+            Some("assistant")
+        );
+        assert!(
+            history[0]
+                .get("content")
+                .and_then(Value::as_str)
+                .is_some_and(|content| content.starts_with("[Conversation Summary]\n\nsummary"))
+        );
+        assert_eq!(history[1].get("role").and_then(Value::as_str), Some("user"));
+        assert_eq!(
+            history[2].get("content").and_then(Value::as_str),
+            Some("final reply")
+        );
+
+        let main_history = store.read("main").await.unwrap_or_default();
+        assert!(
+            main_history.is_empty(),
+            "auto-compact should not touch the default web session"
         );
     }
 


### PR DESCRIPTION
## Summary
- Pass `_session_key` to auto-compact so channel messages compact the active channel session instead of falling back to `main`.
- Add a regression test that drives `chat.send()` with a Discord-style session key, forces auto-compact, and verifies the channel session is compacted while `main` remains untouched.
- Regenerate the web CSS asset required for workspace validation in this checkout.

Closes #103.

## Validation
### Completed
- [x] `just format`
- [x] `cargo +nightly-2025-11-30 test -p moltis-chat auto_compact_uses_explicit_session_key_for_channel_sessions -- --nocapture`
- [x] `just format-check`
- [x] `just build-css`
- [x] `cargo +nightly-2025-11-30 clippy -Z unstable-options --workspace --all-targets --timings -- -D warnings`

Note: `just lint` failed on this macOS host because it forces `--all-features`, which pulls in the CUDA-backed local LLM build. `scripts/local-validate.sh` documents the non-`--all-features` clippy fallback for macOS without `nvcc`, and that is the clippy command above.

### Remaining
- [ ] `./scripts/local-validate.sh <PR_NUMBER>`

## Manual QA
- Start with a channel session near the context limit.
- Send a Discord message that triggers auto-compact.
- Confirm the channel session history is compacted and the default `main` session remains unchanged.