### PR TITLE
Fix GitHub issue template links

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -11,14 +11,14 @@ body:
 
         Before submitting, please check:
         - You're using the latest version of Moltis (`moltis --version`)
-        - This issue hasn't already been [reported](https://github.com/moltisorg/moltis/issues?q=is%3Aissue+label%3Abug)
+        - This issue hasn't already been [reported](https://github.com/moltis-org/moltis/issues?q=is%3Aissue+label%3Abug)
 
   - type: checkboxes
     id: preflight
     attributes:
       label: Preflight Checklist
       options:
-        - label: I have searched [existing issues](https://github.com/moltisorg/moltis/issues?q=is%3Aissue+label%3Abug) and this hasn't been reported yet
+        - label: I have searched [existing issues](https://github.com/moltis-org/moltis/issues?q=is%3Aissue+label%3Abug) and this hasn't been reported yet
           required: true
         - label: I am using the latest version of Moltis
           required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -9,14 +9,14 @@ body:
       value: |
         We'd love to hear your ideas! Please describe what you need and why.
 
-        Before submitting, check if this has already been [requested](https://github.com/moltisorg/moltis/issues?q=is%3Aissue+label%3Aenhancement).
+        Before submitting, check if this has already been [requested](https://github.com/moltis-org/moltis/issues?q=is%3Aissue+label%3Aenhancement).
 
   - type: checkboxes
     id: preflight
     attributes:
       label: Preflight Checklist
       options:
-        - label: I have searched [existing requests](https://github.com/moltisorg/moltis/issues?q=is%3Aissue+label%3Aenhancement) and this hasn't been proposed yet
+        - label: I have searched [existing requests](https://github.com/moltis-org/moltis/issues?q=is%3Aissue+label%3Aenhancement) and this hasn't been proposed yet
           required: true
         - label: If this request came from a chat session issue, I included relevant session context and redacted secrets
 

--- a/.github/ISSUE_TEMPLATE/model_behavior.yml
+++ b/.github/ISSUE_TEMPLATE/model_behavior.yml
@@ -17,7 +17,7 @@ body:
     attributes:
       label: Preflight Checklist
       options:
-        - label: I have searched [existing issues](https://github.com/moltisorg/moltis/issues?q=is%3Aissue+label%3Amodel-behavior) for similar reports
+        - label: I have searched [existing issues](https://github.com/moltis-org/moltis/issues?q=is%3Aissue+label%3Amodel-behavior) for similar reports
           required: true
         - label: This report does NOT contain sensitive information (API keys, passwords, personal data)
           required: true


### PR DESCRIPTION
I'm not sure if the org was renamed, but these links seem wrong and 404.