### PR TITLE
Add `live_url` action, tracked browser sessions listing, and web UI integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5890,6 +5890,7 @@ dependencies = [
  "moltis-config",
  "moltis-metrics",
  "rand 0.9.2",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "sysinfo",

--- a/crates/browser/Cargo.toml
+++ b/crates/browser/Cargo.toml
@@ -12,6 +12,7 @@ moltis-common  = { workspace = true }
 moltis-config  = { workspace = true }
 moltis-metrics = { optional = true, workspace = true }
 rand           = { workspace = true }
+reqwest        = { workspace = true }
 serde          = { workspace = true }
 serde_json     = { workspace = true }
 sysinfo        = { workspace = true }

--- a/crates/browser/src/manager.rs
+++ b/crates/browser/src/manager.rs
@@ -223,6 +223,10 @@ impl BrowserManager {
             BrowserAction::Back => self.go_back(session_id, sandbox).await,
             BrowserAction::Forward => self.go_forward(session_id, sandbox).await,
             BrowserAction::Refresh => self.refresh(session_id, sandbox).await,
+            BrowserAction::LiveUrl { interactive } => {
+                self.live_url(session_id, sandbox, browser, interactive)
+                    .await
+            },
             BrowserAction::Close => self.close(session_id, sandbox).await,
         };
 
@@ -313,6 +317,36 @@ impl BrowserManager {
             sid.clone(),
             BrowserResponse::success(sid, 0, sandbox).with_url(current_url),
         ))
+    }
+
+    /// Return a human-usable live URL for this browser session.
+    async fn live_url(
+        &self,
+        session_id: Option<&str>,
+        sandbox: bool,
+        browser: Option<BrowserPreference>,
+        _interactive: bool,
+    ) -> Result<(String, BrowserResponse), Error> {
+        if !sandbox {
+            return Err(Error::InvalidAction(
+                "live_url currently requires sandboxed browser sessions".to_string(),
+            ));
+        }
+
+        let sid = self
+            .pool
+            .get_or_create(session_id, sandbox, browser)
+            .await?;
+        // Ensure a page target exists before asking browserless for /json/list
+        let _ = self.pool.get_page(&sid).await?;
+
+        let http_url = self.pool.sandbox_http_url(&sid).await.ok_or_else(|| {
+            Error::LaunchFailed("sandbox browser HTTP endpoint not available".to_string())
+        })?;
+
+        let live_url = fetch_devtools_live_url(&http_url).await?;
+        let response = BrowserResponse::success(sid.clone(), 0, true).with_live_url(live_url);
+        Ok((sid, response))
     }
 
     /// Take a screenshot of the page.
@@ -872,6 +906,40 @@ fn truncate_url(url: &str) -> String {
         format!("{}...", &url[..url.floor_char_boundary(100)])
     } else {
         url.to_string()
+    }
+}
+
+async fn fetch_devtools_live_url(http_base: &str) -> Result<String, Error> {
+    let endpoint = format!("{}/json/list", http_base.trim_end_matches('/'));
+    let response = reqwest::get(&endpoint)
+        .await
+        .map_err(|e| Error::Cdp(format!("failed to query browser targets: {e}")))?;
+
+    if !response.status().is_success() {
+        return Err(Error::Cdp(format!(
+            "browser target list returned HTTP {}",
+            response.status()
+        )));
+    }
+
+    let targets = response
+        .json::<Vec<serde_json::Value>>()
+        .await
+        .map_err(|e| Error::Cdp(format!("failed to parse browser target list: {e}")))?;
+
+    let target = targets.first().ok_or_else(|| {
+        Error::Cdp("browser target list is empty; navigate first, then retry live_url".to_string())
+    })?;
+    let frontend = target
+        .get("devtoolsFrontendUrl")
+        .and_then(serde_json::Value::as_str)
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| Error::Cdp("browser target is missing devtoolsFrontendUrl".to_string()))?;
+
+    if frontend.starts_with("http://") || frontend.starts_with("https://") {
+        Ok(frontend.to_string())
+    } else {
+        Ok(format!("{}{}", http_base.trim_end_matches('/'), frontend))
     }
 }
 

--- a/crates/browser/src/pool.rs
+++ b/crates/browser/src/pool.rs
@@ -323,6 +323,19 @@ impl BrowserPool {
         self.instances.read().await.len()
     }
 
+    /// Return the sandbox browser HTTP base URL for a session, if available.
+    pub async fn sandbox_http_url(&self, session_id: &str) -> Option<String> {
+        let instance = {
+            let instances = self.instances.read().await;
+            instances.get(session_id).cloned()
+        }?;
+
+        let inst = instance.lock().await;
+        inst.container
+            .as_ref()
+            .map(|container| container.http_url())
+    }
+
     /// Launch a new browser instance.
     async fn launch_browser(
         &self,

--- a/crates/browser/src/types.rs
+++ b/crates/browser/src/types.rs
@@ -70,12 +70,25 @@ pub enum BrowserAction {
     /// Refresh the page.
     Refresh,
 
+    /// Return a user-facing URL for live manual interaction with this browser
+    /// session (for login/takeover workflows).
+    LiveUrl {
+        /// Optional hint for future transport backends.
+        /// `true` = full interactive session, `false` = read-only view preferred.
+        #[serde(default = "default_live_interactive")]
+        interactive: bool,
+    },
+
     /// Close the browser session.
     Close,
 }
 
 fn default_wait_timeout_ms() -> u64 {
     30000
+}
+
+fn default_live_interactive() -> bool {
+    true
 }
 
 /// Known Chromium-family browser engines we can launch.
@@ -181,6 +194,13 @@ impl fmt::Display for BrowserAction {
             Self::Back => write!(f, "back"),
             Self::Forward => write!(f, "forward"),
             Self::Refresh => write!(f, "refresh"),
+            Self::LiveUrl { interactive } => {
+                if *interactive {
+                    write!(f, "live_url(interactive)")
+                } else {
+                    write!(f, "live_url(read_only)")
+                }
+            },
             Self::Close => write!(f, "close"),
         }
     }
@@ -334,6 +354,10 @@ pub struct BrowserResponse {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub title: Option<String>,
 
+    /// User-facing URL for manual browser viewing/control.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub live_url: Option<String>,
+
     /// Duration of the action in milliseconds.
     pub duration_ms: u64,
 }
@@ -351,6 +375,7 @@ impl BrowserResponse {
             result: None,
             url: None,
             title: None,
+            live_url: None,
             duration_ms,
         }
     }
@@ -367,6 +392,7 @@ impl BrowserResponse {
             result: None,
             url: None,
             title: None,
+            live_url: None,
             duration_ms,
         }
     }
@@ -394,6 +420,11 @@ impl BrowserResponse {
 
     pub fn with_title(mut self, title: String) -> Self {
         self.title = Some(title);
+        self
+    }
+
+    pub fn with_live_url(mut self, live_url: String) -> Self {
+        self.live_url = Some(live_url);
         self
     }
 }
@@ -614,6 +645,16 @@ mod tests {
             Err(error) => panic!("failed to deserialize browser preference: {error}"),
         };
         assert_eq!(value, BrowserPreference::Brave);
+    }
+
+    #[test]
+    fn test_browser_action_live_url_deserialize_defaults_interactive() {
+        let req: BrowserRequest = serde_json::from_str(r#"{"action":"live_url"}"#)
+            .unwrap_or_else(|e| panic!("failed to deserialize live_url action: {e}"));
+        match req.action {
+            BrowserAction::LiveUrl { interactive } => assert!(interactive),
+            _ => panic!("expected BrowserAction::LiveUrl"),
+        }
     }
 
     #[test]

--- a/crates/tools/src/browser.rs
+++ b/crates/tools/src/browser.rs
@@ -12,7 +12,12 @@ use {
     async_trait::async_trait,
     moltis_agents::tool_registry::AgentTool,
     moltis_browser::{BrowserManager, BrowserRequest},
-    std::{borrow::Cow, collections::HashMap, sync::Arc},
+    std::{
+        borrow::Cow,
+        collections::HashMap,
+        sync::{Arc, LazyLock, RwLock as StdRwLock},
+    },
+    time::OffsetDateTime,
     tokio::sync::{OnceCell, RwLock},
     tracing::debug,
 };
@@ -40,6 +45,26 @@ pub struct BrowserTool {
     /// Bounded to [`MAX_TRACKED_SESSIONS`] to prevent unbounded growth when
     /// chats end without an explicit browser close action.
     session_ids: RwLock<HashMap<String, String>>,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct BrowserSessionOverview {
+    pub chat_session_key: String,
+    pub browser_session_id: String,
+    pub sandboxed: bool,
+    pub last_seen_unix_ms: i128,
+}
+
+static TRACKED_BROWSER_SESSIONS: LazyLock<StdRwLock<HashMap<String, BrowserSessionOverview>>> =
+    LazyLock::new(|| StdRwLock::new(HashMap::new()));
+
+pub fn list_tracked_browser_sessions() -> Vec<BrowserSessionOverview> {
+    let guard = TRACKED_BROWSER_SESSIONS
+        .read()
+        .unwrap_or_else(|e| e.into_inner());
+    let mut items: Vec<BrowserSessionOverview> = guard.values().cloned().collect();
+    items.sort_by(|a, b| b.last_seen_unix_ms.cmp(&a.last_seen_unix_ms));
+    items
 }
 
 impl BrowserTool {
@@ -86,11 +111,15 @@ impl BrowserTool {
     async fn clear_session(&self, session_key: &str) {
         let mut guard = self.session_ids.write().await;
         guard.remove(session_key);
+        let mut tracked = TRACKED_BROWSER_SESSIONS
+            .write()
+            .unwrap_or_else(|e| e.into_inner());
+        tracked.remove(session_key);
     }
 
     /// Save the browser session ID for future reuse in the same chat/session
     /// context.
-    async fn save_session(&self, session_key: &str, session_id: &str) {
+    async fn save_session(&self, session_key: &str, session_id: &str, sandboxed: bool) {
         if !session_id.is_empty() {
             let mut guard = self.session_ids.write().await;
             // Evict an arbitrary entry when at capacity to bound memory.
@@ -100,8 +129,22 @@ impl BrowserTool {
             {
                 debug!(evicted = %evict_key, "browser session cache full, evicting entry");
                 guard.remove(&evict_key);
+                let mut tracked = TRACKED_BROWSER_SESSIONS
+                    .write()
+                    .unwrap_or_else(|e| e.into_inner());
+                tracked.remove(&evict_key);
             }
             guard.insert(session_key.to_string(), session_id.to_string());
+
+            let mut tracked = TRACKED_BROWSER_SESSIONS
+                .write()
+                .unwrap_or_else(|e| e.into_inner());
+            tracked.insert(session_key.to_string(), BrowserSessionOverview {
+                chat_session_key: session_key.to_string(),
+                browser_session_id: session_id.to_string(),
+                sandboxed,
+                last_seen_unix_ms: OffsetDateTime::now_utc().unix_timestamp_nanos() / 1_000_000,
+            });
         }
     }
 
@@ -153,7 +196,8 @@ impl AgentTool for BrowserTool {
          or needs interaction (clicking, forms, screenshots, JavaScript-heavy pages).\n\n\
          REQUIRED: You MUST specify an 'action' parameter. Example:\n\
          {\"action\": \"navigate\", \"url\": \"https://example.com\"}\n\n\
-         Actions: navigate, screenshot, snapshot, click, type, scroll, evaluate, wait, close\n\n\
+         Actions: navigate, screenshot, snapshot, click, type, scroll, evaluate, wait, \
+         get_url, get_title, back, forward, refresh, live_url, close\n\n\
          BROWSER CHOICE: optionally set \"browser\" to choose one (auto, chrome, chromium, \
          edge, brave, opera, vivaldi, arc). If no browser is installed, Moltis will try \
          to auto-install one.\n\n\
@@ -165,7 +209,8 @@ impl AgentTool for BrowserTool {
          2. {\"action\": \"snapshot\"} - get interactive elements with ref numbers\n\
          3. {\"action\": \"click\", \"ref_\": N} - click element by ref number\n\
          4. {\"action\": \"screenshot\"} - capture the current view\n\
-         5. {\"action\": \"close\"} - close the browser when done"
+         5. {\"action\": \"live_url\"} - get a manual browser view URL for human login/takeover\n\
+         6. {\"action\": \"close\"} - close the browser when done"
     }
 
     fn parameters_schema(&self) -> serde_json::Value {
@@ -175,7 +220,7 @@ impl AgentTool for BrowserTool {
             "properties": {
                 "action": {
                     "type": "string",
-                    "enum": ["navigate", "screenshot", "snapshot", "click", "type", "scroll", "evaluate", "wait", "get_url", "get_title", "back", "forward", "refresh", "close"],
+                    "enum": ["navigate", "screenshot", "snapshot", "click", "type", "scroll", "evaluate", "wait", "get_url", "get_title", "back", "forward", "refresh", "live_url", "close"],
                     "description": "REQUIRED. The browser action to perform. Use 'navigate' with 'url' to open a page, 'snapshot' to see elements, 'screenshot' to capture."
                 },
                 "session_id": {
@@ -222,6 +267,10 @@ impl AgentTool for BrowserTool {
                 "timeout_ms": {
                     "type": "integer",
                     "description": "Timeout in milliseconds (default: 60000)"
+                },
+                "interactive": {
+                    "type": "boolean",
+                    "description": "For 'live_url': true for interactive takeover, false to prefer read-only view."
                 }
             }
         })
@@ -302,7 +351,8 @@ impl AgentTool for BrowserTool {
             if is_close {
                 self.clear_session(&session_key).await;
             } else {
-                self.save_session(&session_key, &response.session_id).await;
+                self.save_session(&session_key, &response.session_id, response.sandboxed)
+                    .await;
             }
         }
 
@@ -367,9 +417,9 @@ mod tests {
         };
         let tool = BrowserTool::from_config(&config).unwrap();
 
-        tool.save_session("web:session:one", "browser-session-one")
+        tool.save_session("web:session:one", "browser-session-one", true)
             .await;
-        tool.save_session("web:session:two", "browser-session-two")
+        tool.save_session("web:session:two", "browser-session-two", false)
             .await;
 
         assert_eq!(
@@ -390,7 +440,7 @@ mod tests {
             ..Default::default()
         };
         let tool = BrowserTool::from_config(&config).unwrap();
-        tool.save_session("web:session:one", "").await;
+        tool.save_session("web:session:one", "", true).await;
         assert_eq!(tool.get_saved_session("web:session:one").await, None);
     }
 
@@ -404,7 +454,7 @@ mod tests {
 
         // Fill the cache to capacity
         for i in 0..BrowserTool::MAX_TRACKED_SESSIONS {
-            tool.save_session(&format!("session-{i}"), &format!("sid-{i}"))
+            tool.save_session(&format!("session-{i}"), &format!("sid-{i}"), true)
                 .await;
         }
         assert_eq!(
@@ -413,7 +463,7 @@ mod tests {
         );
 
         // Adding one more should evict an entry and stay at capacity
-        tool.save_session("session-new", "sid-new").await;
+        tool.save_session("session-new", "sid-new", true).await;
         let guard = tool.session_ids.read().await;
         assert_eq!(guard.len(), BrowserTool::MAX_TRACKED_SESSIONS);
         assert_eq!(guard.get("session-new"), Some(&"sid-new".to_string()));
@@ -427,9 +477,9 @@ mod tests {
         };
         let tool = BrowserTool::from_config(&config).unwrap();
 
-        tool.save_session("web:session:one", "browser-session-one")
+        tool.save_session("web:session:one", "browser-session-one", true)
             .await;
-        tool.save_session("web:session:two", "browser-session-two")
+        tool.save_session("web:session:two", "browser-session-two", false)
             .await;
 
         tool.clear_session("web:session:one").await;
@@ -439,5 +489,24 @@ mod tests {
             tool.get_saved_session("web:session:two").await,
             Some("browser-session-two".to_string())
         );
+    }
+
+    #[tokio::test]
+    async fn tracked_browser_sessions_are_listed() {
+        let config = moltis_config::schema::BrowserConfig {
+            enabled: true,
+            ..Default::default()
+        };
+        let tool = BrowserTool::from_config(&config).unwrap();
+
+        tool.save_session("web:session:list", "browser-session-list", true)
+            .await;
+
+        let list = list_tracked_browser_sessions();
+        assert!(list.iter().any(|entry| {
+            entry.chat_session_key == "web:session:list"
+                && entry.browser_session_id == "browser-session-list"
+                && entry.sandboxed
+        }));
     }
 }

--- a/crates/web/src/api.rs
+++ b/crates/web/src/api.rs
@@ -41,6 +41,7 @@ const SESSION_LIST_DEFAULT_LIMIT: usize = 40;
 const SESSION_LIST_MAX_LIMIT: usize = 200;
 const SESSION_HISTORY_DEFAULT_LIMIT: usize = 120;
 const SESSION_HISTORY_MAX_LIMIT: usize = 500;
+const BROWSER_SESSIONS_LIST_FAILED: &str = "BROWSER_SESSIONS_LIST_FAILED";
 
 fn api_error(code: &str, error: impl Into<String>) -> serde_json::Value {
     serde_json::json!({
@@ -161,6 +162,22 @@ pub async fn api_sessions_handler(
             StatusCode::INTERNAL_SERVER_ERROR,
             SESSION_LIST_FAILED,
             e.to_string(),
+        ),
+    }
+}
+
+pub async fn api_browser_sessions_handler() -> impl IntoResponse {
+    let sessions = moltis_tools::browser::list_tracked_browser_sessions();
+    if sessions.is_empty() {
+        return Json(serde_json::json!({ "sessions": [] })).into_response();
+    }
+
+    match serde_json::to_value(&sessions) {
+        Ok(serialized) => Json(serde_json::json!({ "sessions": serialized })).into_response(),
+        Err(error) => api_error_response(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            BROWSER_SESSIONS_LIST_FAILED,
+            error.to_string(),
         ),
     }
 }

--- a/crates/web/src/assets/js/page-settings.js
+++ b/crates/web/src/assets/js/page-settings.js
@@ -1731,12 +1731,13 @@ function ToolsSection() {
 	var [loadingTools, setLoadingTools] = useState(true);
 	var [toolData, setToolData] = useState(null);
 	var [nodeInventory, setNodeInventory] = useState([]);
+	var [browserSessions, setBrowserSessions] = useState([]);
 	var [toolsErr, setToolsErr] = useState(null);
 
 	function loadToolsOverview() {
 		setLoadingTools(true);
 		setToolsErr(null);
-		Promise.allSettled([sendRpc("chat.context", {}), sendRpc("node.list", {})])
+		Promise.allSettled([sendRpc("chat.context", {}), sendRpc("node.list", {}), fetch("/api/browser/sessions")])
 			.then((results) => {
 				var contextResult = results[0];
 				if (contextResult.status !== "fulfilled" || !contextResult.value?.ok) {
@@ -1748,8 +1749,20 @@ function ToolsSection() {
 					nodesResult.status === "fulfilled" && nodesResult.value?.ok && Array.isArray(nodesResult.value.payload)
 						? nodesResult.value.payload
 						: [];
+				var browserSessionsResult = results[2];
+				var nextBrowserSessions = [];
+				if (browserSessionsResult.status === "fulfilled") {
+					nextBrowserSessions = browserSessionsResult.value
+						.json()
+						.then((payload) => (Array.isArray(payload?.sessions) ? payload.sessions : []))
+						.catch(() => []);
+				}
 				setToolData(nextToolData);
 				setNodeInventory(nextNodeInventory);
+				return Promise.resolve(nextBrowserSessions);
+			})
+			.then((nextBrowserSessions) => {
+				setBrowserSessions(nextBrowserSessions);
 				setLoadingTools(false);
 			})
 			.catch((error) => {
@@ -2024,6 +2037,49 @@ function ToolsSection() {
 					}
 				</div>
 			</div>
+		</div>
+
+		<div class="rounded border border-[var(--border)] bg-[var(--surface)] p-4 max-w-[1100px]">
+			<div class="flex items-center justify-between gap-2 flex-wrap">
+				<h3 class="text-sm font-medium text-[var(--text-strong)] m-0">Browser Sessions</h3>
+				<span class="provider-item-badge muted">${browserSessions.length}</span>
+			</div>
+			<div class="text-xs text-[var(--muted)] mt-2 leading-relaxed">
+				Tracked browser sessions mapped to chat sessions. Use this to find active browser IDs before requesting
+				<code class="text-[var(--text)]">live_url</code> for manual login/takeover.
+			</div>
+			${
+				browserSessions.length > 0
+					? html`<div class="mt-3 overflow-x-auto">
+						<table class="w-full text-xs border border-[var(--border)] rounded">
+							<thead class="bg-[var(--surface2)] text-[var(--muted)]">
+								<tr>
+									<th class="text-left p-2 font-medium">Chat Session</th>
+									<th class="text-left p-2 font-medium">Browser Session</th>
+									<th class="text-left p-2 font-medium">Mode</th>
+									<th class="text-left p-2 font-medium">Last Seen</th>
+								</tr>
+							</thead>
+							<tbody>
+								${browserSessions.map(
+									(entry) => html`<tr key=${entry.chat_session_key} class="border-t border-[var(--border)]">
+										<td class="p-2 break-all text-[var(--text)]">${entry.chat_session_key || "main"}</td>
+										<td class="p-2 break-all text-[var(--text)]">${entry.browser_session_id || "—"}</td>
+										<td class="p-2">
+											<span class="provider-item-badge ${entry.sandboxed ? "configured" : "warning"}">
+												${entry.sandboxed ? "Sandbox" : "Host"}
+											</span>
+										</td>
+										<td class="p-2 text-[var(--muted)]">
+											${entry.last_seen_unix_ms ? new Date(Number(entry.last_seen_unix_ms)).toLocaleString() : "—"}
+										</td>
+									</tr>`,
+								)}
+							</tbody>
+						</table>
+					</div>`
+					: html`<div class="text-xs text-[var(--muted)] mt-3">No tracked browser sessions yet.</div>`
+			}
 		</div>
 	</div>`;
 }

--- a/crates/web/src/lib.rs
+++ b/crates/web/src/lib.rs
@@ -190,6 +190,10 @@ fn build_api_routes() -> Router<AppState> {
         )
         .route("/api/sessions", get(api::api_sessions_handler))
         .route(
+            "/api/browser/sessions",
+            get(api::api_browser_sessions_handler),
+        )
+        .route(
             "/api/sessions/{session_key}/history",
             get(api::api_session_history_handler),
         )

--- a/docs/src/browser-automation.md
+++ b/docs/src/browser-automation.md
@@ -119,6 +119,7 @@ also the base domain itself.
 | `back` | Go back in history | - |
 | `forward` | Go forward in history | - |
 | `refresh` | Reload the page | - |
+| `live_url` | Get a human-viewable DevTools URL for manual login/takeover (sandbox mode) | `interactive` (optional) |
 | `close` | Close browser session | - |
 
 ### Automatic Session Tracking
@@ -145,6 +146,10 @@ pass `session_id` explicitly:
 ```
 
 This prevents pool exhaustion from LLMs that forget to pass the session_id.
+
+The web UI now exposes tracked browser sessions in **Settings → Tools** so you
+can see active chat-to-browser mappings and copy a session ID before requesting
+`live_url`.
 
 ### Browser selection
 


### PR DESCRIPTION
### Motivation

- Provide a way to obtain a human-usable DevTools URL for manual login/takeover of sandboxed browser sessions.
- Surface currently tracked browser session mappings so operators can find session IDs for `live_url`/debugging.
- Keep session tracking bounded and expose it to the web UI and API for observability.

### Description

- Add a new `BrowserAction::LiveUrl` action and default `interactive` flag via `types.rs`, and extend `BrowserResponse` with `live_url` and a `with_live_url` helper.
- Implement `BrowserManager::live_url` which queries the sandboxed browser HTTP endpoint and returns the DevTools frontend URL; add `fetch_devtools_live_url` using `reqwest` and add `reqwest` to the `crates/browser` dependencies.
- Add `BrowserPool::sandbox_http_url` to expose the sandbox HTTP base URL for a session and wire usage from `live_url` to ensure a page target exists before querying `/json/list`.
- Track per-chat saved browser sessions in `crates/tools::browser` with a global `TRACKED_BROWSER_SESSIONS` map and `list_tracked_browser_sessions()` helper, update `save_session`/`clear_session` to maintain this map, and add `BrowserSessionOverview` type.
- Expose tracked sessions via a new API handler `api_browser_sessions_handler` at `GET /api/browser/sessions` and add the route in the web server router.
- Update the web UI (`page-settings.js`) to fetch and display the tracked browser sessions table in Settings → Tools, and update docs (`browser-automation.md`) and tool help text/schema to include `live_url`.

### Testing

- Added unit test `test_browser_action_live_url_deserialize_defaults_interactive` in `crates/browser` to verify `live_url` deserializes with default `interactive = true`, and it passes.
- Added/updated `crates/tools` async tests (`saved_browser_sessions_are_scoped_by_chat_session`, `empty_session_id_is_not_saved`, `session_cache_evicts_when_full`, `clearing_one_chat_session_keeps_other_browser_sessions`, `tracked_browser_sessions_are_listed`) to cover session tracking behavior, and they pass under `cargo test`.
- Ran the full test suite with `cargo test` across the workspace and all automated tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc135397fc832b864672da4c333333)