### PR TITLE
fix(chat): honor [skills] enabled=false at runtime

### DIFF
--- a/crates/chat/src/lib.rs
+++ b/crates/chat/src/lib.rs
@@ -13941,14 +13941,20 @@ mod tests {
 
     /// Serializes tests that mutate the global `moltis_config` data_dir
     /// override so they don't race within the chat crate's test binary.
-    /// Uses a Tokio mutex because the guard is held across `.await` points.
-    static SKILLS_TEST_DATA_DIR_LOCK: Mutex<()> = Mutex::const_new(());
+    /// A `Semaphore` with a single permit is used here instead of
+    /// `Mutex<()>` because CLAUDE.md forbids bare `Mutex<()>` — a mutex must
+    /// guard real state. This semaphore is a pure serialization primitive
+    /// for a separately-owned global (`moltis_config`'s data_dir override).
+    static SKILLS_TEST_DATA_DIR_LOCK: Semaphore = Semaphore::const_new(1);
 
     /// Regression test for #655: `[skills] enabled = false` must short-circuit
     /// skill discovery so nothing from the filesystem ends up in the LLM prompt.
     #[tokio::test]
     async fn discover_skills_if_enabled_short_circuits_when_disabled() {
-        let _guard = SKILLS_TEST_DATA_DIR_LOCK.lock().await;
+        let _permit = SKILLS_TEST_DATA_DIR_LOCK
+            .acquire()
+            .await
+            .expect("semaphore closed");
 
         // Point data_dir at a temp dir containing a real SKILL.md so that if
         // the helper *did* fall through to the discoverer, it would return a
@@ -13980,7 +13986,10 @@ mod tests {
     /// `enabled` branch so we don't accidentally hard-code `Vec::new()`.
     #[tokio::test]
     async fn discover_skills_if_enabled_runs_discoverer_when_enabled() {
-        let _guard = SKILLS_TEST_DATA_DIR_LOCK.lock().await;
+        let _permit = SKILLS_TEST_DATA_DIR_LOCK
+            .acquire()
+            .await
+            .expect("semaphore closed");
 
         let tmp = tempfile::tempdir().expect("tempdir");
         let skills_dir = tmp.path().join("skills").join("live-skill");

--- a/crates/chat/src/lib.rs
+++ b/crates/chat/src/lib.rs
@@ -4960,7 +4960,7 @@ impl ChatService for LiveChatService {
         // Discover enabled skills/plugins (only if provider supports tools and
         // `[skills] enabled` is true — see #655).
         let skills_list: Vec<Value> = if supports_tools {
-            discover_skills_if_enabled(&moltis_config::discover_and_load())
+            discover_skills_if_enabled(&config)
                 .await
                 .iter()
                 .map(|s| {

--- a/crates/chat/src/lib.rs
+++ b/crates/chat/src/lib.rs
@@ -1134,6 +1134,28 @@ fn prompt_build_limits_from_config(config: &moltis_config::MoltisConfig) -> Prom
     }
 }
 
+/// Discover skills from the default filesystem paths, honoring `[skills] enabled`.
+///
+/// Returns an empty list when `config.skills.enabled` is `false`, so callers can
+/// unconditionally feed the result into prompt building / tool filtering without
+/// injecting skills into the LLM context when the operator has disabled them.
+async fn discover_skills_if_enabled(
+    config: &moltis_config::MoltisConfig,
+) -> Vec<moltis_skills::types::SkillMetadata> {
+    if !config.skills.enabled {
+        return Vec::new();
+    }
+    let search_paths = moltis_skills::discover::FsSkillDiscoverer::default_paths();
+    let discoverer = moltis_skills::discover::FsSkillDiscoverer::new(search_paths);
+    match discoverer.discover().await {
+        Ok(skills) => skills,
+        Err(e) => {
+            warn!("failed to discover skills: {e}");
+            Vec::new()
+        },
+    }
+}
+
 fn resolve_channel_runtime_context(
     session_key: &str,
     session_entry: Option<&SessionEntry>,
@@ -3690,16 +3712,10 @@ impl ChatService for LiveChatService {
             run_id: Some(run_id.clone()),
         };
 
-        // Discover enabled skills/plugins for prompt injection.
-        let search_paths = moltis_skills::discover::FsSkillDiscoverer::default_paths();
-        let discoverer = moltis_skills::discover::FsSkillDiscoverer::new(search_paths);
-        let discovered_skills = match discoverer.discover().await {
-            Ok(s) => s,
-            Err(e) => {
-                warn!("failed to discover skills: {e}");
-                Vec::new()
-            },
-        };
+        // Discover enabled skills/plugins for prompt injection (gated on
+        // `[skills] enabled` — see #655).
+        let discovered_skills =
+            discover_skills_if_enabled(&moltis_config::discover_and_load()).await;
 
         // Check if MCP tools are disabled for this session and capture
         // per-session sandbox override details for prompt runtime context.
@@ -4941,23 +4957,20 @@ impl ChatService for LiveChatService {
             "promptSymbol": exec_prompt_symbol,
         });
 
-        // Discover enabled skills/plugins (only if provider supports tools)
+        // Discover enabled skills/plugins (only if provider supports tools and
+        // `[skills] enabled` is true — see #655).
         let skills_list: Vec<Value> = if supports_tools {
-            let search_paths = moltis_skills::discover::FsSkillDiscoverer::default_paths();
-            let discoverer = moltis_skills::discover::FsSkillDiscoverer::new(search_paths);
-            match discoverer.discover().await {
-                Ok(s) => s
-                    .iter()
-                    .map(|s| {
-                        serde_json::json!({
-                            "name": s.name,
-                            "description": s.description,
-                            "source": s.source,
-                        })
+            discover_skills_if_enabled(&moltis_config::discover_and_load())
+                .await
+                .iter()
+                .map(|s| {
+                    serde_json::json!({
+                        "name": s.name,
+                        "description": s.description,
+                        "source": s.source,
                     })
-                    .collect(),
-                Err(_) => vec![],
-            }
+                })
+                .collect()
         } else {
             vec![]
         };
@@ -5035,16 +5048,8 @@ impl ChatService for LiveChatService {
             .resolve_project_context(&session_key, conn_id.as_deref())
             .await;
 
-        // Discover skills.
-        let search_paths = moltis_skills::discover::FsSkillDiscoverer::default_paths();
-        let discoverer = moltis_skills::discover::FsSkillDiscoverer::new(search_paths);
-        let discovered_skills = match discoverer.discover().await {
-            Ok(s) => s,
-            Err(e) => {
-                warn!("failed to discover skills: {e}");
-                Vec::new()
-            },
-        };
+        // Discover skills (gated on `[skills] enabled` — see #655).
+        let discovered_skills = discover_skills_if_enabled(&persona.config).await;
 
         // Check MCP disabled.
         let mcp_disabled = session_entry
@@ -5160,16 +5165,8 @@ impl ChatService for LiveChatService {
             .resolve_project_context(&session_key, conn_id.as_deref())
             .await;
 
-        // Discover skills.
-        let search_paths = moltis_skills::discover::FsSkillDiscoverer::default_paths();
-        let discoverer = moltis_skills::discover::FsSkillDiscoverer::new(search_paths);
-        let discovered_skills = match discoverer.discover().await {
-            Ok(s) => s,
-            Err(e) => {
-                warn!("failed to discover skills: {e}");
-                Vec::new()
-            },
-        };
+        // Discover skills (gated on `[skills] enabled` — see #655).
+        let discovered_skills = discover_skills_if_enabled(&persona.config).await;
 
         // Check MCP disabled.
         let mcp_disabled = session_entry
@@ -13939,6 +13936,71 @@ mod tests {
         assert!(
             err.contains("timed out"),
             "error should mention timeout: {err}"
+        );
+    }
+
+    /// Serializes tests that mutate the global `moltis_config` data_dir
+    /// override so they don't race within the chat crate's test binary.
+    /// Uses a Tokio mutex because the guard is held across `.await` points.
+    static SKILLS_TEST_DATA_DIR_LOCK: Mutex<()> = Mutex::const_new(());
+
+    /// Regression test for #655: `[skills] enabled = false` must short-circuit
+    /// skill discovery so nothing from the filesystem ends up in the LLM prompt.
+    #[tokio::test]
+    async fn discover_skills_if_enabled_short_circuits_when_disabled() {
+        let _guard = SKILLS_TEST_DATA_DIR_LOCK.lock().await;
+
+        // Point data_dir at a temp dir containing a real SKILL.md so that if
+        // the helper *did* fall through to the discoverer, it would return a
+        // non-empty list and fail this assertion.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let skills_dir = tmp.path().join("skills").join("planted-skill");
+        std::fs::create_dir_all(&skills_dir).expect("mkdir");
+        std::fs::write(
+            skills_dir.join("SKILL.md"),
+            "---\nname: planted-skill\ndescription: should not appear\n---\nbody",
+        )
+        .expect("write");
+        moltis_config::set_data_dir(tmp.path().to_path_buf());
+
+        let mut cfg = moltis_config::MoltisConfig::default();
+        cfg.skills.enabled = false;
+
+        let result = discover_skills_if_enabled(&cfg).await;
+        moltis_config::clear_data_dir();
+
+        assert!(
+            result.is_empty(),
+            "disabled skills must yield no discovered skills, got: {result:?}",
+        );
+    }
+
+    /// Complement to the short-circuit test: when enabled, the helper actually
+    /// invokes the filesystem discoverer. Validates the other arm of the
+    /// `enabled` branch so we don't accidentally hard-code `Vec::new()`.
+    #[tokio::test]
+    async fn discover_skills_if_enabled_runs_discoverer_when_enabled() {
+        let _guard = SKILLS_TEST_DATA_DIR_LOCK.lock().await;
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let skills_dir = tmp.path().join("skills").join("live-skill");
+        std::fs::create_dir_all(&skills_dir).expect("mkdir");
+        std::fs::write(
+            skills_dir.join("SKILL.md"),
+            "---\nname: live-skill\ndescription: visible to prompt\n---\nbody",
+        )
+        .expect("write");
+        moltis_config::set_data_dir(tmp.path().to_path_buf());
+
+        let mut cfg = moltis_config::MoltisConfig::default();
+        cfg.skills.enabled = true;
+
+        let result = discover_skills_if_enabled(&cfg).await;
+        moltis_config::clear_data_dir();
+
+        assert!(
+            result.iter().any(|s| s.name == "live-skill"),
+            "enabled skills must be discovered from data_dir, got: {result:?}",
         );
     }
 }


### PR DESCRIPTION
## Summary

Closes #655.

`SkillsConfig.enabled` is documented and defaulted to `true` in the schema (`crates/config/src/schema.rs:1275`), but the runtime never consulted it — `FsSkillDiscoverer::default_paths()` was invoked unconditionally from every chat.rs callsite, so every discovered `SKILL.md` landed in the system prompt regardless of `[skills] enabled = false`. This is the same failure mode as #638 / #639: schema promises behavior the code doesn't deliver.

- Added `discover_skills_if_enabled(&MoltisConfig)` helper in `crates/chat/src/lib.rs` that returns `Vec::new()` when `config.skills.enabled` is `false`, otherwise delegates to `FsSkillDiscoverer`.
- Routed all four `FsSkillDiscoverer` usages inside `LiveChatService` (send path, model-probe path, and the two `load_prompt_persona_for_session` paths) through the helper. The first two thread a fresh `moltis_config::discover_and_load()` (matching surrounding patterns); the other two reuse the already-loaded `persona.config`.

Non-chat callsites (`cli`, `gateway/services`, `gateway/server`, `skills/watcher`, `tools/skill_tools`, `httpd/server`) are intentionally out of scope — they don't inject skills into the LLM prompt. Can be a follow-up if full coverage is desired.

## Validation

### Completed
- [x] `cargo check -p moltis-chat`
- [x] `cargo +nightly-2025-11-30 fmt --all -- --check`
- [x] `cargo +nightly-2025-11-30 clippy -p moltis-chat -p moltis-config -p moltis-skills --all-targets -- -D warnings`
- [x] `cargo test -p moltis-chat --lib` → 175 passed, 0 failed (includes two new regression tests)

### Remaining
- [ ] `just lint` (full Darwin clippy sweep)
- [ ] `just test` (full test suite)
- [ ] `./scripts/local-validate.sh <PR>`

## Manual QA

1. Add to `moltis.toml`:
   ```toml
   [skills]
   enabled = false
   ```
2. Place a `SKILL.md` under `<data_dir>/skills/test-skill/SKILL.md`.
3. Start a session and inspect the system prompt / `<available_skills>` block.
4. Expected: no skills discovered, no `<available_skills>` entries. Flip `enabled = true` and confirm the skill reappears.

## Tests

Two new `#[tokio::test]`s in `crates/chat/src/lib.rs`:
- `discover_skills_if_enabled_short_circuits_when_disabled` — plants a real `SKILL.md` under a temp `data_dir` and asserts the helper returns an empty list when `enabled = false`, proving we don't fall through to the filesystem.
- `discover_skills_if_enabled_runs_discoverer_when_enabled` — the complementary arm, asserting the planted skill is discovered when `enabled = true`.

Tests share a module-local `tokio::sync::Mutex` so they serialize their mutations to the global `moltis_config::set_data_dir` override.