### PR TITLE
fix(import): preserve config template comments during OpenClaw import

### DIFF
--- a/crates/openclaw-import/src/lib.rs
+++ b/crates/openclaw-import/src/lib.rs
@@ -1124,7 +1124,11 @@ mod tests {
             identity: true,
             ..Default::default()
         };
-        import(&detection, &selection, &config_dir, &data_dir);
+        let report = import(&detection, &selection, &config_dir, &data_dir);
+        assert!(
+            report.imported_identity.is_some(),
+            "identity should have been imported, report: {report:?}"
+        );
 
         let content = std::fs::read_to_string(config_dir.join("moltis.toml")).unwrap();
 


### PR DESCRIPTION
## Summary

- OpenClaw import's local `save_config_to_path()` used `toml::to_string_pretty` + `fs::write`, which overwrote the ~700-line commented config template with a bare ~20-line config
- Delegate to `moltis_config::loader::save_config_to_path` which uses `toml_edit` to merge new values into the existing document while preserving comments
- Added test that verifies comments survive an import

Closes #458

## Validation

### Completed
- [x] `cargo test -p moltis-openclaw-import` — all 127 tests pass
- [x] `cargo clippy -p moltis-openclaw-import --all-targets -- -D warnings` — clean
- [x] New `import_preserves_toml_comments` test covers the fix

### Remaining
- [ ] `./scripts/local-validate.sh <PR_NUMBER>` — full workspace validation

## Manual QA

1. Fresh install (or delete `~/.moltis/moltis.toml`)
2. Start server → config template is written with comments
3. Import from OpenClaw → verify `moltis.toml` retains commented examples