### PR TITLE
(fix) Claude - allow for whitespaces in the hook location

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -37,7 +37,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/save-session.sh"
+            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/save-session.sh\""
           },
           {
             "type": "command",
@@ -63,7 +63,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/rename-plan.sh"
+            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/rename-plan.sh\""
           },
           {
             "type": "command",


### PR DESCRIPTION
This avoids errors when someone is using Claude in a directory that contains spaces at any point in the path.