### PR TITLE
fix(tools): harden apple container bootstrap execs

### DIFF
--- a/crates/tools/src/sandbox.rs
+++ b/crates/tools/src/sandbox.rs
@@ -6231,7 +6231,10 @@ mod tests {
 
     #[test]
     fn test_create_sandbox_off() {
-        let config = SandboxConfig::default();
+        let config = SandboxConfig {
+            mode: SandboxMode::Off,
+            ..Default::default()
+        };
         let sandbox = create_sandbox(config);
         let id = SandboxId {
             scope: SandboxScope::Session,


### PR DESCRIPTION
Fixes #159.

## Summary
- harden Apple Container exec command construction so provisioning also runs from `/tmp` and re-creates `/home/sandbox` before shell commands run
- centralize container exec shell argument building so Apple Container and Docker paths stay aligned without duplicating the old unsafe `container exec` shape
- add regression coverage for Apple Container bootstrap/run/exec arguments and make `test_create_sandbox_off` deterministic so it does not depend on a real backend being healthy on macOS hosts

## Validation
### Completed
- [x] `cargo test -p moltis-tools test_create_sandbox_off -- --nocapture`
- [x] `cargo test -p moltis-tools apple_container -- --nocapture`
- [x] `cargo test -p moltis-tools container_exec_shell_args -- --nocapture`
- [x] `just format`
- [x] `cargo +nightly-2025-11-30 clippy -Z unstable-options --workspace --all-targets --timings -- -D warnings`

### Remaining
- [ ] Apple Container runtime smoke test on macOS with persisted `/home/sandbox`
- [ ] `just lint` on a machine with CUDA / `nvcc` available for the workspace `--all-features` path

## Manual QA
- Not run locally beyond unit tests and linting in this worktree.
- Recommended follow-up: start Moltis with Apple Container, trigger sandbox execution, and verify both fresh and persisted-home sessions succeed.