### PR TITLE
fix(tools): enforce exec allowlist when approval_mode is off

### DIFF
--- a/crates/config/src/template.rs
+++ b/crates/config/src/template.rs
@@ -248,12 +248,15 @@ max_output_bytes = 204800         # Max command output bytes (200KB)
 approval_mode = "on-miss"         # When to require approval:
                                   #   "always"  - Always ask before running
                                   #   "on-miss" - Ask if not in allowlist
-                                  #   "never"   - Never ask (dangerous)
+                                  #   "never"   - Never ask (for headless deployments)
 security_level = "allowlist"      # Security mode:
                                   #   "permissive" - Allow most commands
                                   #   "allowlist"  - Only allow listed commands
                                   #   "strict"     - Very restrictive
-allowlist = []                    # Command patterns to allow (when security_level = "allowlist")
+allowlist = []                    # Command patterns to allow (when security_level = "allowlist").
+                                  # With approval_mode = "never", a non-empty allowlist is enforced:
+                                  # commands that don't match are denied (safe bins still allowed).
+                                  # An empty allowlist in "never" mode is unrestricted.
                                   # Example: ["git *", "npm *", "cargo *"]
 host = "local"                    # Where to run commands:
                                   #   "local" - Run on this machine (default)

--- a/crates/tools/src/approval.rs
+++ b/crates/tools/src/approval.rs
@@ -287,7 +287,23 @@ impl ApprovalManager {
         }
 
         match self.mode {
-            ApprovalMode::Off => Ok(ApprovalAction::Proceed),
+            ApprovalMode::Off => {
+                // With an empty allowlist, Off mode is unrestricted (preserves
+                // historical behavior for deployments that never configured a list).
+                // With a non-empty allowlist, the list is authoritative: the user
+                // explicitly asked for enforcement, and there is no human to prompt
+                // in headless deployments — non-matches must be denied, not silently
+                // proceeded (moltis-org/moltis#654).
+                if self.allowlist.is_empty() {
+                    return Ok(ApprovalAction::Proceed);
+                }
+                if is_safe_command(command) || matches_allowlist(command, &self.allowlist) {
+                    return Ok(ApprovalAction::Proceed);
+                }
+                Err(Error::message(format!(
+                    "exec denied: command not in allowlist (approval_mode=off): {command}"
+                )))
+            },
             ApprovalMode::Always => Ok(ApprovalAction::NeedsApproval),
             ApprovalMode::OnMiss => {
                 // Check safe bins.
@@ -430,7 +446,82 @@ mod tests {
             mode: ApprovalMode::Off,
             ..Default::default()
         };
-        // Non-dangerous commands proceed when mode is off.
+        // Non-dangerous commands proceed when mode is off and allowlist is empty.
+        let action = mgr.check_command("curl https://example.com").await.unwrap();
+        assert_eq!(action, ApprovalAction::Proceed);
+    }
+
+    #[tokio::test]
+    async fn test_approval_off_with_allowlist_match() {
+        // Regression test for moltis-org/moltis#654: non-empty allowlist must be
+        // enforced even when approval_mode is off (headless deployments).
+        let mgr = ApprovalManager {
+            mode: ApprovalMode::Off,
+            allowlist: vec!["git *".into()],
+            ..Default::default()
+        };
+        let action = mgr.check_command("git status").await.unwrap();
+        assert_eq!(action, ApprovalAction::Proceed);
+    }
+
+    #[tokio::test]
+    async fn test_approval_off_with_allowlist_miss_denies() {
+        // Regression test for moltis-org/moltis#654: commands outside the
+        // configured allowlist must be denied in Off mode, not silently proceeded.
+        let mgr = ApprovalManager {
+            mode: ApprovalMode::Off,
+            allowlist: vec!["git *".into()],
+            ..Default::default()
+        };
+        let err = mgr
+            .check_command("curl https://evil.example.com")
+            .await
+            .expect_err("expected denial for non-allowlisted command in off mode");
+        assert!(
+            err.to_string().contains("not in allowlist"),
+            "unexpected error message: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_approval_off_with_allowlist_safe_bin() {
+        // Safe bins are still allowed in Off mode so operators don't have to
+        // enumerate them in every allowlist.
+        let mgr = ApprovalManager {
+            mode: ApprovalMode::Off,
+            allowlist: vec!["git *".into()],
+            ..Default::default()
+        };
+        let action = mgr.check_command("echo hi").await.unwrap();
+        assert_eq!(action, ApprovalAction::Proceed);
+    }
+
+    #[tokio::test]
+    async fn test_approval_off_empty_allowlist_unrestricted() {
+        // Explicit contract lock: Off mode with an empty allowlist preserves
+        // historical unrestricted semantics.
+        let mgr = ApprovalManager {
+            mode: ApprovalMode::Off,
+            allowlist: Vec::new(),
+            ..Default::default()
+        };
+        let action = mgr
+            .check_command(r#"python3 -c "print('hi')""#)
+            .await
+            .unwrap();
+        assert_eq!(action, ApprovalAction::Proceed);
+    }
+
+    #[tokio::test]
+    async fn test_approval_off_full_security_bypasses_allowlist() {
+        // SecurityLevel::Full short-circuits before the mode match, so even an
+        // explicit allowlist has no effect.
+        let mgr = ApprovalManager {
+            mode: ApprovalMode::Off,
+            security_level: SecurityLevel::Full,
+            allowlist: vec!["git *".into()],
+            ..Default::default()
+        };
         let action = mgr.check_command("curl https://example.com").await.unwrap();
         assert_eq!(action, ApprovalAction::Proceed);
     }

--- a/crates/tools/src/approval.rs
+++ b/crates/tools/src/approval.rs
@@ -269,10 +269,11 @@ impl ApprovalManager {
     /// Decide whether a command needs approval.
     /// Returns Ok(()) if the command can proceed, Err if denied.
     pub async fn check_command(&self, command: &str) -> Result<ApprovalAction> {
-        // Safety floor: dangerous patterns force approval regardless of mode.
-        // In Off mode there is no human approver to gate on, so denying is the
-        // only safe outcome — otherwise the agent would hang on `NeedsApproval`
-        // forever in headless deployments (moltis-org/moltis#654 follow-up).
+        // Safety floor: dangerous patterns are blocked unless explicitly
+        // allowlisted. In OnMiss/Always mode we escalate to NeedsApproval so a
+        // human can gate. In Off mode there is no human approver to wait on,
+        // so the only safe outcome is to deny — otherwise the agent would hang
+        // on `NeedsApproval` forever in headless deployments (moltis-org/moltis#654).
         if let Some(desc) = check_dangerous(command) {
             if !matches_allowlist(command, &self.allowlist) {
                 if self.mode == ApprovalMode::Off {
@@ -311,7 +312,19 @@ impl ApprovalManager {
                 if self.allowlist.is_empty() {
                     return Ok(ApprovalAction::Proceed);
                 }
-                if is_safe_command(command) || matches_allowlist(command, &self.allowlist) {
+                if matches_allowlist(command, &self.allowlist) {
+                    return Ok(ApprovalAction::Proceed);
+                }
+                if is_safe_command(command) {
+                    // Safe bins bypass the explicit allowlist so operators don't
+                    // have to enumerate common read-only utilities. Emit a warn
+                    // so strict-posture operators can detect the gap at runtime
+                    // (they can `grep safe-bin` their logs to audit, or file a
+                    // follow-up for an opt-in strict mode that gates safe bins).
+                    warn!(
+                        command,
+                        "exec safe-bin bypassed non-empty allowlist in approval_mode=off",
+                    );
                     return Ok(ApprovalAction::Proceed);
                 }
                 Err(Error::message(format!(

--- a/crates/tools/src/approval.rs
+++ b/crates/tools/src/approval.rs
@@ -270,8 +270,22 @@ impl ApprovalManager {
     /// Returns Ok(()) if the command can proceed, Err if denied.
     pub async fn check_command(&self, command: &str) -> Result<ApprovalAction> {
         // Safety floor: dangerous patterns force approval regardless of mode.
+        // In Off mode there is no human approver to gate on, so denying is the
+        // only safe outcome — otherwise the agent would hang on `NeedsApproval`
+        // forever in headless deployments (moltis-org/moltis#654 follow-up).
         if let Some(desc) = check_dangerous(command) {
             if !matches_allowlist(command, &self.allowlist) {
+                if self.mode == ApprovalMode::Off {
+                    warn!(
+                        command,
+                        pattern = %desc,
+                        "dangerous command denied in approval_mode=off",
+                    );
+                    return Err(Error::message(format!(
+                        "exec denied: dangerous command pattern '{desc}' (approval_mode=off): \
+                         {command}"
+                    )));
+                }
                 warn!(command, pattern = %desc, "dangerous command detected, forcing approval");
                 return Ok(ApprovalAction::NeedsApproval);
             }
@@ -699,13 +713,41 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_dangerous_forces_approval_when_mode_off() {
+    async fn test_dangerous_denied_when_mode_off() {
+        // In Off mode dangerous commands must be denied (not NeedsApproval),
+        // otherwise headless agents hang waiting for an approver that never
+        // arrives (moltis-org/moltis#654).
         let mgr = ApprovalManager {
             mode: ApprovalMode::Off,
             ..Default::default()
         };
-        let action = mgr.check_command("rm -rf /").await.unwrap();
-        assert_eq!(action, ApprovalAction::NeedsApproval);
+        let err = mgr
+            .check_command("rm -rf /")
+            .await
+            .expect_err("expected denial for dangerous command in off mode");
+        assert!(
+            err.to_string().contains("dangerous command pattern"),
+            "unexpected error message: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_dangerous_denied_when_mode_off_full_security() {
+        // Full security level does not change the safety floor: dangerous
+        // commands are still denied in Off mode.
+        let mgr = ApprovalManager {
+            mode: ApprovalMode::Off,
+            security_level: SecurityLevel::Full,
+            ..Default::default()
+        };
+        let err = mgr
+            .check_command("git reset --hard")
+            .await
+            .expect_err("expected denial for dangerous command in off+full");
+        assert!(
+            err.to_string().contains("dangerous command pattern"),
+            "unexpected error message: {err}"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Fixes #654.

`ApprovalManager::check_command` short-circuited to `Proceed` in `ApprovalMode::Off` without consulting the configured `allowlist`, silently disabling the primary exec security control in every headless deployment. Since `on-miss` hangs forever waiting for a human approver that will never arrive, `approval_mode = "never"` is the only viable mode for autonomous agents — which is exactly where the user-configured allowlist was being ignored.

- In `Off` mode with a **non-empty** allowlist, enforce it: safe bins + allowlist matches proceed, everything else is denied with a clear error.
- **Empty** allowlist preserves historical unrestricted semantics so existing deployments are unaffected.
- `SecurityLevel::Full` still bypasses the list (early return before the mode match).
- `SecurityLevel::Deny` still denies everything.
- Dangerous-pattern safety floor (e.g. `rm -rf /`, `git reset --hard`, `DROP TABLE`) now **denies** in `Off` mode instead of returning `NeedsApproval`, so headless agents fail fast instead of hanging forever (addresses Greptile P1 on this PR).

Config template comment updated so users know the allowlist is now enforced under `approval_mode = "never"` when non-empty.

## Validation

### Completed
- [x] `cargo test -p moltis-tools approval` — 34 tests pass (7 new)
- [x] `cargo +nightly-2025-11-30 fmt --all -- --check`
- [x] `cargo +nightly-2025-11-30 clippy -p moltis-tools --all-targets -- -D warnings`
- [x] `cargo +nightly-2025-11-30 clippy -p moltis-config --all-targets -- -D warnings`

### Remaining
- [ ] `just lint` (blocked locally by pre-existing CUDA/CMake issue in `llama-cpp-sys-2` — unrelated to this change; CI runs the OS-aware path)
- [ ] `just test` (CI)
- [ ] `just release-preflight` (CI)

## Manual QA

1. `moltis.toml`:
   ```toml
   [tools.exec]
   approval_mode = "never"
   security_level = "allowlist"
   allowlist = ["git *", "cat /data/*"]
   ```
2. Trigger exec with `git status` → proceeds (allowlist match).
3. Trigger exec with `echo hi` → proceeds (safe bin).
4. Trigger exec with `curl https://example.com` → **denied** with `exec denied: command not in allowlist (approval_mode=off): curl ...` (previously: silently ran).
5. Trigger exec with `rm -rf /` (dangerous, not in allowlist) → **denied** with `exec denied: dangerous command pattern 'rm -r on filesystem root' (approval_mode=off): rm -rf /` (previously: hung forever).
6. Set `allowlist = []` with `approval_mode = "never"` → unrestricted (existing behavior preserved).

## New test cases

- `test_approval_off_with_allowlist_match`
- `test_approval_off_with_allowlist_miss_denies`
- `test_approval_off_with_allowlist_safe_bin`
- `test_approval_off_empty_allowlist_unrestricted`
- `test_approval_off_full_security_bypasses_allowlist`
- `test_dangerous_denied_when_mode_off` (renamed from `test_dangerous_forces_approval_when_mode_off`)
- `test_dangerous_denied_when_mode_off_full_security`

## Follow-ups (out of scope)

- Config validation warning when `approval_mode = "never"` + empty allowlist + `security_level = "allowlist"` (belt-and-suspenders UX from issue #654's Option 3).
- Optional strict-allowlist mode where `SAFE_BINS` does **not** bypass user-configured allowlists (Greptile P2 — would break existing `on-miss` deployments, needs to be opt-in).