### PR TITLE
fix(config): warn when preset tool policies are set but tools.policy is empty

### DIFF
--- a/crates/config/src/schema.rs
+++ b/crates/config/src/schema.rs
@@ -247,10 +247,21 @@ pub struct MoltisConfig {
 }
 
 /// Agent spawn presets used by tools like `spawn_agent`.
+///
+/// **IMPORTANT:** Everything under `[agents.presets.*]` — including each
+/// preset's `tools.allow`/`tools.deny` — applies ONLY to sub-agents spawned
+/// via the `spawn_agent` tool. Preset tool policies have no effect on the
+/// main agent session. To filter tools for the main session, configure
+/// `[tools.policy]` (see `ToolPolicyConfig`).
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(default)]
 pub struct AgentsConfig {
-    /// Optional default preset name used when `spawn_agent.preset` is omitted.
+    /// Default preset name used when `spawn_agent.preset` is omitted.
+    ///
+    /// Applies ONLY to sub-agents spawned via the `spawn_agent` tool. It
+    /// does NOT configure tool policy, model, or identity for the main
+    /// agent session. For main-session tool allow/deny, use
+    /// `[tools.policy]`.
     pub default_preset: Option<String>,
     /// Named spawn presets.
     #[serde(default)]
@@ -347,6 +358,11 @@ impl Default for SessionAccessPolicyConfig {
 /// Presets allow defining specialized agent configurations that can be
 /// selected when spawning sub-agents. Each preset can override identity,
 /// model, tool policies, and system prompt.
+///
+/// **IMPORTANT:** Presets apply ONLY to sub-agents spawned via the
+/// `spawn_agent` tool. The `tools.allow`/`tools.deny` fields on a preset
+/// do NOT filter tools for the main agent session — the main session's
+/// tool policy is controlled by the top-level `[tools.policy]` section.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(default)]
 pub struct AgentPreset {

--- a/crates/config/src/template.rs
+++ b/crates/config/src/template.rs
@@ -206,12 +206,19 @@ message_queue_mode = "followup"   # Default: process queued messages one-by-one 
 # allowed_models = ["gpt 5.2"]  # Legacy field (currently ignored).
 
 # ══════════════════════════════════════════════════════════════════════════════
-# SPAWN PRESETS (OPTIONAL)
+# SUB-AGENT SPAWN PRESETS (OPTIONAL)
 # ══════════════════════════════════════════════════════════════════════════════
-# Configure reusable presets for the `spawn_agent` tool.
+# Configure reusable presets for sub-agents spawned via the `spawn_agent` tool.
+#
+# ⚠️  SCOPE: `[agents.presets.*]` applies ONLY to sub-agents spawned via the
+# `spawn_agent` tool. The `tools.allow` / `tools.deny` fields under a preset
+# do NOT filter tools for the main agent session. To allow/deny tools for the
+# main session, use the `[tools.policy]` section further down this file.
+# `[agents] default_preset` likewise only selects the sub-agent preset used
+# when `spawn_agent.preset` is omitted — it does not apply to the main session.
 #
 # [agents]
-# default_preset = "research"      # Optional: used when spawn_agent.preset is omitted
+# default_preset = "research"      # Sub-agent preset used when spawn_agent.preset is omitted
 #
 # [agents.presets.research]
 # model = "openai/gpt-5.2"
@@ -385,7 +392,12 @@ packages = [
 # pids_max = 100                  # Maximum number of processes
 
 # ── Tool Policy ───────────────────────────────────────────────────────────────
-# Control which tools agents can use.
+# Control which tools the MAIN agent session can use.
+#
+# This is the tool policy for the main session. Preset tool policies under
+# `[agents.presets.*]` apply only to sub-agents spawned via `spawn_agent` and
+# are NOT read by the main session. If you want a deny list to harden the
+# main agent, it must live here.
 
 [tools.policy]
 allow = []                        # Tools to always allow (e.g., ["exec", "web_fetch"])

--- a/crates/config/src/validate.rs
+++ b/crates/config/src/validate.rs
@@ -1212,6 +1212,49 @@ fn check_semantic_warnings(config: &MoltisConfig, diagnostics: &mut Vec<Diagnost
         });
     }
 
+    // Silent-misconfiguration trap: `[agents.presets.*]` tool policies apply
+    // ONLY to sub-agents spawned via `spawn_agent`. They do NOT filter tools
+    // for the main agent session — that is controlled exclusively by
+    // `[tools.policy]`. Users hardening their deployment often put a deny
+    // list under a preset and expect it to apply to the main session; it
+    // silently doesn't. Warn when at least one preset declares
+    // `tools.allow`/`tools.deny` while `[tools.policy]` is entirely empty.
+    {
+        let main_policy_empty = config.tools.policy.allow.is_empty()
+            && config.tools.policy.deny.is_empty()
+            && config.tools.policy.profile.is_none();
+        if main_policy_empty {
+            let mut offending: Vec<&str> = config
+                .agents
+                .presets
+                .iter()
+                .filter(|(_, preset)| {
+                    !preset.tools.allow.is_empty() || !preset.tools.deny.is_empty()
+                })
+                .map(|(name, _)| name.as_str())
+                .collect();
+            if !offending.is_empty() {
+                offending.sort_unstable();
+                let quoted: Vec<String> =
+                    offending.iter().map(|name| format!("\"{name}\"")).collect();
+                diagnostics.push(Diagnostic {
+                    severity: Severity::Warning,
+                    category: "security",
+                    path: "agents.presets".into(),
+                    message: format!(
+                        "preset(s) [{}] declare tools.allow/tools.deny, but \
+                         [tools.policy] is empty. Preset tool policies apply \
+                         ONLY to sub-agents spawned via the spawn_agent tool; \
+                         they do NOT filter tools for the main agent session. \
+                         To allow/deny tools for the main session, set \
+                         tools.policy.allow / tools.policy.deny.",
+                        quoted.join(", ")
+                    ),
+                });
+            }
+        }
+    }
+
     // agents.presets.*.reasoning_effort is now a typed enum (ReasoningEffort)
     // and validated at deserialization time (step 4). No semantic check needed.
 
@@ -2942,5 +2985,165 @@ cache_retention = "{mode}"
                 "upstream_proxy with {scheme} should not produce errors: {errors:?}"
             );
         }
+    }
+
+    /// Helper: locate the silent-misconfiguration warning about preset tool
+    /// policies vs. empty `[tools.policy]`.
+    fn find_preset_silent_policy_warning(result: &ValidationResult) -> Option<&Diagnostic> {
+        result.diagnostics.iter().find(|d| {
+            d.category == "security"
+                && d.path == "agents.presets"
+                && d.message.contains("spawn_agent")
+        })
+    }
+
+    #[test]
+    fn preset_tools_deny_without_main_policy_warns() {
+        let toml = r#"
+[agents]
+default_preset = "full"
+
+[agents.presets.full]
+[agents.presets.full.tools]
+deny = ["browser", "web_fetch"]
+"#;
+        let result = validate_toml_str(toml);
+        let warning = find_preset_silent_policy_warning(&result).unwrap_or_else(|| {
+            panic!(
+                "expected silent-policy warning, got: {:?}",
+                result.diagnostics
+            )
+        });
+        assert_eq!(warning.severity, Severity::Warning);
+        assert!(
+            warning.message.contains("\"full\""),
+            "expected preset name in message: {}",
+            warning.message
+        );
+        assert!(
+            warning.message.contains("[tools.policy]"),
+            "expected pointer to [tools.policy] in message: {}",
+            warning.message
+        );
+    }
+
+    #[test]
+    fn preset_tools_allow_without_main_policy_also_warns() {
+        let toml = r#"
+[agents.presets.research]
+[agents.presets.research.tools]
+allow = ["web_search", "web_fetch"]
+"#;
+        let result = validate_toml_str(toml);
+        let warning = find_preset_silent_policy_warning(&result).unwrap_or_else(|| {
+            panic!(
+                "expected silent-policy warning, got: {:?}",
+                result.diagnostics
+            )
+        });
+        assert!(warning.message.contains("\"research\""));
+    }
+
+    #[test]
+    fn preset_tools_deny_with_main_policy_deny_does_not_warn() {
+        let toml = r#"
+[tools.policy]
+deny = ["exec"]
+
+[agents.presets.full]
+[agents.presets.full.tools]
+deny = ["browser"]
+"#;
+        let result = validate_toml_str(toml);
+        assert!(
+            find_preset_silent_policy_warning(&result).is_none(),
+            "should not warn when [tools.policy] is non-empty, got: {:?}",
+            result.diagnostics
+        );
+    }
+
+    #[test]
+    fn preset_tools_deny_with_main_policy_allow_does_not_warn() {
+        let toml = r#"
+[tools.policy]
+allow = ["web_search"]
+
+[agents.presets.full]
+[agents.presets.full.tools]
+deny = ["browser"]
+"#;
+        let result = validate_toml_str(toml);
+        assert!(
+            find_preset_silent_policy_warning(&result).is_none(),
+            "should not warn when [tools.policy] has allow list, got: {:?}",
+            result.diagnostics
+        );
+    }
+
+    #[test]
+    fn preset_tools_deny_with_main_policy_profile_does_not_warn() {
+        let toml = r#"
+[tools.policy]
+profile = "default"
+
+[agents.presets.full]
+[agents.presets.full.tools]
+deny = ["browser"]
+"#;
+        let result = validate_toml_str(toml);
+        assert!(
+            find_preset_silent_policy_warning(&result).is_none(),
+            "should not warn when [tools.policy.profile] is set, got: {:?}",
+            result.diagnostics
+        );
+    }
+
+    #[test]
+    fn empty_preset_tools_does_not_warn() {
+        let toml = r#"
+[agents]
+default_preset = "basic"
+
+[agents.presets.basic]
+model = "openai/gpt-5.2"
+"#;
+        let result = validate_toml_str(toml);
+        assert!(
+            find_preset_silent_policy_warning(&result).is_none(),
+            "should not warn when presets declare no tool policy, got: {:?}",
+            result.diagnostics
+        );
+    }
+
+    #[test]
+    fn multiple_offending_presets_are_rolled_up() {
+        let toml = r#"
+[agents.presets.full]
+[agents.presets.full.tools]
+deny = ["browser"]
+
+[agents.presets.minimal]
+[agents.presets.minimal.tools]
+allow = ["web_search"]
+"#;
+        let result = validate_toml_str(toml);
+        let warning = find_preset_silent_policy_warning(&result).unwrap_or_else(|| {
+            panic!(
+                "expected silent-policy warning, got: {:?}",
+                result.diagnostics
+            )
+        });
+        assert!(
+            warning.message.contains("\"full\"") && warning.message.contains("\"minimal\""),
+            "expected both preset names in single rolled-up warning: {}",
+            warning.message
+        );
+        // And only one such diagnostic should be emitted.
+        let count = result
+            .diagnostics
+            .iter()
+            .filter(|d| d.category == "security" && d.path == "agents.presets")
+            .count();
+        assert_eq!(count, 1, "expected exactly one rolled-up warning");
     }
 }

--- a/crates/config/src/validate.rs
+++ b/crates/config/src/validate.rs
@@ -1247,7 +1247,8 @@ fn check_semantic_warnings(config: &MoltisConfig, diagnostics: &mut Vec<Diagnost
                          ONLY to sub-agents spawned via the spawn_agent tool; \
                          they do NOT filter tools for the main agent session. \
                          To allow/deny tools for the main session, set \
-                         tools.policy.allow / tools.policy.deny.",
+                         tools.policy.allow, tools.policy.deny, or \
+                         tools.policy.profile.",
                         quoted.join(", ")
                     ),
                 });


### PR DESCRIPTION
## Summary

- Closes #656. `[agents.presets.*]` tool policies silently apply only to sub-agents spawned via `spawn_agent` — the main agent session reads `[tools.policy]` exclusively. Users hardening their deployment via a preset deny list get zero enforcement on the main session with no diagnostic.
- Add a `security`-category validation warning at `agents.presets` when at least one preset declares `tools.allow`/`tools.deny` while `[tools.policy]` is entirely empty (no `allow`, no `deny`, no `profile`). Message names the offending presets (sorted) and points to `tools.policy` as the correct section for main-session filtering.
- Clarify scope in the config template (renamed "SPAWN PRESETS" → "SUB-AGENT SPAWN PRESETS", added a ⚠️ SCOPE note, and added a reciprocal comment on `[tools.policy]`) and in the `AgentsConfig` / `AgentsConfig.default_preset` / `AgentPreset` rustdoc comments. No behavioral code change — the preset→main-session bridge is intentionally not introduced; this PR only closes the silent-trap.

## Validation

### Completed

- [x] `cargo test -p moltis-config` → 192 passed, 0 failed (includes 7 new tests: deny-only trigger, allow-only trigger, pass-through for each of `tools.policy.{allow,deny,profile}`, pass-through for empty preset tools, rolled-up multi-preset message)
- [x] `cargo +nightly-2025-11-30 fmt --all -- --check` → clean
- [x] `cargo clippy -p moltis-config --all-targets -- -D warnings` → clean
- [x] Template still round-trips through `load_config` (`loader::tests::save_config_to_path_preserves_provider_and_voice_comment_blocks` passes)

### Remaining

- [ ] `just lint` (workspace-wide clippy)
- [ ] `just test` (workspace-wide)
- [ ] `./scripts/local-validate.sh <PR_NUMBER>` once this PR number is assigned

## Manual QA

1. Create a `moltis.toml` with a populated preset deny list but no `[tools.policy]` section:
   ```toml
   [agents]
   default_preset = "full"

   [agents.presets.full]
   [agents.presets.full.tools]
   deny = ["browser", "web_fetch"]
   ```
2. Load the config (via `moltis` startup or `moltis config validate` if available). Confirm a `Warning`-severity diagnostic fires at path `agents.presets`, naming the `"full"` preset and pointing to `tools.policy.allow` / `tools.policy.deny`.
3. Add a non-empty `[tools.policy] deny = ["exec"]` block and reload. Confirm the warning disappears.
4. Repeat step 3 swapping in `allow = [...]` and then `profile = "default"`. Confirm the warning stays suppressed in both cases.
5. Open the generated `moltis.toml` (from a fresh `moltis` run). Confirm the new ⚠️ SCOPE note appears above the sub-agent preset example and the reciprocal comment appears above `[tools.policy]`.