### PR TITLE
fix(web): new session button on plain HTTP

### DIFF
--- a/crates/web/src/assets/js/sessions.js
+++ b/crates/web/src/assets/js/sessions.js
@@ -530,7 +530,12 @@ export function clearSessionHistoryCache(key) {
 // ── New session button ──────────────────────────────────────
 var newSessionBtn = S.$("newSessionBtn");
 newSessionBtn.addEventListener("click", () => {
-	var key = `session:${crypto.randomUUID()}`;
+	var id = crypto.randomUUID
+		? crypto.randomUUID()
+		: ([1e7] + -1e3 + -4e3 + -8e3 + -1e11).replace(/[018]/g, (c) =>
+				(c ^ (crypto.getRandomValues(new Uint8Array(1))[0] & (15 >> (c / 4)))).toString(16),
+			);
+	var key = `session:${id}`;
 	var filterId = projectStore.projectFilterId.value;
 	if (currentPrefix === "/chats") {
 		switchSession(key, null, filterId || undefined);


### PR DESCRIPTION
## Summary
- `crypto.randomUUID()` requires a secure context (HTTPS or localhost) and throws `TypeError` on plain HTTP
- Users accessing Moltis over LAN via HTTP cannot create new sessions
- Falls back to `crypto.getRandomValues()`-based UUID v4 when `randomUUID` is unavailable

Fixes #520

## Validation

### Completed
- [x] `biome check --write` passes
- [ ] `cargo +nightly-2025-11-30 fmt --all -- --check`
- [ ] `just lint`
- [ ] `just test`
- [ ] `./scripts/local-validate.sh 521`

### Remaining
- [ ] Manual test on plain HTTP (non-localhost) to confirm new session creation works

## Manual QA
1. Access Moltis over plain HTTP (e.g. `http://192.168.x.x:port`)
2. Click the "+" button to create a new session
3. Verify session is created without errors