### PR TITLE
fix(httpd): redirect remote setup traffic to onboarding wizard

### DIFF
--- a/crates/httpd/src/auth_middleware.rs
+++ b/crates/httpd/src/auth_middleware.rs
@@ -155,10 +155,16 @@ pub async fn auth_gate(
                 next.run(request).await
             } else {
                 // Remote connections to other pages when auth is not
-                // configured yet: redirect to a static "setup required"
-                // page instead of passing through, which would cause a
-                // redirect loop between `/` and `/onboarding` (#350).
-                Redirect::to("/setup-required").into_response()
+                // configured yet: send them to /onboarding so they can
+                // complete first-time setup via the setup-code flow
+                // (#350, #646).  The original redirect loop between `/`
+                // and `/onboarding` was fixed separately at the SPA
+                // template layer via `should_redirect_from_onboarding`,
+                // which keeps remote visitors on /onboarding while auth
+                // setup is pending.  The setup code (printed to stdout)
+                // still prevents an unauthorized remote visitor from
+                // claiming the instance.
+                Redirect::to("/onboarding").into_response()
             }
         },
         AuthResult::Unauthorized => {

--- a/crates/httpd/tests/auth_middleware.rs
+++ b/crates/httpd/tests/auth_middleware.rs
@@ -1360,10 +1360,11 @@ async fn onboarding_passes_through_for_remote_during_setup() {
 }
 
 /// During setup (no password), a remote connection to / is redirected to
-/// /setup-required (same as /onboarding).
+/// /onboarding so the user can enter the setup code and complete first-
+/// time setup via the wizard's AuthStep (#646).
 #[cfg(feature = "web-ui")]
 #[tokio::test]
-async fn root_redirects_to_setup_required_for_remote() {
+async fn root_redirects_to_onboarding_for_remote() {
     let (addr, _store, _state) = start_proxied_server().await;
 
     let client = reqwest::Client::builder()
@@ -1383,13 +1384,15 @@ async fn root_redirects_to_setup_required_for_remote() {
         .and_then(|v| v.to_str().ok())
         .unwrap_or("");
     assert_eq!(
-        location, "/setup-required",
-        "remote / during setup must redirect to /setup-required"
+        location, "/onboarding",
+        "remote / during setup must redirect to /onboarding"
     );
 }
 
-/// /setup-required is a public path and serves content even for remote
-/// connections during setup (no redirect loop).
+/// /setup-required is still served as a public stale-bookmark fallback
+/// even for remote connections during setup. It is no longer the default
+/// redirect target, but direct navigation must still work and must not
+/// redirect-loop.
 #[cfg(feature = "web-ui")]
 #[tokio::test]
 async fn setup_required_page_accessible_for_remote() {
@@ -1414,8 +1417,12 @@ async fn setup_required_page_accessible_for_remote() {
     );
     let body = resp.text().await.unwrap();
     assert!(
-        body.contains("Authentication Not Configured"),
-        "/setup-required should contain the setup heading"
+        body.contains("First-time setup"),
+        "/setup-required should contain the new setup heading"
+    );
+    assert!(
+        body.contains("href=\"/onboarding\""),
+        "/setup-required should link to /onboarding"
     );
 }
 

--- a/crates/web/src/templates.rs
+++ b/crates/web/src/templates.rs
@@ -844,12 +844,16 @@ mod tests {
             "should produce a full HTML document"
         );
         assert!(
-            html.contains("Authentication Not Configured"),
-            "should contain the setup-required heading"
+            html.contains("First-time setup"),
+            "should contain the new setup heading"
         );
         assert!(
-            html.contains("moltis auth reset-password"),
-            "should contain the CLI reset command"
+            html.contains("setup code"),
+            "should mention the one-time setup code"
+        );
+        assert!(
+            html.contains("href=\"/onboarding\""),
+            "should link to the onboarding wizard"
         );
         assert!(
             html.contains("/assets/v/test123/"),

--- a/crates/web/src/templates/setup-required.html
+++ b/crates/web/src/templates/setup-required.html
@@ -16,7 +16,7 @@
   h1{margin:0 0 .75rem;font-size:1.35rem}
   p{margin:.6rem 0;line-height:1.6;color:var(--muted)}
   code{background:rgba(128,128,128,.15);padding:.15em .4em;border-radius:4px;font-size:.9em}
-  .cta{display:inline-block;margin-top:1.25rem;padding:.6rem 1.1rem;border-radius:8px;border:1px solid var(--border);text-decoration:none;font-weight:600}
+  .cta{display:inline-block;margin-top:1.25rem;text-decoration:none}
   .note{margin-top:1.5rem;font-size:.85em;opacity:.75}
 </style>
 </head>
@@ -26,7 +26,7 @@
   <p>This instance has not been configured yet. To finish setup remotely, use the one-time <strong>setup code</strong> printed to the server's standard output when the process started.</p>
   <p>For a docker-compose deployment, find the code with:</p>
   <p><code>docker compose logs moltis</code></p>
-  <a class="cta" href="/onboarding">Continue setup &rarr;</a>
+  <a class="cta provider-btn provider-btn-secondary" href="/onboarding">Continue setup &rarr;</a>
   <p class="note">Locked out of an existing instance with filesystem access? The <code>moltis auth reset-password</code> CLI command can recover it &mdash; do not use it on a fresh install.</p>
 </div>
 </body>

--- a/crates/web/src/templates/setup-required.html
+++ b/crates/web/src/templates/setup-required.html
@@ -12,18 +12,22 @@
 <link rel="stylesheet" href="{{ asset_prefix }}style.css">
 <style>
   body{display:flex;align-items:center;justify-content:center;min-height:100vh;margin:0}
-  .card{max-width:460px;padding:2.5rem;border-radius:12px;border:1px solid var(--border);text-align:center}
+  .card{max-width:480px;padding:2.5rem;border-radius:12px;border:1px solid var(--border);text-align:center}
   h1{margin:0 0 .75rem;font-size:1.35rem}
-  p{margin:.5rem 0;line-height:1.6;color:var(--muted)}
+  p{margin:.6rem 0;line-height:1.6;color:var(--muted)}
   code{background:rgba(128,128,128,.15);padding:.15em .4em;border-radius:4px;font-size:.9em}
+  .cta{display:inline-block;margin-top:1.25rem;padding:.6rem 1.1rem;border-radius:8px;border:1px solid var(--border);text-decoration:none;font-weight:600}
+  .note{margin-top:1.5rem;font-size:.85em;opacity:.75}
 </style>
 </head>
 <body>
 <div class="card">
-  <h1>Authentication Not Configured</h1>
-  <p>This instance requires authentication to be set up before it can be accessed remotely.</p>
-  <p>Connect from the local machine or use the CLI:</p>
-  <p><code>moltis auth reset-password</code></p>
+  <h1>First-time setup</h1>
+  <p>This instance has not been configured yet. To finish setup remotely, use the one-time <strong>setup code</strong> printed to the server's standard output when the process started.</p>
+  <p>For a docker-compose deployment, find the code with:</p>
+  <p><code>docker compose logs moltis</code></p>
+  <a class="cta" href="/onboarding">Continue setup &rarr;</a>
+  <p class="note">Locked out of an existing instance with filesystem access? The <code>moltis auth reset-password</code> CLI command can recover it &mdash; do not use it on a fresh install.</p>
 </div>
 </body>
 </html>

--- a/crates/web/ui/e2e/specs/onboarding-auth.spec.js
+++ b/crates/web/ui/e2e/specs/onboarding-auth.spec.js
@@ -127,12 +127,11 @@ test.describe("Onboarding with forced auth (remote)", () => {
 
 	test("completes auth and identity steps via WebSocket", async ({ page }) => {
 		const pageErrors = watchPageErrors(page);
-		// Fresh runs should land on /onboarding (remote setup allows the
-		// onboarding page through for the setup-code auth flow).  Retries
-		// can land on /login if a previous attempt already configured auth.
-		// Navigate directly to /onboarding since / redirects to
-		// /setup-required for remote connections during setup (#350).
-		await page.goto("/onboarding");
+		// Fresh runs visiting `/` on a remote (proxied) connection should
+		// be redirected to /onboarding so the setup-code AuthStep is
+		// shown (#350, #646).  Retries can land on /login if a previous
+		// attempt already configured auth.
+		await page.goto("/");
 		await expect
 			.poll(() => new URL(page.url()).pathname, { timeout: 15_000 })
 			.toMatch(/^\/(?:onboarding|login|chats\/.+)$/);


### PR DESCRIPTION
## Summary

Fixes #646 — remote visitors on fresh deployments (docker-compose with `MOLTIS_NO_TLS=true`) were stuck on a static "Authentication Not Configured" dead-end page that told them to run `moltis auth reset-password`. That CLI command is useless on a fresh install (no credentials to reset) and left users with no path to complete first-time setup.

The onboarding wizard's `AuthStep` already supports remote setup via a one-time setup code printed to stdout, but remote users were never sent there.

- Redirect remote `SetupRequired` traffic to `/onboarding` (was `/setup-required`). Users can now enter the 6-digit setup code from `docker compose logs moltis` and complete setup normally.
- The original `/` ↔ `/onboarding` redirect loop (#350) is already fixed at the SPA template layer via `should_redirect_from_onboarding`, and the setup-code requirement still prevents an unauthorized remote visitor from claiming the instance.
- Repurpose `/setup-required` as a stale-bookmark fallback: rewritten body with a prominent "Continue setup →" link to `/onboarding` and updated copy pointing users at the setup code. `moltis auth reset-password` is demoted to a side note for locked-out recovery scenarios.

## Validation

### Completed
- [x] `cargo test -p moltis-httpd --test auth_middleware -- root_redirects_to_onboarding_for_remote setup_required_page_accessible_for_remote setup_required_redirects_to_login_after_setup onboarding_passes` — 5/5 passing
- [x] `cargo test -p moltis-web --lib --features vault,web-ui templates::tests::setup_required` — passing
- [x] `cargo check -p moltis-httpd -p moltis-web` — clean
- [x] `cargo +nightly-2025-11-30 fmt --all -- --check` — clean
- [x] `biome check --write crates/web/ui/e2e/specs/onboarding-auth.spec.js` — clean

### Remaining
- [ ] `just lint` (OS-aware clippy)
- [ ] `just test` (full test suite)
- [ ] `npx playwright test e2e/specs/onboarding-auth.spec.js` (restored to visit `/` instead of `/onboarding`)

## Manual QA

Mirror the bug report:
1. `docker build -t moltis-local .`
2. Start with `MOLTIS_NO_TLS=true` bound to a non-loopback interface (or access via LAN IP).
3. From a different machine, visit `http://<host>:<port>/`.
4. **Expect:** redirected to `/onboarding`, AuthStep shows "Setup code" input.
5. `docker compose logs moltis` prints the 6-digit code.
6. Paste the code, set a password (or register a passkey), complete the wizard.
7. Confirm no redirect loop, no `/setup-required` dead-end, and subsequent visits after logout land on `/login`.

## Security sanity check

- Remote visitor without the setup code cannot complete `POST /api/auth/setup` (validated at `crates/httpd/src/auth_routes.rs:179-183`).
- `/api/*` remote calls during `SetupRequired` still return `AUTH_SETUP_REQUIRED` 401 — unchanged.
- Once setup is complete, `/onboarding` gets the normal auth gate back — unchanged.