### PR TITLE
[codex] feat(discord): handle inbound voice and image attachments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6890,6 +6890,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "futures",
+ "ipnet",
  "moltis-metrics",
  "reqwest 0.12.28",
  "secrecy 0.8.0",
@@ -6898,6 +6899,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
+ "url",
  "uuid",
 ]
 

--- a/crates/channels/src/lib.rs
+++ b/crates/channels/src/lib.rs
@@ -9,6 +9,7 @@ pub mod config_view;
 pub mod contract;
 pub mod error;
 pub mod gating;
+pub mod media_download;
 pub mod message_log;
 pub mod otp;
 pub mod plugin;
@@ -22,6 +23,7 @@ pub use {
     },
     config_view::ChannelConfigView,
     error::{Error, Result},
+    media_download::{InboundMediaDownloader, InboundMediaSource},
     plugin::{
         ButtonRow, ButtonStyle, ChannelAttachment, ChannelCapabilities, ChannelDescriptor,
         ChannelEvent, ChannelEventSink, ChannelHealthSnapshot, ChannelMessageKind,

--- a/crates/channels/src/media_download.rs
+++ b/crates/channels/src/media_download.rs
@@ -1,0 +1,26 @@
+use async_trait::async_trait;
+
+use crate::Result;
+
+/// Opaque source for downloading inbound media bytes from a channel.
+///
+/// The source shape is intentionally higher-level than "just a URL" so channel
+/// implementations can extend this enum as new platforms need authenticated or
+/// non-HTTP fetch paths.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum InboundMediaSource {
+    /// Download media bytes from a remote URL.
+    RemoteUrl { url: String },
+}
+
+/// Fetches inbound media payloads for a channel-specific media source.
+#[async_trait]
+pub trait InboundMediaDownloader: Send + Sync {
+    /// Download the source payload, enforcing a caller-provided size cap.
+    async fn download_media(
+        &self,
+        source: &InboundMediaSource,
+        max_bytes: usize,
+    ) -> Result<Vec<u8>>;
+}

--- a/crates/channels/src/plugin.rs
+++ b/crates/channels/src/plugin.rs
@@ -154,7 +154,7 @@ impl ChannelType {
                     supports_streaming: true,
                     supports_interactive: true,
                     supports_threads: true,
-                    supports_voice_ingest: false,
+                    supports_voice_ingest: true,
                     supports_pairing: false,
                     supports_otp: false,
                     supports_reactions: false,

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -6,6 +6,7 @@ version.workspace = true
 [dependencies]
 async-trait    = { workspace = true }
 futures        = { workspace = true }
+ipnet          = { workspace = true }
 moltis-metrics = { optional = true, workspace = true }
 reqwest        = { workspace = true }
 secrecy        = { workspace = true }
@@ -14,6 +15,7 @@ serde_json     = { workspace = true }
 thiserror      = { workspace = true }
 tokio          = { workspace = true }
 tracing        = { workspace = true }
+url            = { workspace = true }
 uuid           = { workspace = true }
 
 [features]

--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -4,6 +4,7 @@ pub mod error;
 pub mod hooks;
 pub mod http_client;
 pub mod secret_serde;
+pub mod ssrf;
 pub mod types;
 
 pub use error::{Error, FromMessage, MoltisError, Result};

--- a/crates/common/src/ssrf.rs
+++ b/crates/common/src/ssrf.rs
@@ -1,0 +1,141 @@
+use std::net::IpAddr;
+
+use url::Url;
+
+use crate::{Error, Result};
+
+/// Check if an IP is covered by an SSRF allowlist entry.
+#[must_use]
+pub fn is_ssrf_allowed(ip: &IpAddr, allowlist: &[ipnet::IpNet]) -> bool {
+    allowlist.iter().any(|net| net.contains(ip))
+}
+
+/// Check if an IP address is private, loopback, link-local, or otherwise
+/// unsuitable for outbound fetches.
+#[must_use]
+pub fn is_private_ip(ip: &IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(v4) => {
+            v4.is_loopback()
+                || v4.is_private()
+                || v4.is_link_local()
+                || v4.is_broadcast()
+                || v4.is_unspecified()
+                || (v4.octets()[0] == 100 && (v4.octets()[1] & 0xC0) == 64)
+                || (v4.octets()[0] == 192 && v4.octets()[1] == 0 && v4.octets()[2] == 0)
+        },
+        IpAddr::V6(v6) => {
+            v6.is_loopback()
+                || v6.is_unspecified()
+                || (v6.segments()[0] & 0xFE00) == 0xFC00
+                || (v6.segments()[0] & 0xFFC0) == 0xFE80
+        },
+    }
+}
+
+fn validate_ssrf_ips(host: &str, ips: &[IpAddr], allowlist: &[ipnet::IpNet]) -> Result<()> {
+    if ips.is_empty() {
+        return Err(Error::message(format!("DNS resolution failed for {host}")));
+    }
+
+    for ip in ips {
+        if is_private_ip(ip) && !is_ssrf_allowed(ip, allowlist) {
+            return Err(Error::message(format!(
+                "SSRF blocked: {host} resolves to private IP {ip}"
+            )));
+        }
+    }
+
+    Ok(())
+}
+
+/// Resolve the URL host and reject private/loopback/link-local IPs unless
+/// explicitly allowlisted.
+pub async fn ssrf_check(url: &Url, allowlist: &[ipnet::IpNet]) -> Result<()> {
+    let host = url
+        .host_str()
+        .ok_or_else(|| Error::message("URL has no host"))?;
+
+    if let Ok(ip) = host.parse::<IpAddr>() {
+        return validate_ssrf_ips(host, &[ip], allowlist);
+    }
+
+    let port = url.port_or_known_default().unwrap_or(443);
+    let addrs: Vec<IpAddr> = tokio::net::lookup_host(format!("{host}:{port}"))
+        .await?
+        .map(|socket_addr| socket_addr.ip())
+        .collect();
+    validate_ssrf_ips(host, &addrs, allowlist)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{net::IpAddr, str::FromStr};
+
+    use super::{is_private_ip, is_ssrf_allowed, ssrf_check};
+    use url::Url;
+
+    #[test]
+    fn private_ip_v4_rules() {
+        for addr in [
+            "127.0.0.1",
+            "192.168.1.1",
+            "10.0.0.1",
+            "172.16.0.1",
+            "169.254.1.1",
+            "0.0.0.0",
+            "100.64.0.1",
+            "192.0.0.1",
+        ] {
+            let ip =
+                IpAddr::from_str(addr).unwrap_or_else(|error| panic!("valid test ip: {error}"));
+            assert!(is_private_ip(&ip), "{addr} should be private");
+        }
+
+        for addr in ["8.8.8.8", "1.1.1.1"] {
+            let ip =
+                IpAddr::from_str(addr).unwrap_or_else(|error| panic!("valid test ip: {error}"));
+            assert!(!is_private_ip(&ip), "{addr} should be public");
+        }
+    }
+
+    #[test]
+    fn private_ip_v6_rules() {
+        for addr in ["::1", "::", "fd00::1", "fe80::1"] {
+            let ip =
+                IpAddr::from_str(addr).unwrap_or_else(|error| panic!("valid test ip: {error}"));
+            assert!(is_private_ip(&ip), "{addr} should be private");
+        }
+
+        let public = IpAddr::from_str("2607:f8b0:4004:800::200e")
+            .unwrap_or_else(|error| panic!("valid test ip: {error}"));
+        assert!(!is_private_ip(&public));
+    }
+
+    #[test]
+    fn allowlist_cidr_match() {
+        let allowlist: Vec<ipnet::IpNet> = vec![
+            "172.22.0.0/16"
+                .parse()
+                .unwrap_or_else(|error| panic!("valid cidr: {error}")),
+        ];
+        let ip =
+            IpAddr::from_str("172.22.1.5").unwrap_or_else(|error| panic!("valid test ip: {error}"));
+        assert!(is_ssrf_allowed(&ip, &allowlist));
+    }
+
+    #[tokio::test]
+    async fn blocks_localhost_async() {
+        let url = Url::parse("http://127.0.0.1/secret")
+            .unwrap_or_else(|error| panic!("valid url: {error}"));
+        let result = ssrf_check(&url, &[]).await;
+        assert!(result.is_err());
+        assert!(
+            result
+                .err()
+                .unwrap_or_else(|| panic!("expected ssrf error"))
+                .to_string()
+                .contains("SSRF")
+        );
+    }
+}

--- a/crates/common/src/ssrf.rs
+++ b/crates/common/src/ssrf.rs
@@ -4,6 +4,17 @@ use url::Url;
 
 use crate::{Error, Result};
 
+#[must_use]
+fn is_private_ipv4(v4: &std::net::Ipv4Addr) -> bool {
+    v4.is_loopback()
+        || v4.is_private()
+        || v4.is_link_local()
+        || v4.is_broadcast()
+        || v4.is_unspecified()
+        || (v4.octets()[0] == 100 && (v4.octets()[1] & 0xC0) == 64)
+        || (v4.octets()[0] == 192 && v4.octets()[1] == 0 && v4.octets()[2] == 0)
+}
+
 /// Check if an IP is covered by an SSRF allowlist entry.
 #[must_use]
 pub fn is_ssrf_allowed(ip: &IpAddr, allowlist: &[ipnet::IpNet]) -> bool {
@@ -15,20 +26,13 @@ pub fn is_ssrf_allowed(ip: &IpAddr, allowlist: &[ipnet::IpNet]) -> bool {
 #[must_use]
 pub fn is_private_ip(ip: &IpAddr) -> bool {
     match ip {
-        IpAddr::V4(v4) => {
-            v4.is_loopback()
-                || v4.is_private()
-                || v4.is_link_local()
-                || v4.is_broadcast()
-                || v4.is_unspecified()
-                || (v4.octets()[0] == 100 && (v4.octets()[1] & 0xC0) == 64)
-                || (v4.octets()[0] == 192 && v4.octets()[1] == 0 && v4.octets()[2] == 0)
-        },
+        IpAddr::V4(v4) => is_private_ipv4(v4),
         IpAddr::V6(v6) => {
             v6.is_loopback()
                 || v6.is_unspecified()
                 || (v6.segments()[0] & 0xFE00) == 0xFC00
                 || (v6.segments()[0] & 0xFFC0) == 0xFE80
+                || v6.to_ipv4_mapped().is_some_and(|v4| is_private_ipv4(&v4))
         },
     }
 }
@@ -103,7 +107,15 @@ mod tests {
 
     #[test]
     fn private_ip_v6_rules() {
-        for addr in ["::1", "::", "fd00::1", "fe80::1"] {
+        for addr in [
+            "::1",
+            "::",
+            "fd00::1",
+            "fe80::1",
+            "::ffff:127.0.0.1",
+            "::ffff:10.0.0.1",
+            "::ffff:192.168.1.1",
+        ] {
             let ip =
                 IpAddr::from_str(addr).unwrap_or_else(|error| panic!("valid test ip: {error}"));
             assert!(is_private_ip(&ip), "{addr} should be private");
@@ -112,6 +124,10 @@ mod tests {
         let public = IpAddr::from_str("2607:f8b0:4004:800::200e")
             .unwrap_or_else(|error| panic!("valid test ip: {error}"));
         assert!(!is_private_ip(&public));
+
+        let mapped_public = IpAddr::from_str("::ffff:8.8.8.8")
+            .unwrap_or_else(|error| panic!("valid test ip: {error}"));
+        assert!(!is_private_ip(&mapped_public));
     }
 
     #[test]
@@ -129,6 +145,21 @@ mod tests {
     #[tokio::test]
     async fn blocks_localhost_async() {
         let url = Url::parse("http://127.0.0.1/secret")
+            .unwrap_or_else(|error| panic!("valid url: {error}"));
+        let result = ssrf_check(&url, &[]).await;
+        assert!(result.is_err());
+        assert!(
+            result
+                .err()
+                .unwrap_or_else(|| panic!("expected ssrf error"))
+                .to_string()
+                .contains("SSRF")
+        );
+    }
+
+    #[tokio::test]
+    async fn blocks_ipv4_mapped_localhost_async() {
+        let url = Url::parse("http://[::ffff:127.0.0.1]/secret")
             .unwrap_or_else(|error| panic!("valid url: {error}"));
         let result = ssrf_check(&url, &[]).await;
         assert!(result.is_err());

--- a/crates/common/src/ssrf.rs
+++ b/crates/common/src/ssrf.rs
@@ -72,8 +72,10 @@ pub async fn ssrf_check(url: &Url, allowlist: &[ipnet::IpNet]) -> Result<()> {
 mod tests {
     use std::{net::IpAddr, str::FromStr};
 
-    use super::{is_private_ip, is_ssrf_allowed, ssrf_check};
-    use url::Url;
+    use {
+        super::{is_private_ip, is_ssrf_allowed, ssrf_check},
+        url::Url,
+    };
 
     #[test]
     fn private_ip_v4_rules() {

--- a/crates/discord/src/handler.rs
+++ b/crates/discord/src/handler.rs
@@ -51,6 +51,18 @@ pub fn required_intents() -> GatewayIntents {
 pub struct Handler {
     pub account_id: String,
     pub accounts: AccountStateMap,
+    downloader: DiscordInboundMediaDownloader,
+}
+
+impl Handler {
+    #[must_use]
+    pub fn new(account_id: String, accounts: AccountStateMap) -> Self {
+        Self {
+            account_id,
+            accounts,
+            downloader: DiscordInboundMediaDownloader::new(),
+        }
+    }
 }
 
 fn unix_now() -> i64 {
@@ -854,14 +866,13 @@ impl EventHandler for Handler {
         // Resolve inbound media attachments (voice transcription, image
         // optimization) before further processing. This mirrors the Telegram
         // flow in `crates/telegram/src/handlers.rs`.
-        let downloader = DiscordInboundMediaDownloader::new();
         let (body, attachments, voice_audio, mut inferred_kind) =
             match resolve_discord_inbound_media(
                 &msg.attachments,
                 &text,
                 sink.as_ref(),
                 &self.account_id,
-                &downloader,
+                &self.downloader,
             )
             .await
             {

--- a/crates/discord/src/handler.rs
+++ b/crates/discord/src/handler.rs
@@ -17,19 +17,22 @@ use crate::config::{
 
 use crate::access;
 
-use moltis_channels::{
-    ChannelEvent, ChannelType, Error as ChannelError, InboundMediaDownloader, InboundMediaSource,
-    Result as ChannelsResult,
-    gating::DmPolicy,
-    message_log::MessageLogEntry,
-    otp::{
-        OtpInitResult, OtpVerifyResult, approve_sender_via_otp, emit_otp_challenge,
-        emit_otp_resolution,
+use {
+    moltis_channels::{
+        ChannelEvent, ChannelType, Error as ChannelError, InboundMediaDownloader,
+        InboundMediaSource, Result as ChannelsResult,
+        gating::DmPolicy,
+        message_log::MessageLogEntry,
+        otp::{
+            OtpInitResult, OtpVerifyResult, approve_sender_via_otp, emit_otp_challenge,
+            emit_otp_resolution,
+        },
+        plugin::{
+            ChannelAttachment, ChannelEventSink, ChannelMessageKind, ChannelMessageMeta,
+            ChannelReplyTarget,
+        },
     },
-    plugin::{
-        ChannelAttachment, ChannelEventSink, ChannelMessageKind, ChannelMessageMeta,
-        ChannelReplyTarget,
-    },
+    moltis_common::{http_client::build_default_http_client, ssrf::ssrf_check},
 };
 
 use crate::state::AccountStateMap;
@@ -204,8 +207,18 @@ enum MediaResolveOutcome {
     VoiceSttUnavailable,
 }
 
-#[derive(Debug, Default)]
-struct DiscordInboundMediaDownloader;
+#[derive(Debug, Clone)]
+struct DiscordInboundMediaDownloader {
+    client: reqwest::Client,
+}
+
+impl DiscordInboundMediaDownloader {
+    fn new() -> Self {
+        Self {
+            client: build_default_http_client(),
+        }
+    }
+}
 
 /// Returns true if the attachment looks like an audio/voice file.
 fn attachment_is_audio(a: &Attachment) -> bool {
@@ -300,8 +313,21 @@ fn image_media_type_fallback(content_type: Option<&str>, filename: &str) -> Stri
 }
 
 /// Download a Discord CDN attachment, enforcing a size cap.
-async fn download_discord_attachment(url: &str, max_bytes: usize) -> ChannelsResult<Vec<u8>> {
-    let response = reqwest::get(url)
+async fn download_discord_attachment(
+    client: &reqwest::Client,
+    url: &str,
+    max_bytes: usize,
+) -> ChannelsResult<Vec<u8>> {
+    let parsed_url = reqwest::Url::parse(url).map_err(|error| {
+        ChannelError::invalid_input(format!("invalid discord attachment URL: {error}"))
+    })?;
+    ssrf_check(&parsed_url, &[])
+        .await
+        .map_err(|error| ChannelError::external("discord attachment ssrf check", error))?;
+
+    let response = client
+        .get(parsed_url)
+        .send()
         .await
         .map_err(|e| ChannelError::external("discord attachment request", e))?;
     if !response.status().is_success() {
@@ -339,12 +365,46 @@ impl InboundMediaDownloader for DiscordInboundMediaDownloader {
     ) -> ChannelsResult<Vec<u8>> {
         match source {
             InboundMediaSource::RemoteUrl { url } => {
-                download_discord_attachment(url, max_bytes).await
+                download_discord_attachment(&self.client, url, max_bytes).await
             },
             _ => Err(ChannelError::invalid_input(
                 "discord downloader received unsupported media source",
             )),
         }
+    }
+}
+
+async fn log_discord_message(
+    message_log: Option<&std::sync::Arc<dyn moltis_channels::message_log::MessageLog>>,
+    account_id: &str,
+    peer_id: &str,
+    username: &Option<String>,
+    sender_name: &Option<String>,
+    chat_id: &str,
+    is_guild: bool,
+    body: &str,
+    access_granted: bool,
+) {
+    if let Some(log) = message_log {
+        let _ = log
+            .log(MessageLogEntry {
+                id: 0,
+                account_id: account_id.to_string(),
+                channel_type: "discord".into(),
+                peer_id: peer_id.to_string(),
+                username: username.clone(),
+                sender_name: sender_name.clone(),
+                chat_id: chat_id.to_string(),
+                chat_type: if is_guild {
+                    "group".into()
+                } else {
+                    "private".into()
+                },
+                body: body.to_string(),
+                access_granted,
+                created_at: unix_now(),
+            })
+            .await;
     }
 }
 
@@ -667,29 +727,6 @@ impl EventHandler for Handler {
         .is_ok();
         let access_granted = policy_allowed;
 
-        // Log the message.
-        if let Some(log) = message_log {
-            let _ = log
-                .log(MessageLogEntry {
-                    id: 0,
-                    account_id: self.account_id.clone(),
-                    channel_type: "discord".into(),
-                    peer_id: peer_id.clone(),
-                    username: username.clone(),
-                    sender_name: sender_name.clone(),
-                    chat_id: chat_id.clone(),
-                    chat_type: if is_guild {
-                        "group".into()
-                    } else {
-                        "private".into()
-                    },
-                    body: text.clone(),
-                    access_granted,
-                    created_at: unix_now(),
-                })
-                .await;
-        }
-
         // Emit inbound message event.
         if let Some(sink) = event_sink.as_ref() {
             sink.emit(ChannelEvent::InboundMessage {
@@ -705,6 +742,19 @@ impl EventHandler for Handler {
         }
 
         if !access_granted {
+            log_discord_message(
+                message_log.as_ref(),
+                &self.account_id,
+                &peer_id,
+                &username,
+                &sender_name,
+                &chat_id,
+                is_guild,
+                &text,
+                access_granted,
+            )
+            .await;
+
             // OTP self-approval for non-allowlisted DM users.
             if !is_guild
                 && !policy_allowed
@@ -757,6 +807,19 @@ impl EventHandler for Handler {
 
         // Handle slash commands.
         if let Some(command) = text.strip_prefix('/') {
+            log_discord_message(
+                message_log.as_ref(),
+                &self.account_id,
+                &peer_id,
+                &username,
+                &sender_name,
+                &chat_id,
+                is_guild,
+                &text,
+                access_granted,
+            )
+            .await;
+
             let response_text = match sink
                 .dispatch_command(command.trim(), reply_to.clone())
                 .await
@@ -783,7 +846,7 @@ impl EventHandler for Handler {
         // Resolve inbound media attachments (voice transcription, image
         // optimization) before further processing. This mirrors the Telegram
         // flow in `crates/telegram/src/handlers.rs`.
-        let downloader = DiscordInboundMediaDownloader;
+        let downloader = DiscordInboundMediaDownloader::new();
         let (body, attachments, voice_audio, mut inferred_kind) =
             match resolve_discord_inbound_media(
                 &msg.attachments,
@@ -817,6 +880,19 @@ impl EventHandler for Handler {
                     return;
                 },
             };
+
+        log_discord_message(
+            message_log.as_ref(),
+            &self.account_id,
+            &peer_id,
+            &username,
+            &sender_name,
+            &chat_id,
+            is_guild,
+            &body,
+            access_granted,
+        )
+        .await;
 
         if let Some((latitude, longitude)) = extract_location_coordinates(&body) {
             let resolved = sink

--- a/crates/discord/src/handler.rs
+++ b/crates/discord/src/handler.rs
@@ -1,8 +1,8 @@
 use {
     serenity::{
         all::{
-            Context, CreateMessage, EventHandler, GatewayIntents, Interaction, Message, MessageId,
-            ReactionType, Ready,
+            Attachment, Context, CreateMessage, EventHandler, GatewayIntents, Interaction, Message,
+            MessageId, ReactionType, Ready,
         },
         async_trait,
         gateway::ActivityData,
@@ -18,14 +18,18 @@ use crate::config::{
 use crate::access;
 
 use moltis_channels::{
-    ChannelEvent, ChannelType,
+    ChannelEvent, ChannelType, Error as ChannelError, InboundMediaDownloader, InboundMediaSource,
+    Result as ChannelsResult,
     gating::DmPolicy,
     message_log::MessageLogEntry,
     otp::{
         OtpInitResult, OtpVerifyResult, approve_sender_via_otp, emit_otp_challenge,
         emit_otp_resolution,
     },
-    plugin::{ChannelEventSink, ChannelMessageKind, ChannelMessageMeta, ChannelReplyTarget},
+    plugin::{
+        ChannelAttachment, ChannelEventSink, ChannelMessageKind, ChannelMessageMeta,
+        ChannelReplyTarget,
+    },
 };
 
 use crate::state::AccountStateMap;
@@ -172,6 +176,356 @@ fn extract_location_coordinates(text: &str) -> Option<(f64, f64)> {
     parse_map_link_coordinates(text).or_else(|| parse_plain_text_coordinates(text))
 }
 
+/// Maximum byte size for inbound Discord attachments we download. Matches the
+/// 25 MiB free-tier upload limit; anything larger is either a Discord Nitro
+/// upload we don't want to spend bandwidth on or a misbehaving client.
+const MAX_ATTACHMENT_BYTES: usize = 25 * 1024 * 1024;
+
+/// Resolved inbound media from a Discord message: the body text the LLM sees,
+/// any multimodal attachments, and — if voice — the raw audio bytes so the
+/// gateway can persist them to the session media directory.
+#[derive(Debug)]
+struct InboundMedia {
+    body: String,
+    attachments: Vec<ChannelAttachment>,
+    voice_audio: Option<(Vec<u8>, String)>,
+    kind: ChannelMessageKind,
+}
+
+/// Outcome of attempting to handle inbound Discord attachments.
+#[derive(Debug)]
+enum MediaResolveOutcome {
+    /// No audio or image attachment present; caller should dispatch text only.
+    NoMedia,
+    /// Media was handled (successfully or with a recoverable error-fallback body).
+    Media(InboundMedia),
+    /// A voice attachment was present but STT is not configured. Caller should
+    /// send the user-facing hint and stop.
+    VoiceSttUnavailable,
+}
+
+#[derive(Debug, Default)]
+struct DiscordInboundMediaDownloader;
+
+/// Returns true if the attachment looks like an audio/voice file.
+fn attachment_is_audio(a: &Attachment) -> bool {
+    if a.content_type
+        .as_deref()
+        .is_some_and(|ct| ct.starts_with("audio/"))
+    {
+        return true;
+    }
+    let name = a.filename.to_ascii_lowercase();
+    [".ogg", ".opus", ".mp3", ".wav", ".m4a", ".webm"]
+        .iter()
+        .any(|ext| name.ends_with(ext))
+}
+
+/// Returns true if the attachment looks like a still image.
+fn attachment_is_image(a: &Attachment) -> bool {
+    if a.content_type
+        .as_deref()
+        .is_some_and(|ct| ct.starts_with("image/"))
+    {
+        return true;
+    }
+    let name = a.filename.to_ascii_lowercase();
+    [".png", ".jpg", ".jpeg", ".gif", ".webp"]
+        .iter()
+        .any(|ext| name.ends_with(ext))
+}
+
+/// Pick the first handleable attachment. Audio wins over image when both are
+/// present, matching Telegram's voice-first ordering.
+fn select_media_attachment(attachments: &[Attachment]) -> Option<&Attachment> {
+    if let Some(a) = attachments.iter().find(|a| attachment_is_audio(a)) {
+        return Some(a);
+    }
+    attachments.iter().find(|a| attachment_is_image(a))
+}
+
+/// Normalize an audio attachment to a short format string the STT provider
+/// understands (`ogg`, `mp3`, `wav`, `m4a`, `webm`).
+fn audio_format_from_attachment(content_type: Option<&str>, filename: &str) -> String {
+    if let Some(ct) = content_type
+        && let Some(rest) = ct.strip_prefix("audio/")
+    {
+        let first = rest.split(';').next().unwrap_or(rest).trim();
+        let first = first.strip_prefix("x-").unwrap_or(first);
+        return match first {
+            "mpeg" | "mp3" => "mp3".to_string(),
+            "mp4" | "m4a" => "m4a".to_string(),
+            "wav" | "wave" => "wav".to_string(),
+            "webm" => "webm".to_string(),
+            "ogg" | "opus" | "vorbis" => "ogg".to_string(),
+            other if !other.is_empty() => other.to_string(),
+            _ => "ogg".to_string(),
+        };
+    }
+    let lower = filename.to_ascii_lowercase();
+    for (ext, fmt) in [
+        (".mp3", "mp3"),
+        (".m4a", "m4a"),
+        (".wav", "wav"),
+        (".webm", "webm"),
+        (".opus", "ogg"),
+        (".ogg", "ogg"),
+    ] {
+        if lower.ends_with(ext) {
+            return fmt.to_string();
+        }
+    }
+    // Discord voice messages are OGG Opus; safe default.
+    "ogg".to_string()
+}
+
+/// Normalize an image attachment to a MIME media type. Used as a fallback when
+/// `optimize_for_llm` fails and we must send the original bytes anyway.
+fn image_media_type_fallback(content_type: Option<&str>, filename: &str) -> String {
+    if let Some(ct) = content_type
+        && ct.starts_with("image/")
+    {
+        return ct.split(';').next().unwrap_or(ct).trim().to_string();
+    }
+    let lower = filename.to_ascii_lowercase();
+    if lower.ends_with(".png") {
+        "image/png".to_string()
+    } else if lower.ends_with(".gif") {
+        "image/gif".to_string()
+    } else if lower.ends_with(".webp") {
+        "image/webp".to_string()
+    } else {
+        "image/jpeg".to_string()
+    }
+}
+
+/// Download a Discord CDN attachment, enforcing a size cap.
+async fn download_discord_attachment(url: &str, max_bytes: usize) -> ChannelsResult<Vec<u8>> {
+    let response = reqwest::get(url)
+        .await
+        .map_err(|e| ChannelError::external("discord attachment request", e))?;
+    if !response.status().is_success() {
+        return Err(ChannelError::unavailable(format!(
+            "discord attachment request returned HTTP {}",
+            response.status()
+        )));
+    }
+    if let Some(len) = response.content_length()
+        && len as usize > max_bytes
+    {
+        return Err(ChannelError::unavailable(format!(
+            "attachment too large: {len} bytes (cap {max_bytes})"
+        )));
+    }
+    let bytes = response
+        .bytes()
+        .await
+        .map_err(|e| ChannelError::external("discord attachment read body", e))?;
+    if bytes.len() > max_bytes {
+        return Err(ChannelError::unavailable(format!(
+            "attachment too large: {} bytes (cap {max_bytes})",
+            bytes.len()
+        )));
+    }
+    Ok(bytes.to_vec())
+}
+
+#[async_trait]
+impl InboundMediaDownloader for DiscordInboundMediaDownloader {
+    async fn download_media(
+        &self,
+        source: &InboundMediaSource,
+        max_bytes: usize,
+    ) -> ChannelsResult<Vec<u8>> {
+        match source {
+            InboundMediaSource::RemoteUrl { url } => {
+                download_discord_attachment(url, max_bytes).await
+            },
+            _ => Err(ChannelError::invalid_input(
+                "discord downloader received unsupported media source",
+            )),
+        }
+    }
+}
+
+/// Resolve inbound media attachments on a Discord message into a body +
+/// multimodal attachment list the gateway can dispatch.
+async fn resolve_discord_inbound_media(
+    attachments: &[Attachment],
+    caption: &str,
+    sink: &dyn ChannelEventSink,
+    account_id: &str,
+    downloader: &dyn InboundMediaDownloader,
+) -> MediaResolveOutcome {
+    let Some(media) = select_media_attachment(attachments) else {
+        return MediaResolveOutcome::NoMedia;
+    };
+
+    if attachment_is_audio(media) {
+        if !sink.voice_stt_available().await {
+            return MediaResolveOutcome::VoiceSttUnavailable;
+        }
+
+        let format = audio_format_from_attachment(media.content_type.as_deref(), &media.filename);
+        let source = InboundMediaSource::RemoteUrl {
+            url: media.url.clone(),
+        };
+        match downloader
+            .download_media(&source, MAX_ATTACHMENT_BYTES)
+            .await
+        {
+            Ok(audio_data) => {
+                debug!(
+                    account_id,
+                    attachment_id = %media.id,
+                    format,
+                    size = audio_data.len(),
+                    "downloaded discord voice attachment, transcribing"
+                );
+                let saved_audio = Some((audio_data.clone(), format.clone()));
+                match sink.transcribe_voice(&audio_data, &format).await {
+                    Ok(transcribed) if transcribed.trim().is_empty() => {
+                        warn!(
+                            account_id,
+                            audio_size = audio_data.len(),
+                            "discord voice transcription returned empty text"
+                        );
+                        MediaResolveOutcome::Media(InboundMedia {
+                            body: "[Voice message - could not transcribe]".to_string(),
+                            attachments: Vec::new(),
+                            voice_audio: saved_audio,
+                            kind: ChannelMessageKind::Voice,
+                        })
+                    },
+                    Ok(transcribed) => {
+                        debug!(
+                            account_id,
+                            text_len = transcribed.len(),
+                            "discord voice transcription successful"
+                        );
+                        let body = if caption.is_empty() {
+                            transcribed
+                        } else {
+                            format!("{caption}\n\n[Voice message]: {transcribed}")
+                        };
+                        MediaResolveOutcome::Media(InboundMedia {
+                            body,
+                            attachments: Vec::new(),
+                            voice_audio: saved_audio,
+                            kind: ChannelMessageKind::Voice,
+                        })
+                    },
+                    Err(e) => {
+                        warn!(account_id, error = %e, "discord voice transcription failed");
+                        let body = if caption.is_empty() {
+                            "[Voice message - transcription unavailable]".to_string()
+                        } else {
+                            caption.to_string()
+                        };
+                        MediaResolveOutcome::Media(InboundMedia {
+                            body,
+                            attachments: Vec::new(),
+                            voice_audio: saved_audio,
+                            kind: ChannelMessageKind::Voice,
+                        })
+                    },
+                }
+            },
+            Err(e) => {
+                warn!(account_id, error = %e, "failed to download discord voice attachment");
+                let body = if caption.is_empty() {
+                    "[Voice message - download failed]".to_string()
+                } else {
+                    caption.to_string()
+                };
+                MediaResolveOutcome::Media(InboundMedia {
+                    body,
+                    attachments: Vec::new(),
+                    voice_audio: None,
+                    kind: ChannelMessageKind::Voice,
+                })
+            },
+        }
+    } else {
+        let source = InboundMediaSource::RemoteUrl {
+            url: media.url.clone(),
+        };
+        match downloader
+            .download_media(&source, MAX_ATTACHMENT_BYTES)
+            .await
+        {
+            Ok(image_data) => {
+                debug!(
+                    account_id,
+                    attachment_id = %media.id,
+                    size = image_data.len(),
+                    "downloaded discord image attachment"
+                );
+                let (final_data, media_type) =
+                    match moltis_media::image_ops::optimize_for_llm(&image_data, None) {
+                        Ok(optimized) => {
+                            if optimized.was_resized {
+                                info!(
+                                    account_id,
+                                    original_size = image_data.len(),
+                                    final_size = optimized.data.len(),
+                                    original_dims = %format!(
+                                        "{}x{}",
+                                        optimized.original_width, optimized.original_height
+                                    ),
+                                    final_dims = %format!(
+                                        "{}x{}",
+                                        optimized.final_width, optimized.final_height
+                                    ),
+                                    "resized discord image for LLM"
+                                );
+                            }
+                            (optimized.data, optimized.media_type)
+                        },
+                        Err(e) => {
+                            warn!(
+                                account_id,
+                                error = %e,
+                                "failed to optimize discord image, using original"
+                            );
+                            (
+                                image_data,
+                                image_media_type_fallback(
+                                    media.content_type.as_deref(),
+                                    &media.filename,
+                                ),
+                            )
+                        },
+                    };
+                let attachment = ChannelAttachment {
+                    media_type,
+                    data: final_data,
+                };
+                MediaResolveOutcome::Media(InboundMedia {
+                    body: caption.to_string(),
+                    attachments: vec![attachment],
+                    voice_audio: None,
+                    kind: ChannelMessageKind::Photo,
+                })
+            },
+            Err(e) => {
+                warn!(account_id, error = %e, "failed to download discord image attachment");
+                let body = if caption.is_empty() {
+                    "[Photo - download failed]".to_string()
+                } else {
+                    caption.to_string()
+                };
+                MediaResolveOutcome::Media(InboundMedia {
+                    body,
+                    attachments: Vec::new(),
+                    voice_audio: None,
+                    kind: ChannelMessageKind::Photo,
+                })
+            },
+        }
+    }
+}
+
 /// Strip the bot mention (e.g. `<@123456789>`) from the beginning of a message.
 pub fn strip_bot_mention(text: &str, bot_id: u64) -> String {
     let mention = format!("<@{bot_id}>");
@@ -261,7 +615,9 @@ impl EventHandler for Handler {
             msg.content.clone()
         };
 
-        if text.is_empty() {
+        // Drop truly empty messages (no text and no attachments). Messages with
+        // attachments but no caption still need processing (e.g. voice notes).
+        if text.is_empty() && msg.attachments.is_empty() {
             return;
         }
 
@@ -424,8 +780,45 @@ impl EventHandler for Handler {
             return;
         }
 
-        let mut inferred_kind = ChannelMessageKind::Text;
-        if let Some((latitude, longitude)) = extract_location_coordinates(&text) {
+        // Resolve inbound media attachments (voice transcription, image
+        // optimization) before further processing. This mirrors the Telegram
+        // flow in `crates/telegram/src/handlers.rs`.
+        let downloader = DiscordInboundMediaDownloader;
+        let (body, attachments, voice_audio, mut inferred_kind) =
+            match resolve_discord_inbound_media(
+                &msg.attachments,
+                &text,
+                sink.as_ref(),
+                &self.account_id,
+                &downloader,
+            )
+            .await
+            {
+                MediaResolveOutcome::NoMedia => {
+                    (text.clone(), Vec::new(), None, ChannelMessageKind::Text)
+                },
+                MediaResolveOutcome::Media(media) => {
+                    (media.body, media.attachments, media.voice_audio, media.kind)
+                },
+                MediaResolveOutcome::VoiceSttUnavailable => {
+                    if let Err(e) = send_discord_text_simple(
+                        &ctx,
+                        msg.channel_id,
+                        "I can't understand voice, you did not configure it, please visit Settings -> Voice",
+                    )
+                    .await
+                    {
+                        warn!(
+                            account_id = %self.account_id,
+                            chat_id,
+                            "failed to send STT setup hint: {e}"
+                        );
+                    }
+                    return;
+                },
+            };
+
+        if let Some((latitude, longitude)) = extract_location_coordinates(&body) {
             let resolved = sink
                 .resolve_pending_location(&reply_to, latitude, longitude)
                 .await;
@@ -452,12 +845,23 @@ impl EventHandler for Handler {
             inferred_kind = ChannelMessageKind::Location;
         }
 
+        // Save voice audio to the session media directory (best-effort).
+        let audio_filename = if let Some((ref audio_data, ref format)) = voice_audio {
+            let filename = format!("voice-discord-{}.{format}", msg.id.get());
+            sink.save_channel_voice(audio_data, &filename, &reply_to)
+                .await
+        } else {
+            None
+        };
+
         // Dispatch to chat.
         info!(
             account_id = %self.account_id,
             chat_id,
             peer_id,
-            text_len = text.len(),
+            body_len = body.len(),
+            attachment_count = attachments.len(),
+            ?inferred_kind,
             "discord dispatching to chat"
         );
 
@@ -468,15 +872,21 @@ impl EventHandler for Handler {
         )
         .increment(1);
 
-        sink.dispatch_to_chat(&text, reply_to, ChannelMessageMeta {
+        let meta = ChannelMessageMeta {
             channel_type: ChannelType::Discord,
             sender_name,
             username,
             message_kind: Some(inferred_kind),
             model: config.model.clone(),
-            audio_filename: None,
-        })
-        .await;
+            audio_filename,
+        };
+
+        if attachments.is_empty() {
+            sink.dispatch_to_chat(&body, reply_to, meta).await;
+        } else {
+            sink.dispatch_to_chat_with_attachments(&body, attachments, reply_to, meta)
+                .await;
+        }
     }
 
     async fn ready(&self, ctx: Context, ready: Ready) {
@@ -1077,5 +1487,397 @@ mod tests {
         // Example snowflake from Discord docs / Serenity tests.
         let id = MessageId::new(175_928_847_299_117_063);
         assert_eq!(discord_message_created_ms(id), 1_462_015_105_796);
+    }
+
+    // ── Inbound media attachment tests ───────────────────────────────
+
+    fn make_attachment(content_type: Option<&str>, filename: &str) -> Attachment {
+        let content_type_json = match content_type {
+            Some(ct) => format!("\"{ct}\""),
+            None => "null".to_string(),
+        };
+        let json = format!(
+            r#"{{
+                "id": "1",
+                "filename": "{filename}",
+                "size": 1024,
+                "url": "https://cdn.discordapp.com/attachments/1/2/{filename}",
+                "proxy_url": "https://media.discordapp.net/attachments/1/2/{filename}",
+                "content_type": {content_type_json}
+            }}"#
+        );
+        match serde_json::from_str(&json) {
+            Ok(attachment) => attachment,
+            Err(error) => panic!("attachment json should deserialize: {error}"),
+        }
+    }
+
+    #[test]
+    fn audio_format_maps_common_mime_types() {
+        assert_eq!(
+            audio_format_from_attachment(Some("audio/ogg"), "x.ogg"),
+            "ogg"
+        );
+        assert_eq!(
+            audio_format_from_attachment(Some("audio/ogg; codecs=opus"), "voice.ogg"),
+            "ogg"
+        );
+        assert_eq!(
+            audio_format_from_attachment(Some("audio/mpeg"), "x.mp3"),
+            "mp3"
+        );
+        assert_eq!(
+            audio_format_from_attachment(Some("audio/mp3"), "x.mp3"),
+            "mp3"
+        );
+        assert_eq!(
+            audio_format_from_attachment(Some("audio/mp4"), "x.m4a"),
+            "m4a"
+        );
+        assert_eq!(
+            audio_format_from_attachment(Some("audio/x-m4a"), "x.m4a"),
+            "m4a"
+        );
+        assert_eq!(
+            audio_format_from_attachment(Some("audio/wav"), "x.wav"),
+            "wav"
+        );
+        assert_eq!(
+            audio_format_from_attachment(Some("audio/webm"), "x.webm"),
+            "webm"
+        );
+    }
+
+    #[test]
+    fn audio_format_falls_back_to_extension() {
+        assert_eq!(audio_format_from_attachment(None, "note.mp3"), "mp3");
+        assert_eq!(audio_format_from_attachment(None, "note.Ogg"), "ogg");
+        assert_eq!(audio_format_from_attachment(None, "note.opus"), "ogg");
+        assert_eq!(audio_format_from_attachment(None, "note.webm"), "webm");
+        // Unknown: default to ogg (Discord voice messages are OGG Opus).
+        assert_eq!(audio_format_from_attachment(None, "mystery.bin"), "ogg");
+    }
+
+    #[test]
+    fn image_media_type_fallback_picks_extension() {
+        assert_eq!(
+            image_media_type_fallback(Some("image/png; charset=binary"), "x.png"),
+            "image/png"
+        );
+        assert_eq!(
+            image_media_type_fallback(None, "screenshot.PNG"),
+            "image/png"
+        );
+        assert_eq!(image_media_type_fallback(None, "pic.gif"), "image/gif");
+        assert_eq!(image_media_type_fallback(None, "pic.webp"), "image/webp");
+        // Unknown: default to jpeg.
+        assert_eq!(image_media_type_fallback(None, "pic.bin"), "image/jpeg");
+    }
+
+    #[test]
+    fn attachment_is_audio_detects_mime_and_extension() {
+        assert!(attachment_is_audio(&make_attachment(
+            Some("audio/ogg"),
+            "v.ogg"
+        )));
+        assert!(attachment_is_audio(&make_attachment(None, "v.opus")));
+        assert!(attachment_is_audio(&make_attachment(None, "clip.MP3")));
+        assert!(!attachment_is_audio(&make_attachment(
+            Some("image/png"),
+            "x.png"
+        )));
+        assert!(!attachment_is_audio(&make_attachment(None, "notes.txt")));
+    }
+
+    #[test]
+    fn attachment_is_image_detects_mime_and_extension() {
+        assert!(attachment_is_image(&make_attachment(
+            Some("image/jpeg"),
+            "x.jpg"
+        )));
+        assert!(attachment_is_image(&make_attachment(None, "x.PNG")));
+        assert!(attachment_is_image(&make_attachment(None, "x.webp")));
+        assert!(!attachment_is_image(&make_attachment(
+            Some("audio/ogg"),
+            "v.ogg"
+        )));
+        assert!(!attachment_is_image(&make_attachment(None, "doc.pdf")));
+    }
+
+    #[test]
+    fn select_media_prefers_audio_over_image() {
+        let image = make_attachment(Some("image/png"), "a.png");
+        let audio = make_attachment(Some("audio/ogg"), "b.ogg");
+        let attachments = vec![image, audio];
+        let picked = match select_media_attachment(&attachments) {
+            Some(attachment) => attachment,
+            None => panic!("expected audio attachment to be selected"),
+        };
+        assert_eq!(picked.filename, "b.ogg");
+    }
+
+    #[test]
+    fn select_media_returns_none_for_unsupported() {
+        let doc = make_attachment(Some("application/pdf"), "spec.pdf");
+        assert!(select_media_attachment(&[doc]).is_none());
+        assert!(select_media_attachment(&[]).is_none());
+    }
+
+    #[test]
+    fn select_media_picks_image_when_no_audio() {
+        let doc = make_attachment(Some("application/pdf"), "spec.pdf");
+        let image = make_attachment(Some("image/jpeg"), "pic.jpg");
+        let attachments = [doc, image];
+        let picked = match select_media_attachment(&attachments) {
+            Some(attachment) => attachment,
+            None => panic!("expected image attachment to be selected"),
+        };
+        assert_eq!(picked.filename, "pic.jpg");
+    }
+
+    // ── resolve_discord_inbound_media via mock sink ──────────────────
+    //
+    // These tests exercise the branching logic without hitting the network.
+    // We use a minimal sink mock that only implements the required trait
+    // methods; everything else falls through to trait defaults.
+
+    use {
+        image::{DynamicImage, ImageBuffer, ImageFormat, Rgb},
+        std::io::Cursor,
+    };
+
+    use moltis_channels::Result as ChannelsResult;
+
+    enum MockTranscription {
+        Success(String),
+        Failure(String),
+    }
+
+    enum MockDownload {
+        Success(Vec<u8>),
+        Failure(String),
+    }
+
+    struct MockDownloader {
+        outcome: MockDownload,
+    }
+
+    #[async_trait]
+    impl InboundMediaDownloader for MockDownloader {
+        async fn download_media(
+            &self,
+            _source: &InboundMediaSource,
+            _max_bytes: usize,
+        ) -> ChannelsResult<Vec<u8>> {
+            match &self.outcome {
+                MockDownload::Success(bytes) => Ok(bytes.clone()),
+                MockDownload::Failure(message) => Err(ChannelError::unavailable(message)),
+            }
+        }
+    }
+
+    struct MockSink {
+        stt_available: bool,
+        transcription: MockTranscription,
+    }
+
+    #[async_trait]
+    impl ChannelEventSink for MockSink {
+        async fn emit(&self, _event: ChannelEvent) {}
+
+        async fn dispatch_to_chat(
+            &self,
+            _text: &str,
+            _reply_to: ChannelReplyTarget,
+            _meta: ChannelMessageMeta,
+        ) {
+        }
+
+        async fn dispatch_command(
+            &self,
+            _command: &str,
+            _reply_to: ChannelReplyTarget,
+        ) -> ChannelsResult<String> {
+            Ok(String::new())
+        }
+
+        async fn transcribe_voice(
+            &self,
+            _audio_data: &[u8],
+            _format: &str,
+        ) -> ChannelsResult<String> {
+            match &self.transcription {
+                MockTranscription::Success(text) => Ok(text.clone()),
+                MockTranscription::Failure(message) => Err(ChannelError::unavailable(message)),
+            }
+        }
+
+        async fn request_disable_account(
+            &self,
+            _channel_type: &str,
+            _account_id: &str,
+            _reason: &str,
+        ) {
+        }
+
+        async fn voice_stt_available(&self) -> bool {
+            self.stt_available
+        }
+    }
+
+    #[tokio::test]
+    async fn resolve_returns_no_media_when_attachments_empty() {
+        let sink = MockSink {
+            stt_available: true,
+            transcription: MockTranscription::Success(String::new()),
+        };
+        let downloader = MockDownloader {
+            outcome: MockDownload::Success(Vec::new()),
+        };
+        let outcome = resolve_discord_inbound_media(&[], "hello", &sink, "acct", &downloader).await;
+        assert!(matches!(outcome, MediaResolveOutcome::NoMedia));
+    }
+
+    #[tokio::test]
+    async fn resolve_returns_no_media_when_only_unsupported() {
+        let sink = MockSink {
+            stt_available: true,
+            transcription: MockTranscription::Success(String::new()),
+        };
+        let downloader = MockDownloader {
+            outcome: MockDownload::Success(Vec::new()),
+        };
+        let doc = make_attachment(Some("application/pdf"), "spec.pdf");
+        let outcome = resolve_discord_inbound_media(&[doc], "", &sink, "acct", &downloader).await;
+        assert!(matches!(outcome, MediaResolveOutcome::NoMedia));
+    }
+
+    #[tokio::test]
+    async fn resolve_voice_without_stt_returns_unavailable() {
+        let sink = MockSink {
+            stt_available: false,
+            transcription: MockTranscription::Success(String::new()),
+        };
+        let downloader = MockDownloader {
+            outcome: MockDownload::Success(Vec::new()),
+        };
+        let voice = make_attachment(Some("audio/ogg"), "v.ogg");
+        let outcome = resolve_discord_inbound_media(&[voice], "", &sink, "acct", &downloader).await;
+        assert!(matches!(outcome, MediaResolveOutcome::VoiceSttUnavailable));
+    }
+
+    fn tiny_jpeg() -> Vec<u8> {
+        let image = ImageBuffer::from_pixel(1, 1, Rgb([255, 0, 0]));
+        let mut cursor = Cursor::new(Vec::new());
+        let write_result = DynamicImage::ImageRgb8(image).write_to(&mut cursor, ImageFormat::Jpeg);
+        match write_result {
+            Ok(()) => cursor.into_inner(),
+            Err(error) => panic!("tiny jpeg generation should succeed: {error}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn resolve_voice_success_combines_caption_and_transcript() {
+        let sink = MockSink {
+            stt_available: true,
+            transcription: MockTranscription::Success("transcribed discord voice".to_string()),
+        };
+        let downloader = MockDownloader {
+            outcome: MockDownload::Success(b"voice-bytes".to_vec()),
+        };
+        let voice = make_attachment(Some("audio/ogg"), "v.ogg");
+
+        let outcome =
+            resolve_discord_inbound_media(&[voice], "caption", &sink, "acct", &downloader).await;
+
+        let media = match outcome {
+            MediaResolveOutcome::Media(media) => media,
+            _ => panic!("expected voice media outcome"),
+        };
+        assert_eq!(
+            media.body,
+            "caption\n\n[Voice message]: transcribed discord voice"
+        );
+        assert!(media.attachments.is_empty());
+        assert!(matches!(media.kind, ChannelMessageKind::Voice));
+        let (voice_audio, format) = match media.voice_audio {
+            Some(audio) => audio,
+            None => panic!("expected saved voice audio"),
+        };
+        assert_eq!(voice_audio, b"voice-bytes".to_vec());
+        assert_eq!(format, "ogg");
+    }
+
+    #[tokio::test]
+    async fn resolve_voice_download_failure_falls_back_to_marker() {
+        let sink = MockSink {
+            stt_available: true,
+            transcription: MockTranscription::Success(String::new()),
+        };
+        let downloader = MockDownloader {
+            outcome: MockDownload::Failure("boom".to_string()),
+        };
+        let voice = make_attachment(Some("audio/ogg"), "v.ogg");
+
+        let outcome = resolve_discord_inbound_media(&[voice], "", &sink, "acct", &downloader).await;
+
+        let media = match outcome {
+            MediaResolveOutcome::Media(media) => media,
+            _ => panic!("expected voice media fallback outcome"),
+        };
+        assert_eq!(media.body, "[Voice message - download failed]");
+        assert!(media.attachments.is_empty());
+        assert!(media.voice_audio.is_none());
+        assert!(matches!(media.kind, ChannelMessageKind::Voice));
+    }
+
+    #[tokio::test]
+    async fn resolve_voice_transcription_failure_falls_back_to_caption() {
+        let sink = MockSink {
+            stt_available: true,
+            transcription: MockTranscription::Failure("stt offline".to_string()),
+        };
+        let downloader = MockDownloader {
+            outcome: MockDownload::Success(b"voice-bytes".to_vec()),
+        };
+        let voice = make_attachment(Some("audio/ogg"), "v.ogg");
+
+        let outcome =
+            resolve_discord_inbound_media(&[voice], "caption", &sink, "acct", &downloader).await;
+
+        let media = match outcome {
+            MediaResolveOutcome::Media(media) => media,
+            _ => panic!("expected voice media fallback outcome"),
+        };
+        assert_eq!(media.body, "caption");
+        assert!(media.attachments.is_empty());
+        assert!(matches!(media.kind, ChannelMessageKind::Voice));
+        assert!(media.voice_audio.is_some());
+    }
+
+    #[tokio::test]
+    async fn resolve_image_success_builds_multimodal_attachment() {
+        let sink = MockSink {
+            stt_available: true,
+            transcription: MockTranscription::Success(String::new()),
+        };
+        let downloader = MockDownloader {
+            outcome: MockDownload::Success(tiny_jpeg()),
+        };
+        let image = make_attachment(Some("image/jpeg"), "pic.jpg");
+
+        let outcome =
+            resolve_discord_inbound_media(&[image], "diagram", &sink, "acct", &downloader).await;
+
+        let media = match outcome {
+            MediaResolveOutcome::Media(media) => media,
+            _ => panic!("expected image media outcome"),
+        };
+        assert_eq!(media.body, "diagram");
+        assert_eq!(media.attachments.len(), 1);
+        assert!(matches!(media.kind, ChannelMessageKind::Photo));
+        assert!(media.voice_audio.is_none());
+        assert_eq!(media.attachments[0].media_type, "image/jpeg");
+        assert!(!media.attachments[0].data.is_empty());
     }
 }

--- a/crates/discord/src/handler.rs
+++ b/crates/discord/src/handler.rs
@@ -312,6 +312,14 @@ fn image_media_type_fallback(content_type: Option<&str>, filename: &str) -> Stri
     }
 }
 
+fn voice_stt_unavailable_log_body(caption: &str) -> String {
+    if caption.is_empty() {
+        "[Voice message - STT unavailable]".to_string()
+    } else {
+        format!("{caption}\n\n[Voice message - STT unavailable]")
+    }
+}
+
 /// Download a Discord CDN attachment, enforcing a size cap.
 async fn download_discord_attachment(
     client: &reqwest::Client,
@@ -864,6 +872,19 @@ impl EventHandler for Handler {
                     (media.body, media.attachments, media.voice_audio, media.kind)
                 },
                 MediaResolveOutcome::VoiceSttUnavailable => {
+                    let body = voice_stt_unavailable_log_body(&text);
+                    log_discord_message(
+                        message_log.as_ref(),
+                        &self.account_id,
+                        &peer_id,
+                        &username,
+                        &sender_name,
+                        &chat_id,
+                        is_guild,
+                        &body,
+                        access_granted,
+                    )
+                    .await;
                     if let Err(e) = send_discord_text_simple(
                         &ctx,
                         msg.channel_id,
@@ -1648,6 +1669,18 @@ mod tests {
         assert_eq!(image_media_type_fallback(None, "pic.webp"), "image/webp");
         // Unknown: default to jpeg.
         assert_eq!(image_media_type_fallback(None, "pic.bin"), "image/jpeg");
+    }
+
+    #[test]
+    fn voice_stt_unavailable_body_uses_marker_and_caption() {
+        assert_eq!(
+            voice_stt_unavailable_log_body(""),
+            "[Voice message - STT unavailable]"
+        );
+        assert_eq!(
+            voice_stt_unavailable_log_body("caption"),
+            "caption\n\n[Voice message - STT unavailable]"
+        );
     }
 
     #[test]

--- a/crates/discord/src/plugin.rs
+++ b/crates/discord/src/plugin.rs
@@ -155,10 +155,7 @@ impl ChannelPlugin for DiscordPlugin {
         // Spawn the serenity client in a background task.
         let cancel_for_task = cancel.clone();
         tokio::spawn(async move {
-            let handler = Handler {
-                account_id: account_id_owned.clone(),
-                accounts: Arc::clone(&accounts_clone),
-            };
+            let handler = Handler::new(account_id_owned.clone(), Arc::clone(&accounts_clone));
 
             let mut client = match serenity::Client::builder(&token, required_intents())
                 .event_handler(handler)

--- a/crates/discord/src/plugin.rs
+++ b/crates/discord/src/plugin.rs
@@ -333,5 +333,8 @@ mod tests {
 
         // Interactive: Discord supports interactive messages
         assert!(desc.capabilities.supports_interactive);
+
+        // Voice ingest: Discord now handles inbound voice attachments.
+        assert!(desc.capabilities.supports_voice_ingest);
     }
 }

--- a/docs/src/channels.md
+++ b/docs/src/channels.md
@@ -9,7 +9,7 @@ capabilities that control what features are available.
 | Channel | Inbound Mode | Public URL Required | Key Capabilities |
 |---------|-------------|--------------------|--------------------|
 | Telegram | Polling | No | Streaming, voice ingest, reactions, OTP, location |
-| Discord | Gateway (WebSocket) | No | Streaming, interactive messages, threads, reactions |
+| Discord | Gateway (WebSocket) | No | Streaming, interactive messages, threads, voice ingest, reactions |
 | Matrix | Gateway (sync loop) | No | Streaming, voice ingest, interactive polls, threads, reactions, OTP, location, encrypted chats, device verification, ownership bootstrap |
 | Microsoft Teams | Webhook | Yes | Streaming, interactive messages, threads, reactions |
 | WhatsApp | Gateway (WebSocket) | No | Streaming, voice ingest, OTP, pairing, location |


### PR DESCRIPTION
## Summary
- add inbound Discord attachment handling for voice notes and images, including attachment-only messages with no text
- introduce a shared inbound media downloader contract so channel handlers can fetch media behind a testable abstraction
- update Discord capability metadata and channel docs to reflect voice ingest support

Fixes #633.

## Validation
### Completed
- [x] `cargo +nightly-2025-11-30 fmt --all`
- [x] `cargo test -p moltis-channels`
- [x] `cargo clippy -p moltis-channels --all-targets -- -D warnings`
- [x] `cargo test -p moltis-discord`
- [x] `cargo clippy -p moltis-discord --all-targets -- -D warnings`

### Remaining
- [ ] `./scripts/local-validate.sh 649` (started, then interrupted after exceeding the repo's 5 minute command limit during the later workspace/WASM build stages)
- [ ] Manual Discord QA for real voice-note and image uploads against a configured bot account

## Manual QA
- Send a Discord voice note in a DM and verify the bot transcribes and replies
- Send an image without a caption and verify a vision-capable model responds
- Send an image with a caption and verify the caption and image both reach the model
- Send a voice note with STT disabled and verify the user receives the Settings -> Voice guidance
- Send a slash command and verify command handling is unchanged
