### PR TITLE
fix(web): allow session sidebar links to open in new tabs

### DIFF
--- a/crates/web/src/assets/css/layout.css
+++ b/crates/web/src/assets/css/layout.css
@@ -252,6 +252,8 @@
   padding: 8px 12px;
   transition: background 0.15s;
   display: flex;
+  color: inherit;
+  text-decoration: none;
 }
 
 .session-item:hover { background: var(--bg-hover); }

--- a/crates/web/src/assets/js/components/session-list.js
+++ b/crates/web/src/assets/js/components/session-list.js
@@ -186,16 +186,22 @@ function SessionItem({ session, activeKey, depth, keyMap, refreshing }) {
 	var agentId = session.agent_id || "main";
 	var showAgentBadge = !!agentId && agentId !== "main";
 
-	function onClick() {
+	var href = sessionPath(session.key);
+
+	function onClick(event) {
+		if (event.defaultPrevented) return;
+		if (event.button !== 0) return;
+		if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return;
+		event.preventDefault();
 		if (currentPrefix !== "/chats") {
-			navigate(sessionPath(session.key));
+			navigate(href);
 		} else {
 			switchSession(session.key);
 		}
 	}
 
 	return html`
-		<div class=${className} data-session-key=${session.key} style=${style} onClick=${onClick}>
+		<a href=${href} class=${className} data-session-key=${session.key} style=${style} onClick=${onClick}>
 			<div class="session-info">
 				<div class="session-label">
 					<${SessionIcon} session=${session} isBranch=${isBranch} />
@@ -223,7 +229,7 @@ function SessionItem({ session, activeKey, depth, keyMap, refreshing }) {
 				${preview && html`<div class="session-preview">${preview}</div>`}
 				<${SessionMeta} session=${session} />
 			</div>
-		</div>
+		</a>
 	`;
 }
 

--- a/crates/web/ui/e2e/specs/sessions.spec.js
+++ b/crates/web/ui/e2e/specs/sessions.spec.js
@@ -207,6 +207,35 @@ test.describe("Session management", () => {
 		await expectPageContentMounted(page);
 	});
 
+	test("modifier-clicking a session opens it in a new tab", async ({ page }) => {
+		const pageErrors = watchPageErrors(page);
+		await navigateAndWait(page, "/");
+		await waitForWsConnected(page);
+
+		await createSession(page);
+		const currentUrl = page.url();
+
+		const mainItem = page.locator('#sessionList .session-item[data-session-key="main"]');
+		await expect(mainItem).toBeVisible();
+
+		const newPagePromise = page.context().waitForEvent("page");
+		await mainItem.click({
+			modifiers: [process.platform === "darwin" ? "Meta" : "Control"],
+		});
+		const newPage = await newPagePromise;
+		const newPageErrors = watchPageErrors(newPage);
+
+		await newPage.waitForLoadState("domcontentloaded");
+		await expectPageContentMounted(newPage);
+		await waitForWsConnected(newPage);
+		await expect(newPage).toHaveURL(/\/chats\/main$/);
+		await expect(page).toHaveURL(currentUrl);
+
+		expect(pageErrors).toEqual([]);
+		expect(newPageErrors).toEqual([]);
+		await newPage.close();
+	});
+
 	test("shows loading indicator while uncached session switch is pending", async ({ page }) => {
 		const pageErrors = watchPageErrors(page);
 		await navigateAndWait(page, "/");


### PR DESCRIPTION
It would be great to be able to open sessions in new tabs by using a cmd/ctrl key plus click.  This change should add that.