### PR TITLE
fix(mcp): normalize loopback OAuth redirect URIs to http (fixes #629)

### DIFF
--- a/crates/mcp/src/auth.rs
+++ b/crates/mcp/src/auth.rs
@@ -23,7 +23,8 @@ use crate::{
 
 use moltis_oauth::{
     OAuthConfig, OAuthFlow, OAuthTokens, RegistrationStore, StoredRegistration, TokenStore,
-    fetch_as_metadata, fetch_resource_metadata, parse_www_authenticate, register_client,
+    fetch_as_metadata, fetch_resource_metadata, normalize_loopback_redirect,
+    parse_www_authenticate, register_client,
 };
 
 // ── Auth state ─────────────────────────────────────────────────────────────
@@ -529,37 +530,6 @@ impl McpOAuthProvider {
     }
 }
 
-/// Rewrite `https://` → `http://` for loopback redirect URIs so dynamic
-/// client registration (RFC 7591) is accepted by authorization servers that
-/// enforce RFC 8252 §8.3. Non-loopback hosts and non-`https` schemes are
-/// returned unchanged.
-///
-/// The main TLS listener's HTTP peek/redirect bounces the plain-HTTP OAuth
-/// callback back onto the real HTTPS handler transparently, so this rewrite
-/// is safe for any deployment where the web UI is reached via a loopback
-/// host (`localhost`, `127.0.0.1`, `::1`).
-fn normalize_loopback_redirect(uri: &str) -> String {
-    let Ok(mut parsed) = Url::parse(uri) else {
-        return uri.to_string();
-    };
-    if parsed.scheme() != "https" {
-        return uri.to_string();
-    }
-    let is_loopback = match parsed.host() {
-        Some(url::Host::Domain(host)) => host.eq_ignore_ascii_case("localhost"),
-        Some(url::Host::Ipv4(ip)) => ip.is_loopback(),
-        Some(url::Host::Ipv6(ip)) => ip.is_loopback(),
-        None => false,
-    };
-    if !is_loopback {
-        return uri.to_string();
-    }
-    if parsed.set_scheme("http").is_err() {
-        return uri.to_string();
-    }
-    parsed.to_string()
-}
-
 #[async_trait]
 impl McpAuthProvider for McpOAuthProvider {
     async fn access_token(&self) -> Result<Option<Secret<String>>> {
@@ -1061,89 +1031,6 @@ mod tests {
     fn store_key_format() {
         let provider = McpOAuthProvider::new("my-server", "https://mcp.example.com");
         assert_eq!(provider.store_key(), "mcp:my-server");
-    }
-
-    // ── normalize_loopback_redirect ────────────────────────────────────────
-
-    #[test]
-    fn normalize_loopback_rewrites_https_localhost() {
-        assert_eq!(
-            normalize_loopback_redirect("https://localhost:1455/auth/callback"),
-            "http://localhost:1455/auth/callback",
-        );
-    }
-
-    #[test]
-    fn normalize_loopback_rewrites_https_localhost_default_port() {
-        assert_eq!(
-            normalize_loopback_redirect("https://localhost/auth/callback"),
-            "http://localhost/auth/callback",
-        );
-    }
-
-    #[test]
-    fn normalize_loopback_rewrites_https_ipv4_loopback() {
-        assert_eq!(
-            normalize_loopback_redirect("https://127.0.0.1:1455/auth/callback"),
-            "http://127.0.0.1:1455/auth/callback",
-        );
-    }
-
-    #[test]
-    fn normalize_loopback_rewrites_https_ipv6_loopback() {
-        assert_eq!(
-            normalize_loopback_redirect("https://[::1]:1455/auth/callback"),
-            "http://[::1]:1455/auth/callback",
-        );
-    }
-
-    #[test]
-    fn normalize_loopback_rewrites_https_localhost_case_insensitive() {
-        assert_eq!(
-            normalize_loopback_redirect("https://LocalHost:1455/auth/callback"),
-            "http://localhost:1455/auth/callback",
-        );
-    }
-
-    #[test]
-    fn normalize_loopback_preserves_real_hostname() {
-        assert_eq!(
-            normalize_loopback_redirect("https://moltis.lan/auth/callback"),
-            "https://moltis.lan/auth/callback",
-        );
-        assert_eq!(
-            normalize_loopback_redirect("https://moltis.example.com:1455/auth/callback"),
-            "https://moltis.example.com:1455/auth/callback",
-        );
-    }
-
-    #[test]
-    fn normalize_loopback_preserves_non_loopback_ipv4() {
-        assert_eq!(
-            normalize_loopback_redirect("https://192.168.1.10:1455/auth/callback"),
-            "https://192.168.1.10:1455/auth/callback",
-        );
-    }
-
-    #[test]
-    fn normalize_loopback_preserves_http_scheme() {
-        assert_eq!(
-            normalize_loopback_redirect("http://localhost:1455/auth/callback"),
-            "http://localhost:1455/auth/callback",
-        );
-    }
-
-    #[test]
-    fn normalize_loopback_preserves_query_and_path() {
-        assert_eq!(
-            normalize_loopback_redirect("https://localhost:1455/auth/callback?foo=bar"),
-            "http://localhost:1455/auth/callback?foo=bar",
-        );
-    }
-
-    #[test]
-    fn normalize_loopback_returns_unparseable_input_unchanged() {
-        assert_eq!(normalize_loopback_redirect("not a url"), "not a url",);
     }
 
     // ── start_web_oauth_flow loopback rewrite ──────────────────────────────

--- a/crates/mcp/src/auth.rs
+++ b/crates/mcp/src/auth.rs
@@ -228,6 +228,18 @@ impl McpOAuthProvider {
         redirect_uri: &str,
         www_authenticate: Option<&str>,
     ) -> Result<String> {
+        // RFC 8252 §7.3/§8.3: loopback redirect URIs must use the `http`
+        // scheme. Many authorization servers (e.g. Attio) reject
+        // `https://localhost` with `invalid_redirect_uri`. Moltis serves the
+        // web UI over TLS, so the origin-derived callback arrives as
+        // `https://localhost:<port>/auth/callback`. We rewrite the scheme for
+        // loopback hosts; the TLS listener's peek-based HTTP→HTTPS redirect
+        // (see `moltis_tls::serve_tls_with_http_redirect`) transparently
+        // bounces the browser back onto the real HTTPS callback handler,
+        // preserving path and query string.
+        let redirect_uri = normalize_loopback_redirect(redirect_uri);
+        let redirect_uri = redirect_uri.as_str();
+
         let (client_id, auth_url, token_url, scopes, resource) =
             if let Some(ov) = &self.oauth_override {
                 // Manual override: skip discovery
@@ -515,6 +527,37 @@ impl McpOAuthProvider {
             resource,
         ))
     }
+}
+
+/// Rewrite `https://` → `http://` for loopback redirect URIs so dynamic
+/// client registration (RFC 7591) is accepted by authorization servers that
+/// enforce RFC 8252 §8.3. Non-loopback hosts and non-`https` schemes are
+/// returned unchanged.
+///
+/// The main TLS listener's HTTP peek/redirect bounces the plain-HTTP OAuth
+/// callback back onto the real HTTPS handler transparently, so this rewrite
+/// is safe for any deployment where the web UI is reached via a loopback
+/// host (`localhost`, `127.0.0.1`, `::1`).
+fn normalize_loopback_redirect(uri: &str) -> String {
+    let Ok(mut parsed) = Url::parse(uri) else {
+        return uri.to_string();
+    };
+    if parsed.scheme() != "https" {
+        return uri.to_string();
+    }
+    let is_loopback = match parsed.host() {
+        Some(url::Host::Domain(host)) => host.eq_ignore_ascii_case("localhost"),
+        Some(url::Host::Ipv4(ip)) => ip.is_loopback(),
+        Some(url::Host::Ipv6(ip)) => ip.is_loopback(),
+        None => false,
+    };
+    if !is_loopback {
+        return uri.to_string();
+    }
+    if parsed.set_scheme("http").is_err() {
+        return uri.to_string();
+    }
+    parsed.to_string()
 }
 
 #[async_trait]
@@ -1018,5 +1061,177 @@ mod tests {
     fn store_key_format() {
         let provider = McpOAuthProvider::new("my-server", "https://mcp.example.com");
         assert_eq!(provider.store_key(), "mcp:my-server");
+    }
+
+    // ── normalize_loopback_redirect ────────────────────────────────────────
+
+    #[test]
+    fn normalize_loopback_rewrites_https_localhost() {
+        assert_eq!(
+            normalize_loopback_redirect("https://localhost:1455/auth/callback"),
+            "http://localhost:1455/auth/callback",
+        );
+    }
+
+    #[test]
+    fn normalize_loopback_rewrites_https_localhost_default_port() {
+        assert_eq!(
+            normalize_loopback_redirect("https://localhost/auth/callback"),
+            "http://localhost/auth/callback",
+        );
+    }
+
+    #[test]
+    fn normalize_loopback_rewrites_https_ipv4_loopback() {
+        assert_eq!(
+            normalize_loopback_redirect("https://127.0.0.1:1455/auth/callback"),
+            "http://127.0.0.1:1455/auth/callback",
+        );
+    }
+
+    #[test]
+    fn normalize_loopback_rewrites_https_ipv6_loopback() {
+        assert_eq!(
+            normalize_loopback_redirect("https://[::1]:1455/auth/callback"),
+            "http://[::1]:1455/auth/callback",
+        );
+    }
+
+    #[test]
+    fn normalize_loopback_rewrites_https_localhost_case_insensitive() {
+        assert_eq!(
+            normalize_loopback_redirect("https://LocalHost:1455/auth/callback"),
+            "http://localhost:1455/auth/callback",
+        );
+    }
+
+    #[test]
+    fn normalize_loopback_preserves_real_hostname() {
+        assert_eq!(
+            normalize_loopback_redirect("https://moltis.lan/auth/callback"),
+            "https://moltis.lan/auth/callback",
+        );
+        assert_eq!(
+            normalize_loopback_redirect("https://moltis.example.com:1455/auth/callback"),
+            "https://moltis.example.com:1455/auth/callback",
+        );
+    }
+
+    #[test]
+    fn normalize_loopback_preserves_non_loopback_ipv4() {
+        assert_eq!(
+            normalize_loopback_redirect("https://192.168.1.10:1455/auth/callback"),
+            "https://192.168.1.10:1455/auth/callback",
+        );
+    }
+
+    #[test]
+    fn normalize_loopback_preserves_http_scheme() {
+        assert_eq!(
+            normalize_loopback_redirect("http://localhost:1455/auth/callback"),
+            "http://localhost:1455/auth/callback",
+        );
+    }
+
+    #[test]
+    fn normalize_loopback_preserves_query_and_path() {
+        assert_eq!(
+            normalize_loopback_redirect("https://localhost:1455/auth/callback?foo=bar"),
+            "http://localhost:1455/auth/callback?foo=bar",
+        );
+    }
+
+    #[test]
+    fn normalize_loopback_returns_unparseable_input_unchanged() {
+        assert_eq!(normalize_loopback_redirect("not a url"), "not a url",);
+    }
+
+    // ── start_web_oauth_flow loopback rewrite ──────────────────────────────
+
+    /// Integration test: when the UI passes `https://localhost:…/auth/callback`,
+    /// the full `start_web_oauth_flow` must register and request authorization
+    /// with the `http://localhost:…/auth/callback` form, satisfying RFC 8252.
+    #[tokio::test]
+    async fn start_web_oauth_flow_rewrites_loopback_redirect() {
+        let mut server = mockito::Server::new_async().await;
+        let base = server.url();
+        let https_redirect = "https://localhost:1455/auth/callback";
+        let http_redirect = "http://localhost:1455/auth/callback";
+
+        let resource_meta = server
+            .mock("GET", "/mcp/.well-known/oauth-protected-resource")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                serde_json::json!({
+                    "resource": format!("{base}/mcp"),
+                    "authorization_servers": [base.clone()],
+                    "scopes_supported": ["read"],
+                })
+                .to_string(),
+            )
+            .create_async()
+            .await;
+
+        let as_meta = server
+            .mock("GET", "/.well-known/oauth-authorization-server")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                serde_json::json!({
+                    "issuer": base.clone(),
+                    "authorization_endpoint": format!("{base}/authorize"),
+                    "token_endpoint": format!("{base}/token"),
+                    "registration_endpoint": format!("{base}/register"),
+                    "scopes_supported": ["read"],
+                })
+                .to_string(),
+            )
+            .create_async()
+            .await;
+
+        // The registration endpoint must receive the HTTP form, not HTTPS.
+        let register = server
+            .mock("POST", "/register")
+            .match_body(Matcher::PartialJson(serde_json::json!({
+                "redirect_uris": [http_redirect],
+            })))
+            .with_status(201)
+            .with_header("content-type", "application/json")
+            .with_body(
+                serde_json::json!({
+                    "client_id": "client-loopback",
+                    "redirect_uris": [http_redirect],
+                })
+                .to_string(),
+            )
+            .create_async()
+            .await;
+
+        let dir = tempfile::tempdir().unwrap();
+        let provider = McpOAuthProvider::with_stores(
+            "loopback",
+            &format!("{base}/mcp"),
+            TokenStore::with_path(dir.path().join("tokens.json")),
+            RegistrationStore::with_path(dir.path().join("registrations.json")),
+        );
+
+        let auth_url = provider
+            .start_web_oauth_flow(https_redirect, None)
+            .await
+            .expect("start_web_oauth_flow should succeed");
+
+        // The authorization URL must encode the rewritten HTTP redirect URI.
+        let parsed = url::Url::parse(&auth_url).unwrap();
+        let encoded_redirect = parsed
+            .query_pairs()
+            .find(|(k, _)| k == "redirect_uri")
+            .map(|(_, v)| v.into_owned())
+            .expect("auth URL must have redirect_uri");
+        assert_eq!(encoded_redirect, http_redirect);
+
+        resource_meta.assert_async().await;
+        as_meta.assert_async().await;
+        register.assert_async().await;
     }
 }

--- a/crates/oauth/src/lib.rs
+++ b/crates/oauth/src/lib.rs
@@ -8,6 +8,7 @@ pub mod error;
 pub mod flow;
 pub mod kimi;
 pub mod pkce;
+pub mod redirect;
 pub mod registration_store;
 pub mod storage;
 pub mod types;
@@ -23,6 +24,7 @@ pub use {
     },
     flow::OAuthFlow,
     kimi::kimi_headers,
+    redirect::normalize_loopback_redirect,
     registration_store::{RegistrationStore, StoredRegistration},
     storage::TokenStore,
     types::{OAuthConfig, OAuthTokens, PkceChallenge, serialize_option_secret, serialize_secret},

--- a/crates/oauth/src/redirect.rs
+++ b/crates/oauth/src/redirect.rs
@@ -5,7 +5,7 @@
 //! authorization-server-compatible URIs regardless of the scheme the
 //! browser started on.
 
-use url::Url;
+use url::{Host, Url};
 
 /// Rewrite `https://` → `http://` for loopback redirect URIs.
 ///
@@ -35,18 +35,22 @@ pub fn normalize_loopback_redirect(uri: &str) -> String {
     if parsed.scheme() != "https" {
         return uri.to_string();
     }
-    let is_loopback = match parsed.host() {
-        Some(url::Host::Domain(host)) => host.eq_ignore_ascii_case("localhost"),
-        Some(url::Host::Ipv4(ip)) => ip.is_loopback(),
-        Some(url::Host::Ipv6(ip)) => ip.is_loopback(),
-        None => false,
-    };
+    // `https` is a "special" scheme in the WHATWG URL spec, so any Url
+    // with `scheme() == "https"` is guaranteed to have a host. Using
+    // `is_some_and` keeps the `None` branch in the std library rather
+    // than introducing an unreachable arm in our own code.
+    let is_loopback = parsed.host().is_some_and(|host| match host {
+        Host::Domain(domain) => domain.eq_ignore_ascii_case("localhost"),
+        Host::Ipv4(ip) => ip.is_loopback(),
+        Host::Ipv6(ip) => ip.is_loopback(),
+    });
     if !is_loopback {
         return uri.to_string();
     }
-    if parsed.set_scheme("http").is_err() {
-        return uri.to_string();
-    }
+    // `set_scheme` only fails when changing between "special" and
+    // non-"special" schemes; `https`→`http` are both special and share
+    // the same structure, so this never fails in practice.
+    let _ = parsed.set_scheme("http");
     parsed.to_string()
 }
 

--- a/crates/oauth/src/redirect.rs
+++ b/crates/oauth/src/redirect.rs
@@ -1,0 +1,137 @@
+//! Redirect URI normalization helpers.
+//!
+//! Centralizes the RFC 8252 §7.3/§8.3 loopback rewrite so both MCP OAuth
+//! (RFC 7591 dynamic client registration) and provider OAuth produce
+//! authorization-server-compatible URIs regardless of the scheme the
+//! browser started on.
+
+use url::Url;
+
+/// Rewrite `https://` → `http://` for loopback redirect URIs.
+///
+/// RFC 8252 §7.3/§8.3 mandate that loopback redirect URIs use the `http`
+/// scheme. Strict authorization servers (e.g. Attio) reject
+/// `https://localhost` during RFC 7591 dynamic client registration with
+/// `invalid_redirect_uri`, and some also reject it during the authorization
+/// request. Moltis serves the web UI over TLS, so the origin-derived
+/// callback arrives as `https://localhost:<port>/auth/callback`.
+///
+/// The main TLS listener's peek-based HTTP→HTTPS redirect (see
+/// `moltis_tls::serve_tls_with_http_redirect`) transparently bounces the
+/// plain-HTTP OAuth callback back onto the real HTTPS callback handler,
+/// preserving path and query string, so this rewrite is safe for any
+/// deployment where the web UI is reached via a loopback host
+/// (`localhost`, `127.0.0.1`, `::1`).
+///
+/// Non-loopback hosts (`moltis.lan`, real TLS hostnames) and non-`https`
+/// schemes are returned unchanged — a confidential-client HTTPS redirect
+/// on a real hostname is a perfectly valid web-app redirect URI and is
+/// unaffected by §8.3.
+#[must_use]
+pub fn normalize_loopback_redirect(uri: &str) -> String {
+    let Ok(mut parsed) = Url::parse(uri) else {
+        return uri.to_string();
+    };
+    if parsed.scheme() != "https" {
+        return uri.to_string();
+    }
+    let is_loopback = match parsed.host() {
+        Some(url::Host::Domain(host)) => host.eq_ignore_ascii_case("localhost"),
+        Some(url::Host::Ipv4(ip)) => ip.is_loopback(),
+        Some(url::Host::Ipv6(ip)) => ip.is_loopback(),
+        None => false,
+    };
+    if !is_loopback {
+        return uri.to_string();
+    }
+    if parsed.set_scheme("http").is_err() {
+        return uri.to_string();
+    }
+    parsed.to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rewrites_https_localhost() {
+        assert_eq!(
+            normalize_loopback_redirect("https://localhost:1455/auth/callback"),
+            "http://localhost:1455/auth/callback",
+        );
+    }
+
+    #[test]
+    fn rewrites_https_localhost_default_port() {
+        assert_eq!(
+            normalize_loopback_redirect("https://localhost/auth/callback"),
+            "http://localhost/auth/callback",
+        );
+    }
+
+    #[test]
+    fn rewrites_https_ipv4_loopback() {
+        assert_eq!(
+            normalize_loopback_redirect("https://127.0.0.1:1455/auth/callback"),
+            "http://127.0.0.1:1455/auth/callback",
+        );
+    }
+
+    #[test]
+    fn rewrites_https_ipv6_loopback() {
+        assert_eq!(
+            normalize_loopback_redirect("https://[::1]:1455/auth/callback"),
+            "http://[::1]:1455/auth/callback",
+        );
+    }
+
+    #[test]
+    fn rewrites_https_localhost_case_insensitive() {
+        assert_eq!(
+            normalize_loopback_redirect("https://LocalHost:1455/auth/callback"),
+            "http://localhost:1455/auth/callback",
+        );
+    }
+
+    #[test]
+    fn preserves_real_hostname() {
+        assert_eq!(
+            normalize_loopback_redirect("https://moltis.lan/auth/callback"),
+            "https://moltis.lan/auth/callback",
+        );
+        assert_eq!(
+            normalize_loopback_redirect("https://moltis.example.com:1455/auth/callback"),
+            "https://moltis.example.com:1455/auth/callback",
+        );
+    }
+
+    #[test]
+    fn preserves_non_loopback_ipv4() {
+        assert_eq!(
+            normalize_loopback_redirect("https://192.168.1.10:1455/auth/callback"),
+            "https://192.168.1.10:1455/auth/callback",
+        );
+    }
+
+    #[test]
+    fn preserves_http_scheme() {
+        assert_eq!(
+            normalize_loopback_redirect("http://localhost:1455/auth/callback"),
+            "http://localhost:1455/auth/callback",
+        );
+    }
+
+    #[test]
+    fn preserves_query_and_path() {
+        assert_eq!(
+            normalize_loopback_redirect("https://localhost:1455/auth/callback?foo=bar"),
+            "http://localhost:1455/auth/callback?foo=bar",
+        );
+    }
+
+    #[test]
+    fn returns_unparseable_input_unchanged() {
+        assert_eq!(normalize_loopback_redirect("not a url"), "not a url");
+    }
+}

--- a/crates/oauth/src/redirect.rs
+++ b/crates/oauth/src/redirect.rs
@@ -5,7 +5,10 @@
 //! authorization-server-compatible URIs regardless of the scheme the
 //! browser started on.
 
-use url::{Host, Url};
+use {
+    tracing::debug,
+    url::{Host, Url},
+};
 
 /// Rewrite `https://` → `http://` for loopback redirect URIs.
 ///
@@ -51,7 +54,13 @@ pub fn normalize_loopback_redirect(uri: &str) -> String {
     // non-"special" schemes; `https`→`http` are both special and share
     // the same structure, so this never fails in practice.
     let _ = parsed.set_scheme("http");
-    parsed.to_string()
+    let normalized = parsed.to_string();
+    debug!(
+        original = %uri,
+        normalized = %normalized,
+        "rewrote loopback OAuth redirect URI from https to http (RFC 8252 §7.3/§8.3)"
+    );
+    normalized
 }
 
 #[cfg(test)]

--- a/crates/provider-setup/src/lib.rs
+++ b/crates/provider-setup/src/lib.rs
@@ -81,6 +81,30 @@ where
     Ok(normalize_model_list(normalized))
 }
 
+/// Normalize the `redirect_uri` on a provider `OAuthConfig` loaded via
+/// `load_oauth_config` so that loopback values always use the `http`
+/// scheme, per RFC 8252 §7.3/§8.3.
+///
+/// Built-in defaults (e.g. `openai-codex`) already use
+/// `http://localhost:1455/auth/callback`, but `load_oauth_config` also
+/// reads from `~/.config/moltis/oauth_providers.json` and
+/// `MOLTIS_OAUTH_{PROVIDER}_REDIRECT_URI`, either of which could
+/// accidentally specify `https://localhost`. Without normalization:
+///
+/// * `callback_port` would parse the port from the HTTPS form and the
+///   spawned `CallbackServer` would try to bind on Moltis's main TLS
+///   port, which is already in use by the gateway.
+/// * Strict authorization servers would reject the authorization
+///   request with `invalid_redirect_uri`.
+///
+/// No-op for empty or non-loopback URIs.
+fn normalize_loaded_redirect_uri(config: &mut moltis_oauth::OAuthConfig) {
+    if config.redirect_uri.is_empty() {
+        return;
+    }
+    config.redirect_uri = normalize_loopback_redirect(&config.redirect_uri);
+}
+
 fn normalize_model_list(models: impl IntoIterator<Item = String>) -> Vec<String> {
     let mut out = Vec::new();
     for model in models {
@@ -1958,18 +1982,11 @@ impl ProviderSetupService for LiveProviderSetupService {
         let mut oauth_config = load_oauth_config(&provider_name)
             .ok_or_else(|| format!("no OAuth config for provider: {provider_name}"))?;
 
-        // Also normalize any loopback `redirect_uri` loaded from the
-        // user config file (`~/.config/moltis/oauth_providers.json`) or
-        // `MOLTIS_OAUTH_{PROVIDER}_REDIRECT_URI`. Built-in defaults
-        // already use `http://localhost:1455/auth/callback`, but a
-        // custom config could accidentally specify `https://localhost`.
-        // Without normalization here, `callback_port` would parse from
-        // the wrong scheme and the `CallbackServer` would attempt to
-        // bind on Moltis's main TLS port, or a strict AS would reject
-        // the pre-registered redirect during authorization.
-        if !oauth_config.redirect_uri.is_empty() {
-            oauth_config.redirect_uri = normalize_loopback_redirect(&oauth_config.redirect_uri);
-        }
+        // Normalize any loopback `redirect_uri` loaded from the user
+        // config file (`~/.config/moltis/oauth_providers.json`) or
+        // `MOLTIS_OAUTH_{PROVIDER}_REDIRECT_URI`. See
+        // `normalize_loaded_redirect_uri` for the full rationale.
+        normalize_loaded_redirect_uri(&mut oauth_config);
 
         // User explicitly initiated OAuth for this provider; ensure it is enabled.
         set_provider_enabled_in_config(&provider_name, true)?;
@@ -3040,6 +3057,76 @@ mod tests {
     use {
         super::*, moltis_config::schema::ProviderEntry, moltis_oauth::OAuthTokens, secrecy::Secret,
     };
+
+    fn make_oauth_config(redirect_uri: &str) -> moltis_oauth::OAuthConfig {
+        moltis_oauth::OAuthConfig {
+            client_id: "client".into(),
+            auth_url: "https://example.com/authorize".into(),
+            token_url: "https://example.com/token".into(),
+            redirect_uri: redirect_uri.into(),
+            resource: None,
+            scopes: Vec::new(),
+            extra_auth_params: Vec::new(),
+            device_flow: false,
+        }
+    }
+
+    #[test]
+    fn normalize_loaded_redirect_uri_rewrites_https_localhost() {
+        let mut config = make_oauth_config("https://localhost:1455/auth/callback");
+        normalize_loaded_redirect_uri(&mut config);
+        assert_eq!(config.redirect_uri, "http://localhost:1455/auth/callback");
+    }
+
+    #[test]
+    fn normalize_loaded_redirect_uri_rewrites_https_ipv4_loopback() {
+        let mut config = make_oauth_config("https://127.0.0.1:1455/auth/callback");
+        normalize_loaded_redirect_uri(&mut config);
+        assert_eq!(config.redirect_uri, "http://127.0.0.1:1455/auth/callback");
+    }
+
+    #[test]
+    fn normalize_loaded_redirect_uri_rewrites_https_ipv6_loopback() {
+        let mut config = make_oauth_config("https://[::1]:1455/auth/callback");
+        normalize_loaded_redirect_uri(&mut config);
+        assert_eq!(config.redirect_uri, "http://[::1]:1455/auth/callback");
+    }
+
+    #[test]
+    fn normalize_loaded_redirect_uri_preserves_http_scheme() {
+        let mut config = make_oauth_config("http://localhost:1455/auth/callback");
+        normalize_loaded_redirect_uri(&mut config);
+        assert_eq!(config.redirect_uri, "http://localhost:1455/auth/callback");
+    }
+
+    #[test]
+    fn normalize_loaded_redirect_uri_preserves_real_hostname() {
+        let mut config = make_oauth_config("https://moltis.lan/auth/callback");
+        normalize_loaded_redirect_uri(&mut config);
+        assert_eq!(config.redirect_uri, "https://moltis.lan/auth/callback");
+    }
+
+    #[test]
+    fn normalize_loaded_redirect_uri_no_op_on_empty_string() {
+        let mut config = make_oauth_config("");
+        normalize_loaded_redirect_uri(&mut config);
+        assert_eq!(config.redirect_uri, "");
+    }
+
+    /// Regression guard for the full integration path: load `openai-codex`
+    /// through `load_oauth_config` and confirm that, after passing the
+    /// result through `normalize_loaded_redirect_uri`, `callback_port`
+    /// parses a non-conflicting value. This is the safety net that would
+    /// have caught the original bug report if the built-in default had
+    /// been wrong.
+    #[test]
+    fn loaded_openai_codex_redirect_parses_to_http_loopback() {
+        let mut config = load_oauth_config("openai-codex").expect("openai-codex should exist");
+        normalize_loaded_redirect_uri(&mut config);
+        let parsed = url::Url::parse(&config.redirect_uri).expect("parsable URL");
+        assert_eq!(parsed.scheme(), "http");
+        assert_eq!(parsed.host_str(), Some("localhost"));
+    }
 
     #[test]
     fn known_providers_have_valid_auth_types() {

--- a/crates/provider-setup/src/lib.rs
+++ b/crates/provider-setup/src/lib.rs
@@ -1958,6 +1958,19 @@ impl ProviderSetupService for LiveProviderSetupService {
         let mut oauth_config = load_oauth_config(&provider_name)
             .ok_or_else(|| format!("no OAuth config for provider: {provider_name}"))?;
 
+        // Also normalize any loopback `redirect_uri` loaded from the
+        // user config file (`~/.config/moltis/oauth_providers.json`) or
+        // `MOLTIS_OAUTH_{PROVIDER}_REDIRECT_URI`. Built-in defaults
+        // already use `http://localhost:1455/auth/callback`, but a
+        // custom config could accidentally specify `https://localhost`.
+        // Without normalization here, `callback_port` would parse from
+        // the wrong scheme and the `CallbackServer` would attempt to
+        // bind on Moltis's main TLS port, or a strict AS would reject
+        // the pre-registered redirect during authorization.
+        if !oauth_config.redirect_uri.is_empty() {
+            oauth_config.redirect_uri = normalize_loopback_redirect(&oauth_config.redirect_uri);
+        }
+
         // User explicitly initiated OAuth for this provider; ensure it is enabled.
         set_provider_enabled_in_config(&provider_name, true)?;
         self.set_provider_enabled_in_memory(&provider_name, true);
@@ -1994,6 +2007,10 @@ impl ProviderSetupService for LiveProviderSetupService {
         // Overriding it with the gateway URL causes OAuth providers to
         // reject the request with "unknown_error".
         // For these providers we always use the local callback server.
+        //
+        // The pre-registered URI has already been loopback-normalized
+        // above, so strict authorization servers accept it even if the
+        // user's custom config file used the `https://` form.
         let has_registered_redirect = !oauth_config.redirect_uri.is_empty();
         let use_server_callback = redirect_uri.is_some() && !has_registered_redirect;
         if !has_registered_redirect && let Some(uri) = redirect_uri {

--- a/crates/provider-setup/src/lib.rs
+++ b/crates/provider-setup/src/lib.rs
@@ -22,7 +22,7 @@ use {
     moltis_config::schema::ProvidersConfig,
     moltis_oauth::{
         CallbackServer, OAuthFlow, TokenStore, callback_port, device_flow, load_oauth_config,
-        parse_callback_input,
+        normalize_loopback_redirect, parse_callback_input,
     },
     moltis_providers::{ProviderRegistry, raw_model_id},
 };
@@ -1942,12 +1942,18 @@ impl ProviderSetupService for LiveProviderSetupService {
             .ok_or_else(|| "missing 'provider' parameter".to_string())?
             .to_string();
 
+        // RFC 8252 §7.3/§8.3: loopback redirect URIs must use `http`.
+        // The UI sends `${window.location.origin}/auth/callback`, which is
+        // `https://localhost:<port>/auth/callback` on TLS-enabled
+        // deployments. Rewrite loopback origins to `http` so strict
+        // authorization servers accept them; the TLS listener's HTTP peek
+        // redirect bounces the callback back onto the HTTPS handler.
         let redirect_uri = params
             .get("redirectUri")
             .and_then(|v| v.as_str())
             .map(str::trim)
             .filter(|v| !v.is_empty())
-            .map(ToOwned::to_owned);
+            .map(normalize_loopback_redirect);
 
         let mut oauth_config = load_oauth_config(&provider_name)
             .ok_or_else(|| format!("no OAuth config for provider: {provider_name}"))?;


### PR DESCRIPTION
## Summary

- Rewrite the OAuth redirect URI scheme from `https` to `http` when the host is a loopback identifier (`localhost`, `127.0.0.1`, `::1`). RFC 8252 §7.3/§8.3 mandates `http` for loopback redirects; strict authorization servers (Attio in #629) reject `https://localhost` during RFC 7591 dynamic client registration with `invalid_redirect_uri`.
- The rewrite lives in `moltis_oauth::redirect::normalize_loopback_redirect` and is applied at two entry points: `McpOAuthProvider::start_web_oauth_flow` (fixes #629) and `LiveProviderSetupService::oauth_start` (proactive fix so provider OAuth can't hit the same trap).
- **No changes to the callback handler, gateway service layer, or web UI.** The existing TLS-port HTTP peek/redirect in `moltis_tls::serve_tls_with_http_redirect` transparently bounces the plain-HTTP OAuth callback back onto the real HTTPS `/auth/callback` handler, preserving path and query string. `/auth/callback` is unauthenticated (no cookie needed), so the bounce is lossless.
- Non-loopback hosts (`https://moltis.lan/auth/callback`, real TLS hostnames) are **untouched** — a confidential-client HTTPS redirect on a real hostname is a perfectly legitimate web-app redirect URI, unaffected by §8.3.

## Why this shape

Two alternative designs were considered and rejected:

1. **Ephemeral loopback callback server on `127.0.0.1:<random>`** (native-app pattern via the existing `CallbackServer`). Strict RFC 8252 compliance, but breaks deployments where Moltis serves a LAN hostname and the browser runs on a different host from the gateway — the ephemeral port on the Moltis host is unreachable.
2. **Rewrite `redirect_uri` client-side in the UI.** Duplicates logic across `page-mcp.js`, `provider-oauth.js`, and onboarding; leaks TLS topology into the frontend.

The chosen approach — server-side scheme rewrite that relies on Moltis's own HTTP→HTTPS bounce — is minimal, backward compatible, and scales from single-host loopback to LAN-hostname deployments with zero branching.

## Validation

### Completed

- [x] `cargo test -p moltis-oauth -p moltis-mcp -p moltis-provider-setup` — 10 new normalizer unit tests + 1 `start_web_oauth_flow` integration test (mockito) + 86 existing provider-setup tests; all 156+ tests pass
- [x] `cargo +nightly-2025-11-30 fmt -p moltis-oauth -p moltis-mcp -p moltis-provider-setup -- --check`
- [x] `cargo clippy -p moltis-oauth -p moltis-mcp -p moltis-provider-setup --all-targets -- -D warnings`
- [x] `cargo check -p moltis-oauth -p moltis-mcp -p moltis-provider-setup`

### Remaining

- [ ] `./scripts/local-validate.sh <PR>` (full workspace lint + test + macOS/iOS build gates)
- [ ] `just release-preflight`

## Manual QA

1. Run Moltis on a TLS loopback deployment (`https://localhost:1455`).
2. Settings → MCP Servers → Add Server → `https://mcp.attio.com/mcp`.
3. Moltis receives 401, runs OAuth discovery, then POSTs to `https://app.attio.com/oauth/register`.
4. **Expected:** registration body contains `"redirect_uris": ["http://localhost:1455/auth/callback"]` (scheme flipped to `http`).
5. **Expected:** Attio returns 201 Created with a new `client_id` (no more `invalid_redirect_uri`).
6. Browser opens Attio authorize URL; after consent, it redirects to `http://localhost:1455/auth/callback?code=...&state=...`.
7. Moltis's TLS listener peek-redirects to `https://localhost:1455/auth/callback?code=...&state=...`.
8. Browser lands on `oauth_callback_handler`; flow completes; MCP server transitions to Authenticated.

Non-loopback deployments (`https://moltis.lan/auth/callback`) should see **no behavior change** — verify by re-adding a working server on that setup and confirming the registration body still uses the HTTPS form.

## Out of scope (follow-ups)

- **Manual `[mcp.servers.*.oauth]` override being ignored** (sub-complaint in #629). Code review of `build_auth_provider` + `start_web_oauth_flow`'s override branch suggests the plumbing is correct, but the reporter's claim needs a reproduction. Filed for investigation.

Fixes #629