### PR TITLE
[codex] feat(hooks): include channel provenance in hook payloads

### DIFF
--- a/crates/agents/src/runner.rs
+++ b/crates/agents/src/runner.rs
@@ -8,7 +8,7 @@ use {
 #[cfg(feature = "metrics")]
 use moltis_metrics::{counter, histogram, labels, llm as llm_metrics};
 
-use moltis_common::hooks::{HookAction, HookPayload, HookRegistry};
+use moltis_common::hooks::{ChannelBinding, HookAction, HookPayload, HookRegistry};
 
 use crate::{
     model::{
@@ -877,6 +877,10 @@ pub async fn run_agent_loop_with_context(
         .and_then(|v| v.as_str())
         .unwrap_or("")
         .to_string();
+    let channel_for_hooks: Option<ChannelBinding> = tool_context
+        .as_ref()
+        .and_then(|ctx| ctx.get("_channel"))
+        .and_then(|v| serde_json::from_value(v.clone()).ok());
 
     let mut iterations = 0;
     let mut total_tool_calls = 0;
@@ -1256,6 +1260,7 @@ pub async fn run_agent_loop_with_context(
                 // Dispatch BeforeToolCall hook — may block or modify arguments.
                 let hook_registry = hook_registry.clone();
                 let session_key = session_key_for_hooks.clone();
+                let channel_for_hooks = channel_for_hooks.clone();
                 let tc_name = sanitized.to_string();
                 let _tc_id = tc.id.clone();
 
@@ -1273,6 +1278,7 @@ pub async fn run_agent_loop_with_context(
                             session_key: session_key.clone(),
                             tool_name: tc_name.clone(),
                             arguments: args.clone(),
+                            channel: channel_for_hooks.clone(),
                         };
                         match hooks.dispatch(&payload).await {
                             Ok(HookAction::Block(reason)) => {
@@ -1469,6 +1475,10 @@ pub async fn run_agent_loop_streaming(
         .and_then(|v| v.as_str())
         .unwrap_or("")
         .to_string();
+    let channel_for_hooks: Option<ChannelBinding> = tool_context
+        .as_ref()
+        .and_then(|ctx| ctx.get("_channel"))
+        .and_then(|v| serde_json::from_value(v.clone()).ok());
 
     let mut iterations = 0;
     let mut total_tool_calls = 0;
@@ -1977,6 +1987,7 @@ pub async fn run_agent_loop_streaming(
 
                 let hook_registry = hook_registry.clone();
                 let session_key = session_key_for_hooks.clone();
+                let channel_for_hooks = channel_for_hooks.clone();
                 let tc_name = sanitized.to_string();
 
                 if let Some(ref ctx) = tool_context
@@ -1993,6 +2004,7 @@ pub async fn run_agent_loop_streaming(
                             session_key: session_key.clone(),
                             tool_name: tc_name.clone(),
                             arguments: args.clone(),
+                            channel: channel_for_hooks.clone(),
                         };
                         match hooks.dispatch(&payload).await {
                             Ok(HookAction::Block(reason)) => {
@@ -2132,9 +2144,35 @@ mod tests {
             tool_parsing::parse_tool_call_from_text,
         },
         async_trait::async_trait,
+        moltis_common::hooks::{HookEvent, HookHandler},
         std::pin::Pin,
         tokio_stream::Stream,
     };
+
+    struct RecordingHook {
+        payloads: Arc<std::sync::Mutex<Vec<HookPayload>>>,
+    }
+
+    #[async_trait]
+    impl HookHandler for RecordingHook {
+        fn name(&self) -> &str {
+            "recording-hook"
+        }
+
+        fn events(&self) -> &[HookEvent] {
+            static EVENTS: [HookEvent; 1] = [HookEvent::BeforeToolCall];
+            &EVENTS
+        }
+
+        async fn handle(
+            &self,
+            _event: HookEvent,
+            payload: &HookPayload,
+        ) -> moltis_common::error::Result<HookAction> {
+            self.payloads.lock().unwrap().push(payload.clone());
+            Ok(HookAction::Continue)
+        }
+    }
 
     // ── parse_tool_call_from_text tests (delegates to tool_parsing) ──
 
@@ -5530,6 +5568,63 @@ mod tests {
         assert_eq!(name, "process");
         assert_eq!(args["action"], "start");
         assert_eq!(args["command"], "pwd");
+    }
+
+    #[tokio::test]
+    async fn before_tool_call_hook_receives_channel_binding_from_tool_context() {
+        let provider = Arc::new(NativeTextFunctionStreamProvider {
+            call_count: std::sync::atomic::AtomicUsize::new(0),
+        });
+        let mut tools = ToolRegistry::new();
+        tools.register(Box::new(TestProcessTool));
+
+        let payloads = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let mut hook_registry = HookRegistry::new();
+        hook_registry.register(Arc::new(RecordingHook {
+            payloads: Arc::clone(&payloads),
+        }));
+
+        let user_content = UserContent::Text("execute pwd".to_string());
+        let result = run_agent_loop_streaming(
+            provider,
+            &tools,
+            "You are a test bot.",
+            &user_content,
+            None,
+            None,
+            Some(serde_json::json!({
+                "_session_key": "telegram:bot-main:-100123",
+                "_channel": {
+                    "surface": "telegram",
+                    "session_kind": "channel",
+                    "channel_type": "telegram",
+                    "account_id": "bot-main",
+                    "chat_id": "-100123",
+                    "chat_type": "channel_or_supergroup"
+                }
+            })),
+            Some(Arc::new(hook_registry)),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(result.tool_calls_made, 1);
+
+        let payloads = payloads.lock().unwrap();
+        let payload = payloads
+            .iter()
+            .find(|payload| matches!(payload, HookPayload::BeforeToolCall { .. }))
+            .unwrap_or_else(|| panic!("missing BeforeToolCall payload"));
+        match payload {
+            HookPayload::BeforeToolCall { channel, .. } => {
+                let channel = channel.clone().unwrap_or_else(|| panic!("missing channel"));
+                assert_eq!(channel.channel_type.as_deref(), Some("telegram"));
+                assert_eq!(channel.account_id.as_deref(), Some("bot-main"));
+                assert_eq!(channel.chat_id.as_deref(), Some("-100123"));
+                assert_eq!(channel.chat_type.as_deref(), Some("channel_or_supergroup"));
+            },
+            other => panic!("unexpected payload: {other:?}"),
+        }
     }
 
     /// Streaming provider that returns plain text only (no tool calls) on

--- a/crates/agents/src/runner.rs
+++ b/crates/agents/src/runner.rs
@@ -823,6 +823,24 @@ pub async fn run_agent_loop(
     .await
 }
 
+fn channel_binding_from_tool_context(
+    session_key: &str,
+    tool_context: Option<&serde_json::Value>,
+) -> Option<ChannelBinding> {
+    let channel_value = tool_context.and_then(|ctx| ctx.get("_channel"))?;
+    match serde_json::from_value(channel_value.clone()) {
+        Ok(binding) => Some(binding),
+        Err(error) => {
+            warn!(
+                error = %error,
+                session = %session_key,
+                "failed to parse _channel tool context for hooks; ignoring channel provenance"
+            );
+            None
+        },
+    }
+}
+
 /// Like `run_agent_loop` but accepts optional context values that are injected
 /// into every tool call's parameters (e.g. `_session_key`).
 pub async fn run_agent_loop_with_context(
@@ -877,10 +895,8 @@ pub async fn run_agent_loop_with_context(
         .and_then(|v| v.as_str())
         .unwrap_or("")
         .to_string();
-    let channel_for_hooks: Option<ChannelBinding> = tool_context
-        .as_ref()
-        .and_then(|ctx| ctx.get("_channel"))
-        .and_then(|v| serde_json::from_value(v.clone()).ok());
+    let channel_for_hooks =
+        channel_binding_from_tool_context(&session_key_for_hooks, tool_context.as_ref());
 
     let mut iterations = 0;
     let mut total_tool_calls = 0;
@@ -1477,10 +1493,8 @@ pub async fn run_agent_loop_streaming(
         .and_then(|v| v.as_str())
         .unwrap_or("")
         .to_string();
-    let channel_for_hooks: Option<ChannelBinding> = tool_context
-        .as_ref()
-        .and_then(|ctx| ctx.get("_channel"))
-        .and_then(|v| serde_json::from_value(v.clone()).ok());
+    let channel_for_hooks =
+        channel_binding_from_tool_context(&session_key_for_hooks, tool_context.as_ref());
 
     let mut iterations = 0;
     let mut total_tool_calls = 0;
@@ -5641,6 +5655,79 @@ mod tests {
                 assert_eq!(channel.account_id.as_deref(), Some("bot-main"));
                 assert_eq!(channel.chat_id.as_deref(), Some("-100123"));
                 assert_eq!(channel.chat_type.as_deref(), Some("channel_or_supergroup"));
+            },
+            other => panic!("unexpected payload: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn channel_binding_from_tool_context_returns_none_for_invalid_channel_json() {
+        let tool_context = serde_json::json!({
+            "_session_key": "telegram:bot-main:-100123",
+            "_channel": {
+                "surface": 42
+            }
+        });
+
+        let binding =
+            channel_binding_from_tool_context("telegram:bot-main:-100123", Some(&tool_context));
+
+        assert!(binding.is_none());
+    }
+
+    #[tokio::test]
+    async fn non_streaming_hooks_ignore_invalid_channel_binding_from_tool_context() {
+        let provider = Arc::new(NativeTextFunctionProvider {
+            call_count: std::sync::atomic::AtomicUsize::new(0),
+        });
+        let mut tools = ToolRegistry::new();
+        tools.register(Box::new(TestProcessTool));
+
+        let payloads = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let mut hook_registry = HookRegistry::new();
+        hook_registry.register(Arc::new(RecordingHook {
+            payloads: Arc::clone(&payloads),
+        }));
+
+        let result = run_agent_loop_with_context(
+            provider,
+            &tools,
+            "You are a test bot.",
+            &UserContent::text("execute pwd"),
+            None,
+            None,
+            Some(serde_json::json!({
+                "_session_key": "telegram:bot-main:-100123",
+                "_channel": {
+                    "surface": 42
+                }
+            })),
+            Some(Arc::new(hook_registry)),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(result.tool_calls_made, 1);
+
+        let payloads = payloads.lock().unwrap();
+        let before_payload = payloads
+            .iter()
+            .find(|payload| matches!(payload, HookPayload::BeforeToolCall { .. }))
+            .unwrap_or_else(|| panic!("missing BeforeToolCall payload"));
+        match before_payload {
+            HookPayload::BeforeToolCall { channel, .. } => {
+                assert!(channel.is_none());
+            },
+            other => panic!("unexpected payload: {other:?}"),
+        }
+
+        let after_payload = payloads
+            .iter()
+            .find(|payload| matches!(payload, HookPayload::AfterToolCall { .. }))
+            .unwrap_or_else(|| panic!("missing AfterToolCall payload"));
+        match after_payload {
+            HookPayload::AfterToolCall { channel, .. } => {
+                assert!(channel.is_none());
             },
             other => panic!("unexpected payload: {other:?}"),
         }

--- a/crates/agents/src/runner.rs
+++ b/crates/agents/src/runner.rs
@@ -1322,6 +1322,7 @@ pub async fn run_agent_loop_with_context(
                                         tool_name: tc_name.clone(),
                                         success: !has_error,
                                         result: Some(val.clone()),
+                                        channel: channel_for_hooks.clone(),
                                     };
                                     if let Err(e) = hooks.dispatch(&payload).await {
                                         warn!(tool = %tc_name, error = %e, "AfterToolCall hook dispatch failed");
@@ -1344,6 +1345,7 @@ pub async fn run_agent_loop_with_context(
                                         tool_name: tc_name.clone(),
                                         success: false,
                                         result: None,
+                                        channel: channel_for_hooks.clone(),
                                     };
                                     if let Err(e) = hooks.dispatch(&payload).await {
                                         warn!(tool = %tc_name, error = %e, "AfterToolCall hook dispatch failed");
@@ -2047,6 +2049,7 @@ pub async fn run_agent_loop_streaming(
                                         tool_name: tc_name.clone(),
                                         success: !has_error,
                                         result: Some(val.clone()),
+                                        channel: channel_for_hooks.clone(),
                                     };
                                     if let Err(e) = hooks.dispatch(&payload).await {
                                         warn!(tool = %tc_name, error = %e, "AfterToolCall hook dispatch failed");
@@ -2067,6 +2070,7 @@ pub async fn run_agent_loop_streaming(
                                         tool_name: tc_name.clone(),
                                         success: false,
                                         result: None,
+                                        channel: channel_for_hooks.clone(),
                                     };
                                     if let Err(e) = hooks.dispatch(&payload).await {
                                         warn!(tool = %tc_name, error = %e, "AfterToolCall hook dispatch failed");
@@ -2160,7 +2164,7 @@ mod tests {
         }
 
         fn events(&self) -> &[HookEvent] {
-            static EVENTS: [HookEvent; 1] = [HookEvent::BeforeToolCall];
+            static EVENTS: [HookEvent; 2] = [HookEvent::BeforeToolCall, HookEvent::AfterToolCall];
             &EVENTS
         }
 
@@ -5617,6 +5621,21 @@ mod tests {
             .unwrap_or_else(|| panic!("missing BeforeToolCall payload"));
         match payload {
             HookPayload::BeforeToolCall { channel, .. } => {
+                let channel = channel.clone().unwrap_or_else(|| panic!("missing channel"));
+                assert_eq!(channel.channel_type.as_deref(), Some("telegram"));
+                assert_eq!(channel.account_id.as_deref(), Some("bot-main"));
+                assert_eq!(channel.chat_id.as_deref(), Some("-100123"));
+                assert_eq!(channel.chat_type.as_deref(), Some("channel_or_supergroup"));
+            },
+            other => panic!("unexpected payload: {other:?}"),
+        }
+
+        let payload = payloads
+            .iter()
+            .find(|payload| matches!(payload, HookPayload::AfterToolCall { .. }))
+            .unwrap_or_else(|| panic!("missing AfterToolCall payload"));
+        match payload {
+            HookPayload::AfterToolCall { channel, .. } => {
                 let channel = channel.clone().unwrap_or_else(|| panic!("missing channel"));
                 assert_eq!(channel.channel_type.as_deref(), Some("telegram"));
                 assert_eq!(channel.account_id.as_deref(), Some("bot-main"));

--- a/crates/channels/src/lib.rs
+++ b/crates/channels/src/lib.rs
@@ -28,7 +28,7 @@ pub use {
         ChannelMessageMeta, ChannelOtpProvider, ChannelOutbound, ChannelPlugin, ChannelReplyTarget,
         ChannelStatus, ChannelStreamOutbound, ChannelThreadContext, ChannelType, InboundMode,
         InteractiveButton, InteractiveMessage, StreamEvent, StreamReceiver, StreamSender,
-        ThreadMessage,
+        ThreadMessage, resolve_session_channel_binding, web_session_channel_binding,
     },
     registry::{ChannelRegistry, RegistryOutboundRouter},
 };

--- a/crates/channels/src/plugin.rs
+++ b/crates/channels/src/plugin.rs
@@ -1,6 +1,10 @@
 use std::sync::Arc;
 
-use {async_trait::async_trait, moltis_common::types::ReplyPayload, tokio::sync::mpsc};
+use {
+    async_trait::async_trait,
+    moltis_common::{hooks::ChannelBinding, types::ReplyPayload},
+    tokio::sync::mpsc,
+};
 
 use crate::{Error, Result, config_view::ChannelConfigView};
 
@@ -42,6 +46,23 @@ impl ChannelType {
             Self::Discord => "Discord",
             Self::Slack => "Slack",
             Self::Matrix => "Matrix",
+        }
+    }
+
+    /// Best-effort chat classification for hook and prompt context.
+    #[must_use]
+    pub fn classify_chat(&self, chat_id: &str) -> Option<String> {
+        match self {
+            Self::Telegram => {
+                if chat_id.starts_with("-100") {
+                    Some("channel_or_supergroup".to_string())
+                } else if chat_id.starts_with('-') {
+                    Some("group".to_string())
+                } else {
+                    Some("private".to_string())
+                }
+            },
+            _ => None,
         }
     }
 
@@ -499,6 +520,21 @@ impl ChannelReplyTarget {
         match &self.thread_id {
             Some(tid) => std::borrow::Cow::Owned(format!("{}:{}", self.chat_id, tid)),
             None => std::borrow::Cow::Borrowed(&self.chat_id),
+        }
+    }
+}
+
+impl From<&ChannelReplyTarget> for ChannelBinding {
+    fn from(target: &ChannelReplyTarget) -> Self {
+        let channel_type = target.channel_type.as_str().to_string();
+        Self {
+            surface: Some(channel_type.clone()),
+            session_kind: Some("channel".to_string()),
+            channel_type: Some(channel_type),
+            account_id: Some(target.account_id.clone()),
+            chat_id: Some(target.chat_id.clone()),
+            chat_type: target.channel_type.classify_chat(&target.chat_id),
+            sender_id: None,
         }
     }
 }
@@ -1176,5 +1212,42 @@ mod tests {
         assert_eq!(json, "\"socket_mode\"");
         let json = serde_json::to_string(&InboundMode::Webhook).unwrap();
         assert_eq!(json, "\"webhook\"");
+    }
+
+    #[test]
+    fn telegram_chat_classification_matches_chat_id_shape() {
+        assert_eq!(
+            ChannelType::Telegram.classify_chat("-100123").as_deref(),
+            Some("channel_or_supergroup")
+        );
+        assert_eq!(
+            ChannelType::Telegram.classify_chat("-42").as_deref(),
+            Some("group")
+        );
+        assert_eq!(
+            ChannelType::Telegram.classify_chat("123").as_deref(),
+            Some("private")
+        );
+        assert!(ChannelType::Discord.classify_chat("123").is_none());
+    }
+
+    #[test]
+    fn channel_reply_target_converts_to_hook_channel_binding() {
+        let target = ChannelReplyTarget {
+            channel_type: ChannelType::Telegram,
+            account_id: "bot1".into(),
+            chat_id: "-100999".into(),
+            message_id: Some("7".into()),
+            thread_id: Some("42".into()),
+        };
+
+        let binding: ChannelBinding = (&target).into();
+        assert_eq!(binding.surface.as_deref(), Some("telegram"));
+        assert_eq!(binding.session_kind.as_deref(), Some("channel"));
+        assert_eq!(binding.channel_type.as_deref(), Some("telegram"));
+        assert_eq!(binding.account_id.as_deref(), Some("bot1"));
+        assert_eq!(binding.chat_id.as_deref(), Some("-100999"));
+        assert_eq!(binding.chat_type.as_deref(), Some("channel_or_supergroup"));
+        assert!(binding.sender_id.is_none());
     }
 }

--- a/crates/channels/src/plugin.rs
+++ b/crates/channels/src/plugin.rs
@@ -539,6 +539,43 @@ impl From<&ChannelReplyTarget> for ChannelBinding {
     }
 }
 
+#[must_use]
+pub fn web_session_channel_binding() -> ChannelBinding {
+    ChannelBinding {
+        surface: Some("web".to_string()),
+        session_kind: Some("web".to_string()),
+        ..Default::default()
+    }
+}
+
+pub fn resolve_session_channel_binding(
+    session_key: &str,
+    binding_json: Option<&str>,
+) -> std::result::Result<ChannelBinding, serde_json::Error> {
+    if session_key == "cron:heartbeat" {
+        return Ok(ChannelBinding {
+            surface: Some("heartbeat".to_string()),
+            session_kind: Some("cron".to_string()),
+            ..Default::default()
+        });
+    }
+
+    if session_key.starts_with("cron:") {
+        return Ok(ChannelBinding {
+            surface: Some("cron".to_string()),
+            session_kind: Some("cron".to_string()),
+            ..Default::default()
+        });
+    }
+
+    if let Some(binding_json) = binding_json {
+        let binding = serde_json::from_str::<ChannelReplyTarget>(binding_json)?;
+        return Ok((&binding).into());
+    }
+
+    Ok(web_session_channel_binding())
+}
+
 // ── Interactive messages ─────────────────────────────────────────────────────
 
 /// A clickable button in a channel message.
@@ -1249,5 +1286,54 @@ mod tests {
         assert_eq!(binding.chat_id.as_deref(), Some("-100999"));
         assert_eq!(binding.chat_type.as_deref(), Some("channel_or_supergroup"));
         assert!(binding.sender_id.is_none());
+    }
+
+    #[test]
+    fn resolve_session_channel_binding_classifies_special_sessions() {
+        let heartbeat = resolve_session_channel_binding("cron:heartbeat", None)
+            .unwrap_or_else(|error| panic!("heartbeat binding should resolve: {error}"));
+        assert_eq!(heartbeat.surface.as_deref(), Some("heartbeat"));
+        assert_eq!(heartbeat.session_kind.as_deref(), Some("cron"));
+
+        let cron = resolve_session_channel_binding("cron:nightly", None)
+            .unwrap_or_else(|error| panic!("cron binding should resolve: {error}"));
+        assert_eq!(cron.surface.as_deref(), Some("cron"));
+        assert_eq!(cron.session_kind.as_deref(), Some("cron"));
+
+        let web = resolve_session_channel_binding("main", None)
+            .unwrap_or_else(|error| panic!("web binding should resolve: {error}"));
+        assert_eq!(web.surface.as_deref(), Some("web"));
+        assert_eq!(web.session_kind.as_deref(), Some("web"));
+    }
+
+    #[test]
+    fn resolve_session_channel_binding_extracts_channel_target() {
+        let binding_json = serde_json::to_string(&ChannelReplyTarget {
+            channel_type: ChannelType::Telegram,
+            account_id: "bot-main".into(),
+            chat_id: "-100123".into(),
+            message_id: Some("11".into()),
+            thread_id: None,
+        })
+        .unwrap_or_else(|error| panic!("serialize binding: {error}"));
+
+        let binding =
+            resolve_session_channel_binding("telegram:bot-main:-100123", Some(&binding_json))
+                .unwrap_or_else(|error| panic!("channel binding should resolve: {error}"));
+
+        assert_eq!(binding.surface.as_deref(), Some("telegram"));
+        assert_eq!(binding.session_kind.as_deref(), Some("channel"));
+        assert_eq!(binding.channel_type.as_deref(), Some("telegram"));
+        assert_eq!(binding.account_id.as_deref(), Some("bot-main"));
+        assert_eq!(binding.chat_id.as_deref(), Some("-100123"));
+        assert_eq!(binding.chat_type.as_deref(), Some("channel_or_supergroup"));
+    }
+
+    #[test]
+    fn resolve_session_channel_binding_returns_error_for_invalid_json() {
+        let error = resolve_session_channel_binding("telegram:bot-main:-100123", Some("{not-json"))
+            .err()
+            .unwrap_or_else(|| panic!("invalid binding json should fail"));
+        assert!(error.is_syntax());
     }
 }

--- a/crates/chat/src/lib.rs
+++ b/crates/chat/src/lib.rs
@@ -1080,39 +1080,19 @@ fn resolve_channel_runtime_context(
     session_key: &str,
     session_entry: Option<&SessionEntry>,
 ) -> moltis_common::hooks::ChannelBinding {
-    if session_key == "cron:heartbeat" {
-        return moltis_common::hooks::ChannelBinding {
-            surface: Some("heartbeat".to_string()),
-            session_kind: Some("cron".to_string()),
-            ..Default::default()
-        };
-    }
-
-    if session_key.starts_with("cron:") {
-        return moltis_common::hooks::ChannelBinding {
-            surface: Some("cron".to_string()),
-            session_kind: Some("cron".to_string()),
-            ..Default::default()
-        };
-    }
-
-    if let Some(binding_json) = session_entry.and_then(|entry| entry.channel_binding.as_deref()) {
-        match serde_json::from_str::<moltis_channels::ChannelReplyTarget>(binding_json) {
-            Ok(binding) => return (&binding).into(),
-            Err(error) => {
-                warn!(
-                    error = %error,
-                    session = %session_key,
-                    "failed to parse channel_binding JSON; falling back to web"
-                );
-            },
-        }
-    }
-
-    moltis_common::hooks::ChannelBinding {
-        surface: Some("web".to_string()),
-        session_kind: Some("web".to_string()),
-        ..Default::default()
+    match moltis_channels::resolve_session_channel_binding(
+        session_key,
+        session_entry.and_then(|entry| entry.channel_binding.as_deref()),
+    ) {
+        Ok(binding) => binding,
+        Err(error) => {
+            warn!(
+                error = %error,
+                session = %session_key,
+                "failed to parse channel_binding JSON; falling back to web"
+            );
+            moltis_channels::web_session_channel_binding()
+        },
     }
 }
 
@@ -9473,6 +9453,16 @@ mod tests {
             tool_context["_channel"]["chat_type"],
             "channel_or_supergroup"
         );
+    }
+
+    #[test]
+    fn build_tool_context_omits_channel_binding_without_runtime_context() {
+        let tool_context = build_tool_context("main", None, None, None);
+
+        assert_eq!(tool_context["_session_key"], "main");
+        assert!(tool_context.get("_channel").is_none());
+        assert!(tool_context.get("_accept_language").is_none());
+        assert!(tool_context.get("_conn_id").is_none());
     }
 
     #[test]

--- a/crates/chat/src/lib.rs
+++ b/crates/chat/src/lib.rs
@@ -1076,35 +1076,12 @@ fn prompt_build_limits_from_config(config: &moltis_config::MoltisConfig) -> Prom
     }
 }
 
-#[derive(Default)]
-struct ChannelRuntimeContext {
-    surface: Option<String>,
-    session_kind: Option<String>,
-    channel_type: Option<String>,
-    channel_account_id: Option<String>,
-    channel_chat_id: Option<String>,
-    channel_chat_type: Option<String>,
-}
-
-fn infer_channel_chat_type(channel_type: &str, chat_id: &str) -> Option<String> {
-    if channel_type.eq_ignore_ascii_case("telegram") {
-        if chat_id.starts_with("-100") {
-            return Some("channel_or_supergroup".to_string());
-        }
-        if chat_id.starts_with('-') {
-            return Some("group".to_string());
-        }
-        return Some("private".to_string());
-    }
-    None
-}
-
 fn resolve_channel_runtime_context(
     session_key: &str,
     session_entry: Option<&SessionEntry>,
-) -> ChannelRuntimeContext {
+) -> moltis_common::hooks::ChannelBinding {
     if session_key == "cron:heartbeat" {
-        return ChannelRuntimeContext {
+        return moltis_common::hooks::ChannelBinding {
             surface: Some("heartbeat".to_string()),
             session_kind: Some("cron".to_string()),
             ..Default::default()
@@ -1112,7 +1089,7 @@ fn resolve_channel_runtime_context(
     }
 
     if session_key.starts_with("cron:") {
-        return ChannelRuntimeContext {
+        return moltis_common::hooks::ChannelBinding {
             surface: Some("cron".to_string()),
             session_kind: Some("cron".to_string()),
             ..Default::default()
@@ -1123,23 +1100,53 @@ fn resolve_channel_runtime_context(
         && let Ok(binding) =
             serde_json::from_str::<moltis_channels::ChannelReplyTarget>(binding_json)
     {
-        let channel_type = binding.channel_type.as_str().to_string();
-        let chat_id = binding.chat_id;
-        return ChannelRuntimeContext {
-            surface: Some(channel_type.clone()),
-            session_kind: Some("channel".to_string()),
-            channel_chat_type: infer_channel_chat_type(&channel_type, &chat_id),
-            channel_type: Some(channel_type),
-            channel_account_id: Some(binding.account_id),
-            channel_chat_id: Some(chat_id),
-        };
+        return (&binding).into();
     }
 
-    ChannelRuntimeContext {
+    moltis_common::hooks::ChannelBinding {
         surface: Some("web".to_string()),
         session_kind: Some("web".to_string()),
         ..Default::default()
     }
+}
+
+fn channel_binding_from_runtime_context(
+    runtime_context: Option<&PromptRuntimeContext>,
+) -> Option<moltis_common::hooks::ChannelBinding> {
+    let host = &runtime_context?.host;
+    let binding = moltis_common::hooks::ChannelBinding {
+        surface: host.surface.clone(),
+        session_kind: host.session_kind.clone(),
+        channel_type: host.channel_type.clone(),
+        account_id: host.channel_account_id.clone(),
+        chat_id: host.channel_chat_id.clone(),
+        chat_type: host.channel_chat_type.clone(),
+        sender_id: None,
+    };
+    (!binding.is_empty()).then_some(binding)
+}
+
+fn build_tool_context(
+    session_key: &str,
+    accept_language: Option<&str>,
+    conn_id: Option<&str>,
+    runtime_context: Option<&PromptRuntimeContext>,
+) -> Value {
+    let mut tool_context = serde_json::json!({
+        "_session_key": session_key,
+    });
+    if let Some(channel_binding) = channel_binding_from_runtime_context(runtime_context)
+        && let Ok(channel_value) = serde_json::to_value(channel_binding)
+    {
+        tool_context["_channel"] = channel_value;
+    }
+    if let Some(lang) = accept_language {
+        tool_context["_accept_language"] = serde_json::json!(lang);
+    }
+    if let Some(cid) = conn_id {
+        tool_context["_conn_id"] = serde_json::json!(cid);
+    }
+    tool_context
 }
 
 async fn build_prompt_runtime_context(
@@ -1211,9 +1218,9 @@ async fn build_prompt_runtime_context(
         surface: channel_context.surface,
         session_kind: channel_context.session_kind,
         channel_type: channel_context.channel_type,
-        channel_account_id: channel_context.channel_account_id,
-        channel_chat_id: channel_context.channel_chat_id,
-        channel_chat_type: channel_context.channel_chat_type,
+        channel_account_id: channel_context.account_id,
+        channel_chat_id: channel_context.chat_id,
+        channel_chat_type: channel_context.chat_type,
         data_dir: Some(data_dir_display),
         sudo_non_interactive,
         sudo_status,
@@ -3437,14 +3444,21 @@ impl ChatService for LiveChatService {
 
         // Dispatch MessageReceived hook (read-only).
         if let Some(ref hooks) = self.hook_registry {
+            let session_entry = self.session_metadata.get(&session_key).await;
             let channel = params
                 .get("channel")
                 .and_then(|v| v.as_str())
                 .map(String::from);
+            let channel_binding = Some(resolve_channel_runtime_context(
+                &session_key,
+                session_entry.as_ref(),
+            ))
+            .filter(|binding| !binding.is_empty());
             let payload = moltis_common::hooks::HookPayload::MessageReceived {
                 session_key: session_key.clone(),
                 content: text.clone(),
                 channel,
+                channel_binding,
             };
             if let Err(e) = hooks.dispatch(&payload).await {
                 warn!(session = %session_key, error = %e, "MessageReceived hook failed");
@@ -6734,15 +6748,12 @@ async fn run_with_tools(
 
     // Inject session key and accept-language into tool call params so tools can
     // resolve per-session state and forward the user's locale to web requests.
-    let mut tool_context = serde_json::json!({
-        "_session_key": session_key,
-    });
-    if let Some(lang) = accept_language.as_deref() {
-        tool_context["_accept_language"] = serde_json::json!(lang);
-    }
-    if let Some(cid) = conn_id.as_deref() {
-        tool_context["_conn_id"] = serde_json::json!(cid);
-    }
+    let tool_context = build_tool_context(
+        session_key,
+        accept_language.as_deref(),
+        conn_id.as_deref(),
+        runtime_context,
+    );
 
     let provider_ref = provider.clone();
     let first_result = run_agent_loop_streaming(
@@ -9399,9 +9410,9 @@ mod tests {
         assert_eq!(context.surface.as_deref(), Some("telegram"));
         assert_eq!(context.session_kind.as_deref(), Some("channel"));
         assert_eq!(context.channel_type.as_deref(), Some("telegram"));
-        assert_eq!(context.channel_account_id.as_deref(), Some("bot-main"));
-        assert_eq!(context.channel_chat_id.as_deref(), Some("123456"));
-        assert_eq!(context.channel_chat_type.as_deref(), Some("private"));
+        assert_eq!(context.account_id.as_deref(), Some("bot-main"));
+        assert_eq!(context.chat_id.as_deref(), Some("123456"));
+        assert_eq!(context.chat_type.as_deref(), Some("private"));
     }
 
     #[test]
@@ -9410,8 +9421,41 @@ mod tests {
         assert_eq!(context.surface.as_deref(), Some("web"));
         assert_eq!(context.session_kind.as_deref(), Some("web"));
         assert_eq!(context.channel_type, None);
-        assert_eq!(context.channel_account_id, None);
-        assert_eq!(context.channel_chat_id, None);
+        assert_eq!(context.account_id, None);
+        assert_eq!(context.chat_id, None);
+    }
+
+    #[test]
+    fn build_tool_context_includes_channel_binding() {
+        let runtime_context = PromptRuntimeContext {
+            host: PromptHostRuntimeContext {
+                surface: Some("telegram".to_string()),
+                session_kind: Some("channel".to_string()),
+                channel_type: Some("telegram".to_string()),
+                channel_account_id: Some("bot-main".to_string()),
+                channel_chat_id: Some("-100123".to_string()),
+                channel_chat_type: Some("channel_or_supergroup".to_string()),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let tool_context = build_tool_context(
+            "telegram:bot-main:-100123",
+            Some("en-US"),
+            Some("conn-1"),
+            Some(&runtime_context),
+        );
+
+        assert_eq!(tool_context["_session_key"], "telegram:bot-main:-100123");
+        assert_eq!(tool_context["_accept_language"], "en-US");
+        assert_eq!(tool_context["_conn_id"], "conn-1");
+        assert_eq!(tool_context["_channel"]["channel_type"], "telegram");
+        assert_eq!(tool_context["_channel"]["account_id"], "bot-main");
+        assert_eq!(
+            tool_context["_channel"]["chat_type"],
+            "channel_or_supergroup"
+        );
     }
 
     #[test]

--- a/crates/chat/src/lib.rs
+++ b/crates/chat/src/lib.rs
@@ -1096,11 +1096,17 @@ fn resolve_channel_runtime_context(
         };
     }
 
-    if let Some(binding_json) = session_entry.and_then(|entry| entry.channel_binding.as_deref())
-        && let Ok(binding) =
-            serde_json::from_str::<moltis_channels::ChannelReplyTarget>(binding_json)
-    {
-        return (&binding).into();
+    if let Some(binding_json) = session_entry.and_then(|entry| entry.channel_binding.as_deref()) {
+        match serde_json::from_str::<moltis_channels::ChannelReplyTarget>(binding_json) {
+            Ok(binding) => return (&binding).into(),
+            Err(error) => {
+                warn!(
+                    error = %error,
+                    session = %session_key,
+                    "failed to parse channel_binding JSON; falling back to web"
+                );
+            },
+        }
     }
 
     moltis_common::hooks::ChannelBinding {
@@ -9423,6 +9429,17 @@ mod tests {
         assert_eq!(context.channel_type, None);
         assert_eq!(context.account_id, None);
         assert_eq!(context.chat_id, None);
+    }
+
+    #[test]
+    fn resolve_channel_runtime_context_falls_back_to_web_when_binding_is_invalid() {
+        let entry = make_session_entry_with_binding(Some("{not-json".to_string()));
+        let context = resolve_channel_runtime_context("telegram:bot-main:123456", Some(&entry));
+        assert_eq!(context.surface.as_deref(), Some("web"));
+        assert_eq!(context.session_kind.as_deref(), Some("web"));
+        assert!(context.channel_type.is_none());
+        assert!(context.account_id.is_none());
+        assert!(context.chat_id.is_none());
     }
 
     #[test]

--- a/crates/common/src/hooks.rs
+++ b/crates/common/src/hooks.rs
@@ -94,6 +94,38 @@ impl HookEvent {
 
 // ── HookPayload ─────────────────────────────────────────────────────────────
 
+/// Best-effort channel/session provenance attached to hook payloads.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ChannelBinding {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub surface: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session_kind: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub channel_type: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub account_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub chat_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub chat_type: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sender_id: Option<String>,
+}
+
+impl ChannelBinding {
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.surface.is_none()
+            && self.session_kind.is_none()
+            && self.channel_type.is_none()
+            && self.account_id.is_none()
+            && self.chat_id.is_none()
+            && self.chat_type.is_none()
+            && self.sender_id.is_none()
+    }
+}
+
 /// Typed payload carried with each hook event.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "event")]
@@ -138,6 +170,8 @@ pub enum HookPayload {
         session_key: String,
         content: String,
         channel: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        channel_binding: Option<ChannelBinding>,
     },
     MessageSending {
         session_key: String,
@@ -151,6 +185,8 @@ pub enum HookPayload {
         session_key: String,
         tool_name: String,
         arguments: Value,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        channel: Option<ChannelBinding>,
     },
     AfterToolCall {
         session_key: String,
@@ -162,9 +198,13 @@ pub enum HookPayload {
         session_key: String,
         tool_name: String,
         result: Value,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        channel: Option<ChannelBinding>,
     },
     SessionStart {
         session_key: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        channel: Option<ChannelBinding>,
     },
     SessionEnd {
         session_key: String,
@@ -693,12 +733,26 @@ mod tests {
             session_key: "test".into(),
             tool_name: "exec".into(),
             arguments: serde_json::json!({}),
+            channel: None,
         }
     }
 
     fn read_only_payload() -> HookPayload {
         HookPayload::SessionStart {
             session_key: "test".into(),
+            channel: None,
+        }
+    }
+
+    fn test_channel_binding() -> ChannelBinding {
+        ChannelBinding {
+            surface: Some("telegram".into()),
+            session_kind: Some("channel".into()),
+            channel_type: Some("telegram".into()),
+            account_id: Some("bot-main".into()),
+            chat_id: Some("-100123".into()),
+            chat_type: Some("channel_or_supergroup".into()),
+            sender_id: None,
         }
     }
 
@@ -915,5 +969,99 @@ mod tests {
         let json = serde_json::to_string(&after).unwrap();
         let deser: HookPayload = serde_json::from_str(&json).unwrap();
         assert_eq!(deser.event(), HookEvent::AfterLLMCall);
+    }
+
+    #[test]
+    fn channel_binding_is_empty_only_when_all_fields_are_absent() {
+        assert!(ChannelBinding::default().is_empty());
+        assert!(
+            !ChannelBinding {
+                surface: Some("web".into()),
+                ..Default::default()
+            }
+            .is_empty()
+        );
+    }
+
+    #[test]
+    fn hook_payloads_with_channel_binding_round_trip() {
+        let binding = test_channel_binding();
+        let before = HookPayload::BeforeToolCall {
+            session_key: "s".into(),
+            tool_name: "exec".into(),
+            arguments: serde_json::json!({"command": "pwd"}),
+            channel: Some(binding.clone()),
+        };
+        let json = serde_json::to_string(&before).unwrap();
+        let deser: HookPayload = serde_json::from_str(&json).unwrap();
+        match deser {
+            HookPayload::BeforeToolCall { channel, .. } => {
+                assert_eq!(channel, Some(binding.clone()));
+            },
+            other => panic!("unexpected payload: {other:?}"),
+        }
+
+        let message = HookPayload::MessageReceived {
+            session_key: "s".into(),
+            content: "hello".into(),
+            channel: Some("telegram".into()),
+            channel_binding: Some(binding.clone()),
+        };
+        let json = serde_json::to_string(&message).unwrap();
+        let deser: HookPayload = serde_json::from_str(&json).unwrap();
+        match deser {
+            HookPayload::MessageReceived {
+                channel_binding, ..
+            } => {
+                assert_eq!(channel_binding, Some(binding.clone()));
+            },
+            other => panic!("unexpected payload: {other:?}"),
+        }
+
+        let start = HookPayload::SessionStart {
+            session_key: "s".into(),
+            channel: Some(binding.clone()),
+        };
+        let json = serde_json::to_string(&start).unwrap();
+        let deser: HookPayload = serde_json::from_str(&json).unwrap();
+        match deser {
+            HookPayload::SessionStart { channel, .. } => {
+                assert_eq!(channel, Some(binding));
+            },
+            other => panic!("unexpected payload: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn hook_payloads_deserialize_when_channel_binding_is_omitted() {
+        let json = serde_json::json!({
+            "event": "BeforeToolCall",
+            "session_key": "s",
+            "tool_name": "exec",
+            "arguments": {"command": "pwd"}
+        });
+        let payload: HookPayload = serde_json::from_value(json).unwrap();
+        match payload {
+            HookPayload::BeforeToolCall { channel, .. } => {
+                assert!(channel.is_none());
+            },
+            other => panic!("unexpected payload: {other:?}"),
+        }
+
+        let json = serde_json::json!({
+            "event": "MessageReceived",
+            "session_key": "s",
+            "content": "hello",
+            "channel": "telegram"
+        });
+        let payload: HookPayload = serde_json::from_value(json).unwrap();
+        match payload {
+            HookPayload::MessageReceived {
+                channel_binding, ..
+            } => {
+                assert!(channel_binding.is_none());
+            },
+            other => panic!("unexpected payload: {other:?}"),
+        }
     }
 }

--- a/crates/common/src/hooks.rs
+++ b/crates/common/src/hooks.rs
@@ -193,6 +193,8 @@ pub enum HookPayload {
         tool_name: String,
         success: bool,
         result: Option<Value>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        channel: Option<ChannelBinding>,
     },
     ToolResultPersist {
         session_key: String,
@@ -1030,6 +1032,37 @@ mod tests {
             },
             other => panic!("unexpected payload: {other:?}"),
         }
+
+        let after = HookPayload::AfterToolCall {
+            session_key: "s".into(),
+            tool_name: "exec".into(),
+            success: true,
+            result: Some(serde_json::json!({"cwd": "/tmp"})),
+            channel: Some(test_channel_binding()),
+        };
+        let json = serde_json::to_string(&after).unwrap();
+        let deser: HookPayload = serde_json::from_str(&json).unwrap();
+        match deser {
+            HookPayload::AfterToolCall { channel, .. } => {
+                assert_eq!(channel, Some(test_channel_binding()));
+            },
+            other => panic!("unexpected payload: {other:?}"),
+        }
+
+        let persist = HookPayload::ToolResultPersist {
+            session_key: "s".into(),
+            tool_name: "exec".into(),
+            result: serde_json::json!({"cwd": "/tmp"}),
+            channel: Some(test_channel_binding()),
+        };
+        let json = serde_json::to_string(&persist).unwrap();
+        let deser: HookPayload = serde_json::from_str(&json).unwrap();
+        match deser {
+            HookPayload::ToolResultPersist { channel, .. } => {
+                assert_eq!(channel, Some(test_channel_binding()));
+            },
+            other => panic!("unexpected payload: {other:?}"),
+        }
     }
 
     #[test]
@@ -1060,6 +1093,21 @@ mod tests {
                 channel_binding, ..
             } => {
                 assert!(channel_binding.is_none());
+            },
+            other => panic!("unexpected payload: {other:?}"),
+        }
+
+        let json = serde_json::json!({
+            "event": "AfterToolCall",
+            "session_key": "s",
+            "tool_name": "exec",
+            "success": true,
+            "result": {"cwd": "/tmp"}
+        });
+        let payload: HookPayload = serde_json::from_value(json).unwrap();
+        match payload {
+            HookPayload::AfterToolCall { channel, .. } => {
+                assert!(channel.is_none());
             },
             other => panic!("unexpected payload: {other:?}"),
         }

--- a/crates/common/src/hooks.rs
+++ b/crates/common/src/hooks.rs
@@ -881,6 +881,7 @@ mod tests {
             session_key: "test".into(),
             content: "hello".into(),
             channel: Some("telegram".into()),
+            channel_binding: None,
         };
         let result = registry.dispatch(&payload).await.unwrap();
         match result {
@@ -923,6 +924,7 @@ mod tests {
             session_key: "test".into(),
             content: "original".into(),
             channel: None,
+            channel_binding: None,
         };
         let result = registry.dispatch(&payload).await.unwrap();
         match result {

--- a/crates/gateway/src/session.rs
+++ b/crates/gateway/src/session.rs
@@ -59,10 +59,17 @@ fn resolve_hook_channel_binding(
     {
         match serde_json::from_str::<moltis_channels::ChannelReplyTarget>(binding_json) {
             Ok(target) => (&target).into(),
-            Err(_) => moltis_common::hooks::ChannelBinding {
-                surface: Some("web".to_string()),
-                session_kind: Some("web".to_string()),
-                ..Default::default()
+            Err(error) => {
+                warn!(
+                    error = %error,
+                    session = %session_key,
+                    "failed to parse channel_binding JSON; falling back to web"
+                );
+                moltis_common::hooks::ChannelBinding {
+                    surface: Some("web".to_string()),
+                    session_kind: Some("web".to_string()),
+                    ..Default::default()
+                }
             },
         }
     } else {

--- a/crates/gateway/src/session.rs
+++ b/crates/gateway/src/session.rs
@@ -38,6 +38,43 @@ const UI_HISTORY_MAX_BYTES: usize = 2 * 1024 * 1024;
 const UI_HISTORY_MIN_MESSAGES: usize = 120;
 const UI_HISTORY_TRIM_STEP: usize = 50;
 
+fn resolve_hook_channel_binding(
+    session_key: &str,
+    session_entry: Option<&moltis_sessions::metadata::SessionEntry>,
+) -> Option<moltis_common::hooks::ChannelBinding> {
+    let binding = if session_key == "cron:heartbeat" {
+        moltis_common::hooks::ChannelBinding {
+            surface: Some("heartbeat".to_string()),
+            session_kind: Some("cron".to_string()),
+            ..Default::default()
+        }
+    } else if session_key.starts_with("cron:") {
+        moltis_common::hooks::ChannelBinding {
+            surface: Some("cron".to_string()),
+            session_kind: Some("cron".to_string()),
+            ..Default::default()
+        }
+    } else if let Some(binding_json) =
+        session_entry.and_then(|entry| entry.channel_binding.as_deref())
+    {
+        match serde_json::from_str::<moltis_channels::ChannelReplyTarget>(binding_json) {
+            Ok(target) => (&target).into(),
+            Err(_) => moltis_common::hooks::ChannelBinding {
+                surface: Some("web".to_string()),
+                session_kind: Some("web".to_string()),
+                ..Default::default()
+            },
+        }
+    } else {
+        moltis_common::hooks::ChannelBinding {
+            surface: Some("web".to_string()),
+            session_kind: Some("web".to_string()),
+            ..Default::default()
+        }
+    };
+    (!binding.is_empty()).then_some(binding)
+}
+
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct TtsStatusPayload {
@@ -1087,8 +1124,10 @@ impl SessionService for LiveSessionService {
             if entry.message_count == 0
                 && let Some(ref hooks) = self.hook_registry
             {
+                let channel = resolve_hook_channel_binding(key, Some(&entry));
                 let payload = moltis_common::hooks::HookPayload::SessionStart {
                     session_key: key.to_string(),
+                    channel,
                 };
                 if let Err(e) = hooks.dispatch(&payload).await {
                     warn!(session = %key, error = %e, "SessionStart hook failed");
@@ -1136,8 +1175,10 @@ impl SessionService for LiveSessionService {
         if raw_history.is_empty()
             && let Some(ref hooks) = self.hook_registry
         {
+            let channel = resolve_hook_channel_binding(key, Some(&entry));
             let payload = moltis_common::hooks::HookPayload::SessionStart {
                 session_key: key.to_string(),
+                channel,
             };
             if let Err(e) = hooks.dispatch(&payload).await {
                 warn!(session = %key, error = %e, "SessionStart hook failed");
@@ -1888,7 +1929,36 @@ impl SessionService for LiveSessionService {
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
-    use super::*;
+    use {
+        super::*,
+        async_trait::async_trait,
+        moltis_common::hooks::{HookAction, HookEvent, HookHandler, HookPayload},
+    };
+
+    struct RecordingHook {
+        payloads: Arc<std::sync::Mutex<Vec<HookPayload>>>,
+    }
+
+    #[async_trait]
+    impl HookHandler for RecordingHook {
+        fn name(&self) -> &str {
+            "recording-hook"
+        }
+
+        fn events(&self) -> &[HookEvent] {
+            static EVENTS: [HookEvent; 1] = [HookEvent::SessionStart];
+            &EVENTS
+        }
+
+        async fn handle(
+            &self,
+            _event: HookEvent,
+            payload: &HookPayload,
+        ) -> moltis_common::error::Result<HookAction> {
+            self.payloads.lock().unwrap().push(payload.clone());
+            Ok(HookAction::Continue)
+        }
+    }
 
     #[test]
     fn filter_ui_history_removes_empty_assistant_messages() {
@@ -2713,6 +2783,91 @@ mod tests {
         moltis_projects::run_migrations(&pool).await.unwrap();
         SqliteSessionMetadata::init(&pool).await.unwrap();
         pool
+    }
+
+    #[tokio::test]
+    async fn resolve_dispatches_session_start_with_channel_binding() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Arc::new(SessionStore::new(dir.path().to_path_buf()));
+        let pool = sqlite_pool().await;
+        let metadata = Arc::new(SqliteSessionMetadata::new(pool));
+        let key = "telegram:bot-main:-100123";
+        metadata.upsert(key, None).await.unwrap();
+        let binding_json = serde_json::to_string(&moltis_channels::ChannelReplyTarget {
+            channel_type: moltis_channels::ChannelType::Telegram,
+            account_id: "bot-main".to_string(),
+            chat_id: "-100123".to_string(),
+            message_id: Some("9".to_string()),
+            thread_id: None,
+        })
+        .unwrap();
+        metadata.set_channel_binding(key, Some(binding_json)).await;
+
+        let payloads = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let mut hook_registry = HookRegistry::new();
+        hook_registry.register(Arc::new(RecordingHook {
+            payloads: Arc::clone(&payloads),
+        }));
+
+        let service = LiveSessionService::new(store, metadata).with_hooks(Arc::new(hook_registry));
+        service
+            .resolve(serde_json::json!({ "key": key, "include_history": false }))
+            .await
+            .unwrap();
+
+        let payloads = payloads.lock().unwrap();
+        let payload = payloads
+            .first()
+            .unwrap_or_else(|| panic!("missing SessionStart payload"));
+        match payload {
+            HookPayload::SessionStart { channel, .. } => {
+                let channel = channel.clone().unwrap_or_else(|| panic!("missing channel"));
+                assert_eq!(channel.surface.as_deref(), Some("telegram"));
+                assert_eq!(channel.session_kind.as_deref(), Some("channel"));
+                assert_eq!(channel.channel_type.as_deref(), Some("telegram"));
+                assert_eq!(channel.account_id.as_deref(), Some("bot-main"));
+                assert_eq!(channel.chat_id.as_deref(), Some("-100123"));
+                assert_eq!(channel.chat_type.as_deref(), Some("channel_or_supergroup"));
+            },
+            other => panic!("unexpected payload: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn resolve_dispatches_session_start_with_web_binding_for_unbound_session() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Arc::new(SessionStore::new(dir.path().to_path_buf()));
+        let pool = sqlite_pool().await;
+        let metadata = Arc::new(SqliteSessionMetadata::new(pool));
+        metadata.upsert("main", None).await.unwrap();
+
+        let payloads = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let mut hook_registry = HookRegistry::new();
+        hook_registry.register(Arc::new(RecordingHook {
+            payloads: Arc::clone(&payloads),
+        }));
+
+        let service = LiveSessionService::new(store, metadata).with_hooks(Arc::new(hook_registry));
+        service
+            .resolve(serde_json::json!({ "key": "main", "include_history": false }))
+            .await
+            .unwrap();
+
+        let payloads = payloads.lock().unwrap();
+        let payload = payloads
+            .first()
+            .unwrap_or_else(|| panic!("missing SessionStart payload"));
+        match payload {
+            HookPayload::SessionStart { channel, .. } => {
+                let channel = channel.clone().unwrap_or_else(|| panic!("missing channel"));
+                assert_eq!(channel.surface.as_deref(), Some("web"));
+                assert_eq!(channel.session_kind.as_deref(), Some("web"));
+                assert!(channel.channel_type.is_none());
+                assert!(channel.account_id.is_none());
+                assert!(channel.chat_id.is_none());
+            },
+            other => panic!("unexpected payload: {other:?}"),
+        }
     }
 
     #[tokio::test]

--- a/crates/gateway/src/session.rs
+++ b/crates/gateway/src/session.rs
@@ -42,42 +42,19 @@ fn resolve_hook_channel_binding(
     session_key: &str,
     session_entry: Option<&moltis_sessions::metadata::SessionEntry>,
 ) -> Option<moltis_common::hooks::ChannelBinding> {
-    let binding = if session_key == "cron:heartbeat" {
-        moltis_common::hooks::ChannelBinding {
-            surface: Some("heartbeat".to_string()),
-            session_kind: Some("cron".to_string()),
-            ..Default::default()
-        }
-    } else if session_key.starts_with("cron:") {
-        moltis_common::hooks::ChannelBinding {
-            surface: Some("cron".to_string()),
-            session_kind: Some("cron".to_string()),
-            ..Default::default()
-        }
-    } else if let Some(binding_json) =
-        session_entry.and_then(|entry| entry.channel_binding.as_deref())
-    {
-        match serde_json::from_str::<moltis_channels::ChannelReplyTarget>(binding_json) {
-            Ok(target) => (&target).into(),
-            Err(error) => {
-                warn!(
-                    error = %error,
-                    session = %session_key,
-                    "failed to parse channel_binding JSON; falling back to web"
-                );
-                moltis_common::hooks::ChannelBinding {
-                    surface: Some("web".to_string()),
-                    session_kind: Some("web".to_string()),
-                    ..Default::default()
-                }
-            },
-        }
-    } else {
-        moltis_common::hooks::ChannelBinding {
-            surface: Some("web".to_string()),
-            session_kind: Some("web".to_string()),
-            ..Default::default()
-        }
+    let binding = match moltis_channels::resolve_session_channel_binding(
+        session_key,
+        session_entry.and_then(|entry| entry.channel_binding.as_deref()),
+    ) {
+        Ok(binding) => binding,
+        Err(error) => {
+            warn!(
+                error = %error,
+                session = %session_key,
+                "failed to parse channel_binding JSON; falling back to web"
+            );
+            moltis_channels::web_session_channel_binding()
+        },
     };
     (!binding.is_empty()).then_some(binding)
 }
@@ -2857,6 +2834,47 @@ mod tests {
         let service = LiveSessionService::new(store, metadata).with_hooks(Arc::new(hook_registry));
         service
             .resolve(serde_json::json!({ "key": "main", "include_history": false }))
+            .await
+            .unwrap();
+
+        let payloads = payloads.lock().unwrap();
+        let payload = payloads
+            .first()
+            .unwrap_or_else(|| panic!("missing SessionStart payload"));
+        match payload {
+            HookPayload::SessionStart { channel, .. } => {
+                let channel = channel.clone().unwrap_or_else(|| panic!("missing channel"));
+                assert_eq!(channel.surface.as_deref(), Some("web"));
+                assert_eq!(channel.session_kind.as_deref(), Some("web"));
+                assert!(channel.channel_type.is_none());
+                assert!(channel.account_id.is_none());
+                assert!(channel.chat_id.is_none());
+            },
+            other => panic!("unexpected payload: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn resolve_dispatches_session_start_with_web_binding_for_invalid_channel_binding() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Arc::new(SessionStore::new(dir.path().to_path_buf()));
+        let pool = sqlite_pool().await;
+        let metadata = Arc::new(SqliteSessionMetadata::new(pool));
+        let key = "telegram:bot-main:-100123";
+        metadata.upsert(key, None).await.unwrap();
+        metadata
+            .set_channel_binding(key, Some("{not-json".to_string()))
+            .await;
+
+        let payloads = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let mut hook_registry = HookRegistry::new();
+        hook_registry.register(Arc::new(RecordingHook {
+            payloads: Arc::clone(&payloads),
+        }));
+
+        let service = LiveSessionService::new(store, metadata).with_hooks(Arc::new(hook_registry));
+        service
+            .resolve(serde_json::json!({ "key": key, "include_history": false }))
             .await
             .unwrap();
 

--- a/crates/plugins/src/bundled/command_logger.rs
+++ b/crates/plugins/src/bundled/command_logger.rs
@@ -2,7 +2,7 @@
 
 use std::{path::PathBuf, sync::Mutex};
 
-use {async_trait::async_trait, tracing::warn};
+use {async_trait::async_trait, time::OffsetDateTime, tracing::warn};
 
 use moltis_common::{
     Result,
@@ -43,6 +43,15 @@ impl CommandLoggerHook {
         }
         Ok(())
     }
+
+    fn log_entry(session_key: &str, action: &str, sender_id: &Option<String>) -> serde_json::Value {
+        serde_json::json!({
+            "ts": OffsetDateTime::now_utc().unix_timestamp(),
+            "session_key": session_key,
+            "action": action,
+            "sender_id": sender_id,
+        })
+    }
 }
 
 #[async_trait]
@@ -67,15 +76,7 @@ impl HookHandler for CommandLoggerHook {
                 return Ok(HookAction::Continue);
             }
 
-            let entry = serde_json::json!({
-                "ts": std::time::SystemTime::now()
-                    .duration_since(std::time::UNIX_EPOCH)
-                    .unwrap_or_default()
-                    .as_secs(),
-                "session_key": session_key,
-                "action": action,
-                "sender_id": sender_id,
-            });
+            let entry = Self::log_entry(session_key, action, sender_id);
 
             use std::io::Write;
             let mut guard = self.file.lock().unwrap_or_else(|e| e.into_inner());
@@ -97,15 +98,7 @@ impl HookHandler for CommandLoggerHook {
         } = payload
             && self.ensure_file().is_ok()
         {
-            let entry = serde_json::json!({
-                "ts": std::time::SystemTime::now()
-                    .duration_since(std::time::UNIX_EPOCH)
-                    .unwrap_or_default()
-                    .as_secs(),
-                "session_key": session_key,
-                "action": action,
-                "sender_id": sender_id,
-            });
+            let entry = Self::log_entry(session_key, action, sender_id);
             use std::io::Write;
             let mut guard = self.file.lock().unwrap_or_else(|e| e.into_inner());
             if let Some(ref mut f) = *guard {
@@ -140,6 +133,7 @@ mod tests {
         assert_eq!(lines.len(), 2);
 
         let entry: serde_json::Value = serde_json::from_str(lines[0]).unwrap();
+        assert!(entry["ts"].as_i64().is_some_and(|ts| ts > 0));
         assert_eq!(entry["action"], "new");
         assert_eq!(entry["session_key"], "sess-1");
     }

--- a/crates/plugins/src/bundled/command_logger.rs
+++ b/crates/plugins/src/bundled/command_logger.rs
@@ -152,6 +152,7 @@ mod tests {
 
         let payload = HookPayload::SessionStart {
             session_key: "test".into(),
+            channel: None,
         };
         hook.handle(HookEvent::Command, &payload).await.unwrap();
         // File shouldn't even be created

--- a/crates/plugins/src/hooks.rs
+++ b/crates/plugins/src/hooks.rs
@@ -130,6 +130,7 @@ mod tests {
             session_key: "test-session".into(),
             tool_name: "exec".into(),
             arguments: serde_json::json!({"command": "ls"}),
+            channel: None,
         }
     }
 

--- a/crates/plugins/src/shell_hook.rs
+++ b/crates/plugins/src/shell_hook.rs
@@ -205,6 +205,7 @@ mod tests {
     fn test_payload() -> HookPayload {
         HookPayload::SessionStart {
             session_key: "test-123".into(),
+            channel: None,
         }
     }
 

--- a/docs/src/hooks.md
+++ b/docs/src/hooks.md
@@ -105,7 +105,9 @@ Fires after the LLM response is received but before tool calls execute. For stre
 
 ## Channel Provenance
 
-`BeforeToolCall`, `SessionStart`, `MessageReceived`, and `ToolResultPersist` can include channel provenance in a `channel` or `channel_binding` object. The fields are optional so hooks keep working for sessions that do not originate from a channel integration.
+`BeforeToolCall`, `SessionStart`, and `MessageReceived` currently include channel provenance. The fields are optional so hooks keep working for sessions that do not originate from a channel integration.
+
+`MessageReceived` keeps its legacy `channel` string field and adds the richer object as `channel_binding`. `BeforeToolCall` and `SessionStart` expose the same richer object as `channel`. `ToolResultPersist` has a schema field reserved for the same shape, but that event is not currently dispatched.
 
 | Field | Type | Description |
 |-------|------|-------------|

--- a/docs/src/hooks.md
+++ b/docs/src/hooks.md
@@ -257,16 +257,26 @@ The event payload is passed as JSON on stdin:
 ```json
 {
   "event": "BeforeToolCall",
-  "data": {
-    "tool": "bash",
-    "arguments": {
-      "command": "ls -la"
-    }
+  "session_key": "abc123",
+  "tool_name": "exec",
+  "arguments": {
+    "command": "ls -la"
   },
-  "session_id": "abc123",
-  "timestamp": "2024-01-15T10:30:00Z"
+  "channel": {
+    "surface": "telegram",
+    "session_kind": "channel",
+    "channel_type": "telegram",
+    "account_id": "bot-main",
+    "chat_id": "-100123",
+    "chat_type": "channel_or_supergroup"
+  }
 }
 ```
+
+For modifying events, stdin is the full tagged `HookPayload`. If your hook returns
+`{"action":"modify","data":...}`, the `data` value replaces the event-specific
+mutable portion of the payload. For `BeforeToolCall`, that means the replacement
+value becomes the new `arguments` object.
 
 ### Output
 
@@ -281,12 +291,12 @@ The event payload is passed as JSON on stdin:
 ```bash
 #!/bin/bash
 payload=$(cat)
-tool=$(echo "$payload" | jq -r '.data.tool')
+tool=$(echo "$payload" | jq -r '.tool_name')
 
-if [ "$tool" = "bash" ]; then
-    # Add safety flag to all bash commands
-    modified=$(echo "$payload" | jq '.data.arguments.command = "set -e; " + .data.arguments.command')
-    echo "{\"action\":\"modify\",\"data\":$(echo "$modified" | jq '.data')}"
+if [ "$tool" = "exec" ]; then
+    # Add safety flag to shell commands executed by the exec tool
+    modified_args=$(echo "$payload" | jq '.arguments.command = "set -e; " + .arguments.command | .arguments')
+    echo "{\"action\":\"modify\",\"data\":$modified_args}"
 fi
 
 exit 0
@@ -297,7 +307,7 @@ exit 0
 ```bash
 #!/bin/bash
 payload=$(cat)
-command=$(echo "$payload" | jq -r '.data.arguments.command // ""')
+command=$(echo "$payload" | jq -r '.arguments.command // ""')
 
 # Block rm -rf /
 if echo "$command" | grep -qE 'rm\s+-rf\s+/'; then
@@ -479,31 +489,32 @@ through dcg, and blocks any command that dcg flags as destructive. See
 #!/bin/bash
 # slack-notify.sh
 payload=$(cat)
-session_id=$(echo "$payload" | jq -r '.session_id')
-message_count=$(echo "$payload" | jq -r '.data.message_count')
+session_key=$(echo "$payload" | jq -r '.session_key')
 
 curl -X POST "$SLACK_WEBHOOK_URL" \
   -H 'Content-Type: application/json' \
-  -d "{\"text\":\"Session $session_id ended with $message_count messages\"}"
+  -d "{\"text\":\"Session $session_key ended\"}"
 
 exit 0
 ```
 
-### Redact Secrets from Tool Output
+### Redact Secrets from Tool Arguments
 
 ```bash
 #!/bin/bash
 # redact-secrets.sh
 payload=$(cat)
 
-# Redact common secret patterns
-redacted=$(echo "$payload" | sed -E '
+# Redact secrets from exec-tool command arguments before execution
+command=$(echo "$payload" | jq -r '.arguments.command // ""')
+redacted=$(printf '%s' "$command" | sed -E '
   s/sk-[a-zA-Z0-9]{32,}/[REDACTED]/g
   s/ghp_[a-zA-Z0-9]{36}/[REDACTED]/g
-  s/password=[^&\s]+/password=[REDACTED]/g
+  s/password=[^&[:space:]]+/password=[REDACTED]/g
 ')
 
-echo "{\"action\":\"modify\",\"data\":$(echo "$redacted" | jq '.data')}"
+modified_args=$(echo "$payload" | jq --arg command "$redacted" '.arguments.command = $command | .arguments')
+echo "{\"action\":\"modify\",\"data\":$modified_args}"
 exit 0
 ```
 
@@ -513,10 +524,10 @@ exit 0
 #!/bin/bash
 # sandbox-writes.sh
 payload=$(cat)
-tool=$(echo "$payload" | jq -r '.data.tool')
+tool=$(echo "$payload" | jq -r '.tool_name')
 
 if [ "$tool" = "write_file" ]; then
-    path=$(echo "$payload" | jq -r '.data.arguments.path')
+    path=$(echo "$payload" | jq -r '.arguments.path')
 
     # Only allow writes under current project
     if [[ ! "$path" =~ ^/workspace/ ]]; then

--- a/docs/src/hooks.md
+++ b/docs/src/hooks.md
@@ -103,6 +103,41 @@ Fires after the LLM response is received but before tool calls execute. For stre
 | `output_tokens` | number | Tokens in the response |
 | `iteration` | number | 1-based loop iteration |
 
+## Channel Provenance
+
+`BeforeToolCall`, `SessionStart`, `MessageReceived`, and `ToolResultPersist` can include channel provenance in a `channel` or `channel_binding` object. The fields are optional so hooks keep working for sessions that do not originate from a channel integration.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `surface` | string/null | Runtime surface, for example `telegram`, `discord`, `web`, `cron`, `heartbeat` |
+| `session_kind` | string/null | High-level source kind, usually `channel`, `web`, or `cron` |
+| `channel_type` | string/null | Channel plugin type when channel-bound |
+| `account_id` | string/null | Channel account identifier |
+| `chat_id` | string/null | Channel chat, room, or peer identifier |
+| `chat_type` | string/null | Best-effort chat classification, currently most useful for Telegram |
+| `sender_id` | string/null | Reserved for future sender provenance, currently omitted |
+
+Example `BeforeToolCall` payload excerpt:
+
+```json
+{
+  "event": "BeforeToolCall",
+  "session_key": "telegram:bot-main:-100123",
+  "tool_name": "exec",
+  "arguments": {
+    "command": "pwd"
+  },
+  "channel": {
+    "surface": "telegram",
+    "session_kind": "channel",
+    "channel_type": "telegram",
+    "account_id": "bot-main",
+    "chat_id": "-100123",
+    "chat_type": "channel_or_supergroup"
+  }
+}
+```
+
 ### Example: Block Suspicious Tool Calls
 
 ```bash

--- a/docs/src/hooks.md
+++ b/docs/src/hooks.md
@@ -105,9 +105,9 @@ Fires after the LLM response is received but before tool calls execute. For stre
 
 ## Channel Provenance
 
-`BeforeToolCall`, `SessionStart`, and `MessageReceived` currently include channel provenance. The fields are optional so hooks keep working for sessions that do not originate from a channel integration.
+`BeforeToolCall`, `AfterToolCall`, `SessionStart`, and `MessageReceived` currently include channel provenance. The fields are optional so hooks keep working for sessions that do not originate from a channel integration.
 
-`MessageReceived` keeps its legacy `channel` string field and adds the richer object as `channel_binding`. `BeforeToolCall` and `SessionStart` expose the same richer object as `channel`. `ToolResultPersist` has a schema field reserved for the same shape, but that event is not currently dispatched.
+`MessageReceived` keeps its legacy `channel` string field and adds the richer object as `channel_binding`. `BeforeToolCall`, `AfterToolCall`, and `SessionStart` expose the same richer object as `channel`. `ToolResultPersist` has a schema field reserved for the same shape, but that event is not currently dispatched.
 
 | Field | Type | Description |
 |-------|------|-------------|

--- a/prompts/session-2026-04-10-hook-channel-provenance.md
+++ b/prompts/session-2026-04-10-hook-channel-provenance.md
@@ -1,0 +1,36 @@
+## Summary
+
+Implemented GitHub issue #640 by threading channel provenance into hook payloads.
+
+- Added `ChannelBinding` to hook payload schema in `moltis-common`.
+- Kept channel-specific chat classification in `moltis-channels` via `ChannelType::classify_chat()` and `From<&ChannelReplyTarget> for ChannelBinding`.
+- Reworked chat runtime channel context to reuse the shared binding shape and inject `_channel` into tool context.
+- Populated `MessageReceived`, `BeforeToolCall`, and `SessionStart` hook payloads with optional channel metadata.
+- Updated hook docs and adjusted plugin tests that construct these payloads directly.
+
+## Validation
+
+Passed:
+
+- `just format`
+- `just format-check`
+- `cargo test -p moltis-common hooks::tests:: -- --nocapture`
+- `cargo test -p moltis-channels plugin::tests:: -- --nocapture`
+- `cargo test -p moltis-agents before_tool_call_hook_receives_channel_binding_from_tool_context -- --nocapture`
+- `cargo test -p moltis-chat build_tool_context_includes_channel_binding -- --nocapture`
+- `cargo test -p moltis-chat resolve_channel_runtime_context -- --nocapture`
+- `cargo test -p moltis-gateway resolve_dispatches_session_start_with_ -- --nocapture`
+- `cargo test -p moltis-plugins hooks::tests:: -- --nocapture`
+- `cargo test -p moltis-plugins shell_hook::tests:: -- --nocapture`
+- `cargo test -p moltis-plugins command_logger::tests:: -- --nocapture`
+
+Attempted but failed for environment reasons:
+
+- `just lint`
+  - failed in `llama-cpp-sys-2` CMake setup with `CUDA Toolkit not found`
+  - this occurred before any hook-related clippy issue surfaced
+
+## Follow-up
+
+- `ToolResultPersist` now has the schema field but still needs an actual dispatch site from issue #638.
+- `sender_id` remains reserved and unset until the session/channel layer has a real source of truth for it.


### PR DESCRIPTION
## Summary

Closes #640.

This threads channel provenance into hook payloads so hook handlers can make decisions based on where a session originated without maintaining their own session-to-channel map.

The change adds a shared `ChannelBinding` hook schema in `moltis-common`, keeps channel-specific chat classification in `moltis-channels`, injects `_channel` into tool context in chat, and populates `MessageReceived`, `BeforeToolCall`, and `SessionStart` payloads with optional channel metadata. It also updates hook docs and tests across the affected crates.

## Validation

### Completed

- [x] `just format`
- [x] `just format-check`
- [x] `just lint` via `./scripts/local-validate.sh 645` on the script's macOS non-CUDA path
- [x] `cargo test -p moltis-common hooks::tests:: -- --nocapture`
- [x] `cargo test -p moltis-channels plugin::tests:: -- --nocapture`
- [x] `cargo test -p moltis-agents before_tool_call_hook_receives_channel_binding_from_tool_context -- --nocapture`
- [x] `cargo test -p moltis-chat build_tool_context_includes_channel_binding -- --nocapture`
- [x] `cargo test -p moltis-chat resolve_channel_runtime_context -- --nocapture`
- [x] `cargo test -p moltis-gateway resolve_dispatches_session_start_with_ -- --nocapture`
- [x] `cargo test -p moltis-plugins hooks::tests:: -- --nocapture`
- [x] `cargo test -p moltis-plugins shell_hook::tests:: -- --nocapture`
- [x] `cargo test -p moltis-plugins command_logger::tests:: -- --nocapture`

### Remaining

- [ ] `./scripts/local-validate.sh 645`
  - started successfully and reached `[local/lint] passed in 172s`
  - interrupted after 5 minutes per repo guidance while later build/test phases were still running

## Manual QA

- Create or resolve a channel-bound session and verify `SessionStart` includes channel metadata in the hook payload.
- Send a channel message and verify `MessageReceived` preserves the legacy string `channel` while also including `channel_binding`.
- Trigger a tool call from a channel-bound session and verify `BeforeToolCall` includes `channel.channel_type`, `account_id`, and `chat_id`.
- Trigger the same flow from a web session and verify the hook payload falls back to `surface=web` and `session_kind=web`.
