### PR TITLE
feat(providers): add MiniMax M2.7 models

### DIFF
--- a/crates/providers/src/lib.rs
+++ b/crates/providers/src/lib.rs
@@ -649,7 +649,7 @@ pub fn context_window_for_model(model_id: &str) -> u32 {
     if model_id.starts_with("kimi-") {
         return 128_000;
     }
-    // MiniMax M2/M2.1/M2.5: 204,800.
+    // MiniMax M2/M2.1/M2.5/M2.7: 204,800.
     if model_id.starts_with("MiniMax-") {
         return 204_800;
     }


### PR DESCRIPTION
## Summary

- Add `MiniMax-M2.7` and `MiniMax-M2.7-highspeed` to the static model catalog
- Add missing `MiniMax-M2.1-highspeed` variant
- Model IDs confirmed against [MiniMax API docs](https://platform.minimax.io/docs/api-reference/text-anthropic-api)

## Validation

### Completed
- [x] `cargo check -p moltis-providers` passes
- [x] Model IDs verified against MiniMax API documentation

### Remaining
- [ ] `cargo +nightly-2025-11-30 fmt --all -- --check`
- [ ] `cargo +nightly-2025-11-30 clippy -Z unstable-options --workspace --all-features --all-targets --timings -- -D warnings`
- [ ] `cargo test`

## Manual QA

1. Configure MiniMax API key in `moltis.toml`
2. Open model picker — verify M2.7 and M2.7 Highspeed appear at top of MiniMax list
3. Send a message using MiniMax-M2.7 — verify completion works

🤖 Generated with [Claude Code](https://claude.com/claude-code)