### PR TITLE
fix(agents): detect and break tool-call reflex loops (#658)

### DIFF
--- a/crates/agents/src/lib.rs
+++ b/crates/agents/src/lib.rs
@@ -17,4 +17,6 @@ pub mod provider_chain;
 pub mod response_sanitizer;
 pub mod silent_turn;
 pub mod skills;
+pub mod tool_arg_validator;
+pub mod tool_loop_detector;
 pub mod tool_registry;

--- a/crates/agents/src/runner.rs
+++ b/crates/agents/src/runner.rs
@@ -15,6 +15,11 @@ use crate::{
         ChatMessage, CompletionResponse, LlmProvider, StreamEvent, ToolCall, Usage, UserContent,
     },
     response_sanitizer::{clean_response, recover_tool_calls_from_content},
+    tool_arg_validator::validate_tool_args,
+    tool_loop_detector::{
+        LoopDetectorAction, ToolCallFingerprint, ToolLoopDetector, format_intervention_message,
+        format_strip_tools_message,
+    },
     tool_parsing::{
         looks_like_failed_tool_call, new_synthetic_tool_call_id, parse_tool_calls_from_text,
     },
@@ -528,6 +533,24 @@ pub enum RunnerEvent {
         iteration: usize,
         max_iterations: usize,
     },
+    /// A tool call was rejected by pre-dispatch schema validation before the
+    /// tool's `execute` method ran. Used in place of the usual
+    /// `ToolCallStart`/`ToolCallEnd` pair for rejected calls so the UI does
+    /// not render a misleading "executing" status for a call that never
+    /// actually executed.
+    ToolCallRejected {
+        id: String,
+        name: String,
+        arguments: serde_json::Value,
+        error: String,
+    },
+    /// The loop detector fired after observing repeated identical tool-call
+    /// failures. `stage` is 1 for the nudge/directive intervention and 2 for
+    /// the stronger tool-stripping escalation (see issue #658).
+    LoopInterventionFired {
+        stage: u8,
+        tool_name: String,
+    },
 }
 
 /// Detect an explicit shell command in the latest user turn.
@@ -909,6 +932,11 @@ pub async fn run_agent_loop_with_context(
     let mut malformed_retry_count: u8 = 0;
     let mut empty_tool_name_retry_count: u8 = 0;
     let mut auto_continue_count: usize = 0;
+    let mut loop_detector = ToolLoopDetector::new(
+        config.tools.agent_loop_detector_window,
+        config.tools.agent_loop_detector_strip_tools_on_second_fire,
+    );
+    let mut strip_tools_next_iter = false;
 
     loop {
         iterations += 1;
@@ -921,11 +949,17 @@ pub async fn run_agent_loop_with_context(
         }
 
         // Re-compute schemas each iteration so activated tools appear immediately.
-        let schemas_for_api = if native_tools {
+        // When the loop detector has escalated to stage 2, pass an empty tool
+        // list for this single turn so the model is forced to respond in text.
+        let schemas_for_api = if native_tools && !strip_tools_next_iter {
             tools.list_schemas()
         } else {
             vec![]
         };
+        if strip_tools_next_iter {
+            strip_tools_next_iter = false;
+            loop_detector.clear_strip_tools();
+        }
 
         enforce_tool_result_context_budget(
             &mut messages,
@@ -1249,19 +1283,14 @@ pub async fn run_agent_loop_with_context(
         // Execute tool calls concurrently.
         total_tool_calls += response.tool_calls.len();
 
-        // Emit all ToolCallStart events first (preserves notification order).
-        for tc in &response.tool_calls {
-            if let Some(cb) = on_event {
-                cb(RunnerEvent::ToolCallStart {
-                    id: tc.id.clone(),
-                    name: tc.name.clone(),
-                    arguments: tc.arguments.clone(),
-                });
-            }
-            info!(tool = %tc.name, id = %tc.id, args = %tc.arguments, "executing tool");
-        }
-
         // Build futures for all tool calls (executed concurrently).
+        //
+        // Pre-dispatch schema validation runs synchronously against each
+        // tool's declared `parameters_schema`. Calls that fail validation
+        // are short-circuited to a directive error response — the tool's
+        // `execute` method is never invoked, and the UI receives a
+        // `ToolCallRejected` event instead of the misleading
+        // `ToolCallStart`/"executing" status (issue #658).
         let tool_futures: Vec<_> = response
             .tool_calls
             .iter()
@@ -1287,7 +1316,48 @@ pub async fn run_agent_loop_with_context(
                         args_obj.insert(k.clone(), v.clone());
                     }
                 }
+
+                // Pre-dispatch validation against the tool's schema.
+                let validation_error: Option<String> = if let Some(ref t) = tool {
+                    let schema = t.parameters_schema();
+                    match validate_tool_args(&schema, &args) {
+                        Ok(()) => None,
+                        Err(e) => {
+                            warn!(
+                                tool = %tc_name,
+                                summary = %e.short_summary(),
+                                "tool call rejected by pre-dispatch schema validation"
+                            );
+                            Some(e.to_llm_error_message(&tc_name))
+                        },
+                    }
+                } else {
+                    None
+                };
+
+                // Emit ToolCallStart only for calls that will actually run.
+                // Rejected calls get a single `ToolCallRejected` event after
+                // the concurrent batch completes (handled in the result loop).
+                if validation_error.is_none() {
+                    if let Some(cb) = on_event {
+                        cb(RunnerEvent::ToolCallStart {
+                            id: tc.id.clone(),
+                            name: tc.name.clone(),
+                            arguments: args.clone(),
+                        });
+                    }
+                    info!(tool = %tc_name, id = %tc.id, args = %args, "executing tool");
+                }
+
                 async move {
+                    if let Some(err_msg) = validation_error {
+                        return (
+                            false,
+                            serde_json::json!({ "error": err_msg.clone() }),
+                            Some(err_msg),
+                            true,
+                        );
+                    }
                     // Run BeforeToolCall hook.
                     if let Some(ref hooks) = hook_registry {
                         let payload = HookPayload::BeforeToolCall {
@@ -1304,6 +1374,7 @@ pub async fn run_agent_loop_with_context(
                                     false,
                                     serde_json::json!({ "error": err_str }),
                                     Some(err_str),
+                                    false,
                                 );
                             },
                             Ok(HookAction::ModifyPayload(v)) => {
@@ -1347,9 +1418,9 @@ pub async fn run_agent_loop_with_context(
 
                                 if has_error {
                                     // Tool executed but returned an error in the result
-                                    (false, serde_json::json!({ "result": val }), error_msg)
+                                    (false, serde_json::json!({ "result": val }), error_msg, false)
                                 } else {
-                                    (true, serde_json::json!({ "result": val }), None)
+                                    (true, serde_json::json!({ "result": val }), None, false)
                                 }
                             },
                             Err(e) => {
@@ -1371,6 +1442,7 @@ pub async fn run_agent_loop_with_context(
                                     false,
                                     serde_json::json!({ "error": err_str }),
                                     Some(err_str),
+                                    false,
                                 )
                             },
                         }
@@ -1380,6 +1452,7 @@ pub async fn run_agent_loop_with_context(
                             false,
                             serde_json::json!({ "error": err_str }),
                             Some(err_str),
+                            false,
                         )
                     }
                 }
@@ -1389,27 +1462,66 @@ pub async fn run_agent_loop_with_context(
         // Execute all tools concurrently and collect results in order.
         let results = futures::future::join_all(tool_futures).await;
 
+        // Track the strongest loop-detector action observed this batch so we
+        // can inject an intervention message before the next iteration.
+        let mut pending_intervention: LoopDetectorAction = LoopDetectorAction::None;
+
         // Process results in original order: emit events, append messages.
-        for (tc, (success, mut result, error)) in response.tool_calls.iter().zip(results) {
+        for (tc, (success, mut result, error, rejected)) in response.tool_calls.iter().zip(results)
+        {
             if success {
                 info!(tool = %tc.name, id = %tc.id, "tool execution succeeded");
                 trace!(tool = %tc.name, result = %result, "tool result");
+            } else if rejected {
+                warn!(
+                    tool = %tc.name,
+                    id = %tc.id,
+                    "tool call rejected before execution by pre-dispatch validation"
+                );
             } else {
                 warn!(tool = %tc.name, id = %tc.id, error = %error.as_deref().unwrap_or(""), "tool execution failed");
             }
 
+            // Record outcome in the loop detector BEFORE the mutation below
+            // clobbers `error`. Feed the LLM-visible error text so variants
+            // like "missing 'command' parameter" repeated three times fire
+            // the detector even when the args differ slightly.
+            if loop_detector.is_enabled() {
+                let fp = ToolCallFingerprint::new(&tc.name, &tc.arguments, error.as_deref());
+                let action = loop_detector.record(fp);
+                if action != LoopDetectorAction::None {
+                    // Stage 2 (StripTools) takes precedence over stage 1 (Nudge).
+                    pending_intervention = match (action, pending_intervention) {
+                        (LoopDetectorAction::StripTools, _) => LoopDetectorAction::StripTools,
+                        (LoopDetectorAction::InjectNudge, LoopDetectorAction::None) => {
+                            LoopDetectorAction::InjectNudge
+                        },
+                        (_, existing) => existing,
+                    };
+                }
+            }
+
             if let Some(cb) = on_event {
-                cb(RunnerEvent::ToolCallEnd {
-                    id: tc.id.clone(),
-                    name: tc.name.clone(),
-                    success,
-                    error,
-                    result: if success {
-                        result.get("result").cloned()
-                    } else {
-                        None
-                    },
-                });
+                if rejected {
+                    cb(RunnerEvent::ToolCallRejected {
+                        id: tc.id.clone(),
+                        name: tc.name.clone(),
+                        arguments: tc.arguments.clone(),
+                        error: error.clone().unwrap_or_default(),
+                    });
+                } else {
+                    cb(RunnerEvent::ToolCallEnd {
+                        id: tc.id.clone(),
+                        name: tc.name.clone(),
+                        success,
+                        error,
+                        result: if success {
+                            result.get("result").cloned()
+                        } else {
+                            None
+                        },
+                    });
+                }
             }
 
             // Dispatch ToolResultPersist hook — the last opportunity for a handler
@@ -1456,6 +1568,49 @@ pub async fn run_agent_loop_with_context(
             trace!(tool = %tc.name, content = %tool_result_str, "tool result message content");
 
             messages.push(ChatMessage::tool(&tc.id, &tool_result_str));
+        }
+
+        // Apply loop-detector intervention if one fired during this batch.
+        match pending_intervention {
+            LoopDetectorAction::None => {},
+            LoopDetectorAction::InjectNudge => {
+                let window = loop_detector.window_snapshot();
+                let stuck_tool = window
+                    .first()
+                    .map(|fp| fp.tool_name.clone())
+                    .unwrap_or_default();
+                let intervention = format_intervention_message(&window);
+                info!(
+                    tool = %stuck_tool,
+                    "loop detector fired (stage 1): injecting directive intervention"
+                );
+                if let Some(cb) = on_event {
+                    cb(RunnerEvent::LoopInterventionFired {
+                        stage: 1,
+                        tool_name: stuck_tool,
+                    });
+                }
+                messages.push(ChatMessage::user(intervention));
+            },
+            LoopDetectorAction::StripTools => {
+                let stuck_tool = loop_detector
+                    .window_snapshot()
+                    .first()
+                    .map(|fp| fp.tool_name.clone())
+                    .unwrap_or_default();
+                info!(
+                    tool = %stuck_tool,
+                    "loop detector fired (stage 2): stripping tools for next iteration"
+                );
+                if let Some(cb) = on_event {
+                    cb(RunnerEvent::LoopInterventionFired {
+                        stage: 2,
+                        tool_name: stuck_tool,
+                    });
+                }
+                messages.push(ChatMessage::user(format_strip_tools_message()));
+                strip_tools_next_iter = true;
+            },
         }
     }
 }
@@ -1542,6 +1697,11 @@ pub async fn run_agent_loop_streaming(
     let mut malformed_retry_count: u8 = 0;
     let mut empty_tool_name_retry_count: u8 = 0;
     let mut auto_continue_count: usize = 0;
+    let mut loop_detector = ToolLoopDetector::new(
+        config.tools.agent_loop_detector_window,
+        config.tools.agent_loop_detector_strip_tools_on_second_fire,
+    );
+    let mut strip_tools_next_iter = false;
 
     loop {
         iterations += 1;
@@ -1557,11 +1717,18 @@ pub async fn run_agent_loop_streaming(
         }
 
         // Re-compute schemas each iteration so activated tools appear immediately.
-        let schemas_for_api = if native_tools {
+        // When the loop detector has escalated to stage 2, pass an empty tool
+        // list for this single turn so the model is forced to respond in text
+        // (issue #658).
+        let schemas_for_api = if native_tools && !strip_tools_next_iter {
             tools.list_schemas()
         } else {
             vec![]
         };
+        if strip_tools_next_iter {
+            strip_tools_next_iter = false;
+            loop_detector.clear_strip_tools();
+        }
 
         enforce_tool_result_context_budget(
             &mut messages,
@@ -1773,6 +1940,14 @@ pub async fn run_agent_loop_streaming(
         // Use stream_idx_to_vec_pos to map streaming indices (which may not
         // start at 0) to the actual position in the tool_calls vec.
         for (stream_idx, args_str) in &tool_call_args {
+            // Emit raw accumulated string at debug level so future variants of
+            // "default to {} because no deltas arrived" can be diagnosed
+            // without a repro (issue #658).
+            debug!(
+                stream_idx,
+                args_str = %args_str,
+                "finalizing tool call args"
+            );
             if let Some(&vec_pos) = stream_idx_to_vec_pos.get(stream_idx)
                 && vec_pos < tool_calls.len()
                 && !args_str.is_empty()
@@ -2009,19 +2184,13 @@ pub async fn run_agent_loop_streaming(
         // Execute tool calls concurrently.
         total_tool_calls += tool_calls.len();
 
-        // Emit all ToolCallStart events first (preserves notification order).
-        for tc in &tool_calls {
-            if let Some(cb) = on_event {
-                cb(RunnerEvent::ToolCallStart {
-                    id: tc.id.clone(),
-                    name: tc.name.clone(),
-                    arguments: tc.arguments.clone(),
-                });
-            }
-            info!(tool = %tc.name, id = %tc.id, args = %tc.arguments, "executing tool");
-        }
-
         // Build futures for all tool calls (executed concurrently).
+        //
+        // Pre-dispatch schema validation runs synchronously against each
+        // tool's declared `parameters_schema`. Calls that fail validation
+        // are short-circuited to a directive error response without invoking
+        // `execute`, and the UI receives `ToolCallRejected` instead of the
+        // misleading "executing" status (issue #658).
         let tool_futures: Vec<_> = tool_calls
             .iter()
             .map(|tc| {
@@ -2044,7 +2213,45 @@ pub async fn run_agent_loop_streaming(
                         args_obj.insert(k.clone(), v.clone());
                     }
                 }
+
+                // Pre-dispatch validation against the tool's schema.
+                let validation_error: Option<String> = if let Some(ref t) = tool {
+                    let schema = t.parameters_schema();
+                    match validate_tool_args(&schema, &args) {
+                        Ok(()) => None,
+                        Err(e) => {
+                            warn!(
+                                tool = %tc_name,
+                                summary = %e.short_summary(),
+                                "tool call rejected by pre-dispatch schema validation"
+                            );
+                            Some(e.to_llm_error_message(&tc_name))
+                        },
+                    }
+                } else {
+                    None
+                };
+
+                if validation_error.is_none() {
+                    if let Some(cb) = on_event {
+                        cb(RunnerEvent::ToolCallStart {
+                            id: tc.id.clone(),
+                            name: tc.name.clone(),
+                            arguments: args.clone(),
+                        });
+                    }
+                    info!(tool = %tc_name, id = %tc.id, args = %args, "executing tool");
+                }
+
                 async move {
+                    if let Some(err_msg) = validation_error {
+                        return (
+                            false,
+                            serde_json::json!({ "error": err_msg.clone() }),
+                            Some(err_msg),
+                            true,
+                        );
+                    }
                     // Run BeforeToolCall hook.
                     if let Some(ref hooks) = hook_registry {
                         let payload = HookPayload::BeforeToolCall {
@@ -2061,6 +2268,7 @@ pub async fn run_agent_loop_streaming(
                                     false,
                                     serde_json::json!({ "error": err_str }),
                                     Some(err_str),
+                                    false,
                                 );
                             }
                             Ok(HookAction::ModifyPayload(v)) => {
@@ -2102,9 +2310,9 @@ pub async fn run_agent_loop_streaming(
                                 }
 
                                 if has_error {
-                                    (false, serde_json::json!({ "result": val }), error_msg)
+                                    (false, serde_json::json!({ "result": val }), error_msg, false)
                                 } else {
-                                    (true, serde_json::json!({ "result": val }), None)
+                                    (true, serde_json::json!({ "result": val }), None, false)
                                 }
                             }
                             Err(e) => {
@@ -2125,6 +2333,7 @@ pub async fn run_agent_loop_streaming(
                                     false,
                                     serde_json::json!({ "error": err_str }),
                                     Some(err_str),
+                                    false,
                                 )
                             }
                         }
@@ -2134,6 +2343,7 @@ pub async fn run_agent_loop_streaming(
                             false,
                             serde_json::json!({ "error": err_str }),
                             Some(err_str),
+                            false,
                         )
                     }
                 }
@@ -2143,27 +2353,61 @@ pub async fn run_agent_loop_streaming(
         // Execute all tools concurrently and collect results in order.
         let results = futures::future::join_all(tool_futures).await;
 
+        // Track the strongest loop-detector action observed this batch so we
+        // can inject an intervention message before the next iteration.
+        let mut pending_intervention: LoopDetectorAction = LoopDetectorAction::None;
+
         // Process results in original order: emit events, append messages.
-        for (tc, (success, mut result, error)) in tool_calls.iter().zip(results) {
+        for (tc, (success, mut result, error, rejected)) in tool_calls.iter().zip(results) {
             if success {
                 info!(tool = %tc.name, id = %tc.id, "tool execution succeeded");
                 trace!(tool = %tc.name, result = %result, "tool result");
+            } else if rejected {
+                warn!(
+                    tool = %tc.name,
+                    id = %tc.id,
+                    "tool call rejected before execution by pre-dispatch validation"
+                );
             } else {
                 warn!(tool = %tc.name, id = %tc.id, error = %error.as_deref().unwrap_or(""), "tool execution failed");
             }
 
+            // Record outcome in the loop detector (issue #658).
+            if loop_detector.is_enabled() {
+                let fp = ToolCallFingerprint::new(&tc.name, &tc.arguments, error.as_deref());
+                let action = loop_detector.record(fp);
+                if action != LoopDetectorAction::None {
+                    pending_intervention = match (action, pending_intervention) {
+                        (LoopDetectorAction::StripTools, _) => LoopDetectorAction::StripTools,
+                        (LoopDetectorAction::InjectNudge, LoopDetectorAction::None) => {
+                            LoopDetectorAction::InjectNudge
+                        },
+                        (_, existing) => existing,
+                    };
+                }
+            }
+
             if let Some(cb) = on_event {
-                cb(RunnerEvent::ToolCallEnd {
-                    id: tc.id.clone(),
-                    name: tc.name.clone(),
-                    success,
-                    error,
-                    result: if success {
-                        result.get("result").cloned()
-                    } else {
-                        None
-                    },
-                });
+                if rejected {
+                    cb(RunnerEvent::ToolCallRejected {
+                        id: tc.id.clone(),
+                        name: tc.name.clone(),
+                        arguments: tc.arguments.clone(),
+                        error: error.clone().unwrap_or_default(),
+                    });
+                } else {
+                    cb(RunnerEvent::ToolCallEnd {
+                        id: tc.id.clone(),
+                        name: tc.name.clone(),
+                        success,
+                        error,
+                        result: if success {
+                            result.get("result").cloned()
+                        } else {
+                            None
+                        },
+                    });
+                }
             }
 
             // Dispatch ToolResultPersist hook — the last opportunity for a handler
@@ -2210,6 +2454,49 @@ pub async fn run_agent_loop_streaming(
             trace!(tool = %tc.name, content = %tool_result_str, "tool result message content");
 
             messages.push(ChatMessage::tool(&tc.id, &tool_result_str));
+        }
+
+        // Apply loop-detector intervention if one fired during this batch.
+        match pending_intervention {
+            LoopDetectorAction::None => {},
+            LoopDetectorAction::InjectNudge => {
+                let window = loop_detector.window_snapshot();
+                let stuck_tool = window
+                    .first()
+                    .map(|fp| fp.tool_name.clone())
+                    .unwrap_or_default();
+                let intervention = format_intervention_message(&window);
+                info!(
+                    tool = %stuck_tool,
+                    "loop detector fired (stage 1): injecting directive intervention"
+                );
+                if let Some(cb) = on_event {
+                    cb(RunnerEvent::LoopInterventionFired {
+                        stage: 1,
+                        tool_name: stuck_tool,
+                    });
+                }
+                messages.push(ChatMessage::user(intervention));
+            },
+            LoopDetectorAction::StripTools => {
+                let stuck_tool = loop_detector
+                    .window_snapshot()
+                    .first()
+                    .map(|fp| fp.tool_name.clone())
+                    .unwrap_or_default();
+                info!(
+                    tool = %stuck_tool,
+                    "loop detector fired (stage 2): stripping tools for next iteration"
+                );
+                if let Some(cb) = on_event {
+                    cb(RunnerEvent::LoopInterventionFired {
+                        stage: 2,
+                        tool_name: stuck_tool,
+                    });
+                }
+                messages.push(ChatMessage::user(format_strip_tools_message()));
+                strip_tools_next_iter = true;
+            },
         }
     }
 }
@@ -8460,5 +8747,378 @@ mod tests {
             let tool_names = tool_names.lock().unwrap_or_else(|e| e.into_inner());
             assert_eq!(tool_names.as_slice(), ["echo_tool"]);
         }
+    }
+
+    // Reflex-loop detector tests — issue #658.
+
+    struct ReflexExecProvider {
+        reflex_count: std::sync::atomic::AtomicUsize,
+        saw_intervention: std::sync::atomic::AtomicBool,
+    }
+
+    fn history_contains_intervention(messages: &[ChatMessage]) -> bool {
+        messages.iter().any(|m| match m {
+            ChatMessage::User {
+                content: UserContent::Text(text),
+            } => text.contains("LOOP DETECTED") || text.contains("TOOLS DISABLED"),
+            _ => false,
+        })
+    }
+
+    #[async_trait]
+    impl LlmProvider for ReflexExecProvider {
+        fn name(&self) -> &str {
+            "mock-reflex"
+        }
+
+        fn id(&self) -> &str {
+            "mock-reflex"
+        }
+
+        fn supports_tools(&self) -> bool {
+            true
+        }
+
+        async fn complete(
+            &self,
+            messages: &[ChatMessage],
+            _tools: &[serde_json::Value],
+        ) -> Result<CompletionResponse> {
+            if history_contains_intervention(messages) {
+                self.saw_intervention
+                    .store(true, std::sync::atomic::Ordering::SeqCst);
+                return Ok(CompletionResponse {
+                    text: Some("Sorry, I do not know what command you wanted.".into()),
+                    tool_calls: vec![],
+                    usage: Usage {
+                        input_tokens: 5,
+                        output_tokens: 5,
+                        ..Default::default()
+                    },
+                });
+            }
+            let n = self
+                .reflex_count
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            Ok(CompletionResponse {
+                text: None,
+                tool_calls: vec![ToolCall {
+                    id: format!("call_{n}"),
+                    name: "exec".into(),
+                    arguments: serde_json::json!({}),
+                }],
+                usage: Usage {
+                    input_tokens: 5,
+                    output_tokens: 5,
+                    ..Default::default()
+                },
+            })
+        }
+
+        fn stream(
+            &self,
+            _messages: Vec<ChatMessage>,
+        ) -> Pin<Box<dyn Stream<Item = StreamEvent> + Send + '_>> {
+            Box::pin(tokio_stream::empty())
+        }
+    }
+
+    #[tokio::test]
+    async fn reflex_loop_fires_detector_and_terminates_non_streaming() {
+        let provider = Arc::new(ReflexExecProvider {
+            reflex_count: std::sync::atomic::AtomicUsize::new(0),
+            saw_intervention: std::sync::atomic::AtomicBool::new(false),
+        });
+        let saw = Arc::clone(&provider) as Arc<dyn LlmProvider>;
+
+        let mut tools = ToolRegistry::new();
+        tools.register(Box::new(TestExecTool));
+
+        let events: Arc<std::sync::Mutex<Vec<RunnerEvent>>> =
+            Arc::new(std::sync::Mutex::new(Vec::new()));
+        let events_clone = Arc::clone(&events);
+        let on_event: OnEvent = Box::new(move |e| {
+            events_clone.lock().unwrap().push(e);
+        });
+
+        let result = run_agent_loop(
+            saw,
+            &tools,
+            "You are a test bot.",
+            &UserContent::text("Run something"),
+            Some(&on_event),
+            None,
+        )
+        .await
+        .unwrap();
+
+        assert!(
+            result.iterations <= 5,
+            "runner should intervene before iter 5, got {}",
+            result.iterations
+        );
+        assert!(result.text.contains("Sorry"));
+
+        assert!(
+            provider
+                .saw_intervention
+                .load(std::sync::atomic::Ordering::SeqCst),
+            "provider never saw the loop-detector intervention message"
+        );
+
+        let events_snapshot = events.lock().unwrap().clone();
+        let any_start = events_snapshot
+            .iter()
+            .any(|e| matches!(e, RunnerEvent::ToolCallStart { .. }));
+        assert!(
+            !any_start,
+            "rejected calls must not emit ToolCallStart, got: {events_snapshot:?}"
+        );
+        let rejected_count = events_snapshot
+            .iter()
+            .filter(|e| matches!(e, RunnerEvent::ToolCallRejected { .. }))
+            .count();
+        assert!(
+            rejected_count >= 3,
+            "expected at least 3 ToolCallRejected events, got {rejected_count}"
+        );
+        assert!(
+            events_snapshot
+                .iter()
+                .any(|e| matches!(e, RunnerEvent::LoopInterventionFired { .. })),
+            "expected a LoopInterventionFired event"
+        );
+    }
+
+    struct ReflexExecStreamProvider {
+        reflex_count: std::sync::atomic::AtomicUsize,
+        saw_intervention: std::sync::atomic::AtomicBool,
+    }
+
+    #[async_trait]
+    impl LlmProvider for ReflexExecStreamProvider {
+        fn name(&self) -> &str {
+            "mock-reflex-stream"
+        }
+
+        fn id(&self) -> &str {
+            "mock-reflex-stream"
+        }
+
+        fn supports_tools(&self) -> bool {
+            true
+        }
+
+        async fn complete(
+            &self,
+            _messages: &[ChatMessage],
+            _tools: &[serde_json::Value],
+        ) -> Result<CompletionResponse> {
+            unreachable!("streaming test should not call complete()")
+        }
+
+        fn stream(
+            &self,
+            _messages: Vec<ChatMessage>,
+        ) -> Pin<Box<dyn Stream<Item = StreamEvent> + Send + '_>> {
+            Box::pin(tokio_stream::empty())
+        }
+
+        fn stream_with_tools(
+            &self,
+            messages: Vec<ChatMessage>,
+            _tools: Vec<serde_json::Value>,
+        ) -> Pin<Box<dyn Stream<Item = StreamEvent> + Send + '_>> {
+            if history_contains_intervention(&messages) {
+                self.saw_intervention
+                    .store(true, std::sync::atomic::Ordering::SeqCst);
+                let events = vec![
+                    StreamEvent::Delta(
+                        "I cannot proceed because I do not know what command you wanted me to run. \
+                         Please tell me the exact command to execute.".into(),
+                    ),
+                    StreamEvent::Done(Usage {
+                        input_tokens: 5,
+                        output_tokens: 5,
+                        ..Default::default()
+                    }),
+                ];
+                return Box::pin(tokio_stream::iter(events));
+            }
+            let n = self
+                .reflex_count
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            let events = vec![
+                StreamEvent::ToolCallStart {
+                    id: format!("call_{n}"),
+                    name: "exec".into(),
+                    index: 0,
+                },
+                StreamEvent::ToolCallComplete { index: 0 },
+                StreamEvent::Done(Usage {
+                    input_tokens: 5,
+                    output_tokens: 5,
+                    ..Default::default()
+                }),
+            ];
+            Box::pin(tokio_stream::iter(events))
+        }
+    }
+
+    #[tokio::test]
+    async fn reflex_loop_fires_detector_and_terminates_streaming() {
+        let provider = Arc::new(ReflexExecStreamProvider {
+            reflex_count: std::sync::atomic::AtomicUsize::new(0),
+            saw_intervention: std::sync::atomic::AtomicBool::new(false),
+        });
+        let saw = Arc::clone(&provider) as Arc<dyn LlmProvider>;
+
+        let mut tools = ToolRegistry::new();
+        tools.register(Box::new(TestExecTool));
+
+        let events: Arc<std::sync::Mutex<Vec<RunnerEvent>>> =
+            Arc::new(std::sync::Mutex::new(Vec::new()));
+        let events_clone = Arc::clone(&events);
+        let on_event: OnEvent = Box::new(move |e| {
+            events_clone.lock().unwrap().push(e);
+        });
+
+        let result = run_agent_loop_streaming(
+            saw,
+            &tools,
+            "You are a test bot.",
+            &UserContent::text("Run something"),
+            Some(&on_event),
+            None,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+        assert!(
+            result.iterations <= 5,
+            "streaming runner should intervene before iter 5, got {}",
+            result.iterations
+        );
+        assert!(
+            provider
+                .saw_intervention
+                .load(std::sync::atomic::Ordering::SeqCst),
+            "streaming provider never saw the loop-detector intervention"
+        );
+
+        let events_snapshot = events.lock().unwrap().clone();
+        let rejected_count = events_snapshot
+            .iter()
+            .filter(|e| matches!(e, RunnerEvent::ToolCallRejected { .. }))
+            .count();
+        assert!(
+            rejected_count >= 3,
+            "streaming: expected >=3 ToolCallRejected events, got {rejected_count}"
+        );
+        assert!(
+            events_snapshot
+                .iter()
+                .any(|e| matches!(e, RunnerEvent::LoopInterventionFired { .. })),
+            "streaming: expected LoopInterventionFired event"
+        );
+    }
+
+    struct LegitimateRetryProvider {
+        call_count: std::sync::atomic::AtomicUsize,
+    }
+
+    #[async_trait]
+    impl LlmProvider for LegitimateRetryProvider {
+        fn name(&self) -> &str {
+            "mock-legitimate-retry"
+        }
+
+        fn id(&self) -> &str {
+            "mock-legitimate-retry"
+        }
+
+        fn supports_tools(&self) -> bool {
+            true
+        }
+
+        async fn complete(
+            &self,
+            _messages: &[ChatMessage],
+            _tools: &[serde_json::Value],
+        ) -> Result<CompletionResponse> {
+            let n = self
+                .call_count
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            match n {
+                0 => Ok(CompletionResponse {
+                    text: None,
+                    tool_calls: vec![ToolCall {
+                        id: "c1".into(),
+                        name: "exec".into(),
+                        arguments: serde_json::json!({"command": "ls /nonexistent-xyz"}),
+                    }],
+                    usage: Usage::default(),
+                }),
+                1 => Ok(CompletionResponse {
+                    text: None,
+                    tool_calls: vec![ToolCall {
+                        id: "c2".into(),
+                        name: "exec".into(),
+                        arguments: serde_json::json!({"command": "echo recovered"}),
+                    }],
+                    usage: Usage::default(),
+                }),
+                _ => Ok(CompletionResponse {
+                    text: Some("Done".into()),
+                    tool_calls: vec![],
+                    usage: Usage::default(),
+                }),
+            }
+        }
+
+        fn stream(
+            &self,
+            _messages: Vec<ChatMessage>,
+        ) -> Pin<Box<dyn Stream<Item = StreamEvent> + Send + '_>> {
+            Box::pin(tokio_stream::empty())
+        }
+    }
+
+    #[tokio::test]
+    async fn legitimate_retry_does_not_fire_loop_detector() {
+        let provider = Arc::new(LegitimateRetryProvider {
+            call_count: std::sync::atomic::AtomicUsize::new(0),
+        });
+        let mut tools = ToolRegistry::new();
+        tools.register(Box::new(TestExecTool));
+
+        let events: Arc<std::sync::Mutex<Vec<RunnerEvent>>> =
+            Arc::new(std::sync::Mutex::new(Vec::new()));
+        let events_clone = Arc::clone(&events);
+        let on_event: OnEvent = Box::new(move |e| {
+            events_clone.lock().unwrap().push(e);
+        });
+
+        let result = run_agent_loop(
+            provider,
+            &tools,
+            "You are a test bot.",
+            &UserContent::text("Run something"),
+            Some(&on_event),
+            None,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(result.text, "Done");
+        let events_snapshot = events.lock().unwrap().clone();
+        assert!(
+            !events_snapshot
+                .iter()
+                .any(|e| matches!(e, RunnerEvent::LoopInterventionFired { .. })),
+            "legitimate retry must not trigger loop detector, got {events_snapshot:?}"
+        );
     }
 }

--- a/crates/agents/src/runner.rs
+++ b/crates/agents/src/runner.rs
@@ -1487,11 +1487,15 @@ pub async fn run_agent_loop_with_context(
                 warn!(tool = %tc.name, id = %tc.id, error = %error.as_deref().unwrap_or(""), "tool execution failed");
             }
 
-            // Record outcome in the loop detector. Feed the LLM-visible error
-            // text so variants like "missing 'command' parameter" repeated
-            // three times fire the detector even when args differ slightly.
+            // Record outcome in the loop detector. Use explicit success/failure
+            // constructors so tools returning `{success: false}` without an
+            // `error` field still register as failures.
             if loop_detector.is_enabled() {
-                let fp = ToolCallFingerprint::new(&tc.name, &tc.arguments, error.as_deref());
+                let fp = if success {
+                    ToolCallFingerprint::success(&tc.name, &tc.arguments)
+                } else {
+                    ToolCallFingerprint::failure(&tc.name, &tc.arguments, error.as_deref())
+                };
                 let _ = loop_detector.record(fp);
             }
 
@@ -2389,7 +2393,11 @@ pub async fn run_agent_loop_streaming(
 
             // Record outcome in the loop detector (issue #658).
             if loop_detector.is_enabled() {
-                let fp = ToolCallFingerprint::new(&tc.name, &tc.arguments, error.as_deref());
+                let fp = if success {
+                    ToolCallFingerprint::success(&tc.name, &tc.arguments)
+                } else {
+                    ToolCallFingerprint::failure(&tc.name, &tc.arguments, error.as_deref())
+                };
                 let _ = loop_detector.record(fp);
             }
 

--- a/crates/agents/src/runner.rs
+++ b/crates/agents/src/runner.rs
@@ -1462,11 +1462,16 @@ pub async fn run_agent_loop_with_context(
         // Execute all tools concurrently and collect results in order.
         let results = futures::future::join_all(tool_futures).await;
 
-        // Track the strongest loop-detector action observed this batch so we
-        // can inject an intervention message before the next iteration.
-        let mut pending_intervention: LoopDetectorAction = LoopDetectorAction::None;
-
         // Process results in original order: emit events, append messages.
+        // The loop detector records each outcome as it is processed; the
+        // authoritative intervention decision is derived AFTER the loop from
+        // the detector's post-batch state via `consume_pending_action()`.
+        // This avoids two edge cases that per-call return values hit in
+        // mixed batches:
+        //   1. Trailing success after a triggering failure must NOT leave a
+        //      stale intervention — the reset() abandons it cleanly.
+        //   2. A batch that races through both escalation stages must still
+        //      deliver the stage-1 nudge first, not skip straight to strip.
         for (tc, (success, mut result, error, rejected)) in response.tool_calls.iter().zip(results)
         {
             if success {
@@ -1482,23 +1487,12 @@ pub async fn run_agent_loop_with_context(
                 warn!(tool = %tc.name, id = %tc.id, error = %error.as_deref().unwrap_or(""), "tool execution failed");
             }
 
-            // Record outcome in the loop detector BEFORE the mutation below
-            // clobbers `error`. Feed the LLM-visible error text so variants
-            // like "missing 'command' parameter" repeated three times fire
-            // the detector even when the args differ slightly.
+            // Record outcome in the loop detector. Feed the LLM-visible error
+            // text so variants like "missing 'command' parameter" repeated
+            // three times fire the detector even when args differ slightly.
             if loop_detector.is_enabled() {
                 let fp = ToolCallFingerprint::new(&tc.name, &tc.arguments, error.as_deref());
-                let action = loop_detector.record(fp);
-                if action != LoopDetectorAction::None {
-                    // Stage 2 (StripTools) takes precedence over stage 1 (Nudge).
-                    pending_intervention = match (action, pending_intervention) {
-                        (LoopDetectorAction::StripTools, _) => LoopDetectorAction::StripTools,
-                        (LoopDetectorAction::InjectNudge, LoopDetectorAction::None) => {
-                            LoopDetectorAction::InjectNudge
-                        },
-                        (_, existing) => existing,
-                    };
-                }
+                let _ = loop_detector.record(fp);
             }
 
             if let Some(cb) = on_event {
@@ -1571,47 +1565,69 @@ pub async fn run_agent_loop_with_context(
         }
 
         // Apply loop-detector intervention if one fired during this batch.
-        match pending_intervention {
-            LoopDetectorAction::None => {},
-            LoopDetectorAction::InjectNudge => {
-                let window = loop_detector.window_snapshot();
-                let stuck_tool = window
-                    .first()
-                    .map(|fp| fp.tool_name.clone())
-                    .unwrap_or_default();
-                let intervention = format_intervention_message(&window);
-                info!(
-                    tool = %stuck_tool,
-                    "loop detector fired (stage 1): injecting directive intervention"
-                );
-                if let Some(cb) = on_event {
-                    cb(RunnerEvent::LoopInterventionFired {
-                        stage: 1,
-                        tool_name: stuck_tool,
-                    });
-                }
-                messages.push(ChatMessage::user(intervention));
-            },
-            LoopDetectorAction::StripTools => {
-                let stuck_tool = loop_detector
-                    .window_snapshot()
-                    .first()
-                    .map(|fp| fp.tool_name.clone())
-                    .unwrap_or_default();
-                info!(
-                    tool = %stuck_tool,
-                    "loop detector fired (stage 2): stripping tools for next iteration"
-                );
-                if let Some(cb) = on_event {
-                    cb(RunnerEvent::LoopInterventionFired {
-                        stage: 2,
-                        tool_name: stuck_tool,
-                    });
-                }
-                messages.push(ChatMessage::user(format_strip_tools_message()));
-                strip_tools_next_iter = true;
-            },
-        }
+        apply_loop_detector_intervention(
+            &mut loop_detector,
+            &mut messages,
+            &mut strip_tools_next_iter,
+            on_event,
+        );
+    }
+}
+
+/// Consume the detector's post-batch action (if any) and apply it to the
+/// runner state: push the directive user message into `messages`, emit the
+/// `LoopInterventionFired` UI event, and set `strip_tools_next_iter` when
+/// stage 2 fires. Shared by the streaming and non-streaming loops (issue
+/// #658).
+fn apply_loop_detector_intervention(
+    loop_detector: &mut ToolLoopDetector,
+    messages: &mut Vec<ChatMessage>,
+    strip_tools_next_iter: &mut bool,
+    on_event: Option<&OnEvent>,
+) {
+    if !loop_detector.is_enabled() {
+        return;
+    }
+    match loop_detector.consume_pending_action() {
+        LoopDetectorAction::None => {},
+        LoopDetectorAction::InjectNudge => {
+            let window = loop_detector.window_snapshot();
+            let stuck_tool = window
+                .first()
+                .map(|fp| fp.tool_name.clone())
+                .unwrap_or_default();
+            let intervention = format_intervention_message(&window);
+            info!(
+                tool = %stuck_tool,
+                "loop detector fired (stage 1): injecting directive intervention"
+            );
+            if let Some(cb) = on_event {
+                cb(RunnerEvent::LoopInterventionFired {
+                    stage: 1,
+                    tool_name: stuck_tool,
+                });
+            }
+            messages.push(ChatMessage::user(intervention));
+        },
+        LoopDetectorAction::StripTools => {
+            let stuck_tool = loop_detector
+                .window_snapshot()
+                .first()
+                .map(|fp| fp.tool_name.clone())
+                .unwrap_or_default();
+            info!(
+                tool = %stuck_tool,
+                "loop detector fired (stage 2): stripping tools for next iteration"
+            );
+            if let Some(cb) = on_event {
+                cb(RunnerEvent::LoopInterventionFired {
+                    stage: 2,
+                    tool_name: stuck_tool,
+                });
+            }
+            messages.push(ChatMessage::user(format_strip_tools_message()));
+            *strip_tools_next_iter = true;
+        },
     }
 }
 
@@ -2353,11 +2369,10 @@ pub async fn run_agent_loop_streaming(
         // Execute all tools concurrently and collect results in order.
         let results = futures::future::join_all(tool_futures).await;
 
-        // Track the strongest loop-detector action observed this batch so we
-        // can inject an intervention message before the next iteration.
-        let mut pending_intervention: LoopDetectorAction = LoopDetectorAction::None;
-
         // Process results in original order: emit events, append messages.
+        // Intervention is derived from the detector's post-batch state
+        // via `consume_pending_action()` below — see the non-streaming
+        // path for the rationale (issue #658).
         for (tc, (success, mut result, error, rejected)) in tool_calls.iter().zip(results) {
             if success {
                 info!(tool = %tc.name, id = %tc.id, "tool execution succeeded");
@@ -2375,16 +2390,7 @@ pub async fn run_agent_loop_streaming(
             // Record outcome in the loop detector (issue #658).
             if loop_detector.is_enabled() {
                 let fp = ToolCallFingerprint::new(&tc.name, &tc.arguments, error.as_deref());
-                let action = loop_detector.record(fp);
-                if action != LoopDetectorAction::None {
-                    pending_intervention = match (action, pending_intervention) {
-                        (LoopDetectorAction::StripTools, _) => LoopDetectorAction::StripTools,
-                        (LoopDetectorAction::InjectNudge, LoopDetectorAction::None) => {
-                            LoopDetectorAction::InjectNudge
-                        },
-                        (_, existing) => existing,
-                    };
-                }
+                let _ = loop_detector.record(fp);
             }
 
             if let Some(cb) = on_event {
@@ -2457,47 +2463,12 @@ pub async fn run_agent_loop_streaming(
         }
 
         // Apply loop-detector intervention if one fired during this batch.
-        match pending_intervention {
-            LoopDetectorAction::None => {},
-            LoopDetectorAction::InjectNudge => {
-                let window = loop_detector.window_snapshot();
-                let stuck_tool = window
-                    .first()
-                    .map(|fp| fp.tool_name.clone())
-                    .unwrap_or_default();
-                let intervention = format_intervention_message(&window);
-                info!(
-                    tool = %stuck_tool,
-                    "loop detector fired (stage 1): injecting directive intervention"
-                );
-                if let Some(cb) = on_event {
-                    cb(RunnerEvent::LoopInterventionFired {
-                        stage: 1,
-                        tool_name: stuck_tool,
-                    });
-                }
-                messages.push(ChatMessage::user(intervention));
-            },
-            LoopDetectorAction::StripTools => {
-                let stuck_tool = loop_detector
-                    .window_snapshot()
-                    .first()
-                    .map(|fp| fp.tool_name.clone())
-                    .unwrap_or_default();
-                info!(
-                    tool = %stuck_tool,
-                    "loop detector fired (stage 2): stripping tools for next iteration"
-                );
-                if let Some(cb) = on_event {
-                    cb(RunnerEvent::LoopInterventionFired {
-                        stage: 2,
-                        tool_name: stuck_tool,
-                    });
-                }
-                messages.push(ChatMessage::user(format_strip_tools_message()));
-                strip_tools_next_iter = true;
-            },
-        }
+        apply_loop_detector_intervention(
+            &mut loop_detector,
+            &mut messages,
+            &mut strip_tools_next_iter,
+            on_event,
+        );
     }
 }
 
@@ -9119,6 +9090,243 @@ mod tests {
                 .iter()
                 .any(|e| matches!(e, RunnerEvent::LoopInterventionFired { .. })),
             "legitimate retry must not trigger loop detector, got {events_snapshot:?}"
+        );
+    }
+
+    /// Provider that emits a parallel batch `[exec({}), exec("ls /tmp")]`
+    /// on the first turn — one call will fail schema validation and one
+    /// will succeed — then returns text. Exercises the "trailing success in
+    /// the same batch suppresses intervention" edge case end-to-end (Greptile
+    /// finding #1 on commit cf39c1a6).
+    struct MixedBatchProvider {
+        call_count: std::sync::atomic::AtomicUsize,
+    }
+
+    #[async_trait]
+    impl LlmProvider for MixedBatchProvider {
+        fn name(&self) -> &str {
+            "mock-mixed-batch"
+        }
+
+        fn id(&self) -> &str {
+            "mock-mixed-batch"
+        }
+
+        fn supports_tools(&self) -> bool {
+            true
+        }
+
+        async fn complete(
+            &self,
+            _messages: &[ChatMessage],
+            _tools: &[serde_json::Value],
+        ) -> Result<CompletionResponse> {
+            let n = self
+                .call_count
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            if n == 0 {
+                // Two failures followed by a success in a single batch is
+                // the trickiest input for the loop detector: per-call
+                // return values would accumulate a pending nudge that the
+                // success then silently abandons. The runner must agree
+                // with the detector's post-batch state (None) and NOT
+                // inject an intervention.
+                return Ok(CompletionResponse {
+                    text: None,
+                    tool_calls: vec![
+                        ToolCall {
+                            id: "c1".into(),
+                            name: "exec".into(),
+                            arguments: serde_json::json!({}),
+                        },
+                        ToolCall {
+                            id: "c2".into(),
+                            name: "exec".into(),
+                            arguments: serde_json::json!({}),
+                        },
+                        ToolCall {
+                            id: "c3".into(),
+                            name: "exec".into(),
+                            arguments: serde_json::json!({"command": "true"}),
+                        },
+                    ],
+                    usage: Usage::default(),
+                });
+            }
+            Ok(CompletionResponse {
+                text: Some(
+                    "Mixed batch complete — proceeding to the next step of the task.".into(),
+                ),
+                tool_calls: vec![],
+                usage: Usage::default(),
+            })
+        }
+
+        fn stream(
+            &self,
+            _messages: Vec<ChatMessage>,
+        ) -> Pin<Box<dyn Stream<Item = StreamEvent> + Send + '_>> {
+            Box::pin(tokio_stream::empty())
+        }
+    }
+
+    #[tokio::test]
+    async fn mixed_batch_with_trailing_success_does_not_fire_intervention() {
+        // Regression for Greptile finding #1: trailing success must cancel
+        // any pending intervention from earlier rejects in the same batch.
+        let provider = Arc::new(MixedBatchProvider {
+            call_count: std::sync::atomic::AtomicUsize::new(0),
+        });
+        let mut tools = ToolRegistry::new();
+        tools.register(Box::new(TestExecTool));
+
+        let events: Arc<std::sync::Mutex<Vec<RunnerEvent>>> =
+            Arc::new(std::sync::Mutex::new(Vec::new()));
+        let events_clone = Arc::clone(&events);
+        let on_event: OnEvent = Box::new(move |e| {
+            events_clone.lock().unwrap().push(e);
+        });
+
+        let _result = run_agent_loop(
+            provider,
+            &tools,
+            "You are a test bot.",
+            &UserContent::text("Run something"),
+            Some(&on_event),
+            None,
+        )
+        .await
+        .unwrap();
+
+        let events_snapshot = events.lock().unwrap().clone();
+        assert!(
+            !events_snapshot
+                .iter()
+                .any(|e| matches!(e, RunnerEvent::LoopInterventionFired { .. })),
+            "trailing success in the same batch must not fire an intervention; \
+             got events: {events_snapshot:?}"
+        );
+        // Confirm the expected mix of rejected + successful calls was dispatched.
+        let rejected = events_snapshot
+            .iter()
+            .filter(|e| matches!(e, RunnerEvent::ToolCallRejected { .. }))
+            .count();
+        let started = events_snapshot
+            .iter()
+            .filter(|e| matches!(e, RunnerEvent::ToolCallStart { .. }))
+            .count();
+        assert_eq!(rejected, 2, "two calls should have been rejected");
+        assert_eq!(started, 1, "one successful call should have started");
+    }
+
+    /// Provider that emits FOUR identical `exec({})` calls in a single
+    /// batch. This races the loop detector through both escalation stages
+    /// within one batch; the runner must still deliver the stage-1 nudge
+    /// first rather than skipping straight to strip-tools (Greptile finding
+    /// #2 on commit cf39c1a6).
+    struct ParallelReflexProvider {
+        call_count: std::sync::atomic::AtomicUsize,
+    }
+
+    #[async_trait]
+    impl LlmProvider for ParallelReflexProvider {
+        fn name(&self) -> &str {
+            "mock-parallel-reflex"
+        }
+
+        fn id(&self) -> &str {
+            "mock-parallel-reflex"
+        }
+
+        fn supports_tools(&self) -> bool {
+            true
+        }
+
+        async fn complete(
+            &self,
+            messages: &[ChatMessage],
+            _tools: &[serde_json::Value],
+        ) -> Result<CompletionResponse> {
+            if history_contains_intervention(messages) {
+                return Ok(CompletionResponse {
+                    text: Some(
+                        "I cannot proceed without knowing what command to run. Please advise."
+                            .into(),
+                    ),
+                    tool_calls: vec![],
+                    usage: Usage::default(),
+                });
+            }
+            let _n = self
+                .call_count
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            Ok(CompletionResponse {
+                text: None,
+                tool_calls: (0..4)
+                    .map(|i| ToolCall {
+                        id: format!("call_{i}"),
+                        name: "exec".into(),
+                        arguments: serde_json::json!({}),
+                    })
+                    .collect(),
+                usage: Usage::default(),
+            })
+        }
+
+        fn stream(
+            &self,
+            _messages: Vec<ChatMessage>,
+        ) -> Pin<Box<dyn Stream<Item = StreamEvent> + Send + '_>> {
+            Box::pin(tokio_stream::empty())
+        }
+    }
+
+    #[tokio::test]
+    async fn parallel_batch_with_stage_skip_delivers_nudge_first() {
+        // Regression for Greptile finding #2: four identical failing calls
+        // in one batch race past the nudge stage and would skip straight to
+        // strip-tools. The runner must still deliver the stage-1 nudge.
+        let provider = Arc::new(ParallelReflexProvider {
+            call_count: std::sync::atomic::AtomicUsize::new(0),
+        });
+        let mut tools = ToolRegistry::new();
+        tools.register(Box::new(TestExecTool));
+
+        let events: Arc<std::sync::Mutex<Vec<RunnerEvent>>> =
+            Arc::new(std::sync::Mutex::new(Vec::new()));
+        let events_clone = Arc::clone(&events);
+        let on_event: OnEvent = Box::new(move |e| {
+            events_clone.lock().unwrap().push(e);
+        });
+
+        let _result = run_agent_loop(
+            provider,
+            &tools,
+            "You are a test bot.",
+            &UserContent::text("Run something"),
+            Some(&on_event),
+            None,
+        )
+        .await
+        .unwrap();
+
+        let events_snapshot = events.lock().unwrap().clone();
+        let intervention_stages: Vec<u8> = events_snapshot
+            .iter()
+            .filter_map(|e| match e {
+                RunnerEvent::LoopInterventionFired { stage, .. } => Some(*stage),
+                _ => None,
+            })
+            .collect();
+        // The first intervention fired must be stage 1 (nudge), not stage 2.
+        assert!(
+            !intervention_stages.is_empty(),
+            "expected at least one LoopInterventionFired event"
+        );
+        assert_eq!(
+            intervention_stages[0], 1,
+            "stage-1 nudge must be delivered first even when a single batch races \
+             through both escalation stages; stages were: {intervention_stages:?}"
         );
     }
 }

--- a/crates/agents/src/tool_arg_validator.rs
+++ b/crates/agents/src/tool_arg_validator.rs
@@ -1,0 +1,381 @@
+//! Lightweight JSON-Schema-ish validator for tool arguments.
+//!
+//! This is **not** a general-purpose JSON Schema validator. It only checks the
+//! subset of schema features that every built-in `AgentTool` actually uses:
+//!
+//! - `required` array of field names must be present in `args`
+//! - `properties.<field>.type` of `string`, `number`/`integer`, `boolean`,
+//!   `object`, `array` must match (scalars only at the top level).
+//!
+//! The goal is narrow: catch the reflex-retry class where a model emits a tool
+//! call with `{}` or omits a required field (issue #658). Deeper validation is
+//! still each tool's responsibility.
+//!
+//! A schema that is not an object, has no `required` array, or is simply `{}`
+//! is treated as "no required fields" and always passes — this is deliberate
+//! so tools with permissive schemas (or test stubs) are not affected.
+
+use serde_json::Value;
+
+/// Error returned when tool arguments fail validation.
+#[derive(Debug, Clone)]
+pub struct ToolArgError {
+    pub missing_required: Vec<String>,
+    pub type_mismatches: Vec<TypeMismatch>,
+    /// The arguments the runner would have dispatched.
+    pub received: Value,
+}
+
+#[derive(Debug, Clone)]
+pub struct TypeMismatch {
+    pub field: String,
+    pub expected: String,
+    pub actual: String,
+}
+
+impl ToolArgError {
+    /// Format a directive error message targeted at the LLM.
+    ///
+    /// The message is intentionally terse, names the exact failure, echoes
+    /// what the model sent, and explicitly tells the model not to retry with
+    /// identical arguments (see issue #658 for the design rationale).
+    #[must_use]
+    pub fn to_llm_error_message(&self, tool_name: &str) -> String {
+        let mut msg = format!("Tool call rejected before execution by `{tool_name}`.\n");
+
+        if !self.missing_required.is_empty() {
+            let list = self.missing_required.join("`, `");
+            msg.push_str(&format!("Missing required field(s): `{list}`.\n"));
+        }
+        for tm in &self.type_mismatches {
+            msg.push_str(&format!(
+                "Field `{}` has wrong type: expected `{}`, got `{}`.\n",
+                tm.field, tm.expected, tm.actual,
+            ));
+        }
+
+        let received_str = serde_json::to_string(&self.received)
+            .unwrap_or_else(|_| "<unserializable>".to_string());
+        msg.push_str(&format!("You sent: {received_str}\n"));
+        msg.push_str(
+            "Do not retry with the same arguments. If you do not know what arguments to use, \
+             respond in plain text and ask the user for clarification.",
+        );
+        msg
+    }
+
+    /// Short single-line description for logs and metrics.
+    #[must_use]
+    pub fn short_summary(&self) -> String {
+        let mut parts = Vec::new();
+        if !self.missing_required.is_empty() {
+            parts.push(format!("missing={}", self.missing_required.join(",")));
+        }
+        if !self.type_mismatches.is_empty() {
+            let tm: Vec<String> = self
+                .type_mismatches
+                .iter()
+                .map(|t| format!("{}:{}!={}", t.field, t.expected, t.actual))
+                .collect();
+            parts.push(format!("type_mismatch={}", tm.join(",")));
+        }
+        parts.join(" ")
+    }
+}
+
+/// Validate `args` against `schema`.
+///
+/// Returns `Ok(())` when the schema imposes no checkable constraints or all
+/// constraints pass. Returns `Err(ToolArgError)` on the narrow failure class
+/// this validator targets.
+///
+/// # Errors
+/// Returns [`ToolArgError`] when required fields are missing or top-level
+/// types do not match the schema's declared `properties.<field>.type`.
+pub fn validate_tool_args(schema: &Value, args: &Value) -> Result<(), ToolArgError> {
+    // Only object schemas have required/properties we can check.
+    let Some(schema_obj) = schema.as_object() else {
+        return Ok(());
+    };
+
+    // Empty schema: pass.
+    if schema_obj.is_empty() {
+        return Ok(());
+    }
+
+    // If no required array AND no properties to type-check, pass.
+    let required_list: Vec<String> = schema_obj
+        .get("required")
+        .and_then(Value::as_array)
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str().map(String::from))
+                .collect()
+        })
+        .unwrap_or_default();
+
+    let properties = schema_obj.get("properties").and_then(Value::as_object);
+
+    if required_list.is_empty() && properties.is_none() {
+        return Ok(());
+    }
+
+    // Args must be an object to satisfy any required field.
+    let args_obj = match args.as_object() {
+        Some(obj) => obj,
+        None => {
+            // Non-object args with required fields → all missing.
+            if required_list.is_empty() {
+                return Ok(());
+            }
+            return Err(ToolArgError {
+                missing_required: required_list,
+                type_mismatches: Vec::new(),
+                received: args.clone(),
+            });
+        },
+    };
+
+    let mut missing_required = Vec::new();
+    for field in &required_list {
+        match args_obj.get(field) {
+            None => missing_required.push(field.clone()),
+            Some(Value::Null) => missing_required.push(field.clone()),
+            Some(_) => {},
+        }
+    }
+
+    let mut type_mismatches = Vec::new();
+    if let Some(props) = properties {
+        for (field, prop_schema) in props {
+            let Some(actual_val) = args_obj.get(field) else {
+                continue; // Missing-required is handled above; optional missing is fine.
+            };
+            if actual_val.is_null() {
+                continue;
+            }
+            let Some(expected_type) = prop_schema
+                .as_object()
+                .and_then(|o| o.get("type"))
+                .and_then(Value::as_str)
+            else {
+                continue; // No declared type → nothing to check.
+            };
+            let actual_type = value_type_name(actual_val);
+            if !type_matches(expected_type, actual_val) {
+                type_mismatches.push(TypeMismatch {
+                    field: field.clone(),
+                    expected: expected_type.to_string(),
+                    actual: actual_type.to_string(),
+                });
+            }
+        }
+    }
+
+    if missing_required.is_empty() && type_mismatches.is_empty() {
+        return Ok(());
+    }
+
+    Err(ToolArgError {
+        missing_required,
+        type_mismatches,
+        received: args.clone(),
+    })
+}
+
+fn type_matches(expected: &str, value: &Value) -> bool {
+    match expected {
+        "string" => value.is_string(),
+        "number" => value.is_number(),
+        "integer" => value.as_i64().is_some() || value.as_u64().is_some(),
+        "boolean" => value.is_boolean(),
+        "object" => value.is_object(),
+        "array" => value.is_array(),
+        "null" => value.is_null(),
+        // Unknown/complex types (unions, $ref, etc.): don't claim a mismatch.
+        _ => true,
+    }
+}
+
+fn value_type_name(value: &Value) -> &'static str {
+    match value {
+        Value::Null => "null",
+        Value::Bool(_) => "boolean",
+        Value::Number(_) => "number",
+        Value::String(_) => "string",
+        Value::Array(_) => "array",
+        Value::Object(_) => "object",
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use {super::*, serde_json::json};
+
+    #[test]
+    fn empty_schema_always_passes() {
+        assert!(validate_tool_args(&json!({}), &json!({})).is_ok());
+        assert!(validate_tool_args(&json!({}), &json!({"x": 1})).is_ok());
+    }
+
+    #[test]
+    fn schema_without_required_passes_on_empty_args() {
+        let schema = json!({
+            "type": "object",
+            "properties": { "command": { "type": "string" } }
+        });
+        assert!(validate_tool_args(&schema, &json!({})).is_ok());
+    }
+
+    #[test]
+    fn missing_required_field_is_reported() {
+        let schema = json!({
+            "type": "object",
+            "properties": { "command": { "type": "string" } },
+            "required": ["command"]
+        });
+        let err = validate_tool_args(&schema, &json!({})).unwrap_err();
+        assert_eq!(err.missing_required, vec!["command".to_string()]);
+        assert!(err.type_mismatches.is_empty());
+    }
+
+    #[test]
+    fn null_field_counts_as_missing() {
+        let schema = json!({
+            "type": "object",
+            "properties": { "command": { "type": "string" } },
+            "required": ["command"]
+        });
+        let err = validate_tool_args(&schema, &json!({"command": null})).unwrap_err();
+        assert_eq!(err.missing_required, vec!["command".to_string()]);
+    }
+
+    #[test]
+    fn wrong_type_is_reported() {
+        let schema = json!({
+            "type": "object",
+            "properties": { "command": { "type": "string" } },
+            "required": ["command"]
+        });
+        let err = validate_tool_args(&schema, &json!({"command": 42})).unwrap_err();
+        assert!(err.missing_required.is_empty());
+        assert_eq!(err.type_mismatches.len(), 1);
+        assert_eq!(err.type_mismatches[0].field, "command");
+        assert_eq!(err.type_mismatches[0].expected, "string");
+        assert_eq!(err.type_mismatches[0].actual, "number");
+    }
+
+    #[test]
+    fn multiple_required_missing() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "a": { "type": "string" },
+                "b": { "type": "string" }
+            },
+            "required": ["a", "b"]
+        });
+        let err = validate_tool_args(&schema, &json!({})).unwrap_err();
+        assert_eq!(err.missing_required.len(), 2);
+    }
+
+    #[test]
+    fn valid_args_pass() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "command": { "type": "string" },
+                "cwd": { "type": "string" }
+            },
+            "required": ["command"]
+        });
+        assert!(validate_tool_args(&schema, &json!({"command": "ls", "cwd": "/tmp"})).is_ok());
+    }
+
+    #[test]
+    fn optional_field_wrong_type_still_reports() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "command": { "type": "string" },
+                "timeout": { "type": "integer" }
+            },
+            "required": ["command"]
+        });
+        let err =
+            validate_tool_args(&schema, &json!({"command": "ls", "timeout": "slow"})).unwrap_err();
+        assert!(err.missing_required.is_empty());
+        assert_eq!(err.type_mismatches.len(), 1);
+        assert_eq!(err.type_mismatches[0].field, "timeout");
+    }
+
+    #[test]
+    fn non_object_args_with_required_fails() {
+        let schema = json!({
+            "type": "object",
+            "properties": { "command": { "type": "string" } },
+            "required": ["command"]
+        });
+        let err = validate_tool_args(&schema, &json!("ls")).unwrap_err();
+        assert_eq!(err.missing_required, vec!["command".to_string()]);
+    }
+
+    #[test]
+    fn unknown_type_is_permissive() {
+        let schema = json!({
+            "type": "object",
+            "properties": { "x": { "type": "some_future_thing" } },
+            "required": ["x"]
+        });
+        assert!(validate_tool_args(&schema, &json!({"x": "anything"})).is_ok());
+    }
+
+    #[test]
+    fn array_and_object_types() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "items": { "type": "array" },
+                "meta":  { "type": "object" }
+            },
+            "required": ["items", "meta"]
+        });
+        assert!(validate_tool_args(&schema, &json!({"items": [1,2], "meta": {"k": "v"}})).is_ok());
+        let err =
+            validate_tool_args(&schema, &json!({"items": "not-an-array", "meta": {}})).unwrap_err();
+        assert_eq!(err.type_mismatches.len(), 1);
+        assert_eq!(err.type_mismatches[0].field, "items");
+    }
+
+    #[test]
+    fn llm_error_message_is_directive() {
+        let schema = json!({
+            "type": "object",
+            "properties": { "command": { "type": "string" } },
+            "required": ["command"]
+        });
+        let err = validate_tool_args(&schema, &json!({})).unwrap_err();
+        let msg = err.to_llm_error_message("exec");
+        assert!(msg.contains("exec"));
+        assert!(msg.contains("command"));
+        assert!(msg.contains("Do not retry"));
+        assert!(msg.contains("respond in plain text"));
+    }
+
+    #[test]
+    fn short_summary_captures_both_kinds() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "a": { "type": "string" },
+                "b": { "type": "integer" }
+            },
+            "required": ["a", "b"]
+        });
+        let err = validate_tool_args(&schema, &json!({"b": "wrong"})).unwrap_err();
+        let s = err.short_summary();
+        assert!(s.contains("missing=a"));
+        assert!(s.contains("type_mismatch=b:integer!=string"));
+    }
+}

--- a/crates/agents/src/tool_arg_validator.rs
+++ b/crates/agents/src/tool_arg_validator.rs
@@ -187,7 +187,15 @@ fn type_matches(expected: &str, value: &Value) -> bool {
     match expected {
         "string" => value.is_string(),
         "number" => value.is_number(),
-        "integer" => value.as_i64().is_some() || value.as_u64().is_some(),
+        // Some LLMs serialize integers with a trailing decimal (e.g.
+        // `"timeout": 30.0`). Accept integer-valued floats to avoid spurious
+        // rejections that would contribute to loop-detector churn rather than
+        // catching real reflex loops.
+        "integer" => {
+            value.as_i64().is_some()
+                || value.as_u64().is_some()
+                || value.as_f64().is_some_and(|f| f.fract() == 0.0)
+        },
         "boolean" => value.is_boolean(),
         "object" => value.is_object(),
         "array" => value.is_array(),
@@ -361,6 +369,23 @@ mod tests {
         assert!(msg.contains("command"));
         assert!(msg.contains("Do not retry"));
         assert!(msg.contains("respond in plain text"));
+    }
+
+    #[test]
+    fn integer_accepts_integer_valued_floats() {
+        // Some LLMs (e.g. via OpenAI JSON-mode) emit integers with a trailing
+        // decimal point. Schema says "integer" — we must not reject 30.0.
+        let schema = json!({
+            "type": "object",
+            "properties": { "timeout": { "type": "integer" } },
+            "required": ["timeout"]
+        });
+        assert!(validate_tool_args(&schema, &json!({"timeout": 30})).is_ok());
+        assert!(validate_tool_args(&schema, &json!({"timeout": 30.0})).is_ok());
+        // A non-integer float must still be rejected.
+        let err = validate_tool_args(&schema, &json!({"timeout": 30.5})).unwrap_err();
+        assert_eq!(err.type_mismatches.len(), 1);
+        assert_eq!(err.type_mismatches[0].field, "timeout");
     }
 
     #[test]

--- a/crates/agents/src/tool_loop_detector.rs
+++ b/crates/agents/src/tool_loop_detector.rs
@@ -1,0 +1,450 @@
+//! Loop detector for repeated identical tool-call failures (issue #658).
+//!
+//! Tracks a short ring buffer of recent tool-call outcomes and fires an
+//! escalating intervention when the model gets stuck calling the same tool
+//! with the same arguments (or producing the same error) repeatedly.
+//!
+//! Two escalation stages:
+//! 1. **Nudge** — inject a directive system/user message telling the model
+//!    to stop, explain what it was trying to do, and respond in text.
+//! 2. **Tool stripping** — on the very next iteration, pass an empty tool
+//!    schema list to the LLM so it *physically* cannot emit another tool call.
+//!
+//! A successful tool call resets both the ring buffer and the escalation
+//! stage.
+
+use std::{
+    collections::{VecDeque, hash_map::DefaultHasher},
+    hash::{Hash, Hasher},
+};
+
+use serde_json::Value;
+
+/// Fingerprint of a single tool-call outcome used for loop detection.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ToolCallFingerprint {
+    pub tool_name: String,
+    pub args_hash: u64,
+    /// Hash of the tool error string, `None` on success.
+    pub error_hash: Option<u64>,
+    /// Raw error string (kept for formatting the intervention message).
+    pub error_text: Option<String>,
+    /// Raw arguments (kept for formatting the intervention message).
+    pub arguments: Value,
+}
+
+impl ToolCallFingerprint {
+    #[must_use]
+    pub fn new(tool_name: &str, arguments: &Value, error: Option<&str>) -> Self {
+        let args_hash = hash_value(arguments);
+        let error_hash = error.map(hash_str);
+        Self {
+            tool_name: tool_name.to_string(),
+            args_hash,
+            error_hash,
+            error_text: error.map(String::from),
+            arguments: arguments.clone(),
+        }
+    }
+
+    #[must_use]
+    pub fn is_failure(&self) -> bool {
+        self.error_hash.is_some()
+    }
+}
+
+/// Escalation stages for the loop detector.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum InterventionStage {
+    /// No intervention active.
+    #[default]
+    None,
+    /// Stage 1 fired: a directive nudge has been injected; the next iteration
+    /// still passes the normal tool schemas.
+    Nudged,
+    /// Stage 2 fired: the next iteration will pass an empty tool list, forcing
+    /// a text response. After that one forced-text turn the state returns to
+    /// [`InterventionStage::None`].
+    StripTools,
+}
+
+/// Result of recording a new fingerprint.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LoopDetectorAction {
+    /// No intervention — continue normally.
+    None,
+    /// Stage 1: inject a directive intervention message for the next LLM call.
+    InjectNudge,
+    /// Stage 2: strip tool schemas on the next LLM call.
+    StripTools,
+}
+
+/// Rolling loop detector.
+#[derive(Debug)]
+pub struct ToolLoopDetector {
+    recent: VecDeque<ToolCallFingerprint>,
+    window: usize,
+    strip_on_second_fire: bool,
+    stage: InterventionStage,
+}
+
+impl ToolLoopDetector {
+    /// Create a new detector with the given window size. `window == 0`
+    /// disables detection entirely.
+    #[must_use]
+    pub fn new(window: usize, strip_on_second_fire: bool) -> Self {
+        Self {
+            recent: VecDeque::with_capacity(window.max(1)),
+            window,
+            strip_on_second_fire,
+            stage: InterventionStage::None,
+        }
+    }
+
+    #[must_use]
+    pub fn stage(&self) -> InterventionStage {
+        self.stage
+    }
+
+    #[must_use]
+    pub fn is_enabled(&self) -> bool {
+        self.window > 0
+    }
+
+    /// Reset state after a successful tool call.
+    pub fn reset(&mut self) {
+        self.recent.clear();
+        self.stage = InterventionStage::None;
+    }
+
+    /// Record a tool-call outcome and compute the next action.
+    ///
+    /// Returns:
+    /// - `None` when no intervention should fire.
+    /// - `InjectNudge` on the first fire (stage 1).
+    /// - `StripTools` on the second consecutive fire, if enabled.
+    pub fn record(&mut self, fp: ToolCallFingerprint) -> LoopDetectorAction {
+        if self.window == 0 {
+            return LoopDetectorAction::None;
+        }
+
+        // Success anywhere resets everything.
+        if !fp.is_failure() {
+            self.reset();
+            return LoopDetectorAction::None;
+        }
+
+        self.recent.push_back(fp);
+        while self.recent.len() > self.window {
+            self.recent.pop_front();
+        }
+
+        if self.recent.len() < self.window {
+            return LoopDetectorAction::None;
+        }
+
+        // All entries are failures (we only push failures past the success reset above).
+        // Check for identity: same tool + (same args OR same error).
+        if !self.all_match() {
+            return LoopDetectorAction::None;
+        }
+
+        match self.stage {
+            InterventionStage::None => {
+                self.stage = InterventionStage::Nudged;
+                LoopDetectorAction::InjectNudge
+            },
+            InterventionStage::Nudged if self.strip_on_second_fire => {
+                self.stage = InterventionStage::StripTools;
+                LoopDetectorAction::StripTools
+            },
+            InterventionStage::Nudged | InterventionStage::StripTools => {
+                // Already escalated — don't re-fire.
+                LoopDetectorAction::None
+            },
+        }
+    }
+
+    /// Called by the runner once the post-strip iteration has run. Clears
+    /// the strip-tools stage so subsequent iterations use normal schemas.
+    pub fn clear_strip_tools(&mut self) {
+        if self.stage == InterventionStage::StripTools {
+            self.stage = InterventionStage::Nudged;
+        }
+    }
+
+    /// Returns a snapshot of the window used for formatting intervention
+    /// messages. Callers get a cloned vec so they can format freely.
+    #[must_use]
+    pub fn window_snapshot(&self) -> Vec<ToolCallFingerprint> {
+        self.recent.iter().cloned().collect()
+    }
+
+    fn all_match(&self) -> bool {
+        let Some(first) = self.recent.front() else {
+            return false;
+        };
+        let all_same_tool = self.recent.iter().all(|fp| fp.tool_name == first.tool_name);
+        if !all_same_tool {
+            return false;
+        }
+        let all_same_args = self.recent.iter().all(|fp| fp.args_hash == first.args_hash);
+        let all_same_error = first.error_hash.is_some()
+            && self
+                .recent
+                .iter()
+                .all(|fp| fp.error_hash == first.error_hash);
+        all_same_args || all_same_error
+    }
+}
+
+/// Build the stage-1 nudge intervention message from the current window.
+#[must_use]
+pub fn format_intervention_message(window: &[ToolCallFingerprint]) -> String {
+    let mut msg = String::from("SYSTEM INTERVENTION — LOOP DETECTED\n\nYour last ");
+    msg.push_str(&window.len().to_string());
+    msg.push_str(" tool calls were:\n");
+    for (i, fp) in window.iter().enumerate() {
+        let args_str = serde_json::to_string(&fp.arguments).unwrap_or_else(|_| "{}".to_string());
+        let err = fp.error_text.as_deref().unwrap_or("(no error)");
+        msg.push_str(&format!(
+            "  {}. {}({}) → error: {}\n",
+            i + 1,
+            fp.tool_name,
+            args_str,
+            err
+        ));
+    }
+
+    let tool_name = window
+        .first()
+        .map(|fp| fp.tool_name.as_str())
+        .unwrap_or("this tool");
+
+    msg.push_str(
+        "\nThese are identical failed invocations. Retrying with the same arguments will fail \
+         again.\n\nOn your next turn:\n",
+    );
+    msg.push_str(&format!(
+        "1. Do NOT call `{tool_name}` or any other tool.\n"
+    ));
+    msg.push_str("2. Do NOT repeat this call pattern.\n");
+    msg.push_str("3. Respond to the user in plain text.\n");
+    msg.push_str("4. Explain what you were trying to accomplish.\n");
+    msg.push_str("5. If you do not know what arguments to use, ask the user for clarification.\n");
+    msg.push_str("\nThe user is waiting for a text response.");
+    msg
+}
+
+/// Stage-2 reinforcement message used when the runner strips tool schemas for
+/// the next iteration. Kept short because the model is forced into text mode
+/// regardless.
+#[must_use]
+pub fn format_strip_tools_message() -> &'static str {
+    "SYSTEM INTERVENTION — TOOLS DISABLED FOR THIS TURN\n\nYou have been caught in a reflex \
+     retry loop. Tools are disabled for this single turn. Respond to the user in plain text: \
+     explain what you were trying to do, and ask for clarification if needed."
+}
+
+fn hash_value(v: &Value) -> u64 {
+    // Canonicalize by serializing; serde_json already sorts object keys
+    // deterministically within a single `to_string` call only if the input was
+    // a Map<String,_>. serde_json::Map preserves insertion order, so to get a
+    // stable fingerprint we walk the value recursively.
+    let canonical = canonicalize(v);
+    let mut hasher = DefaultHasher::new();
+    canonical.hash(&mut hasher);
+    hasher.finish()
+}
+
+fn hash_str(s: &str) -> u64 {
+    let mut hasher = DefaultHasher::new();
+    s.hash(&mut hasher);
+    hasher.finish()
+}
+
+fn canonicalize(v: &Value) -> String {
+    match v {
+        Value::Null => "null".to_string(),
+        Value::Bool(b) => b.to_string(),
+        Value::Number(n) => n.to_string(),
+        Value::String(s) => format!("\"{s}\""),
+        Value::Array(arr) => {
+            let inner: Vec<String> = arr.iter().map(canonicalize).collect();
+            format!("[{}]", inner.join(","))
+        },
+        Value::Object(map) => {
+            let mut keys: Vec<&String> = map.keys().collect();
+            keys.sort();
+            let inner: Vec<String> = keys
+                .into_iter()
+                .map(|k| format!("\"{}\":{}", k, canonicalize(&map[k])))
+                .collect();
+            format!("{{{}}}", inner.join(","))
+        },
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use {super::*, serde_json::json};
+
+    fn fp(tool: &str, args: Value, err: Option<&str>) -> ToolCallFingerprint {
+        ToolCallFingerprint::new(tool, &args, err)
+    }
+
+    #[test]
+    fn window_zero_disables_detection() {
+        let mut d = ToolLoopDetector::new(0, true);
+        assert!(matches!(
+            d.record(fp("exec", json!({}), Some("missing"))),
+            LoopDetectorAction::None
+        ));
+        assert!(matches!(
+            d.record(fp("exec", json!({}), Some("missing"))),
+            LoopDetectorAction::None
+        ));
+        assert!(matches!(
+            d.record(fp("exec", json!({}), Some("missing"))),
+            LoopDetectorAction::None
+        ));
+    }
+
+    #[test]
+    fn three_identical_failures_fire_nudge() {
+        let mut d = ToolLoopDetector::new(3, true);
+        assert_eq!(
+            d.record(fp("exec", json!({}), Some("missing 'command'"))),
+            LoopDetectorAction::None
+        );
+        assert_eq!(
+            d.record(fp("exec", json!({}), Some("missing 'command'"))),
+            LoopDetectorAction::None
+        );
+        assert_eq!(
+            d.record(fp("exec", json!({}), Some("missing 'command'"))),
+            LoopDetectorAction::InjectNudge
+        );
+        assert_eq!(d.stage(), InterventionStage::Nudged);
+    }
+
+    #[test]
+    fn fourth_failure_after_nudge_strips_tools() {
+        let mut d = ToolLoopDetector::new(3, true);
+        for _ in 0..3 {
+            let _ = d.record(fp("exec", json!({}), Some("missing")));
+        }
+        assert_eq!(d.stage(), InterventionStage::Nudged);
+        assert_eq!(
+            d.record(fp("exec", json!({}), Some("missing"))),
+            LoopDetectorAction::StripTools
+        );
+        assert_eq!(d.stage(), InterventionStage::StripTools);
+    }
+
+    #[test]
+    fn strip_tools_disabled_stays_in_nudged() {
+        let mut d = ToolLoopDetector::new(3, false);
+        for _ in 0..3 {
+            let _ = d.record(fp("exec", json!({}), Some("missing")));
+        }
+        assert_eq!(
+            d.record(fp("exec", json!({}), Some("missing"))),
+            LoopDetectorAction::None
+        );
+        assert_eq!(d.stage(), InterventionStage::Nudged);
+    }
+
+    #[test]
+    fn success_resets_state() {
+        let mut d = ToolLoopDetector::new(3, true);
+        for _ in 0..2 {
+            let _ = d.record(fp("exec", json!({}), Some("missing")));
+        }
+        let _ = d.record(fp("exec", json!({"command": "ls"}), None));
+        assert_eq!(d.stage(), InterventionStage::None);
+
+        // Need 3 more failures to fire.
+        assert_eq!(
+            d.record(fp("exec", json!({}), Some("missing"))),
+            LoopDetectorAction::None
+        );
+        assert_eq!(
+            d.record(fp("exec", json!({}), Some("missing"))),
+            LoopDetectorAction::None
+        );
+        assert_eq!(
+            d.record(fp("exec", json!({}), Some("missing"))),
+            LoopDetectorAction::InjectNudge
+        );
+    }
+
+    #[test]
+    fn different_args_same_tool_same_error_still_fires() {
+        // Same tool + same error text, different args. Should still fire because
+        // `all_match` accepts "all same error".
+        let mut d = ToolLoopDetector::new(3, true);
+        let err = Some("missing 'command' parameter");
+        let _ = d.record(fp("exec", json!({}), err));
+        let _ = d.record(fp("exec", json!({"cmd": ""}), err));
+        assert_eq!(
+            d.record(fp("exec", json!({"cmd": " "}), err)),
+            LoopDetectorAction::InjectNudge
+        );
+    }
+
+    #[test]
+    fn different_tools_do_not_fire() {
+        let mut d = ToolLoopDetector::new(3, true);
+        let _ = d.record(fp("exec", json!({}), Some("e")));
+        let _ = d.record(fp("browser", json!({}), Some("e")));
+        assert_eq!(
+            d.record(fp("exec", json!({}), Some("e"))),
+            LoopDetectorAction::None
+        );
+    }
+
+    #[test]
+    fn legitimate_retry_pattern_does_not_fire() {
+        // Fail → retry with new args → succeed. This should NOT fire.
+        let mut d = ToolLoopDetector::new(3, true);
+        let _ = d.record(fp("exec", json!({"command": "ls"}), Some("no such dir")));
+        let _ = d.record(fp("exec", json!({"command": "ls /tmp"}), None));
+        assert_eq!(d.stage(), InterventionStage::None);
+    }
+
+    #[test]
+    fn clear_strip_tools_returns_to_nudged() {
+        let mut d = ToolLoopDetector::new(3, true);
+        for _ in 0..3 {
+            let _ = d.record(fp("exec", json!({}), Some("missing")));
+        }
+        let _ = d.record(fp("exec", json!({}), Some("missing")));
+        assert_eq!(d.stage(), InterventionStage::StripTools);
+        d.clear_strip_tools();
+        assert_eq!(d.stage(), InterventionStage::Nudged);
+    }
+
+    #[test]
+    fn canonicalize_is_order_stable() {
+        let a = json!({"a": 1, "b": 2});
+        let b = json!({"b": 2, "a": 1});
+        assert_eq!(hash_value(&a), hash_value(&b));
+    }
+
+    #[test]
+    fn intervention_message_contains_evidence() {
+        let window = vec![
+            fp("exec", json!({}), Some("missing 'command'")),
+            fp("exec", json!({}), Some("missing 'command'")),
+            fp("exec", json!({}), Some("missing 'command'")),
+        ];
+        let msg = format_intervention_message(&window);
+        assert!(msg.contains("LOOP DETECTED"));
+        assert!(msg.contains("exec"));
+        assert!(msg.contains("missing 'command'"));
+        assert!(msg.contains("Do NOT"));
+        assert!(msg.contains("plain text"));
+    }
+}

--- a/crates/agents/src/tool_loop_detector.rs
+++ b/crates/agents/src/tool_loop_detector.rs
@@ -165,11 +165,20 @@ impl ToolLoopDetector {
         }
     }
 
-    /// Called by the runner once the post-strip iteration has run. Clears
-    /// the strip-tools stage so subsequent iterations use normal schemas.
+    /// Called by the runner once the post-strip iteration has run. Fully
+    /// resets the detector so the next window starts fresh.
+    ///
+    /// Clearing only the stage but not the ring buffer would leave the deque
+    /// still full of `window` matching failures. A single new identical
+    /// failure after tools are restored would immediately re-fire stage 2
+    /// (`stage: Nudged` + `strip_on_second_fire: true`), oscillating between
+    /// strip-tools and normal turns until `max_iterations` — giving the model
+    /// almost no runway after the first escalation cycle. Treat the forced
+    /// text turn as a hard reset of the detector state.
     pub fn clear_strip_tools(&mut self) {
         if self.stage == InterventionStage::StripTools {
-            self.stage = InterventionStage::Nudged;
+            self.stage = InterventionStage::None;
+            self.recent.clear();
         }
     }
 
@@ -239,11 +248,15 @@ pub fn format_intervention_message(window: &[ToolCallFingerprint]) -> String {
 /// Stage-2 reinforcement message used when the runner strips tool schemas for
 /// the next iteration. Kept short because the model is forced into text mode
 /// regardless.
+///
+/// Returns `String` (not `&'static str`) so callers can treat it uniformly
+/// with [`format_intervention_message`].
 #[must_use]
-pub fn format_strip_tools_message() -> &'static str {
+pub fn format_strip_tools_message() -> String {
     "SYSTEM INTERVENTION — TOOLS DISABLED FOR THIS TURN\n\nYou have been caught in a reflex \
      retry loop. Tools are disabled for this single turn. Respond to the user in plain text: \
      explain what you were trying to do, and ask for clarification if needed."
+        .to_string()
 }
 
 fn hash_value(v: &Value) -> u64 {
@@ -415,7 +428,7 @@ mod tests {
     }
 
     #[test]
-    fn clear_strip_tools_returns_to_nudged() {
+    fn clear_strip_tools_resets_state_fully() {
         let mut d = ToolLoopDetector::new(3, true);
         for _ in 0..3 {
             let _ = d.record(fp("exec", json!({}), Some("missing")));
@@ -423,6 +436,46 @@ mod tests {
         let _ = d.record(fp("exec", json!({}), Some("missing")));
         assert_eq!(d.stage(), InterventionStage::StripTools);
         d.clear_strip_tools();
+        // A hard reset — not just a stage transition — so the next reflex
+        // failure after tools are restored cannot immediately re-fire
+        // stage 2 with a still-full deque (the oscillation Greptile flagged).
+        assert_eq!(d.stage(), InterventionStage::None);
+        assert!(d.window_snapshot().is_empty());
+    }
+
+    #[test]
+    fn post_strip_single_failure_does_not_immediately_refire() {
+        // Regression: after stage 2 has fired and the runner calls
+        // clear_strip_tools(), a single identical failure must NOT jump
+        // straight back to StripTools. It should take another `window` fresh
+        // failures to fire stage 1 again.
+        let mut d = ToolLoopDetector::new(3, true);
+        // Build up and fire both stages.
+        for _ in 0..3 {
+            let _ = d.record(fp("exec", json!({}), Some("missing")));
+        }
+        assert_eq!(d.stage(), InterventionStage::Nudged);
+        let _ = d.record(fp("exec", json!({}), Some("missing")));
+        assert_eq!(d.stage(), InterventionStage::StripTools);
+
+        // Runner processes the forced-text turn and resets state.
+        d.clear_strip_tools();
+
+        // One fresh failure must not re-escalate.
+        assert_eq!(
+            d.record(fp("exec", json!({}), Some("missing"))),
+            LoopDetectorAction::None
+        );
+        assert_eq!(d.stage(), InterventionStage::None);
+        assert_eq!(
+            d.record(fp("exec", json!({}), Some("missing"))),
+            LoopDetectorAction::None
+        );
+        // Third identical failure since reset → fresh nudge, not StripTools.
+        assert_eq!(
+            d.record(fp("exec", json!({}), Some("missing"))),
+            LoopDetectorAction::InjectNudge
+        );
         assert_eq!(d.stage(), InterventionStage::Nudged);
     }
 

--- a/crates/agents/src/tool_loop_detector.rs
+++ b/crates/agents/src/tool_loop_detector.rs
@@ -25,7 +25,11 @@ use serde_json::Value;
 pub struct ToolCallFingerprint {
     pub tool_name: String,
     pub args_hash: u64,
-    /// Hash of the tool error string, `None` on success.
+    /// Whether this call failed (tool error, validation rejection, or
+    /// `{success: false}` even without an `error` key).
+    pub failed: bool,
+    /// Hash of the tool error string, `None` when the tool returned a
+    /// logical failure without an error message.
     pub error_hash: Option<u64>,
     /// Raw error string (kept for formatting the intervention message).
     pub error_text: Option<String>,
@@ -34,14 +38,31 @@ pub struct ToolCallFingerprint {
 }
 
 impl ToolCallFingerprint {
+    /// Create a fingerprint for a **successful** tool call.
     #[must_use]
-    pub fn new(tool_name: &str, arguments: &Value, error: Option<&str>) -> Self {
-        let args_hash = hash_value(arguments);
-        let error_hash = error.map(hash_str);
+    pub fn success(tool_name: &str, arguments: &Value) -> Self {
         Self {
             tool_name: tool_name.to_string(),
-            args_hash,
-            error_hash,
+            args_hash: hash_value(arguments),
+            failed: false,
+            error_hash: None,
+            error_text: None,
+            arguments: arguments.clone(),
+        }
+    }
+
+    /// Create a fingerprint for a **failed** tool call.
+    ///
+    /// `error` may be `None` when the tool returned `{success: false}` but
+    /// no `error` field — the call is still treated as a failure by the
+    /// detector so it contributes to the reflex-loop window.
+    #[must_use]
+    pub fn failure(tool_name: &str, arguments: &Value, error: Option<&str>) -> Self {
+        Self {
+            tool_name: tool_name.to_string(),
+            args_hash: hash_value(arguments),
+            failed: true,
+            error_hash: error.map(hash_str),
             error_text: error.map(String::from),
             arguments: arguments.clone(),
         }
@@ -49,7 +70,7 @@ impl ToolCallFingerprint {
 
     #[must_use]
     pub fn is_failure(&self) -> bool {
-        self.error_hash.is_some()
+        self.failed
     }
 }
 
@@ -358,7 +379,10 @@ mod tests {
     use {super::*, serde_json::json};
 
     fn fp(tool: &str, args: Value, err: Option<&str>) -> ToolCallFingerprint {
-        ToolCallFingerprint::new(tool, &args, err)
+        match err {
+            Some(_) => ToolCallFingerprint::failure(tool, &args, err),
+            None => ToolCallFingerprint::success(tool, &args),
+        }
     }
 
     #[test]
@@ -625,6 +649,23 @@ mod tests {
         let _ = d.record(fp("exec", json!({}), Some("err")));
         assert_eq!(d.stage(), InterventionStage::StripTools);
         assert_eq!(d.consume_pending_action(), LoopDetectorAction::StripTools);
+    }
+
+    #[test]
+    fn failure_without_error_string_still_counts_as_failure() {
+        // Greptile P2: a tool returning `{success: false}` without an `error`
+        // field was previously treated as success because is_failure derived
+        // from error_hash.is_some(). Now `failed` is an explicit field, so
+        // Fingerprint::failure with error=None is still a failure.
+        let mut d = ToolLoopDetector::new(3, true);
+        let _ = d.record(ToolCallFingerprint::failure("browser", &json!({}), None));
+        let _ = d.record(ToolCallFingerprint::failure("browser", &json!({}), None));
+        let action = d.record(ToolCallFingerprint::failure("browser", &json!({}), None));
+        // Must fire because all three are failures with matching args.
+        assert_eq!(action, LoopDetectorAction::InjectNudge);
+        // Conversely, a success resets as expected.
+        let _ = d.record(ToolCallFingerprint::success("browser", &json!({})));
+        assert_eq!(d.stage(), InterventionStage::None);
     }
 
     #[test]

--- a/crates/agents/src/tool_loop_detector.rs
+++ b/crates/agents/src/tool_loop_detector.rs
@@ -86,6 +86,10 @@ pub struct ToolLoopDetector {
     window: usize,
     strip_on_second_fire: bool,
     stage: InterventionStage,
+    /// Whether the stage-1 nudge has already been surfaced to the runner for
+    /// the current intervention cycle. Cleared on a hard reset (success or
+    /// `clear_strip_tools`).
+    nudge_delivered: bool,
 }
 
 impl ToolLoopDetector {
@@ -98,6 +102,7 @@ impl ToolLoopDetector {
             window,
             strip_on_second_fire,
             stage: InterventionStage::None,
+            nudge_delivered: false,
         }
     }
 
@@ -115,6 +120,7 @@ impl ToolLoopDetector {
     pub fn reset(&mut self) {
         self.recent.clear();
         self.stage = InterventionStage::None;
+        self.nudge_delivered = false;
     }
 
     /// Record a tool-call outcome and compute the next action.
@@ -179,6 +185,54 @@ impl ToolLoopDetector {
         if self.stage == InterventionStage::StripTools {
             self.stage = InterventionStage::None;
             self.recent.clear();
+            self.nudge_delivered = false;
+        }
+    }
+
+    /// Compute the action the runner should apply at the end of a batch based
+    /// on the detector's current state, and advance the internal bookkeeping
+    /// so the same action is not returned twice.
+    ///
+    /// This is the **authoritative** way for the runner to decide whether to
+    /// intervene. It sidesteps two edge cases that per-call [`Self::record`]
+    /// return values hit when a batch contains a mix of outcomes:
+    ///
+    /// 1. **False intervention after a trailing success in the same batch.**
+    ///    `[fail, fail, success]` used to leave `pending_intervention` set
+    ///    from the fail that pushed the window full, even though the trailing
+    ///    success already called [`Self::reset`]. Deriving the action from
+    ///    the post-batch `stage` returns `None` in this case.
+    ///
+    /// 2. **Stage-skip when both escalations fire within one batch.**
+    ///    `[fail, fail, fail]` (from a window of 3) used to return
+    ///    `InjectNudge` on call 3 and `StripTools` on call 4 — the runner
+    ///    would apply only the last one and the nudge was never delivered,
+    ///    robbing the model of its chance to recover via plain text. If the
+    ///    state is `StripTools` but the nudge has not yet been delivered,
+    ///    demote the stage back to `Nudged` and return `InjectNudge` so the
+    ///    nudge lands first; strip-tools will fire on the next batch if the
+    ///    pattern repeats.
+    pub fn consume_pending_action(&mut self) -> LoopDetectorAction {
+        match self.stage {
+            InterventionStage::None => LoopDetectorAction::None,
+            InterventionStage::Nudged => {
+                if self.nudge_delivered {
+                    LoopDetectorAction::None
+                } else {
+                    self.nudge_delivered = true;
+                    LoopDetectorAction::InjectNudge
+                }
+            },
+            InterventionStage::StripTools => {
+                if self.nudge_delivered {
+                    LoopDetectorAction::StripTools
+                } else {
+                    // Stage-skip guard — see doc comment above.
+                    self.stage = InterventionStage::Nudged;
+                    self.nudge_delivered = true;
+                    LoopDetectorAction::InjectNudge
+                }
+            },
         }
     }
 
@@ -484,6 +538,93 @@ mod tests {
         let a = json!({"a": 1, "b": 2});
         let b = json!({"b": 2, "a": 1});
         assert_eq!(hash_value(&a), hash_value(&b));
+    }
+
+    #[test]
+    fn consume_pending_action_none_when_empty() {
+        let mut d = ToolLoopDetector::new(3, true);
+        assert_eq!(d.consume_pending_action(), LoopDetectorAction::None);
+    }
+
+    #[test]
+    fn consume_pending_action_returns_nudge_once_then_none() {
+        let mut d = ToolLoopDetector::new(3, true);
+        for _ in 0..3 {
+            let _ = d.record(fp("exec", json!({}), Some("err")));
+        }
+        // Runner calls consume at end of batch — expect nudge.
+        assert_eq!(d.consume_pending_action(), LoopDetectorAction::InjectNudge);
+        // Second call in the same cycle (e.g. next batch without more
+        // failures) must not re-fire the nudge.
+        assert_eq!(d.consume_pending_action(), LoopDetectorAction::None);
+    }
+
+    #[test]
+    fn consume_pending_action_strip_only_after_nudge_delivered() {
+        let mut d = ToolLoopDetector::new(3, true);
+        for _ in 0..3 {
+            let _ = d.record(fp("exec", json!({}), Some("err")));
+        }
+        assert_eq!(d.consume_pending_action(), LoopDetectorAction::InjectNudge);
+        // Next batch: another identical failure advances stage to StripTools.
+        let _ = d.record(fp("exec", json!({}), Some("err")));
+        assert_eq!(d.stage(), InterventionStage::StripTools);
+        // Nudge WAS delivered in the prior cycle, so we progress to strip.
+        assert_eq!(d.consume_pending_action(), LoopDetectorAction::StripTools);
+    }
+
+    #[test]
+    fn trailing_success_in_same_batch_suppresses_intervention() {
+        // Greptile finding #1: [fail, fail, success] in one batch.
+        // Before the batch the detector already has 2 identical failures
+        // recorded; the first fail in the batch pushes the window full and
+        // record() would return InjectNudge. But the trailing success in the
+        // same batch immediately resets the detector. The runner must not
+        // apply an intervention that the detector has already abandoned.
+        let mut d = ToolLoopDetector::new(3, true);
+        let _ = d.record(fp("exec", json!({}), Some("err"))); // 1/3
+        let _ = d.record(fp("exec", json!({}), Some("err"))); // 2/3
+        // Start of a new batch:
+        let action_on_third = d.record(fp("exec", json!({}), Some("err")));
+        assert_eq!(action_on_third, LoopDetectorAction::InjectNudge);
+        // ...but the next record in the same batch is a success (reset).
+        let _ = d.record(fp("exec", json!({"command": "ls"}), None));
+        assert_eq!(d.stage(), InterventionStage::None);
+        // At end-of-batch the runner queries consume_pending_action — must
+        // return None because the success already abandoned the intervention.
+        assert_eq!(d.consume_pending_action(), LoopDetectorAction::None);
+    }
+
+    #[test]
+    fn stage_skip_in_one_batch_delivers_nudge_first() {
+        // Greptile finding #2: [fail, fail, fail, fail] in one batch with
+        // window = 3 — call 3 fires InjectNudge and call 4 immediately fires
+        // StripTools. Per-call return values would skip the nudge entirely.
+        // consume_pending_action must demote the stage back to Nudged and
+        // return InjectNudge so the nudge lands first.
+        let mut d = ToolLoopDetector::new(3, true);
+        let r1 = d.record(fp("exec", json!({}), Some("err")));
+        let r2 = d.record(fp("exec", json!({}), Some("err")));
+        let r3 = d.record(fp("exec", json!({}), Some("err"))); // → Nudged
+        let r4 = d.record(fp("exec", json!({}), Some("err"))); // → StripTools
+        assert_eq!(r1, LoopDetectorAction::None);
+        assert_eq!(r2, LoopDetectorAction::None);
+        assert_eq!(r3, LoopDetectorAction::InjectNudge);
+        assert_eq!(r4, LoopDetectorAction::StripTools);
+        assert_eq!(d.stage(), InterventionStage::StripTools);
+
+        // End-of-batch: runner asks for the authoritative action.
+        assert_eq!(d.consume_pending_action(), LoopDetectorAction::InjectNudge);
+        // Stage demoted back so strip can fire next batch.
+        assert_eq!(d.stage(), InterventionStage::Nudged);
+        // Same batch/cycle: subsequent consume calls yield nothing.
+        assert_eq!(d.consume_pending_action(), LoopDetectorAction::None);
+
+        // Next batch with another identical failure → promotes to StripTools
+        // again, this time the runner applies it (nudge already delivered).
+        let _ = d.record(fp("exec", json!({}), Some("err")));
+        assert_eq!(d.stage(), InterventionStage::StripTools);
+        assert_eq!(d.consume_pending_action(), LoopDetectorAction::StripTools);
     }
 
     #[test]

--- a/crates/chat/src/lib.rs
+++ b/crates/chat/src/lib.rs
@@ -6850,6 +6850,54 @@ async fn run_with_tools(
                         "seq": seq,
                     })
                 },
+                RunnerEvent::ToolCallRejected {
+                    id,
+                    name,
+                    arguments,
+                    error,
+                } => {
+                    // Pre-dispatch validation failure — the tool's `execute`
+                    // method never ran. Emit as a terminal tool_call_end with
+                    // a `rejected: true` marker so the UI can render it
+                    // distinctly from a normal execution failure (issue #658).
+                    if let Some(ref map) = active_tool_calls {
+                        let mut guard = map.write().await;
+                        if let Some(calls) = guard.get_mut(&sk) {
+                            calls.retain(|tc| tc.id != id);
+                            if calls.is_empty() {
+                                guard.remove(&sk);
+                            }
+                        }
+                    }
+                    serde_json::json!({
+                        "runId": run_id,
+                        "sessionKey": sk,
+                        "state": "tool_call_end",
+                        "toolCallId": id,
+                        "toolName": name,
+                        "arguments": arguments,
+                        "success": false,
+                        "rejected": true,
+                        "error": parse_chat_error(&error, None),
+                        "seq": seq,
+                    })
+                },
+                RunnerEvent::LoopInterventionFired { stage, tool_name } => {
+                    serde_json::json!({
+                        "runId": run_id,
+                        "sessionKey": sk,
+                        "state": "notice",
+                        "title": "Loop detected",
+                        "message": format!(
+                            "Detected repeated failed calls to `{}`. \
+                             Intervening (stage {}) to break the loop.",
+                            tool_name, stage
+                        ),
+                        "loopInterventionStage": stage,
+                        "stuckTool": tool_name,
+                        "seq": seq,
+                    })
+                },
             };
             broadcast(&state, "chat", payload, BroadcastOpts::default()).await;
         }

--- a/crates/config/src/schema.rs
+++ b/crates/config/src/schema.rs
@@ -1576,6 +1576,17 @@ pub struct ToolsConfig {
     /// How tool schemas are presented to the model. Default "full".
     #[serde(default)]
     pub registry_mode: ToolRegistryMode,
+    /// Window size for the tool-call reflex-loop detector. When this many
+    /// consecutive tool calls share the same tool + (args or error), the
+    /// runner injects a directive intervention message. Set to 0 to disable.
+    /// Default 3.
+    #[serde(default = "default_agent_loop_detector_window")]
+    pub agent_loop_detector_window: usize,
+    /// When the loop detector fires a second time (stage 2), strip the tool
+    /// schema list for a single LLM turn so the model is forced to respond
+    /// in text. Default true.
+    #[serde(default = "default_agent_loop_detector_strip_tools")]
+    pub agent_loop_detector_strip_tools_on_second_fire: bool,
 }
 
 impl Default for ToolsConfig {
@@ -1592,6 +1603,9 @@ impl Default for ToolsConfig {
             agent_auto_continue_min_tool_calls: default_agent_auto_continue_min_tool_calls(),
             max_tool_result_bytes: default_max_tool_result_bytes(),
             registry_mode: ToolRegistryMode::default(),
+            agent_loop_detector_window: default_agent_loop_detector_window(),
+            agent_loop_detector_strip_tools_on_second_fire: default_agent_loop_detector_strip_tools(
+            ),
         }
     }
 }
@@ -1614,6 +1628,14 @@ fn default_agent_auto_continue_min_tool_calls() -> usize {
 
 fn default_max_tool_result_bytes() -> usize {
     50_000
+}
+
+fn default_agent_loop_detector_window() -> usize {
+    3
+}
+
+fn default_agent_loop_detector_strip_tools() -> bool {
+    true
 }
 
 /// Map tools configuration.

--- a/crates/config/src/template.rs
+++ b/crates/config/src/template.rs
@@ -231,6 +231,8 @@ agent_max_auto_continues = 2      # Auto-continue nudges when model stops mid-ta
 agent_auto_continue_min_tool_calls = 3  # Min tool calls before auto-continue can trigger
 max_tool_result_bytes = 50000     # Max bytes per tool result before truncation (50KB)
 # registry_mode = "full"          # "full" = all schemas every turn, "lazy" = tool_search discovery
+agent_loop_detector_window = 3    # Fire intervention after N identical failing tool calls in a row (0 = disable)
+agent_loop_detector_strip_tools_on_second_fire = true  # On second consecutive fire, strip tool schemas for one turn to force a text response
 
 # ── Maps ─────────────────────────────────────────────────────────────────────
 

--- a/crates/config/src/validate.rs
+++ b/crates/config/src/validate.rs
@@ -277,6 +277,8 @@ fn build_schema_map() -> KnownKeys {
             ("agent_auto_continue_min_tool_calls", Leaf),
             ("max_tool_result_bytes", Leaf),
             ("registry_mode", Leaf),
+            ("agent_loop_detector_window", Leaf),
+            ("agent_loop_detector_strip_tools_on_second_fire", Leaf),
         ]))
     };
 


### PR DESCRIPTION
## Summary

Fixes #658.

The runner previously dispatched tool calls with empty or malformed args straight to `tool.execute` without pre-validation, and had no detection for repeated identical failures. A model stuck in a reflex-retry loop (e.g. `exec({})` on every iteration) burned through all 25 iterations before `max_iterations` fired, producing a ~4 minute dead zone with no visible progress.

Three defensive layers are added at the runner boundary — any one alone would have prevented the reported scenario; together they harden the runner against the whole class.

### 1. Pre-dispatch schema validation (Fix B from the issue)

New `crates/agents/src/tool_arg_validator.rs` checks each tool call's arguments against the tool's own `parameters_schema()` *before* `execute` runs. Missing required fields and top-level type mismatches short-circuit to a directive error message that names the failure, echoes the sent args, and explicitly tells the model not to retry with identical arguments:

```
Tool call rejected before execution by `exec`.
Missing required field(s): `command`.
You sent: {}
Do not retry with the same arguments. If you do not know what arguments to use,
respond in plain text and ask the user for clarification.
```

Deliberately narrow in scope — only catches the reflex-retry class (missing-required / wrong-type at the top level). Tools still own deeper semantic validation.

### 2. Loop detector with escalating intervention (Fix A + Fix C)

New `crates/agents/src/tool_loop_detector.rs` tracks a ring buffer of recent `(tool_name, args_hash, error_hash)` outcomes and fires when N consecutive failures share the same tool and (args OR error).

Two escalation stages:

1. **Stage 1 — Nudge:** inject a directive intervention message into the conversation history listing the exact repeated calls, explicitly forbidding another tool call, and telling the model to respond in plain text.
2. **Stage 2 — Strip tools:** if a fourth consecutive failure lands after the nudge, pass `schemas_for_api = vec![]` for a single turn so the model *physically* cannot emit another tool call. After that forced-text turn, normal schemas are restored.

Any successful tool call resets both the ring buffer and the escalation stage, so legitimate retry patterns (fail → retry with different args → succeed) do not trip the detector.

### 3. Event reorder + debug logging (Fix D)

- `RunnerEvent::ToolCallStart` is now emitted only for calls that pass validation. Rejected calls emit a new `ToolCallRejected` event instead, so the UI stops showing `💻 Executing command...` for calls that never executed.
- The streaming tool-call accumulator now logs each finalized args string at `debug!` level so future variants of "default to `{}` because no deltas arrived" can be diagnosed from a single log file.

### Config

Two new fields in `[tools]` (defaults are opt-out, per CLAUDE.md):

```toml
agent_loop_detector_window = 3                         # 0 = disable
agent_loop_detector_strip_tools_on_second_fire = true
```

### New RunnerEvent variants

Both surfaced through `crates/chat/src/lib.rs` event forwarder so the UI and channels get appropriate signals:

- `ToolCallRejected { id, name, arguments, error }` — reported as a `tool_call_end` with `rejected: true`
- `LoopInterventionFired { stage, tool_name }` — reported as a `notice` with `loopInterventionStage` + `stuckTool`

## Test plan

### Automated

New tests (all passing):

- [x] `tool_arg_validator::tests::*` — 13 unit tests covering empty schema, missing required, null-as-missing, type mismatch, non-object args, array/object types, unknown types, LLM error message formatting
- [x] `tool_loop_detector::tests::*` — 11 unit tests covering window=0 disabled, 3-identical-fires-nudge, 4th-strips-tools, strip-disabled-stays-nudged, success resets state, same-error-different-args still fires, different tools do not fire, legitimate-retry does not fire, canonicalization stability, intervention message content
- [x] `runner::tests::reflex_loop_fires_detector_and_terminates_non_streaming` — end-to-end: reflex `exec({})` → validation rejects → detector fires → intervention → model returns text → run terminates at iter ≤5
- [x] `runner::tests::reflex_loop_fires_detector_and_terminates_streaming` — same scenario on the streaming path (uses `stream_with_tools` + mid-stream tool_use with no argument deltas)
- [x] `runner::tests::legitimate_retry_does_not_fire_loop_detector` — regression: fail once with a real error, retry with different args, succeed. Detector must not fire.

### Validation

#### Completed

- [x] `cargo test -p moltis-agents` — 352 passed, 0 failed
- [x] `cargo test -p moltis-config` — 185 passed
- [x] `cargo test -p moltis-chat` — 173 passed
- [x] `cargo test --workspace --exclude moltis-providers --exclude moltis-gateway` — all green
- [x] `cargo +nightly-2025-11-30 fmt --all -- --check` — clean
- [x] `cargo +nightly-2025-11-30 clippy -p moltis-agents -p moltis-config -p moltis-chat --all-targets -- -D warnings` — clean

#### Remaining

- [ ] `just lint` — local env missing CUDA toolkit for `llama-cpp-sys-2`; CI will run the full matrix
- [ ] `just test` — same
- [ ] Swift/iOS build steps — Darwin-only gates, will be exercised by CI

### Manual QA

- [ ] Reproduce the original #658 scenario with a real Claude Haiku session (ambiguous prompt that triggers empty `exec` args) and confirm the run terminates within ~4 iterations instead of hanging for 25 iterations
- [ ] Confirm the UI activity log shows the new `loop-detected` notice and that rejected calls no longer display "Executing command..."
- [ ] Verify a legitimate failure-then-retry flow (e.g. `ls /nonexistent` → `ls /tmp`) does not emit any `LoopInterventionFired` event
- [ ] Confirm `agent_loop_detector_window = 0` in `moltis.toml` disables detection end-to-end