### PR TITLE
fix(plugins): use cmd.exe on Windows for shell hooks

### DIFF
--- a/crates/plugins/src/shell_hook.rs
+++ b/crates/plugins/src/shell_hook.rs
@@ -98,10 +98,16 @@ impl HookHandler for ShellHookHandler {
             "spawning shell hook"
         );
 
-        let mut cmd = Command::new("sh");
-        cmd.arg("-c")
-            .arg(&self.command)
-            .envs(&self.env)
+        let mut cmd = if cfg!(target_os = "windows") {
+            let mut c = Command::new("cmd");
+            c.arg("/C").arg(&self.command);
+            c
+        } else {
+            let mut c = Command::new("sh");
+            c.arg("-c").arg(&self.command);
+            c
+        };
+        cmd.envs(&self.env)
             .stdin(std::process::Stdio::piped())
             .stdout(std::process::Stdio::piped())
             .stderr(std::process::Stdio::piped());


### PR DESCRIPTION
Shell hooks fail on Windows because `sh -c` isn't available. This uses `cmd.exe /C` on Windows targets.

## Changes
- Detect Windows at runtime and use `cmd.exe /C` instead of `sh -c` for shell hook execution

## Testing
- Tested on Windows 10 with moltis v0.9.10 (port 57553)
- Windows CI passes