### PR TITLE
fix(voice): honor whisper.model and whisper.language in STT factory

### DIFF
--- a/crates/config/src/template.rs
+++ b/crates/config/src/template.rs
@@ -610,7 +610,7 @@ providers = ["whisper", "mistral", "elevenlabs"] # UI allowlist (empty = show al
 # model = "tts-1"                 # tts-1 or tts-1-hd
 
 # [voice.stt.whisper]
-# model = "whisper-1"             # whisper-1 (OpenAI currently only exposes this model)
+# model = "whisper-1"             # default; override when using an OpenAI-compatible proxy
 # language = "en"                 # Optional ISO 639-1 hint; omit for auto-detect
 
 # ══════════════════════════════════════════════════════════════════════════════

--- a/crates/config/src/template.rs
+++ b/crates/config/src/template.rs
@@ -609,6 +609,10 @@ providers = ["whisper", "mistral", "elevenlabs"] # UI allowlist (empty = show al
 # voice = "alloy"                 # alloy, echo, fable, onyx, nova, shimmer
 # model = "tts-1"                 # tts-1 or tts-1-hd
 
+# [voice.stt.whisper]
+# model = "whisper-1"             # whisper-1 (OpenAI currently only exposes this model)
+# language = "en"                 # Optional ISO 639-1 hint; omit for auto-detect
+
 # ══════════════════════════════════════════════════════════════════════════════
 # NGROK
 # ══════════════════════════════════════════════════════════════════════════════

--- a/crates/gateway/src/voice.rs
+++ b/crates/gateway/src/voice.rs
@@ -519,7 +519,11 @@ impl LiveSttService {
             SttProviderId::Whisper => {
                 let key = resolve_openai_key(cfg.voice.stt.whisper.api_key.as_ref(), &cfg);
                 key.map(|k| {
-                    Box::new(WhisperStt::new(Some(k))) as Box<dyn SttProvider + Send + Sync>
+                    Box::new(WhisperStt::with_options(
+                        Some(k),
+                        cfg.voice.stt.whisper.model.clone(),
+                        cfg.voice.stt.whisper.language.clone(),
+                    )) as Box<dyn SttProvider + Send + Sync>
                 })
             },
             SttProviderId::Groq => cfg.voice.stt.groq.api_key.as_ref().map(|key| {

--- a/crates/voice/src/stt/whisper.rs
+++ b/crates/voice/src/stt/whisper.rs
@@ -31,6 +31,7 @@ pub struct WhisperStt {
     client: Client,
     api_key: Option<Secret<String>>,
     model: String,
+    language: Option<String>,
 }
 
 impl std::fmt::Debug for WhisperStt {
@@ -38,6 +39,7 @@ impl std::fmt::Debug for WhisperStt {
         f.debug_struct("WhisperStt")
             .field("api_key", &"[REDACTED]")
             .field("model", &self.model)
+            .field("language", &self.language)
             .finish()
     }
 }
@@ -52,20 +54,27 @@ impl WhisperStt {
     /// Create a new Whisper STT provider.
     #[must_use]
     pub fn new(api_key: Option<Secret<String>>) -> Self {
-        Self {
-            client: Client::new(),
-            api_key,
-            model: DEFAULT_MODEL.into(),
-        }
+        Self::with_options(api_key, None, None)
     }
 
     /// Create with custom model.
     #[must_use]
     pub fn with_model(api_key: Option<Secret<String>>, model: Option<String>) -> Self {
+        Self::with_options(api_key, model, None)
+    }
+
+    /// Create with custom model and language.
+    #[must_use]
+    pub fn with_options(
+        api_key: Option<Secret<String>>,
+        model: Option<String>,
+        language: Option<String>,
+    ) -> Self {
         Self {
             client: Client::new(),
             api_key,
             model: model.unwrap_or_else(|| DEFAULT_MODEL.into()),
+            language,
         }
     }
 
@@ -118,7 +127,8 @@ impl SttProvider for WhisperStt {
             .text("model", self.model.clone())
             .text("response_format", "verbose_json");
 
-        if let Some(language) = request.language {
+        // Request language overrides the configured language, otherwise fall back.
+        if let Some(language) = request.language.or_else(|| self.language.clone()) {
             form = form.text("language", language);
         }
 
@@ -244,6 +254,46 @@ mod tests {
             Some("whisper-large-v3".into()),
         );
         assert_eq!(provider.model, "whisper-large-v3");
+        assert!(provider.language.is_none());
+    }
+
+    #[test]
+    fn test_with_options_sets_model_and_language() {
+        let provider = WhisperStt::with_options(
+            Some(Secret::new("key".into())),
+            Some("whisper-large-v3".into()),
+            Some("ru".into()),
+        );
+        assert_eq!(provider.model, "whisper-large-v3");
+        assert_eq!(provider.language, Some("ru".into()));
+    }
+
+    #[test]
+    fn test_with_options_defaults() {
+        let provider = WhisperStt::with_options(Some(Secret::new("key".into())), None, None);
+        assert_eq!(provider.model, DEFAULT_MODEL);
+        assert!(provider.language.is_none());
+    }
+
+    #[test]
+    fn test_new_delegates_to_with_options() {
+        let provider = WhisperStt::new(Some(Secret::new("key".into())));
+        assert_eq!(provider.model, DEFAULT_MODEL);
+        assert!(provider.language.is_none());
+    }
+
+    #[test]
+    fn test_debug_includes_language() {
+        let provider = WhisperStt::with_options(
+            Some(Secret::new("super-secret-key".into())),
+            Some("whisper-large-v3".into()),
+            Some("ru".into()),
+        );
+        let debug_output = format!("{:?}", provider);
+        assert!(debug_output.contains("[REDACTED]"));
+        assert!(!debug_output.contains("super-secret-key"));
+        assert!(debug_output.contains("whisper-large-v3"));
+        assert!(debug_output.contains("ru"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- `WhisperStt` was constructed via `WhisperStt::new(Some(k))` in the gateway voice factory (`crates/gateway/src/voice.rs:519`), which hardcodes `model = whisper-1` and has no language field at all. The `[voice.stt.whisper]` schema advertised `model` and `language` but both were silently ignored.
- Added `language: Option<String>` to `WhisperStt` plus a `with_options(api_key, model, language)` constructor mirroring `GroqStt`. Per-request `TranscribeRequest.language` still wins but the configured language is now the fallback.
- Wired both config fields through in `create_provider`, matching every other STT provider.
- Documented the `[voice.stt.whisper]` block in the config template so users discover the fields.

Closes #631

## Validation

### Completed
- [x] `cargo check -p moltis-voice -p moltis-gateway`
- [x] `cargo test -p moltis-voice -p moltis-config` (129 passed, 16 in `stt::whisper`)
- [x] `cargo +nightly-2025-11-30 fmt --all -- --check`
- [x] `cargo +nightly-2025-11-30 clippy -p moltis-voice -p moltis-gateway -p moltis-config --all-targets -- -D warnings`

### Remaining
- [ ] `just lint` — blew up on a pre-existing macOS CUDA build issue in `llama-cpp-sys-2` unrelated to this change; targeted clippy above covers the touched crates.
- [ ] `just test` (OS-aware full suite)
- [ ] `./scripts/local-validate.sh <PR_NUMBER>`

## Manual QA

1. In `moltis.toml`:
   ```toml
   [voice.stt]
   enabled = true
   provider = "whisper"

   [voice.stt.whisper]
   model = "whisper-large-v3"
   language = "ru"
   ```
2. Send a voice message through an active channel (e.g. Telegram).
3. Confirm the outbound OpenAI transcription request uses `whisper-large-v3` and sends `language=ru` (via proxy/network capture or `tracing` debug logs on the multipart form).
4. Unset `language` in config and confirm Whisper auto-detects as before.
5. Override `TranscribeRequest.language` from an upstream caller and confirm it still wins over the configured value.