### PR TITLE
feat(gateway): sanitize channel config access and masked secrets

### DIFF
--- a/crates/gateway/src/channel.rs
+++ b/crates/gateway/src/channel.rs
@@ -19,11 +19,72 @@ use {
 
 use crate::services::{ChannelService, ServiceError, ServiceResult};
 
+const REDACTED_SECRET: &str = "[REDACTED]";
+
 fn unix_now() -> i64 {
     std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap_or_default()
         .as_secs() as i64
+}
+
+fn is_secret_config_key(key: &str) -> bool {
+    matches!(
+        key,
+        "token" | "app_password" | "app_secret" | "webhook_secret" | "bot_token" | "app_token"
+    )
+}
+
+fn redact_channel_config(config: Value) -> Value {
+    match config {
+        Value::Object(mut map) => {
+            for (key, value) in &mut map {
+                if is_secret_config_key(key) {
+                    *value = Value::String(REDACTED_SECRET.to_string());
+                    continue;
+                }
+                *value = redact_channel_config(value.take());
+            }
+            Value::Object(map)
+        },
+        Value::Array(items) => Value::Array(items.into_iter().map(redact_channel_config).collect()),
+        other => other,
+    }
+}
+
+fn merge_channel_config(existing: Value, incoming: Value) -> Value {
+    let mut existing_map = match existing {
+        Value::Object(map) => map,
+        _ => return incoming,
+    };
+    let incoming_map = match incoming {
+        Value::Object(map) => map,
+        other => return other,
+    };
+
+    for (key, value) in incoming_map {
+        let keep_existing_secret = is_secret_config_key(&key)
+            && match &value {
+                Value::Null => true,
+                Value::String(raw) => {
+                    let trimmed = raw.trim();
+                    trimmed.is_empty() || trimmed == REDACTED_SECRET
+                },
+                _ => false,
+            };
+        if keep_existing_secret {
+            continue;
+        }
+        let merged_value = match (existing_map.remove(&key), value) {
+            (Some(Value::Object(existing_child)), Value::Object(incoming_child)) => {
+                merge_channel_config(Value::Object(existing_child), Value::Object(incoming_child))
+            },
+            (_, incoming_value) => incoming_value,
+        };
+        existing_map.insert(key, merged_value);
+    }
+
+    Value::Object(existing_map)
 }
 
 /// Live channel service backed by the channel registry.
@@ -167,7 +228,7 @@ impl ChannelService for LiveChannelService {
                         Some(status) => Some(status.probe(aid).await),
                         None => None,
                     };
-                    let cfg = p.account_config_json(aid);
+                    let cfg = p.account_config_json(aid).map(redact_channel_config);
                     (snap, cfg)
                 };
 
@@ -191,6 +252,42 @@ impl ChannelService for LiveChannelService {
         }
 
         Ok(serde_json::json!({ "channels": channels }))
+    }
+
+    #[tracing::instrument(skip(self, params))]
+    async fn account_config(&self, params: Value) -> ServiceResult {
+        let account_id = params
+            .get("account_id")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| "missing 'account_id'".to_string())?;
+        let channel_type = self
+            .resolve_channel_type(&params, account_id, ChannelType::Telegram)
+            .await?;
+
+        let mut config = if let Some(plugin_lock) = self.registry.get(channel_type.as_str()) {
+            let plugin = plugin_lock.read().await;
+            plugin.account_config_json(account_id)
+        } else {
+            None
+        };
+        if config.is_none() {
+            config = self
+                .store
+                .get(channel_type.as_str(), account_id)
+                .await
+                .map_err(ServiceError::message)?
+                .map(|stored| stored.config);
+        }
+
+        config
+            .map(redact_channel_config)
+            .ok_or_else(|| {
+                ServiceError::message(format!(
+                    "channel '{}' ({}) is not active",
+                    account_id,
+                    channel_type.as_str()
+                ))
+            })
     }
 
     #[tracing::instrument(skip(self, params))]
@@ -291,6 +388,14 @@ impl ChannelService for LiveChannelService {
             .get("config")
             .cloned()
             .ok_or_else(|| "missing 'config'".to_string())?;
+        let existing_config = self
+            .store
+            .get(channel_type.as_str(), account_id)
+            .await
+            .map_err(|e| e.to_string())?
+            .map(|s| s.config)
+            .unwrap_or_else(|| Value::Object(Default::default()));
+        let merged_config = merge_channel_config(existing_config, config);
 
         info!(
             account_id,
@@ -310,7 +415,7 @@ impl ChannelService for LiveChannelService {
                 // request so we don't persist bad config to the store.
                 match self
                     .registry
-                    .update_account_config(account_id, config.clone())
+                    .update_account_config(account_id, merged_config.clone())
                     .await
                 {
                     Ok(()) => {},
@@ -338,7 +443,7 @@ impl ChannelService for LiveChannelService {
                         e.to_string()
                     })?;
                 self.registry
-                    .start_account(ct, account_id, config.clone())
+                    .start_account(ct, account_id, merged_config.clone())
                     .await
                     .map_err(|e| {
                         error!(error = %e, account_id, channel_type = ct, "failed to start account");
@@ -360,7 +465,7 @@ impl ChannelService for LiveChannelService {
             .upsert(StoredChannel {
                 account_id: account_id.to_string(),
                 channel_type: channel_type.to_string(),
-                config,
+                config: merged_config,
                 created_at,
                 updated_at: now,
             })
@@ -687,5 +792,165 @@ impl ChannelService for LiveChannelService {
             "denied": identifier,
             "type": channel_type.to_string()
         }))
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use async_trait::async_trait;
+    use moltis_channels::{
+        Result as ChannelResult,
+        message_log::{MessageLog, MessageLogEntry, SenderSummary},
+        plugin::ChannelOutbound,
+        registry::ChannelRegistry,
+    };
+    use moltis_common::types::ReplyPayload;
+    use sqlx::SqlitePool;
+
+    use crate::{channel_store::SqliteChannelStore, message_log_store::SqliteMessageLog};
+
+    struct NullOutbound;
+
+    #[async_trait]
+    impl ChannelOutbound for NullOutbound {
+        async fn send_text(
+            &self,
+            _account_id: &str,
+            _to: &str,
+            _text: &str,
+            _reply_to: Option<&str>,
+        ) -> ChannelResult<()> {
+            Ok(())
+        }
+
+        async fn send_media(
+            &self,
+            _account_id: &str,
+            _to: &str,
+            _payload: &ReplyPayload,
+            _reply_to: Option<&str>,
+        ) -> ChannelResult<()> {
+            Ok(())
+        }
+
+        async fn send_typing(&self, _account_id: &str, _to: &str) -> ChannelResult<()> {
+            Ok(())
+        }
+    }
+
+    struct NullMessageLog;
+
+    #[async_trait]
+    impl MessageLog for NullMessageLog {
+        async fn log(&self, _entry: MessageLogEntry) -> ChannelResult<()> {
+            Ok(())
+        }
+
+        async fn list_by_account(
+            &self,
+            _channel_type: &str,
+            _account_id: &str,
+            _limit: u32,
+        ) -> ChannelResult<Vec<MessageLogEntry>> {
+            Ok(Vec::new())
+        }
+
+        async fn unique_senders(
+            &self,
+            _channel_type: &str,
+            _account_id: &str,
+        ) -> ChannelResult<Vec<SenderSummary>> {
+            Ok(Vec::new())
+        }
+    }
+
+    async fn sqlite_pool() -> SqlitePool {
+        SqlitePool::connect("sqlite::memory:").await.unwrap()
+    }
+
+    fn test_service(store: Arc<dyn ChannelStore>, metadata: Arc<SqliteSessionMetadata>) -> LiveChannelService {
+        LiveChannelService::new(
+            Arc::new(ChannelRegistry::new()),
+            Arc::new(NullOutbound),
+            store,
+            Arc::new(NullMessageLog),
+            metadata,
+        )
+    }
+
+    #[test]
+    fn redact_channel_config_masks_known_secrets_recursively() {
+        let redacted = redact_channel_config(serde_json::json!({
+            "token": "abc",
+            "nested": {
+                "app_secret": "def",
+                "non_secret": "ok"
+            }
+        }));
+
+        assert_eq!(redacted["token"], REDACTED_SECRET);
+        assert_eq!(redacted["nested"]["app_secret"], REDACTED_SECRET);
+        assert_eq!(redacted["nested"]["non_secret"], "ok");
+    }
+
+    #[test]
+    fn merge_channel_config_preserves_masked_secrets() {
+        let merged = merge_channel_config(
+            serde_json::json!({
+                "token": "real-token",
+                "nested": {
+                    "app_secret": "real-secret",
+                    "enabled": true
+                }
+            }),
+            serde_json::json!({
+                "token": "[REDACTED]",
+                "nested": {
+                    "app_secret": "",
+                    "enabled": false
+                }
+            }),
+        );
+
+        assert_eq!(merged["token"], "real-token");
+        assert_eq!(merged["nested"]["app_secret"], "real-secret");
+        assert_eq!(merged["nested"]["enabled"], false);
+    }
+
+    #[tokio::test]
+    async fn account_config_reads_from_store_and_returns_redacted_config() {
+        let pool = sqlite_pool().await;
+        SqliteChannelStore::init(&pool).await.unwrap();
+        SqliteMessageLog::init(&pool).await.unwrap();
+
+        let store = Arc::new(SqliteChannelStore::new(pool.clone()));
+        let metadata = Arc::new(SqliteSessionMetadata::new(pool));
+        store
+            .upsert(StoredChannel {
+                account_id: "bot1".into(),
+                channel_type: "telegram".into(),
+                config: serde_json::json!({
+                    "token": "secret-token",
+                    "allowlist": ["alice"],
+                }),
+                created_at: 1,
+                updated_at: 1,
+            })
+            .await
+            .unwrap();
+
+        let service = test_service(store, metadata);
+        let response = service
+            .account_config(serde_json::json!({
+                "type": "telegram",
+                "account_id": "bot1",
+            }))
+            .await
+            .unwrap();
+
+        assert_eq!(response["token"], REDACTED_SECRET);
+        assert_eq!(response["allowlist"][0], "alice");
     }
 }

--- a/crates/gateway/src/channel_agent_tools.rs
+++ b/crates/gateway/src/channel_agent_tools.rs
@@ -107,6 +107,10 @@ mod tests {
             Ok(json!({}))
         }
 
+        async fn account_config(&self, _params: Value) -> ServiceResult {
+            Ok(json!({}))
+        }
+
         async fn logout(&self, _params: Value) -> ServiceResult {
             Ok(json!({}))
         }
@@ -173,6 +177,10 @@ mod tests {
         #[async_trait]
         impl ChannelService for FailingChannelService {
             async fn status(&self) -> ServiceResult {
+                Ok(json!({}))
+            }
+
+            async fn account_config(&self, _: Value) -> ServiceResult {
                 Ok(json!({}))
             }
 

--- a/crates/service-traits/src/lib.rs
+++ b/crates/service-traits/src/lib.rs
@@ -186,6 +186,7 @@ impl SessionService for NoopSessionService {
 #[async_trait]
 pub trait ChannelService: Send + Sync {
     async fn status(&self) -> ServiceResult;
+    async fn account_config(&self, params: Value) -> ServiceResult;
     async fn logout(&self, params: Value) -> ServiceResult;
     async fn send(&self, params: Value) -> ServiceResult;
     async fn add(&self, params: Value) -> ServiceResult;
@@ -202,6 +203,10 @@ pub struct NoopChannelService;
 impl ChannelService for NoopChannelService {
     async fn status(&self) -> ServiceResult {
         Ok(serde_json::json!({ "channels": [] }))
+    }
+
+    async fn account_config(&self, _p: Value) -> ServiceResult {
+        Err("no channel service configured".into())
     }
 
     async fn logout(&self, _p: Value) -> ServiceResult {


### PR DESCRIPTION
## Summary
- add `ChannelService::account_config` so gateway logic can read channel account settings through a generic service API
- recursively redact secret-like fields from returned channel config payloads
- preserve existing stored secrets when updates submit masked placeholders or empty secret values

## Validation
### Completed
- `git diff --cached --stat`
- partial `cargo check -p moltis-gateway --lib` confirmed the patch compiles through the changed gateway/session/channel trait surfaces before the machine became resource-constrained

### Remaining
- `cargo check -p moltis-gateway --lib`
- `cargo test -p moltis-gateway --lib redact_channel_config_masks_known_secrets_recursively -- --nocapture`
- `cargo test -p moltis-gateway --lib merge_channel_config_preserves_masked_secrets -- --nocapture`
- `cargo test -p moltis-gateway --lib account_config_reads_from_store_and_returns_redacted_config -- --nocapture`

## Manual QA
- not run; this PR only changes channel config access and secret merging behavior
