### PR TITLE
ci: add GitHub artifact attestations to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1126,7 +1126,8 @@ jobs:
     permissions:
       contents: read
       packages: write
-      id-token: write # Required for Sigstore keyless signing
+      id-token: write        # Required for Sigstore keyless signing
+      attestations: write    # Required for artifact attestations
 
     steps:
       - name: Download digests
@@ -1234,6 +1235,14 @@ jobs:
             --certificate-oidc-issuer="https://token.actions.githubusercontent.com" \
             "ghcr.io/${{ github.repository }}@${DIGEST}"
 
+      - name: Attest build provenance for container image
+        if: github.event_name != 'pull_request'
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4
+        with:
+          subject-name: ghcr.io/${{ github.repository }}
+          subject-digest: ${{ steps.manifest.outputs.digest }}
+          push-to-registry: true
+
   upload-release:
     needs:
       - build-deb
@@ -1249,6 +1258,8 @@ jobs:
     name: Upload release assets
     permissions:
       contents: write
+      id-token: write        # Required for artifact attestations
+      attestations: write    # Required for artifact attestations
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -1287,6 +1298,19 @@ jobs:
           files: release-files/*
           prerelease: ${{ env.RELEASE_PRE_RELEASE == 'true' }}
 
+      - name: Attest build provenance for release artifacts
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4
+        with:
+          subject-path: |
+            release-files/*.tar.gz
+            release-files/*.deb
+            release-files/*.rpm
+            release-files/*.pkg.tar.zst
+            release-files/*.AppImage
+            release-files/*.snap
+            release-files/*.zip
+            release-files/*.exe
+
   # Generate SBOM for the entire release
   generate-sbom:
     needs:
@@ -1297,7 +1321,8 @@ jobs:
     name: Generate Release SBOM
     permissions:
       contents: write
-      id-token: write # Required for Sigstore keyless signing
+      id-token: write        # Required for Sigstore keyless signing
+      attestations: write    # Required for artifact attestations
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -1334,6 +1359,13 @@ jobs:
             moltis-sbom.spdx.json.sha256
             moltis-sbom.spdx.json.sig
             moltis-sbom.spdx.json.crt
+
+      - name: Attest build provenance for SBOMs
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4
+        with:
+          subject-path: |
+            moltis-sbom.cdx.json
+            moltis-sbom.spdx.json
 
   update-homebrew-tap:
     needs:

--- a/README.md
+++ b/README.md
@@ -116,8 +116,10 @@ Use `--no-default-features --features lightweight` for constrained devices (Rasp
 - **SSRF protection** — DNS-resolved, blocks loopback/private/link-local
 - **Origin validation** — rejects cross-origin WebSocket upgrades
 - **Hook gating** — `BeforeToolCall` hooks can inspect/block any tool invocation
+- **Supply chain integrity** — [artifact attestations](https://github.com/moltis-org/moltis/attestations), Sigstore keyless signing, GPG signing (YubiKey), SHA-256/SHA-512 checksums
 
 See [Security Architecture](https://docs.moltis.org/security.html) for details.
+Verify releases with `gh attestation verify <artifact> -R moltis-org/moltis` or see [Release Verification](https://docs.moltis.org/release-verification.html).
 
 ## Features
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -27,9 +27,23 @@ Security updates are provided for the latest release only.
 
 ## Verifying Release Signatures
 
-All release artifacts are signed using [Sigstore](https://sigstore.dev) keyless
-signing. This provides cryptographic proof that artifacts were built by our
-GitHub Actions workflow, not tampered with after the fact.
+All release artifacts are protected with multiple verification layers:
+
+- **[GitHub artifact attestations](https://github.com/moltis-org/moltis/attestations)** — SLSA v1.0 Build Level 2 provenance
+- **[Sigstore](https://sigstore.dev) keyless signing** — OIDC-bound CI signatures recorded in the Rekor transparency log
+- **GPG signing** — maintainer authorization via YubiKey-resident key
+
+### Quick verification (recommended)
+
+```bash
+# Verify any release artifact with the GitHub CLI
+gh attestation verify <artifact> -R moltis-org/moltis
+
+# Verify a Docker image
+gh attestation verify oci://ghcr.io/moltis-org/moltis:VERSION -R moltis-org/moltis
+```
+
+Browse all attestations at <https://github.com/moltis-org/moltis/attestations>.
 
 ### Install cosign
 

--- a/docs/src/release-verification.md
+++ b/docs/src/release-verification.md
@@ -1,12 +1,16 @@
 # Release Verification
 
-Moltis releases use **dual signing** to provide strong supply chain guarantees:
+Moltis releases use **multiple signing layers** to provide strong supply chain guarantees:
 
 | Method | Proves | Verification |
 |--------|--------|-------------|
+| **GitHub Artifact Attestations** (CI-generated) | Artifact was built by this repo's GitHub Actions workflow | `gh attestation verify` |
 | **Sigstore** (keyless, CI-generated) | Artifact was built by GitHub Actions from this repo | `cosign verify-blob` |
 | **GPG** (YubiKey-resident key, maintainer-signed) | A specific maintainer authorized the release | `gpg --verify` |
 | **SHA256/SHA512 checksums** | File integrity (no corruption/tampering in transit) | `sha256sum --check` |
+
+All attestations are publicly visible on the
+[repository attestations page](https://github.com/moltis-org/moltis/attestations).
 
 ## Quick Verification
 
@@ -22,6 +26,29 @@ The easiest way to verify a release is with the included script:
 # Verify specific local files
 ./scripts/verify-release.sh moltis-VERSION-x86_64-unknown-linux-gnu.tar.gz
 ```
+
+### GitHub Artifact Attestations
+
+GitHub artifact attestations provide cryptographic proof that release artifacts
+were built inside this repository's GitHub Actions workflow. Verification uses
+the [GitHub CLI](https://cli.github.com/):
+
+```bash
+# Verify a downloaded binary
+gh attestation verify moltis-VERSION-x86_64-unknown-linux-gnu.tar.gz \
+  -R moltis-org/moltis
+
+# Verify a Docker image
+gh attestation verify oci://ghcr.io/moltis-org/moltis:VERSION \
+  -R moltis-org/moltis
+
+# Verify an SBOM
+gh attestation verify moltis-sbom.spdx.json \
+  -R moltis-org/moltis
+```
+
+Browse all attestations at
+<https://github.com/moltis-org/moltis/attestations>.
 
 ### Manual Verification
 
@@ -92,20 +119,25 @@ cosign verify \
 **Checksums** detect download corruption or CDN tampering. They do not prove
 who created the file.
 
+**GitHub artifact attestations** create unfalsifiable provenance records tied
+to the repository, workflow, commit SHA, and triggering event. They are stored
+in GitHub's attestation ledger and verifiable with `gh attestation verify`.
+This provides SLSA v1.0 Build Level 2 guarantees.
+
 **Sigstore signatures** prove the artifact was built inside the
 `moltis-org/moltis` GitHub Actions workflow using OIDC-based keyless signing.
 This guards against a compromised maintainer laptop — even if someone steals
 credentials, they cannot reproduce a valid Sigstore certificate from the CI
-environment.
+environment. Signatures are recorded in Sigstore's Rekor transparency log.
 
 **GPG signatures** prove the release was reviewed and authorized by a specific
 maintainer holding the corresponding private key. Because the key lives on a
 YubiKey hardware token, compromise requires physical access to the device plus
 the PIN.
 
-Together, the two signatures create a strong chain: Sigstore proves *where* the
-artifact was built (CI), and GPG proves *who* authorized it (maintainer with
-hardware key).
+Together, these layers create a strong chain: GitHub attestations and Sigstore
+prove *where* the artifact was built (CI), and GPG proves *who* authorized it
+(maintainer with hardware key).
 
 ## Release Artifacts Per File
 

--- a/docs/src/security.md
+++ b/docs/src/security.md
@@ -569,11 +569,16 @@ disclosed.
 
 ## Release Signing and Verification
 
-All release artifacts are signed with two independent methods:
+All release artifacts are signed with three independent methods:
 
-1. **Sigstore keyless signing** (automated in CI) — proves the artifact was
-   built by the `moltis-org/moltis` GitHub Actions pipeline
-2. **GPG signing** (maintainer's YubiKey hardware key) — proves a specific
+1. **[GitHub artifact attestations](https://github.com/moltis-org/moltis/attestations)**
+   (automated in CI) — cryptographic provenance records tied to the repository,
+   workflow, and commit SHA; provides SLSA v1.0 Build Level 2 guarantees;
+   verifiable with `gh attestation verify`
+2. **Sigstore keyless signing** (automated in CI) — proves the artifact was
+   built by the `moltis-org/moltis` GitHub Actions pipeline; recorded in
+   Sigstore's Rekor transparency log
+3. **GPG signing** (maintainer's YubiKey hardware key) — proves a specific
    maintainer authorized the release
 
 Checksums (SHA-256 and SHA-512) are generated for every artifact.


### PR DESCRIPTION
## Summary

- Add `actions/attest-build-provenance@v4` (SHA-pinned) to the release pipeline, covering binary release artifacts, container images, and SBOMs
- This adds SLSA v1.0 Build Level 2 provenance on top of the existing Sigstore keyless signing and GPG signing layers
- Update security documentation across README.md, SECURITY.md, and docs

## Changes

**Workflow** (`.github/workflows/release.yml`):
- `upload-release` job: attest all binary artifacts (`.tar.gz`, `.deb`, `.rpm`, `.pkg.tar.zst`, `.AppImage`, `.snap`, `.zip`, `.exe`)
- `merge-docker` job: attest the multi-arch container image (pushed to GHCR registry)
- `generate-sbom` job: attest CycloneDX and SPDX SBOMs
- Added `id-token: write` and `attestations: write` permissions where needed

**Documentation**:
- `README.md` — added supply chain integrity bullet and `gh attestation verify` example
- `SECURITY.md` — added quick verification section with `gh attestation verify`
- `docs/src/security.md` — updated from two to three signing methods
- `docs/src/release-verification.md` — added attestations to verification table, new section with `gh attestation verify` examples, updated "What Each Layer Proves"

## Validation

### Completed
- [x] YAML syntax validated (Ruby YAML parser)
- [x] No untrusted input in workflow steps (security hook reviewed)
- [x] Action pinned to commit SHA (`a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32`)
- [x] Permissions follow least-privilege (only added where needed)

### Remaining
- [ ] `gh attestation verify` on next release to confirm end-to-end

## Manual QA

1. Review the [attestations page](https://github.com/moltis-org/moltis/attestations) after the next tagged release
2. Download a release artifact and run `gh attestation verify <artifact> -R moltis-org/moltis`
3. Verify Docker image: `gh attestation verify oci://ghcr.io/moltis-org/moltis:VERSION -R moltis-org/moltis`