### PR TITLE
feat(tools): add native file_read and file_info tools with containment and approval gating

### DIFF
--- a/crates/config/src/schema.rs
+++ b/crates/config/src/schema.rs
@@ -1558,6 +1558,7 @@ pub struct ToolsConfig {
     pub web: WebConfig,
     pub maps: MapsConfig,
     pub browser: BrowserConfig,
+    pub filesystem: FilesystemToolsConfig,
     /// Maximum wall-clock seconds for an agent run (0 = no timeout). Default 600.
     #[serde(default = "default_agent_timeout_secs")]
     pub agent_timeout_secs: u64,
@@ -1586,6 +1587,7 @@ impl Default for ToolsConfig {
             web: WebConfig::default(),
             maps: MapsConfig::default(),
             browser: BrowserConfig::default(),
+            filesystem: FilesystemToolsConfig::default(),
             agent_timeout_secs: default_agent_timeout_secs(),
             agent_max_iterations: default_agent_max_iterations(),
             agent_max_auto_continues: default_agent_max_auto_continues(),
@@ -1614,6 +1616,40 @@ fn default_agent_auto_continue_min_tool_calls() -> usize {
 
 fn default_max_tool_result_bytes() -> usize {
     50_000
+}
+
+
+/// Native filesystem tools configuration.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct FilesystemToolsConfig {
+    /// Maximum lines returned per `file_read` call. Default 150.
+    #[serde(default = "default_fs_max_lines")]
+    pub max_lines: usize,
+    /// Maximum bytes for `file_write` content. Default 20 MB.
+    #[serde(default = "default_fs_max_write_bytes")]
+    pub max_write_bytes: u64,
+    /// Allowed root directories (empty = all paths allowed).
+    #[serde(default)]
+    pub allowed_dirs: Vec<String>,
+}
+
+impl Default for FilesystemToolsConfig {
+    fn default() -> Self {
+        Self {
+            max_lines: default_fs_max_lines(),
+            max_write_bytes: default_fs_max_write_bytes(),
+            allowed_dirs: Vec::new(),
+        }
+    }
+}
+
+fn default_fs_max_lines() -> usize {
+    150
+}
+
+fn default_fs_max_write_bytes() -> u64 {
+    20 * 1024 * 1024
 }
 
 /// Map tools configuration.

--- a/crates/config/src/schema.rs
+++ b/crates/config/src/schema.rs
@@ -1618,7 +1618,6 @@ fn default_max_tool_result_bytes() -> usize {
     50_000
 }
 
-
 /// Native filesystem tools configuration.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]

--- a/crates/config/src/schema.rs
+++ b/crates/config/src/schema.rs
@@ -1626,6 +1626,7 @@ pub struct FilesystemToolsConfig {
     #[serde(default = "default_fs_max_lines")]
     pub max_lines: usize,
     /// Maximum bytes for `file_write` content. Default 20 MB.
+    // TODO: consumed by file_write tool (phase 2)
     #[serde(default = "default_fs_max_write_bytes")]
     pub max_write_bytes: u64,
     /// Allowed root directories (empty = all paths allowed).

--- a/crates/config/src/template.rs
+++ b/crates/config/src/template.rs
@@ -392,6 +392,16 @@ allow = []                        # Tools to always allow (e.g., ["exec", "web_f
 deny = []                         # Tools to always deny (e.g., ["browser"])
 # profile = "default"             # Named policy profile
 
+# ── Filesystem Tools ──────────────────────────────────────────────────────────
+# Native file_read and file_info tools. Enable to replace MCP filesystem server.
+# NOTE: allowed_dirs = [] is unconditionally permissive and overrides
+# security_level. Set explicit dirs to enforce containment.
+
+# [tools.filesystem]
+# max_lines = 150           # Maximum lines returned per file_read call (1–10000)
+# max_write_bytes = 20971520 # Maximum bytes for file_write content (phase 2, 20 MB default)
+# allowed_dirs = []         # Allowed root directories (empty = all paths allowed)
+
 # ── Web Search ────────────────────────────────────────────────────────────────
 
 [tools.web.search]

--- a/crates/config/src/validate.rs
+++ b/crates/config/src/validate.rs
@@ -270,6 +270,14 @@ fn build_schema_map() -> KnownKeys {
                     ("firecrawl", firecrawl()),
                 ])),
             ),
+            (
+                "filesystem",
+                Struct(HashMap::from([
+                    ("max_lines", Leaf),
+                    ("max_write_bytes", Leaf),
+                    ("allowed_dirs", Leaf),
+                ])),
+            ),
             ("maps", Struct(HashMap::from([("provider", Leaf)]))),
             ("agent_timeout_secs", Leaf),
             ("agent_max_iterations", Leaf),

--- a/crates/gateway/src/server.rs
+++ b/crates/gateway/src/server.rs
@@ -3514,7 +3514,8 @@ pub async fn prepare_gateway_core(
 
     // Wire live chat service (needs state reference, so done after state creation).
     {
-        let broadcaster = Arc::new(GatewayApprovalBroadcaster::new(Arc::clone(&state)));
+        let broadcaster: Arc<dyn moltis_tools::approval::ApprovalBroadcaster> =
+            Arc::new(GatewayApprovalBroadcaster::new(Arc::clone(&state)));
         let env_provider: Arc<dyn EnvVarProvider> = credential_store.clone();
         let eq = cron_service.events_queue().clone();
         let cs = Arc::clone(&cron_service);
@@ -3532,7 +3533,7 @@ pub async fn prepare_gateway_core(
                 config.tools.exec.default_timeout_secs,
             ))
             .with_max_output_bytes(config.tools.exec.max_output_bytes)
-            .with_approval(Arc::clone(&approval_manager), broadcaster)
+            .with_approval(Arc::clone(&approval_manager), Arc::clone(&broadcaster))
             .with_sandbox_router(Arc::clone(&sandbox_router))
             .with_env_provider(Arc::clone(&env_provider))
             .with_completion_callback(exec_cb);
@@ -3568,6 +3569,23 @@ pub async fn prepare_gateway_core(
             .with_sandbox_router(Arc::clone(&sandbox_router));
 
         tool_registry.register(Box::new(exec_tool));
+
+        // Native filesystem tools with approval gating.
+        let fs_config = &config.tools.filesystem;
+        tool_registry.register(Box::new(
+            moltis_tools::filesystem::read::FileReadTool::new_with_allowed_dirs(
+                fs_config.max_lines,
+                fs_config.allowed_dirs.clone(),
+            )
+            .with_approval(Arc::clone(&approval_manager), Arc::clone(&broadcaster)),
+        ));
+        tool_registry.register(Box::new(
+            moltis_tools::filesystem::info::FileInfoTool::new_with_allowed_dirs(
+                fs_config.allowed_dirs.clone(),
+            )
+            .with_approval(Arc::clone(&approval_manager), Arc::clone(&broadcaster)),
+        ));
+
         tool_registry.register(Box::new(moltis_tools::calc::CalcTool::new()));
         #[cfg(feature = "wasm")]
         {

--- a/crates/tools/src/approval.rs
+++ b/crates/tools/src/approval.rs
@@ -315,42 +315,30 @@ impl ApprovalManager {
 
     /// Decide whether a filesystem path needs approval.
     ///
-    /// Uses [`check_allowed_dir`] from the filesystem module to determine if
-    /// the path falls within the allowed directories.
+    /// Security level and approval mode are consulted **first**, before the
+    /// `allowed_dirs` containment check.  This prevents `allowed_dirs` from
+    /// bypassing a `Deny` security level or an `Always` approval mode.
     ///
-    /// # Returns
-    /// - `Proceed` if the path is inside `allowed_dirs` (empty allowed_dirs = all allowed)
-    /// - `Proceed` if `security_level` is `Full`
-    /// - `Err` if `security_level` is `Deny`
-    /// - For `Allowlist` + `OnMiss` mode: `NeedsApproval` for paths outside allowed_dirs
-    /// - For `Off` mode: `Proceed` (no approval needed)
+    /// # Precedence
+    ///
+    /// 1. `SecurityLevel::Deny` → **reject** all paths (regardless of containment).
+    /// 2. `SecurityLevel::Full` → **proceed** for all paths.
+    /// 3. `SecurityLevel::Allowlist` → consult mode:
+    ///    - `Off`    → inside `allowed_dirs` = proceed, outside = reject (containment only).
+    ///    - `OnMiss` → inside = proceed, outside = needs approval.
+    ///    - `Always` → needs approval for **all** paths (even inside `allowed_dirs`).
+    ///
+    /// When the path does not exist on disk, it is treated as outside `allowed_dirs`.
     pub fn check_path(&self, path: &str, allowed_dirs: &[String]) -> Result<ApprovalAction> {
         use std::path::Path;
 
-        let Some(resolved) = crate::filesystem::canonicalize_or_original(Path::new(path)) else {
-            // Path doesn't exist — treat as outside allowed_dirs.
-            // The caller will either deny, request approval, or proceed
-            // based on its security level and mode.
-            return match self.security_level {
-                SecurityLevel::Deny => Err(Error::message(
-                    "filesystem access denied: path does not exist",
-                )),
-                SecurityLevel::Full => Ok(ApprovalAction::Proceed),
-                SecurityLevel::Allowlist => match self.mode {
-                    ApprovalMode::Off => Ok(ApprovalAction::Proceed),
-                    ApprovalMode::Always | ApprovalMode::OnMiss => {
-                        Ok(ApprovalAction::NeedsApproval)
-                    },
-                },
-            };
-        };
+        let resolved = crate::filesystem::canonicalize_or_original(Path::new(path));
+        let is_inside = resolved
+            .as_ref()
+            .map(|r| check_allowed_dir(r, allowed_dirs).is_ok())
+            .unwrap_or(false);
 
-        // If the path is inside allowed_dirs, proceed immediately.
-        if check_allowed_dir(&resolved, allowed_dirs).is_ok() {
-            return Ok(ApprovalAction::Proceed);
-        }
-
-        // Path is outside allowed_dirs — check security level and mode.
+        // Always consult security level first — it overrides everything.
         match self.security_level {
             SecurityLevel::Deny => {
                 return Err(Error::message(
@@ -361,29 +349,25 @@ impl ApprovalManager {
             SecurityLevel::Allowlist => {},
         }
 
+        // SecurityLevel::Allowlist — consult mode.
         match self.mode {
-            ApprovalMode::Off => Ok(ApprovalAction::Proceed),
-            ApprovalMode::Always => Ok(ApprovalAction::NeedsApproval),
-            ApprovalMode::OnMiss => Ok(ApprovalAction::NeedsApproval),
-        }
-    }
-
-    /// Like [`check_path`](Self::check_path) but accepts an already-canonicalized
-    /// path.  Skips the canonicalization and `check_allowed_dir` calls since the
-    /// caller has already determined the path is outside the allowed directories.
-    pub fn check_path_resolved(
-        &self,
-        _resolved: &std::path::Path,
-    ) -> Result<ApprovalAction> {
-        match self.security_level {
-            SecurityLevel::Deny => Err(Error::message(
-                "filesystem access denied: security level is 'deny'",
-            )),
-            SecurityLevel::Full => Ok(ApprovalAction::Proceed),
-            SecurityLevel::Allowlist => match self.mode {
-                ApprovalMode::Off => Ok(ApprovalAction::Proceed),
-                ApprovalMode::Always | ApprovalMode::OnMiss => Ok(ApprovalAction::NeedsApproval),
+            ApprovalMode::Off => {
+                if is_inside {
+                    Ok(ApprovalAction::Proceed)
+                } else {
+                    Err(Error::message(format!(
+                        "path '{path}' is outside the allowed directories"
+                    )))
+                }
             },
+            ApprovalMode::OnMiss => {
+                if is_inside {
+                    Ok(ApprovalAction::Proceed)
+                } else {
+                    Ok(ApprovalAction::NeedsApproval)
+                }
+            },
+            ApprovalMode::Always => Ok(ApprovalAction::NeedsApproval),
         }
     }
 
@@ -759,10 +743,9 @@ mod tests {
             ..Default::default()
         };
         let allowed = tempfile::tempdir().unwrap();
-        let other = tempfile::tempdir().unwrap();
-        let file = other.path().join("test.txt");
+        // Create the test file INSIDE allowed_dirs — Deny must still reject.
+        let file = allowed.path().join("test.txt");
         std::fs::write(&file, "data").unwrap();
-        // Path is outside allowed_dirs and security level is Deny.
         assert!(
             mgr.check_path(file.to_str().unwrap(), &[allowed
                 .path()
@@ -798,14 +781,16 @@ mod tests {
         let other = tempfile::tempdir().unwrap();
         let file = other.path().join("test.txt");
         std::fs::write(&file, "data").unwrap();
-        let action = mgr
-            .check_path(file.to_str().unwrap(), &[allowed
-                .path()
-                .to_str()
-                .unwrap()
-                .to_string()])
-            .unwrap();
-        assert_eq!(action, ApprovalAction::Proceed);
+        // Off mode is containment-only: outside allowed_dirs → reject
+        let result = mgr.check_path(file.to_str().unwrap(), &[allowed
+            .path()
+            .to_str()
+            .unwrap()
+            .to_string()]);
+        assert!(result.is_err(), "Off mode should reject paths outside allowed_dirs");
+        assert!(
+            result.unwrap_err().to_string().contains("outside the allowed directories"),
+        );
     }
 
     #[test]
@@ -817,7 +802,26 @@ mod tests {
         let allowed = tempfile::tempdir().unwrap();
         let file = allowed.path().join("test.txt");
         std::fs::write(&file, "data").unwrap();
-        // Inside allowed_dirs → Proceed even with Always mode
+        // Always mode → NeedsApproval even when inside allowed_dirs
+        let action = mgr
+            .check_path(file.to_str().unwrap(), &[allowed
+                .path()
+                .to_str()
+                .unwrap()
+                .to_string()])
+            .unwrap();
+        assert_eq!(action, ApprovalAction::NeedsApproval);
+    }
+
+    #[test]
+    fn test_check_path_off_mode_inside_allowed() {
+        let mgr = ApprovalManager {
+            mode: ApprovalMode::Off,
+            ..Default::default()
+        };
+        let allowed = tempfile::tempdir().unwrap();
+        let file = allowed.path().join("test.txt");
+        std::fs::write(&file, "data").unwrap();
         let action = mgr
             .check_path(file.to_str().unwrap(), &[allowed
                 .path()

--- a/crates/tools/src/approval.rs
+++ b/crates/tools/src/approval.rs
@@ -2,14 +2,20 @@ use std::{collections::HashSet, sync::Arc, time::Duration};
 
 use {
     crate::error::Error,
+    async_trait::async_trait,
     regex::RegexSet,
     serde::{Deserialize, Serialize},
     tokio::sync::{RwLock, oneshot},
     tracing::{debug, warn},
 };
 
-use crate::Result;
+use crate::{Result, filesystem::check_allowed_dir};
 
+/// Broadcaster that notifies connected clients about pending approval requests.
+#[async_trait]
+pub trait ApprovalBroadcaster: Send + Sync {
+    async fn broadcast_request(&self, request_id: &str, command: &str) -> Result<()>;
+}
 /// Outcome of an approval request.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
@@ -304,6 +310,45 @@ impl ApprovalManager {
                 }
                 Ok(ApprovalAction::NeedsApproval)
             },
+        }
+    }
+
+    /// Decide whether a filesystem path needs approval.
+    ///
+    /// Uses [`check_allowed_dir`] from the filesystem module to determine if
+    /// the path falls within the allowed directories.
+    ///
+    /// # Returns
+    /// - `Proceed` if the path is inside `allowed_dirs` (empty allowed_dirs = all allowed)
+    /// - `Proceed` if `security_level` is `Full`
+    /// - `Err` if `security_level` is `Deny`
+    /// - For `Allowlist` + `OnMiss` mode: `NeedsApproval` for paths outside allowed_dirs
+    /// - For `Off` mode: `Proceed` (no approval needed)
+    pub fn check_path(&self, path: &str, allowed_dirs: &[String]) -> Result<ApprovalAction> {
+        use std::path::Path;
+
+        let resolved = crate::filesystem::canonicalize_or_original(Path::new(path));
+
+        // If the path is inside allowed_dirs, proceed immediately.
+        if check_allowed_dir(&resolved, allowed_dirs).is_ok() {
+            return Ok(ApprovalAction::Proceed);
+        }
+
+        // Path is outside allowed_dirs — check security level and mode.
+        match self.security_level {
+            SecurityLevel::Deny => {
+                return Err(Error::message(
+                    "filesystem access denied: security level is 'deny'",
+                ));
+            },
+            SecurityLevel::Full => return Ok(ApprovalAction::Proceed),
+            SecurityLevel::Allowlist => {},
+        }
+
+        match self.mode {
+            ApprovalMode::Off => Ok(ApprovalAction::Proceed),
+            ApprovalMode::Always => Ok(ApprovalAction::NeedsApproval),
+            ApprovalMode::OnMiss => Ok(ApprovalAction::NeedsApproval),
         }
     }
 
@@ -625,5 +670,126 @@ mod tests {
         };
         let action = mgr.check_command("git reset --hard").await.unwrap();
         assert_eq!(action, ApprovalAction::NeedsApproval);
+    }
+
+    // --- check_path tests ---
+
+    #[test]
+    fn test_check_path_empty_allowed_dirs() {
+        let mgr = ApprovalManager::default();
+        let tmp = tempfile::tempdir().unwrap();
+        let file = tmp.path().join("test.txt");
+        std::fs::write(&file, "data").unwrap();
+        let action = mgr.check_path(file.to_str().unwrap(), &[]).unwrap();
+        assert_eq!(action, ApprovalAction::Proceed);
+    }
+
+    #[test]
+    fn test_check_path_inside_allowed_dir() {
+        let mgr = ApprovalManager::default();
+        let allowed = tempfile::tempdir().unwrap();
+        let file = allowed.path().join("test.txt");
+        std::fs::write(&file, "data").unwrap();
+        let action = mgr
+            .check_path(file.to_str().unwrap(), &[allowed
+                .path()
+                .to_str()
+                .unwrap()
+                .to_string()])
+            .unwrap();
+        assert_eq!(action, ApprovalAction::Proceed);
+    }
+
+    #[test]
+    fn test_check_path_outside_allowed_dir_needs_approval() {
+        let mgr = ApprovalManager::default(); // Allowlist + OnMiss
+        let allowed = tempfile::tempdir().unwrap();
+        let other = tempfile::tempdir().unwrap();
+        let file = other.path().join("test.txt");
+        std::fs::write(&file, "data").unwrap();
+        let action = mgr
+            .check_path(file.to_str().unwrap(), &[allowed
+                .path()
+                .to_str()
+                .unwrap()
+                .to_string()])
+            .unwrap();
+        assert_eq!(action, ApprovalAction::NeedsApproval);
+    }
+
+    #[test]
+    fn test_check_path_deny_security_level() {
+        let mgr = ApprovalManager {
+            security_level: SecurityLevel::Deny,
+            ..Default::default()
+        };
+        let allowed = tempfile::tempdir().unwrap();
+        let other = tempfile::tempdir().unwrap();
+        let file = other.path().join("test.txt");
+        std::fs::write(&file, "data").unwrap();
+        // Path is outside allowed_dirs and security level is Deny.
+        assert!(
+            mgr.check_path(file.to_str().unwrap(), &[allowed
+                .path()
+                .to_str()
+                .unwrap()
+                .to_string()],)
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn test_check_path_full_security_level() {
+        let mgr = ApprovalManager {
+            security_level: SecurityLevel::Full,
+            ..Default::default()
+        };
+        let other = tempfile::tempdir().unwrap();
+        let file = other.path().join("test.txt");
+        std::fs::write(&file, "data").unwrap();
+        let action = mgr
+            .check_path(file.to_str().unwrap(), &["/nonexistent".to_string()])
+            .unwrap();
+        assert_eq!(action, ApprovalAction::Proceed);
+    }
+
+    #[test]
+    fn test_check_path_off_mode_outside_allowed() {
+        let mgr = ApprovalManager {
+            mode: ApprovalMode::Off,
+            ..Default::default()
+        };
+        let allowed = tempfile::tempdir().unwrap();
+        let other = tempfile::tempdir().unwrap();
+        let file = other.path().join("test.txt");
+        std::fs::write(&file, "data").unwrap();
+        let action = mgr
+            .check_path(file.to_str().unwrap(), &[allowed
+                .path()
+                .to_str()
+                .unwrap()
+                .to_string()])
+            .unwrap();
+        assert_eq!(action, ApprovalAction::Proceed);
+    }
+
+    #[test]
+    fn test_check_path_always_mode_inside_allowed() {
+        let mgr = ApprovalManager {
+            mode: ApprovalMode::Always,
+            ..Default::default()
+        };
+        let allowed = tempfile::tempdir().unwrap();
+        let file = allowed.path().join("test.txt");
+        std::fs::write(&file, "data").unwrap();
+        // Inside allowed_dirs → Proceed even with Always mode
+        let action = mgr
+            .check_path(file.to_str().unwrap(), &[allowed
+                .path()
+                .to_str()
+                .unwrap()
+                .to_string()])
+            .unwrap();
+        assert_eq!(action, ApprovalAction::Proceed);
     }
 }

--- a/crates/tools/src/approval.rs
+++ b/crates/tools/src/approval.rs
@@ -368,6 +368,25 @@ impl ApprovalManager {
         }
     }
 
+    /// Like [`check_path`](Self::check_path) but accepts an already-canonicalized
+    /// path.  Skips the canonicalization and `check_allowed_dir` calls since the
+    /// caller has already determined the path is outside the allowed directories.
+    pub fn check_path_resolved(
+        &self,
+        _resolved: &std::path::Path,
+    ) -> Result<ApprovalAction> {
+        match self.security_level {
+            SecurityLevel::Deny => Err(Error::message(
+                "filesystem access denied: security level is 'deny'",
+            )),
+            SecurityLevel::Full => Ok(ApprovalAction::Proceed),
+            SecurityLevel::Allowlist => match self.mode {
+                ApprovalMode::Off => Ok(ApprovalAction::Proceed),
+                ApprovalMode::Always | ApprovalMode::OnMiss => Ok(ApprovalAction::NeedsApproval),
+            },
+        }
+    }
+
     /// Register a pending approval request. Returns an ID and a receiver for the decision.
     pub async fn create_request(
         &self,

--- a/crates/tools/src/approval.rs
+++ b/crates/tools/src/approval.rs
@@ -327,7 +327,23 @@ impl ApprovalManager {
     pub fn check_path(&self, path: &str, allowed_dirs: &[String]) -> Result<ApprovalAction> {
         use std::path::Path;
 
-        let resolved = crate::filesystem::canonicalize_or_original(Path::new(path));
+        let Some(resolved) = crate::filesystem::canonicalize_or_original(Path::new(path)) else {
+            // Path doesn't exist — treat as outside allowed_dirs.
+            // The caller will either deny, request approval, or proceed
+            // based on its security level and mode.
+            return match self.security_level {
+                SecurityLevel::Deny => Err(Error::message(
+                    "filesystem access denied: path does not exist",
+                )),
+                SecurityLevel::Full => Ok(ApprovalAction::Proceed),
+                SecurityLevel::Allowlist => match self.mode {
+                    ApprovalMode::Off => Ok(ApprovalAction::Proceed),
+                    ApprovalMode::Always | ApprovalMode::OnMiss => {
+                        Ok(ApprovalAction::NeedsApproval)
+                    },
+                },
+            };
+        };
 
         // If the path is inside allowed_dirs, proceed immediately.
         if check_allowed_dir(&resolved, allowed_dirs).is_ok() {

--- a/crates/tools/src/exec.rs
+++ b/crates/tools/src/exec.rs
@@ -39,11 +39,7 @@ use crate::{
 
 const MAX_SANDBOX_RECOVERY_RETRIES: usize = 1;
 
-/// Broadcaster that notifies connected clients about pending approval requests.
-#[async_trait]
-pub trait ApprovalBroadcaster: Send + Sync {
-    async fn broadcast_request(&self, request_id: &str, command: &str) -> Result<()>;
-}
+pub use crate::approval::ApprovalBroadcaster;
 
 /// Provider of environment variables to inject into sandbox execution.
 /// Values are wrapped in `Secret` to prevent accidental logging.

--- a/crates/tools/src/filesystem/info.rs
+++ b/crates/tools/src/filesystem/info.rs
@@ -1,0 +1,279 @@
+//! `file_info` tool — retrieve file/directory metadata without reading content.
+//!
+//! Provides size, line count, type, extension, modification time, and
+//! permissions. Useful for deciding whether to read a file at all.
+
+use {
+    async_trait::async_trait,
+    moltis_agents::tool_registry::AgentTool,
+    serde_json::{Value, json},
+    time::format_description::well_known::Rfc3339,
+    tracing::instrument,
+};
+
+use crate::error::Error;
+
+/// File size threshold (bytes) below which we count lines by reading.
+/// Above this, line_count is omitted from the response to avoid loading
+/// large binaries into memory just to count newlines.
+const LINE_COUNT_MAX_BYTES: u64 = 1024 * 1024; // 1 MB
+
+/// Retrieve file or directory metadata without reading content.
+#[derive(Default)]
+pub struct FileInfoTool;
+
+impl FileInfoTool {
+    #[must_use]
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+#[async_trait]
+impl AgentTool for FileInfoTool {
+    fn name(&self) -> &str {
+        "file_info"
+    }
+
+    fn description(&self) -> &str {
+        "Retrieve detailed metadata about a file or directory. Returns size, \
+         type, line count (for files under 1 MB), extension, last modified \
+         time, and read/write permissions. Does not return file content."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "required": ["path"],
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "description": "Path to the file or directory"
+                }
+            }
+        })
+    }
+
+    #[instrument(skip(self, params))]
+    async fn execute(&self, params: Value) -> anyhow::Result<Value> {
+        let path = params
+            .get("path")
+            .and_then(Value::as_str)
+            .ok_or_else(|| Error::message("missing 'path' parameter"))?;
+
+        let meta = tokio::fs::metadata(path)
+            .await
+            .map_err(|e| Error::message(format!("cannot access '{path}': {e}")))?;
+
+        let display_path = std::path::Path::new(path)
+            .canonicalize()
+            .unwrap_or_else(|_| std::path::PathBuf::from(path))
+            .to_string_lossy()
+            .to_string();
+
+        let name = std::path::Path::new(path)
+            .file_name()
+            .map(|n| n.to_string_lossy().to_string())
+            .unwrap_or_else(|| display_path.clone());
+
+        let size_bytes = meta.len();
+        let modified = meta
+            .modified()
+            .ok()
+            .and_then(|t| {
+                let dt = time::OffsetDateTime::from(t);
+                dt.format(&Rfc3339).ok()
+            })
+            .unwrap_or_default();
+
+        let readable = {
+            use std::os::unix::fs::PermissionsExt;
+            meta.permissions().mode() & 0o444 != 0
+        };
+        let writable = {
+            use std::os::unix::fs::PermissionsExt;
+            meta.permissions().mode() & 0o222 != 0
+        };
+
+        if meta.is_file() {
+            let extension = std::path::Path::new(path)
+                .extension()
+                .map(|e| e.to_string_lossy().to_string())
+                .unwrap_or_default();
+
+            let mut result = json!({
+                "path": display_path,
+                "name": name,
+                "type": "file",
+                "size_bytes": size_bytes,
+                "extension": extension,
+                "last_modified": modified,
+                "readable": readable,
+                "writable": writable,
+            });
+
+            // Count lines only for files under the threshold.
+            if size_bytes <= LINE_COUNT_MAX_BYTES {
+                match tokio::fs::read_to_string(path).await {
+                    Ok(content) => {
+                        let line_count = content.lines().count();
+                        result["line_count"] = json!(line_count);
+                    },
+                    Err(_) => {
+                        // Non-UTF-8 file — skip line count.
+                    },
+                }
+            }
+
+            Ok(result)
+        } else if meta.is_dir() {
+            let entry_count = match tokio::fs::read_dir(path).await {
+                Ok(mut rd) => {
+                    let mut count = 0usize;
+                    while let Ok(Some(_)) = rd.next_entry().await {
+                        count = count.saturating_add(1);
+                    }
+                    count
+                },
+                Err(_) => 0,
+            };
+
+            Ok(json!({
+                "path": display_path,
+                "name": name,
+                "type": "directory",
+                "size_bytes": size_bytes,
+                "entry_count": entry_count,
+                "last_modified": modified,
+                "readable": readable,
+                "writable": writable,
+            }))
+        } else {
+            Ok(json!({
+                "path": display_path,
+                "name": name,
+                "type": "special",
+                "size_bytes": size_bytes,
+                "last_modified": modified,
+                "readable": readable,
+                "writable": writable,
+            }))
+        }
+    }
+}
+
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    #[tokio::test]
+    async fn file_info_basic() {
+        let mut f = tempfile::NamedTempFile::new().unwrap();
+        write!(f, "hello\nworld\nfoo").unwrap();
+        f.flush().unwrap();
+
+        let tool = FileInfoTool::new();
+        let result = tool
+            .execute(json!({ "path": f.path().to_str().unwrap() }))
+            .await
+            .unwrap();
+
+        assert_eq!(result["type"], "file");
+        assert_eq!(result["line_count"], 3);
+        assert!(result["readable"].as_bool().unwrap());
+        assert!(result["writable"].as_bool().unwrap());
+        assert!(result["size_bytes"].as_u64().unwrap() > 0);
+    }
+
+    #[tokio::test]
+    async fn file_info_extension() {
+        let mut f = tempfile::Builder::new()
+            .suffix(".rs")
+            .tempfile()
+            .unwrap();
+        write!(f, "fn main() {{}}").unwrap();
+        f.flush().unwrap();
+
+        let tool = FileInfoTool::new();
+        let result = tool
+            .execute(json!({ "path": f.path().to_str().unwrap() }))
+            .await
+            .unwrap();
+
+        assert_eq!(result["extension"], "rs");
+    }
+
+    #[tokio::test]
+    async fn file_info_no_extension() {
+        let f = tempfile::Builder::new()
+            .suffix("")
+            .tempfile()
+            .unwrap();
+
+        let tool = FileInfoTool::new();
+        let result = tool
+            .execute(json!({ "path": f.path().to_str().unwrap() }))
+            .await
+            .unwrap();
+
+        assert_eq!(result["extension"], "");
+    }
+
+    #[tokio::test]
+    async fn directory_info() {
+        let dir = tempfile::tempdir().unwrap();
+        // Create a few children.
+        std::fs::write(dir.path().join("a.txt"), "a").unwrap();
+        std::fs::write(dir.path().join("b.rs"), "b").unwrap();
+        std::fs::create_dir(dir.path().join("sub")).unwrap();
+
+        let tool = FileInfoTool::new();
+        let result = tool
+            .execute(json!({ "path": dir.path().to_str().unwrap() }))
+            .await
+            .unwrap();
+
+        assert_eq!(result["type"], "directory");
+        assert_eq!(result["entry_count"], 3);
+        // Directories should not have line_count or extension.
+        assert!(result.get("line_count").is_none());
+        assert!(result.get("extension").is_none());
+    }
+
+    #[tokio::test]
+    async fn non_existent_path() {
+        let tool = FileInfoTool::new();
+        let err = tool
+            .execute(json!({ "path": "/tmp/does-not-exist-file-info-test-98765" }))
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("cannot access"));
+    }
+
+    #[tokio::test]
+    async fn missing_path_parameter() {
+        let tool = FileInfoTool::new();
+        let err = tool.execute(json!({})).await.unwrap_err();
+        assert!(err.to_string().contains("missing 'path'"));
+    }
+
+    #[tokio::test]
+    async fn binary_file_skips_line_count() {
+        // Create a binary file >1MB so line_count is skipped.
+        let dir = tempfile::tempdir().unwrap();
+        let bin_path = dir.path().join("large.bin");
+        let f = std::fs::File::create(&bin_path).unwrap();
+        f.set_len(LINE_COUNT_MAX_BYTES + 1).unwrap();
+
+        let tool = FileInfoTool::new();
+        let result = tool
+            .execute(json!({ "path": bin_path.to_str().unwrap() }))
+            .await
+            .unwrap();
+
+        assert_eq!(result["type"], "file");
+        assert!(result.get("line_count").is_none());
+    }
+}

--- a/crates/tools/src/filesystem/info.rs
+++ b/crates/tools/src/filesystem/info.rs
@@ -141,11 +141,11 @@ impl AgentTool for FileInfoTool {
 
         let readable = {
             use std::os::unix::fs::PermissionsExt;
-            meta.permissions().mode() & 0o444 != 0
+            meta.permissions().mode() & 0o400 != 0
         };
         let writable = {
             use std::os::unix::fs::PermissionsExt;
-            meta.permissions().mode() & 0o222 != 0
+            meta.permissions().mode() & 0o200 != 0
         };
 
         if meta.is_file() {

--- a/crates/tools/src/filesystem/info.rs
+++ b/crates/tools/src/filesystem/info.rs
@@ -10,15 +10,15 @@ use {
     moltis_agents::tool_registry::AgentTool,
     serde_json::{Value, json},
     time::format_description::well_known::Rfc3339,
-    tracing::{info, instrument, warn},
+    tracing::instrument,
 };
 
 use crate::{
-    approval::{ApprovalAction, ApprovalBroadcaster, ApprovalDecision, ApprovalManager},
+    approval::{ApprovalBroadcaster, ApprovalManager},
     error::Error,
 };
 
-use super::{canonicalize_or_original, check_allowed_dir};
+use super::{canonicalize_or_original, enforce_approval};
 
 /// File size threshold (bytes) below which we count lines by reading.
 /// Above this, line_count is omitted from the response to avoid loading
@@ -58,6 +58,7 @@ impl FileInfoTool {
     }
 
     /// Attach approval gating to this tool.
+    #[must_use]
     pub fn with_approval(
         mut self,
         manager: Arc<ApprovalManager>,
@@ -102,46 +103,20 @@ impl AgentTool for FileInfoTool {
             .ok_or_else(|| Error::message("missing 'path' parameter"))?;
 
         // --- Resolve & validate path ---
-        let resolved = canonicalize_or_original(std::path::Path::new(path));
+        let Some(resolved) = canonicalize_or_original(std::path::Path::new(path)) else {
+            return Err(Error::message(format!("path '{path}' does not exist")).into());
+        };
 
-        // Approval gating: if an approval manager is attached, route
-        // out-of-bounds paths through the approval flow instead of
-        // hard-rejecting.
-        if let Some(ref mgr) = self.approval_manager {
-            let action = mgr.check_path(path, &self.allowed_dirs)?;
-            if action == ApprovalAction::NeedsApproval {
-                info!(path, "filesystem access needs approval, waiting...");
-                let (req_id, rx) = mgr.create_request(path).await;
-
-                if let Some(ref bc) = self.broadcaster
-                    && let Err(e) = bc.broadcast_request(&req_id, path).await
-                {
-                    warn!(error = %e, "failed to broadcast approval request");
-                }
-
-                let decision = mgr.wait_for_decision(rx).await;
-                match decision {
-                    ApprovalDecision::Approved => {
-                        info!(path, "filesystem access approved");
-                    },
-                    ApprovalDecision::Denied => {
-                        return Err(Error::message(format!(
-                            "filesystem access denied by user: {path}"
-                        ))
-                        .into());
-                    },
-                    ApprovalDecision::Timeout => {
-                        return Err(Error::message(format!(
-                            "approval timed out for filesystem access: {path}"
-                        ))
-                        .into());
-                    },
-                }
-            }
-        } else {
-            // No approval manager — hard-reject paths outside allowed_dirs.
-            check_allowed_dir(&resolved, &self.allowed_dirs)?;
-        }
+        // Approval gating: route out-of-bounds paths through the approval
+        // flow (if configured) or hard-reject.
+        enforce_approval(
+            path,
+            &resolved,
+            &self.allowed_dirs,
+            self.approval_manager.as_ref(),
+            self.broadcaster.as_ref(),
+        )
+        .await?;
 
         let display_path = resolved.to_string_lossy().to_string();
 
@@ -192,13 +167,19 @@ impl AgentTool for FileInfoTool {
 
             // Count lines only for files under the threshold.
             if size_bytes <= LINE_COUNT_MAX_BYTES {
-                match tokio::fs::read_to_string(&resolved).await {
-                    Ok(content) => {
-                        let line_count = content.lines().count();
-                        result["line_count"] = json!(line_count);
+                match tokio::fs::File::open(&resolved).await {
+                    Ok(file) => {
+                        use tokio::io::{AsyncBufReadExt, BufReader};
+                        let reader = BufReader::new(file);
+                        let mut count = 0usize;
+                        let mut lines = reader.lines();
+                        while lines.next_line().await.is_ok_and(|line| line.is_some()) {
+                            count = count.saturating_add(1);
+                        }
+                        result["line_count"] = json!(count);
                     },
                     Err(_) => {
-                        // Non-UTF-8 file — skip line count.
+                        // Can't open — skip line count.
                     },
                 }
             }
@@ -320,7 +301,7 @@ mod tests {
             .execute(json!({ "path": "/tmp/does-not-exist-file-info-test-98765" }))
             .await
             .unwrap_err();
-        assert!(err.to_string().contains("cannot access"));
+        assert!(err.to_string().contains("does not exist"));
     }
 
     #[tokio::test]

--- a/crates/tools/src/filesystem/info.rs
+++ b/crates/tools/src/filesystem/info.rs
@@ -3,15 +3,20 @@
 //! Provides size, line count, type, extension, modification time, and
 //! permissions. Useful for deciding whether to read a file at all.
 
+use std::sync::Arc;
+
 use {
     async_trait::async_trait,
     moltis_agents::tool_registry::AgentTool,
     serde_json::{Value, json},
     time::format_description::well_known::Rfc3339,
-    tracing::instrument,
+    tracing::{info, instrument, warn},
 };
 
-use crate::error::Error;
+use crate::{
+    approval::{ApprovalAction, ApprovalBroadcaster, ApprovalDecision, ApprovalManager},
+    error::Error,
+};
 
 use super::{canonicalize_or_original, check_allowed_dir};
 
@@ -24,6 +29,8 @@ const LINE_COUNT_MAX_BYTES: u64 = 1024 * 1024; // 1 MB
 #[derive(Default)]
 pub struct FileInfoTool {
     allowed_dirs: Vec<String>,
+    approval_manager: Option<Arc<ApprovalManager>>,
+    broadcaster: Option<Arc<dyn ApprovalBroadcaster>>,
 }
 
 impl FileInfoTool {
@@ -31,6 +38,8 @@ impl FileInfoTool {
     pub fn new() -> Self {
         Self {
             allowed_dirs: Vec::new(),
+            approval_manager: None,
+            broadcaster: None,
         }
     }
 
@@ -41,7 +50,22 @@ impl FileInfoTool {
     /// mode, same as `new`).
     #[must_use]
     pub fn new_with_allowed_dirs(allowed_dirs: Vec<String>) -> Self {
-        Self { allowed_dirs }
+        Self {
+            allowed_dirs,
+            approval_manager: None,
+            broadcaster: None,
+        }
+    }
+
+    /// Attach approval gating to this tool.
+    pub fn with_approval(
+        mut self,
+        manager: Arc<ApprovalManager>,
+        broadcaster: Arc<dyn ApprovalBroadcaster>,
+    ) -> Self {
+        self.approval_manager = Some(manager);
+        self.broadcaster = Some(broadcaster);
+        self
     }
 }
 
@@ -79,7 +103,45 @@ impl AgentTool for FileInfoTool {
 
         // --- Resolve & validate path ---
         let resolved = canonicalize_or_original(std::path::Path::new(path));
-        check_allowed_dir(&resolved, &self.allowed_dirs)?;
+
+        // Approval gating: if an approval manager is attached, route
+        // out-of-bounds paths through the approval flow instead of
+        // hard-rejecting.
+        if let Some(ref mgr) = self.approval_manager {
+            let action = mgr.check_path(path, &self.allowed_dirs)?;
+            if action == ApprovalAction::NeedsApproval {
+                info!(path, "filesystem access needs approval, waiting...");
+                let (req_id, rx) = mgr.create_request(path).await;
+
+                if let Some(ref bc) = self.broadcaster
+                    && let Err(e) = bc.broadcast_request(&req_id, path).await
+                {
+                    warn!(error = %e, "failed to broadcast approval request");
+                }
+
+                let decision = mgr.wait_for_decision(rx).await;
+                match decision {
+                    ApprovalDecision::Approved => {
+                        info!(path, "filesystem access approved");
+                    },
+                    ApprovalDecision::Denied => {
+                        return Err(Error::message(format!(
+                            "filesystem access denied by user: {path}"
+                        ))
+                        .into());
+                    },
+                    ApprovalDecision::Timeout => {
+                        return Err(Error::message(format!(
+                            "approval timed out for filesystem access: {path}"
+                        ))
+                        .into());
+                    },
+                }
+            }
+        } else {
+            // No approval manager — hard-reject paths outside allowed_dirs.
+            check_allowed_dir(&resolved, &self.allowed_dirs)?;
+        }
 
         let display_path = resolved.to_string_lossy().to_string();
 

--- a/crates/tools/src/filesystem/info.rs
+++ b/crates/tools/src/filesystem/info.rs
@@ -13,6 +13,8 @@ use {
 
 use crate::error::Error;
 
+use super::{canonicalize_or_original, check_allowed_dir};
+
 /// File size threshold (bytes) below which we count lines by reading.
 /// Above this, line_count is omitted from the response to avoid loading
 /// large binaries into memory just to count newlines.
@@ -20,12 +22,26 @@ const LINE_COUNT_MAX_BYTES: u64 = 1024 * 1024; // 1 MB
 
 /// Retrieve file or directory metadata without reading content.
 #[derive(Default)]
-pub struct FileInfoTool;
+pub struct FileInfoTool {
+    allowed_dirs: Vec<String>,
+}
 
 impl FileInfoTool {
     #[must_use]
     pub fn new() -> Self {
-        Self
+        Self {
+            allowed_dirs: Vec::new(),
+        }
+    }
+
+    /// Create a tool that restricts info queries to the given directories.
+    ///
+    /// Paths are canonicalized before checking, so symlinks cannot escape
+    /// the boundary.  An empty `allowed_dirs` permits all paths (permissive
+    /// mode, same as `new`).
+    #[must_use]
+    pub fn new_with_allowed_dirs(allowed_dirs: Vec<String>) -> Self {
+        Self { allowed_dirs }
     }
 }
 
@@ -61,17 +77,17 @@ impl AgentTool for FileInfoTool {
             .and_then(Value::as_str)
             .ok_or_else(|| Error::message("missing 'path' parameter"))?;
 
-        let meta = tokio::fs::metadata(path)
+        // --- Resolve & validate path ---
+        let resolved = canonicalize_or_original(std::path::Path::new(path));
+        check_allowed_dir(&resolved, &self.allowed_dirs)?;
+
+        let display_path = resolved.to_string_lossy().to_string();
+
+        let meta = tokio::fs::metadata(&resolved)
             .await
-            .map_err(|e| Error::message(format!("cannot access '{path}': {e}")))?;
+            .map_err(|e| Error::message(format!("cannot access '{display_path}': {e}")))?;
 
-        let display_path = std::path::Path::new(path)
-            .canonicalize()
-            .unwrap_or_else(|_| std::path::PathBuf::from(path))
-            .to_string_lossy()
-            .to_string();
-
-        let name = std::path::Path::new(path)
+        let name = resolved
             .file_name()
             .map(|n| n.to_string_lossy().to_string())
             .unwrap_or_else(|| display_path.clone());
@@ -96,7 +112,7 @@ impl AgentTool for FileInfoTool {
         };
 
         if meta.is_file() {
-            let extension = std::path::Path::new(path)
+            let extension = resolved
                 .extension()
                 .map(|e| e.to_string_lossy().to_string())
                 .unwrap_or_default();
@@ -114,7 +130,7 @@ impl AgentTool for FileInfoTool {
 
             // Count lines only for files under the threshold.
             if size_bytes <= LINE_COUNT_MAX_BYTES {
-                match tokio::fs::read_to_string(path).await {
+                match tokio::fs::read_to_string(&resolved).await {
                     Ok(content) => {
                         let line_count = content.lines().count();
                         result["line_count"] = json!(line_count);
@@ -127,7 +143,7 @@ impl AgentTool for FileInfoTool {
 
             Ok(result)
         } else if meta.is_dir() {
-            let entry_count = match tokio::fs::read_dir(path).await {
+            let entry_count = match tokio::fs::read_dir(&resolved).await {
                 Ok(mut rd) => {
                     let mut count = 0usize;
                     while let Ok(Some(_)) = rd.next_entry().await {
@@ -165,8 +181,7 @@ impl AgentTool for FileInfoTool {
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use std::io::Write;
+    use {super::*, std::io::Write};
 
     #[tokio::test]
     async fn file_info_basic() {
@@ -189,10 +204,7 @@ mod tests {
 
     #[tokio::test]
     async fn file_info_extension() {
-        let mut f = tempfile::Builder::new()
-            .suffix(".rs")
-            .tempfile()
-            .unwrap();
+        let mut f = tempfile::Builder::new().suffix(".rs").tempfile().unwrap();
         write!(f, "fn main() {{}}").unwrap();
         f.flush().unwrap();
 
@@ -207,10 +219,7 @@ mod tests {
 
     #[tokio::test]
     async fn file_info_no_extension() {
-        let f = tempfile::Builder::new()
-            .suffix("")
-            .tempfile()
-            .unwrap();
+        let f = tempfile::Builder::new().suffix("").tempfile().unwrap();
 
         let tool = FileInfoTool::new();
         let result = tool
@@ -275,5 +284,105 @@ mod tests {
 
         assert_eq!(result["type"], "file");
         assert!(result.get("line_count").is_none());
+    }
+
+    // --- allowed_dirs containment tests ---
+
+    #[tokio::test]
+    async fn allowed_dirs_path_inside_is_allowed() {
+        let allowed = tempfile::tempdir().unwrap();
+        let file = allowed.path().join("info_test.txt");
+        std::fs::write(&file, "data").unwrap();
+
+        let tool =
+            FileInfoTool::new_with_allowed_dirs(vec![allowed.path().to_str().unwrap().to_string()]);
+        let result = tool
+            .execute(json!({ "path": file.to_str().unwrap() }))
+            .await
+            .unwrap();
+        assert_eq!(result["type"], "file");
+    }
+
+    #[tokio::test]
+    async fn allowed_dirs_directory_inside_is_allowed() {
+        let allowed = tempfile::tempdir().unwrap();
+        std::fs::write(allowed.path().join("a.txt"), "a").unwrap();
+
+        let tool =
+            FileInfoTool::new_with_allowed_dirs(vec![allowed.path().to_str().unwrap().to_string()]);
+        let result = tool
+            .execute(json!({ "path": allowed.path().to_str().unwrap() }))
+            .await
+            .unwrap();
+        assert_eq!(result["type"], "directory");
+        assert_eq!(result["entry_count"], 1);
+    }
+
+    #[tokio::test]
+    async fn allowed_dirs_path_outside_is_rejected() {
+        let allowed = tempfile::tempdir().unwrap();
+        let other = tempfile::tempdir().unwrap();
+        let file = other.path().join("outside.txt");
+        std::fs::write(&file, "data").unwrap();
+
+        let tool =
+            FileInfoTool::new_with_allowed_dirs(vec![allowed.path().to_str().unwrap().to_string()]);
+        let err = tool
+            .execute(json!({ "path": file.to_str().unwrap() }))
+            .await
+            .unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("outside the allowed directories"), "{msg}");
+    }
+
+    #[tokio::test]
+    async fn allowed_dirs_empty_allows_everything() {
+        let other = tempfile::tempdir().unwrap();
+        let file = other.path().join("anywhere.txt");
+        std::fs::write(&file, "data").unwrap();
+
+        let tool = FileInfoTool::new_with_allowed_dirs(vec![]);
+        let result = tool
+            .execute(json!({ "path": file.to_str().unwrap() }))
+            .await
+            .unwrap();
+        assert_eq!(result["type"], "file");
+    }
+
+    #[tokio::test]
+    async fn allowed_dirs_symlink_escape_is_blocked() {
+        let allowed = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+
+        let outside_dir = outside.path().join("secret_dir");
+        std::fs::create_dir_all(&outside_dir).unwrap();
+
+        let link = allowed.path().join("sneaky");
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(&outside_dir, &link).unwrap();
+
+        let tool =
+            FileInfoTool::new_with_allowed_dirs(vec![allowed.path().to_str().unwrap().to_string()]);
+        let err = tool
+            .execute(json!({ "path": link.to_str().unwrap() }))
+            .await
+            .unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("outside the allowed directories"), "{msg}");
+    }
+
+    #[tokio::test]
+    async fn allowed_dirs_default_constructor_is_permissive() {
+        let other = tempfile::tempdir().unwrap();
+        let file = other.path().join("unrestricted.txt");
+        std::fs::write(&file, "ok").unwrap();
+
+        // Plain new() has no allowed_dirs — should be permissive.
+        let tool = FileInfoTool::new();
+        let result = tool
+            .execute(json!({ "path": file.to_str().unwrap() }))
+            .await
+            .unwrap();
+        assert_eq!(result["type"], "file");
     }
 }

--- a/crates/tools/src/filesystem/mod.rs
+++ b/crates/tools/src/filesystem/mod.rs
@@ -9,7 +9,7 @@ pub mod read;
 
 use {
     crate::{
-        approval::{ApprovalAction, ApprovalBroadcaster, ApprovalDecision, ApprovalManager},
+        approval::{ApprovalBroadcaster, ApprovalDecision, ApprovalManager},
         error::Error,
     },
     std::{
@@ -93,9 +93,28 @@ pub(crate) fn canonicalize_or_original(path: &Path) -> Option<PathBuf> {
 
 /// Enforce path containment and approval gating for filesystem tools.
 ///
-/// If an approval manager is attached, paths outside `allowed_dirs` are routed
-/// through the user approval flow.  Without an approval manager, paths outside
-/// `allowed_dirs` are hard-rejected.
+/// The approval manager (if present) is consulted **first**, before the
+/// `allowed_dirs` containment check.  This ensures that a `Deny` security
+/// level or an `Always` approval mode cannot be bypassed by placing a path
+/// inside `allowed_dirs`.
+///
+/// # Precedence
+///
+/// ```text
+/// is_inside = check_allowed_dir(resolved, allowed_dirs).is_ok()
+///
+/// No approval manager → allowed_dirs is the only gate:
+///   inside  = proceed
+///   outside = reject
+///
+/// Approval manager present → ALWAYS consult it:
+///   SecurityLevel::Deny     → reject ALL paths
+///   SecurityLevel::Full     → proceed ALL paths
+///   SecurityLevel::Allowlist:
+///     ApprovalMode::Off     → inside = proceed, outside = reject (containment only)
+///     ApprovalMode::OnMiss  → inside = proceed, outside = needs_approval
+///     ApprovalMode::Always  → needs_approval for ALL paths (even inside allowed_dirs)
+/// ```
 ///
 /// # Arguments
 /// * `path` — the raw user-supplied path string (used in approval messages)
@@ -110,45 +129,92 @@ pub(crate) async fn enforce_approval(
     approval_manager: Option<&Arc<ApprovalManager>>,
     broadcaster: Option<&Arc<dyn ApprovalBroadcaster>>,
 ) -> crate::Result<()> {
-    // If inside allowed_dirs, proceed immediately.
-    if check_allowed_dir(resolved, allowed_dirs).is_ok() {
-        return Ok(());
-    }
+    let is_inside = check_allowed_dir(resolved, allowed_dirs).is_ok();
 
     match approval_manager {
-        Some(mgr) => {
-            let action = mgr.check_path_resolved(resolved)?;
-            if action == ApprovalAction::NeedsApproval {
-                tracing::info!(path, "filesystem access needs approval, waiting...");
-                let (req_id, rx) = mgr.create_request(path).await;
-
-                if let Some(bc) = broadcaster
-                    && let Err(e) = bc.broadcast_request(&req_id, path).await
-                {
-                    tracing::warn!(error = %e, "failed to broadcast approval request");
-                }
-
-                match mgr.wait_for_decision(rx).await {
-                    ApprovalDecision::Approved => {
-                        tracing::info!(path, "filesystem access approved");
-                    },
-                    ApprovalDecision::Denied => {
-                        return Err(Error::message(format!(
-                            "filesystem access denied by user: {path}"
-                        )));
-                    },
-                    ApprovalDecision::Timeout => {
-                        return Err(Error::message(format!(
-                            "approval timed out for filesystem access: {path}"
-                        )));
-                    },
-                }
+        None => {
+            // No approval manager — allowed_dirs is the only gate.
+            if is_inside {
+                Ok(())
+            } else {
+                check_allowed_dir(resolved, allowed_dirs)
             }
+        },
+        Some(mgr) => {
+            // Always consult the approval manager first.
+            match mgr.security_level {
+                crate::approval::SecurityLevel::Deny => {
+                    return Err(Error::message(format!(
+                        "filesystem access denied: security level is 'deny': {path}"
+                    )));
+                },
+                crate::approval::SecurityLevel::Full => return Ok(()),
+                crate::approval::SecurityLevel::Allowlist => {},
+            }
+
+            // SecurityLevel::Allowlist — consult mode.
+            let needs_approval = match mgr.mode {
+                crate::approval::ApprovalMode::Off => {
+                    // Containment only: inside = proceed, outside = reject.
+                    if is_inside {
+                        return Ok(());
+                    } else {
+                        return check_allowed_dir(resolved, allowed_dirs);
+                    }
+                },
+                crate::approval::ApprovalMode::OnMiss => {
+                    // Inside = proceed, outside = needs_approval.
+                    !is_inside
+                },
+                crate::approval::ApprovalMode::Always => {
+                    // Always prompt, even for inside paths.
+                    true
+                },
+            };
+
+            if needs_approval {
+                let display = if is_inside {
+                    format!("{path} (path is inside allowed directories)")
+                } else {
+                    path.to_string()
+                };
+                request_approval(&display, mgr, broadcaster).await
+            } else {
+                Ok(())
+            }
+        },
+    }
+}
+
+/// Broadcast an approval request and wait for the user's decision.
+async fn request_approval(
+    display_path: &str,
+    approval_manager: &Arc<ApprovalManager>,
+    broadcaster: Option<&Arc<dyn ApprovalBroadcaster>>,
+) -> crate::Result<()> {
+    tracing::info!(path = %display_path, "filesystem access needs approval, waiting...");
+    let (req_id, rx) = approval_manager.create_request(display_path).await;
+
+    if let Some(bc) = broadcaster
+        && let Err(e) = bc.broadcast_request(&req_id, display_path).await
+    {
+        tracing::warn!(error = %e, "failed to broadcast approval request");
+    }
+
+    match approval_manager.wait_for_decision(rx).await {
+        ApprovalDecision::Approved => {
+            tracing::info!(path = %display_path, "filesystem access approved");
             Ok(())
         },
-        None => {
-            // No approval manager — hard-reject.
-            check_allowed_dir(resolved, allowed_dirs)
+        ApprovalDecision::Denied => {
+            Err(Error::message(format!(
+                "filesystem access denied by user: {display_path}"
+            )))
+        },
+        ApprovalDecision::Timeout => {
+            Err(Error::message(format!(
+                "approval timed out for filesystem access: {display_path}"
+            )))
         },
     }
 }
@@ -297,5 +363,67 @@ mod tests {
 
         // Only allowed dir is non-existent — file should be rejected.
         assert!(check_allowed_dir(&resolved, &["/nonexistent/path/12345".to_string()]).is_err());
+    }
+
+    // --- enforce_approval tests ---
+
+    #[tokio::test]
+    async fn deny_level_blocks_even_when_inside_allowed_dir() {
+        use crate::approval::{ApprovalManager, SecurityLevel};
+
+        let tmp = tempfile::tempdir().unwrap();
+        let file = tmp.path().join("secret.txt");
+        std::fs::write(&file, "data").unwrap();
+        let resolved = canonicalize_or_original(&file).unwrap();
+
+        let mut mgr = ApprovalManager::default();
+        mgr.security_level = SecurityLevel::Deny;
+
+        let result = enforce_approval(
+            file.to_str().unwrap(),
+            &resolved,
+            &[tmp.path().to_str().unwrap().to_string()],
+            Some(&Arc::new(mgr)),
+            None,
+        )
+        .await;
+
+        assert!(result.is_err(), "Deny level should reject even paths inside allowed_dirs");
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("deny"), "error message should mention deny: {msg}");
+    }
+
+    #[tokio::test]
+    async fn always_mode_prompts_even_when_inside_allowed_dir() {
+        use crate::approval::{ApprovalManager, ApprovalMode};
+
+        let tmp = tempfile::tempdir().unwrap();
+        let file = tmp.path().join("test.txt");
+        std::fs::write(&file, "data").unwrap();
+        let resolved = canonicalize_or_original(&file).unwrap();
+
+        let mut mgr = ApprovalManager::default();
+        mgr.mode = ApprovalMode::Always;
+        mgr.timeout = std::time::Duration::from_millis(100);
+
+        let result = enforce_approval(
+            file.to_str().unwrap(),
+            &resolved,
+            &[tmp.path().to_str().unwrap().to_string()],
+            Some(&Arc::new(mgr)),
+            None,
+        )
+        .await;
+
+        // No broadcaster → no one to approve → should timeout (which we map to error)
+        assert!(
+            result.is_err(),
+            "Always mode should require approval even for paths inside allowed_dirs"
+        );
+        let msg = result.unwrap_err().to_string();
+        assert!(
+            msg.contains("timed out") || msg.contains("denied"),
+            "expected timeout/denied but got: {msg}"
+        );
     }
 }

--- a/crates/tools/src/filesystem/mod.rs
+++ b/crates/tools/src/filesystem/mod.rs
@@ -6,3 +6,228 @@
 
 pub mod info;
 pub mod read;
+
+use {
+    crate::error::Error,
+    std::path::{Path, PathBuf},
+};
+
+/// Validate that a resolved (canonicalized) path falls within the allowed
+/// directory list.
+///
+/// # Rules
+/// - If `allowed_dirs` is empty, all paths are permitted (permissive mode).
+/// - Otherwise the canonical path must start with one of the canonicalized
+///   allowed-dir prefixes.  The prefix comparison is done with a trailing
+///   separator so that `/tmp/foo` does *not* match allowed dir `/tmp/fo`.
+///
+/// # Errors
+/// Returns an `Error` with a human-readable message listing the allowed dirs
+/// when the path is outside the boundary.
+pub(crate) fn check_allowed_dir(
+    resolved_path: &Path,
+    allowed_dirs: &[String],
+) -> crate::Result<()> {
+    if allowed_dirs.is_empty() {
+        return Ok(());
+    }
+
+    let resolved_str = resolved_path.to_string_lossy();
+
+    for dir in allowed_dirs {
+        // Canonicalize the allowed dir once per check.  In production the
+        // caller typically caches canonicalized prefixes, but since this
+        // function is called per-execute the overhead is negligible.
+        let canonical_dir = match std::fs::canonicalize(dir) {
+            Ok(p) => p,
+            Err(_) => continue, // non-existent allowed dir — skip
+        };
+
+        let canonical_str = canonical_dir.to_string_lossy();
+
+        // Exact match (the resolved path *is* the allowed dir).
+        if resolved_str == canonical_str {
+            return Ok(());
+        }
+
+        // Prefix match — ensure trailing separator so `/tmp/fo` doesn't
+        // match `/tmp/foo/bar`.
+        let prefix = if canonical_str.ends_with('/') {
+            canonical_str.into_owned()
+        } else {
+            format!("{canonical_str}/")
+        };
+
+        if resolved_str.starts_with(&prefix) {
+            return Ok(());
+        }
+    }
+
+    // Build a helpful message listing the allowed directories.
+    let dir_list = allowed_dirs
+        .iter()
+        .map(|d| format!("  - {d}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    Err(Error::message(format!(
+        "path '{resolved_str}' is outside the allowed directories:\n{dir_list}"
+    )))
+}
+
+/// Canonicalize a path, returning the canonical form or the original as a
+/// fallback (e.g. when the file doesn't exist yet).
+///
+/// For allowed-dir enforcement we want to resolve symlinks first, so the
+/// canonical form is preferred.  The fallback ensures we can still produce
+/// a useful error when the path doesn't exist at all.
+pub(crate) fn canonicalize_or_original(path: &Path) -> PathBuf {
+    std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- check_allowed_dir tests ---
+
+    #[test]
+    fn empty_allowed_dirs_allows_everything() {
+        let tmp = tempfile::tempdir().unwrap();
+        let file = tmp.path().join("some_file.txt");
+        std::fs::write(&file, "data").unwrap();
+        let resolved = canonicalize_or_original(&file);
+        assert!(check_allowed_dir(&resolved, &[]).is_ok());
+    }
+
+    #[test]
+    fn path_inside_allowed_dir_is_allowed() {
+        let tmp = tempfile::tempdir().unwrap();
+        let file = tmp.path().join("subdir").join("file.txt");
+        std::fs::create_dir_all(file.parent().unwrap()).unwrap();
+        std::fs::write(&file, "data").unwrap();
+        let resolved = canonicalize_or_original(&file);
+        assert!(check_allowed_dir(&resolved, &[tmp.path().to_str().unwrap().to_string()]).is_ok());
+    }
+
+    #[test]
+    fn path_outside_allowed_dir_is_rejected() {
+        let allowed = tempfile::tempdir().unwrap();
+        let other = tempfile::tempdir().unwrap();
+        let file = other.path().join("secret.txt");
+        std::fs::write(&file, "data").unwrap();
+        let resolved = canonicalize_or_original(&file);
+        let err = check_allowed_dir(&resolved, &[allowed.path().to_str().unwrap().to_string()])
+            .unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("outside the allowed directories"), "{msg}");
+        assert!(msg.contains(allowed.path().to_str().unwrap()), "{msg}");
+    }
+
+    #[test]
+    fn prefix_boundary_prevents_false_match() {
+        // Create /tmp/test_prefix_guard and /tmp/test_prefix_guard_extra
+        let base = tempfile::tempdir().unwrap();
+        let allowed_dir = base.path().join("foo");
+        let sneaky_dir = base.path().join("foo_secret");
+        std::fs::create_dir_all(&allowed_dir).unwrap();
+        std::fs::create_dir_all(&sneaky_dir).unwrap();
+
+        let sneaky_file = sneaky_dir.join("data.txt");
+        std::fs::write(&sneaky_file, "sneaky").unwrap();
+        let resolved = canonicalize_or_original(&sneaky_file);
+
+        let err =
+            check_allowed_dir(&resolved, &[allowed_dir.to_str().unwrap().to_string()]).unwrap_err();
+        assert!(
+            err.to_string().contains("outside the allowed directories"),
+            "{}",
+            err.to_string()
+        );
+    }
+
+    #[test]
+    fn canonicalizes_allowed_dir_entry() {
+        let tmp = tempfile::tempdir().unwrap();
+        let link = tmp.path().join("link");
+        let target = tmp.path().join("target");
+        std::fs::create_dir_all(&target).unwrap();
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(&target, &link).unwrap();
+
+        let file = target.join("file.txt");
+        std::fs::write(&file, "data").unwrap();
+        let resolved = canonicalize_or_original(&file);
+
+        // Allowed dir is specified via symlink — should still work because
+        // both sides canonicalize to the same real path.
+        assert!(check_allowed_dir(&resolved, &[link.to_str().unwrap().to_string()]).is_ok());
+    }
+
+    #[test]
+    fn symlink_escape_is_detected() {
+        let allowed = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+
+        let link = allowed.path().join("escape_link");
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(outside.path(), &link).unwrap();
+
+        let resolved = canonicalize_or_original(&link);
+        let err = check_allowed_dir(&resolved, &[allowed.path().to_str().unwrap().to_string()])
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("outside the allowed directories"),
+            "{}",
+            err.to_string()
+        );
+    }
+
+    #[test]
+    fn exact_allowed_dir_match_is_allowed() {
+        let tmp = tempfile::tempdir().unwrap();
+        let resolved = canonicalize_or_original(tmp.path());
+        assert!(check_allowed_dir(&resolved, &[tmp.path().to_str().unwrap().to_string()]).is_ok());
+    }
+
+    #[test]
+    fn multiple_allowed_dirs() {
+        let dir1 = tempfile::tempdir().unwrap();
+        let dir2 = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+
+        let file_in_dir2 = dir2.path().join("file.txt");
+        std::fs::write(&file_in_dir2, "data").unwrap();
+        let resolved = canonicalize_or_original(&file_in_dir2);
+
+        assert!(
+            check_allowed_dir(&resolved, &[
+                dir1.path().to_str().unwrap().to_string(),
+                dir2.path().to_str().unwrap().to_string(),
+            ])
+            .is_ok()
+        );
+
+        let file_outside = outside.path().join("other.txt");
+        std::fs::write(&file_outside, "data").unwrap();
+        let resolved_out = canonicalize_or_original(&file_outside);
+        assert!(
+            check_allowed_dir(&resolved_out, &[
+                dir1.path().to_str().unwrap().to_string(),
+                dir2.path().to_str().unwrap().to_string(),
+            ])
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn non_existent_allowed_dir_is_skipped() {
+        let outside = tempfile::tempdir().unwrap();
+        let file = outside.path().join("file.txt");
+        std::fs::write(&file, "data").unwrap();
+        let resolved = canonicalize_or_original(&file);
+
+        // Only allowed dir is non-existent — file should be rejected.
+        assert!(check_allowed_dir(&resolved, &["/nonexistent/path/12345".to_string()]).is_err());
+    }
+}

--- a/crates/tools/src/filesystem/mod.rs
+++ b/crates/tools/src/filesystem/mod.rs
@@ -1,0 +1,8 @@
+//! Native filesystem tools.
+//!
+//! Provides `file_read` and `file_info` as built-in replacements for the
+//! MCP filesystem server's read/info tools. Additional tools (write, edit,
+//! tree, list, search, create_dir, move) will follow in later phases.
+
+pub mod info;
+pub mod read;

--- a/crates/tools/src/filesystem/mod.rs
+++ b/crates/tools/src/filesystem/mod.rs
@@ -8,8 +8,14 @@ pub mod info;
 pub mod read;
 
 use {
-    crate::error::Error,
-    std::path::{Path, PathBuf},
+    crate::{
+        approval::{ApprovalAction, ApprovalBroadcaster, ApprovalDecision, ApprovalManager},
+        error::Error,
+    },
+    std::{
+        path::{Path, PathBuf},
+        sync::Arc,
+    },
 };
 
 /// Validate that a resolved (canonicalized) path falls within the allowed
@@ -75,14 +81,76 @@ pub(crate) fn check_allowed_dir(
     )))
 }
 
-/// Canonicalize a path, returning the canonical form or the original as a
-/// fallback (e.g. when the file doesn't exist yet).
+/// Canonicalize a path.  Returns `None` if the path does not exist on disk.
 ///
-/// For allowed-dir enforcement we want to resolve symlinks first, so the
-/// canonical form is preferred.  The fallback ensures we can still produce
-/// a useful error when the path doesn't exist at all.
-pub(crate) fn canonicalize_or_original(path: &Path) -> PathBuf {
-    std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
+/// For allowed-dir enforcement we want to resolve symlinks first.  Returning
+/// `None` (rather than falling back to the raw string) prevents crafted paths
+/// like `/allowed/sneaky/../etc/passwd` from bypassing containment when the
+/// intermediate components don't exist.
+pub(crate) fn canonicalize_or_original(path: &Path) -> Option<PathBuf> {
+    std::fs::canonicalize(path).ok()
+}
+
+/// Enforce path containment and approval gating for filesystem tools.
+///
+/// If an approval manager is attached, paths outside `allowed_dirs` are routed
+/// through the user approval flow.  Without an approval manager, paths outside
+/// `allowed_dirs` are hard-rejected.
+///
+/// # Arguments
+/// * `path` — the raw user-supplied path string (used in approval messages)
+/// * `resolved` — the canonicalized path (used for containment checks)
+/// * `allowed_dirs` — directory allowlist (empty = all allowed)
+/// * `approval_manager` — optional approval manager
+/// * `broadcaster` — optional approval broadcaster
+pub(crate) async fn enforce_approval(
+    path: &str,
+    resolved: &Path,
+    allowed_dirs: &[String],
+    approval_manager: Option<&Arc<ApprovalManager>>,
+    broadcaster: Option<&Arc<dyn ApprovalBroadcaster>>,
+) -> crate::Result<()> {
+    // If inside allowed_dirs, proceed immediately.
+    if check_allowed_dir(resolved, allowed_dirs).is_ok() {
+        return Ok(());
+    }
+
+    match approval_manager {
+        Some(mgr) => {
+            let action = mgr.check_path(path, allowed_dirs)?;
+            if action == ApprovalAction::NeedsApproval {
+                tracing::info!(path, "filesystem access needs approval, waiting...");
+                let (req_id, rx) = mgr.create_request(path).await;
+
+                if let Some(bc) = broadcaster
+                    && let Err(e) = bc.broadcast_request(&req_id, path).await
+                {
+                    tracing::warn!(error = %e, "failed to broadcast approval request");
+                }
+
+                match mgr.wait_for_decision(rx).await {
+                    ApprovalDecision::Approved => {
+                        tracing::info!(path, "filesystem access approved");
+                    },
+                    ApprovalDecision::Denied => {
+                        return Err(Error::message(format!(
+                            "filesystem access denied by user: {path}"
+                        )));
+                    },
+                    ApprovalDecision::Timeout => {
+                        return Err(Error::message(format!(
+                            "approval timed out for filesystem access: {path}"
+                        )));
+                    },
+                }
+            }
+            Ok(())
+        },
+        None => {
+            // No approval manager — hard-reject.
+            check_allowed_dir(resolved, allowed_dirs)
+        },
+    }
 }
 
 #[cfg(test)]
@@ -96,7 +164,7 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let file = tmp.path().join("some_file.txt");
         std::fs::write(&file, "data").unwrap();
-        let resolved = canonicalize_or_original(&file);
+        let resolved = canonicalize_or_original(&file).unwrap();
         assert!(check_allowed_dir(&resolved, &[]).is_ok());
     }
 
@@ -106,7 +174,7 @@ mod tests {
         let file = tmp.path().join("subdir").join("file.txt");
         std::fs::create_dir_all(file.parent().unwrap()).unwrap();
         std::fs::write(&file, "data").unwrap();
-        let resolved = canonicalize_or_original(&file);
+        let resolved = canonicalize_or_original(&file).unwrap();
         assert!(check_allowed_dir(&resolved, &[tmp.path().to_str().unwrap().to_string()]).is_ok());
     }
 
@@ -116,7 +184,7 @@ mod tests {
         let other = tempfile::tempdir().unwrap();
         let file = other.path().join("secret.txt");
         std::fs::write(&file, "data").unwrap();
-        let resolved = canonicalize_or_original(&file);
+        let resolved = canonicalize_or_original(&file).unwrap();
         let err = check_allowed_dir(&resolved, &[allowed.path().to_str().unwrap().to_string()])
             .unwrap_err();
         let msg = err.to_string();
@@ -135,7 +203,7 @@ mod tests {
 
         let sneaky_file = sneaky_dir.join("data.txt");
         std::fs::write(&sneaky_file, "sneaky").unwrap();
-        let resolved = canonicalize_or_original(&sneaky_file);
+        let resolved = canonicalize_or_original(&sneaky_file).unwrap();
 
         let err =
             check_allowed_dir(&resolved, &[allowed_dir.to_str().unwrap().to_string()]).unwrap_err();
@@ -157,7 +225,7 @@ mod tests {
 
         let file = target.join("file.txt");
         std::fs::write(&file, "data").unwrap();
-        let resolved = canonicalize_or_original(&file);
+        let resolved = canonicalize_or_original(&file).unwrap();
 
         // Allowed dir is specified via symlink — should still work because
         // both sides canonicalize to the same real path.
@@ -173,7 +241,7 @@ mod tests {
         #[cfg(unix)]
         std::os::unix::fs::symlink(outside.path(), &link).unwrap();
 
-        let resolved = canonicalize_or_original(&link);
+        let resolved = canonicalize_or_original(&link).unwrap();
         let err = check_allowed_dir(&resolved, &[allowed.path().to_str().unwrap().to_string()])
             .unwrap_err();
         assert!(
@@ -186,7 +254,7 @@ mod tests {
     #[test]
     fn exact_allowed_dir_match_is_allowed() {
         let tmp = tempfile::tempdir().unwrap();
-        let resolved = canonicalize_or_original(tmp.path());
+        let resolved = canonicalize_or_original(tmp.path()).unwrap();
         assert!(check_allowed_dir(&resolved, &[tmp.path().to_str().unwrap().to_string()]).is_ok());
     }
 
@@ -198,7 +266,7 @@ mod tests {
 
         let file_in_dir2 = dir2.path().join("file.txt");
         std::fs::write(&file_in_dir2, "data").unwrap();
-        let resolved = canonicalize_or_original(&file_in_dir2);
+        let resolved = canonicalize_or_original(&file_in_dir2).unwrap();
 
         assert!(
             check_allowed_dir(&resolved, &[
@@ -210,7 +278,7 @@ mod tests {
 
         let file_outside = outside.path().join("other.txt");
         std::fs::write(&file_outside, "data").unwrap();
-        let resolved_out = canonicalize_or_original(&file_outside);
+        let resolved_out = canonicalize_or_original(&file_outside).unwrap();
         assert!(
             check_allowed_dir(&resolved_out, &[
                 dir1.path().to_str().unwrap().to_string(),
@@ -225,7 +293,7 @@ mod tests {
         let outside = tempfile::tempdir().unwrap();
         let file = outside.path().join("file.txt");
         std::fs::write(&file, "data").unwrap();
-        let resolved = canonicalize_or_original(&file);
+        let resolved = canonicalize_or_original(&file).unwrap();
 
         // Only allowed dir is non-existent — file should be rejected.
         assert!(check_allowed_dir(&resolved, &["/nonexistent/path/12345".to_string()]).is_err());

--- a/crates/tools/src/filesystem/mod.rs
+++ b/crates/tools/src/filesystem/mod.rs
@@ -117,7 +117,7 @@ pub(crate) async fn enforce_approval(
 
     match approval_manager {
         Some(mgr) => {
-            let action = mgr.check_path(path, allowed_dirs)?;
+            let action = mgr.check_path_resolved(resolved)?;
             if action == ApprovalAction::NeedsApproval {
                 tracing::info!(path, "filesystem access needs approval, waiting...");
                 let (req_id, rx) = mgr.create_request(path).await;

--- a/crates/tools/src/filesystem/read.rs
+++ b/crates/tools/src/filesystem/read.rs
@@ -185,7 +185,9 @@ impl AgentTool for FileReadTool {
             None => (start + max_lines - 1).min(total_lines),
         };
 
-        let truncated = end < total_lines;
+        // Truncation only applies when the range was capped by max_lines,
+        // not when the user explicitly requested a specific end_line.
+        let truncated = end_line.is_none() && end < total_lines;
         let selected: Vec<&str> = lines[(start - 1)..end].to_vec();
         let result_content = selected.join("\n");
 

--- a/crates/tools/src/filesystem/read.rs
+++ b/crates/tools/src/filesystem/read.rs
@@ -1,0 +1,390 @@
+//! `file_read` tool — read file contents with line-range control.
+//!
+//! Key behavioural difference from the MCP `read_text_file`: this tool
+//! defaults to returning at most 150 lines (configurable) instead of the
+//! entire file. Every response includes metadata (total_lines, byte_size,
+//! truncated flag) so the model can decide whether it needs another call
+//! without a separate `file_info` round-trip.
+
+use {
+    async_trait::async_trait,
+    moltis_agents::tool_registry::AgentTool,
+    serde_json::{Value, json},
+    tracing::instrument,
+};
+
+use crate::error::Error;
+
+/// Default maximum lines per call when no config override is set.
+const DEFAULT_MAX_LINES: usize = 150;
+
+/// Maximum file size (bytes) that will be read into memory.
+const MAX_FILE_BYTES: u64 = 20 * 1024 * 1024;
+
+/// Read file contents with line-range control and metadata.
+pub struct FileReadTool {
+    max_lines: usize,
+}
+
+impl FileReadTool {
+    #[must_use]
+    pub fn new(max_lines: usize) -> Self {
+        Self {
+            max_lines: max_lines.clamp(1, 10_000),
+        }
+    }
+
+    #[must_use]
+    pub fn with_defaults() -> Self {
+        Self::new(DEFAULT_MAX_LINES)
+    }
+}
+
+impl Default for FileReadTool {
+    fn default() -> Self {
+        Self::with_defaults()
+    }
+}
+
+#[async_trait]
+impl AgentTool for FileReadTool {
+    fn name(&self) -> &str {
+        "file_read"
+    }
+
+    fn description(&self) -> &str {
+        "Read a file's contents with line-range control. Returns the requested \
+         lines along with metadata (total_lines, byte_size, truncated). By \
+         default returns at most 150 lines starting from line 1. Use \
+         start_line and end_line to read a specific range, or set max_lines \
+         to override the per-call limit."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "required": ["path"],
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "description": "Absolute or relative path to the file to read"
+                },
+                "start_line": {
+                    "type": "integer",
+                    "description": "First line to read (1-indexed, inclusive). Default: 1"
+                },
+                "end_line": {
+                    "type": "integer",
+                    "description": "Last line to read (inclusive). Default: start_line + max_lines - 1"
+                },
+                "max_lines": {
+                    "type": "integer",
+                    "description": "Maximum lines to return for this call. Overrides the configured default."
+                }
+            }
+        })
+    }
+
+    #[instrument(skip(self, params))]
+    async fn execute(&self, params: Value) -> anyhow::Result<Value> {
+        let path = params
+            .get("path")
+            .and_then(Value::as_str)
+            .ok_or_else(|| Error::message("missing 'path' parameter"))?;
+
+        let start_line = params
+            .get("start_line")
+            .and_then(Value::as_i64)
+            .unwrap_or(1);
+        let end_line = params.get("end_line").and_then(Value::as_i64);
+        let max_lines = params
+            .get("max_lines")
+            .and_then(Value::as_i64)
+            .map(|v| v as usize)
+            .unwrap_or(self.max_lines);
+
+        // --- Resolve display path ---
+        let display_path = std::path::Path::new(path)
+            .canonicalize()
+            .unwrap_or_else(|_| std::path::PathBuf::from(path))
+            .to_string_lossy()
+            .to_string();
+
+        // --- File metadata ---
+        let meta = tokio::fs::metadata(path)
+            .await
+            .map_err(|e| Error::message(format!("cannot access '{path}': {e}")))?;
+
+        if !meta.is_file() {
+            return Err(Error::message(format!("'{path}' is not a regular file")).into());
+        }
+
+        let byte_size = meta.len();
+        if byte_size > MAX_FILE_BYTES {
+            return Err(Error::message(format!(
+                "file is too large ({:.1} MB) — maximum is {:.0} MB",
+                byte_size as f64 / (1024.0 * 1024.0),
+                MAX_FILE_BYTES as f64 / (1024.0 * 1024.0),
+            )).into());
+        }
+
+        // --- Read content ---
+        let raw = tokio::fs::read(path)
+            .await
+            .map_err(|e| Error::message(format!("failed to read '{path}': {e}")))?;
+
+        let content = String::from_utf8(raw)
+            .map_err(|e| Error::message(format!(
+                "'{path}' is not valid UTF-8 (first error at byte {})",
+                e.utf8_error().valid_up_to()
+            )))?;
+
+        // --- Line logic ---
+        let lines: Vec<&str> = content.lines().collect();
+        let total_lines = lines.len();
+
+        // An empty file or a file with only a trailing newline has 0 lines.
+        if total_lines == 0 {
+            return Ok(json!({
+                "content": "",
+                "metadata": {
+                    "path": display_path,
+                    "total_lines": 0,
+                    "start_line": 1,
+                    "end_line": 0,
+                    "byte_size": byte_size,
+                    "truncated": false,
+                }
+            }));
+        }
+
+        // Clamp start_line to [1, total_lines].
+        let start = if start_line < 1 {
+            1
+        } else if start_line as usize > total_lines {
+            // Start is beyond the file — return empty content.
+            return Ok(json!({
+                "content": "",
+                "metadata": {
+                    "path": display_path,
+                    "total_lines": total_lines,
+                    "start_line": start_line as usize,
+                    "end_line": total_lines,
+                    "byte_size": byte_size,
+                    "truncated": false,
+                }
+            }));
+        } else {
+            start_line as usize
+        };
+
+        // Compute end line.
+        let end = match end_line {
+            Some(e) if e < start as i64 => start,
+            Some(e) => (e as usize).min(total_lines),
+            None => (start + max_lines - 1).min(total_lines),
+        };
+
+        let truncated = end < total_lines;
+        let selected: Vec<&str> = lines[(start - 1)..end].to_vec();
+        let result_content = selected.join("\n");
+
+        Ok(json!({
+            "content": result_content,
+            "metadata": {
+                "path": display_path,
+                "total_lines": total_lines,
+                "start_line": start,
+                "end_line": end,
+                "byte_size": byte_size,
+                "truncated": truncated,
+            }
+        }))
+    }
+}
+
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    fn tmp_file_with(content: &str) -> tempfile::NamedTempFile {
+        let mut f = tempfile::NamedTempFile::new().unwrap();
+        f.write_all(content.as_bytes()).unwrap();
+        f.flush().unwrap();
+        f
+    }
+
+    #[tokio::test]
+    async fn happy_path_default_read() {
+        let lines: Vec<String> = (1..=200).map(|i| format!("line {i}")).collect();
+        let f = tmp_file_with(&lines.join("\n"));
+
+        let tool = FileReadTool::with_defaults();
+        let result = tool
+            .execute(json!({ "path": f.path().to_str().unwrap() }))
+            .await
+            .unwrap();
+
+        assert_eq!(result["metadata"]["total_lines"], 200);
+        assert_eq!(result["metadata"]["start_line"], 1);
+        assert_eq!(result["metadata"]["end_line"], 150);
+        assert_eq!(result["metadata"]["truncated"], true);
+        assert!(result["content"].as_str().unwrap().starts_with("line 1\nline 2"));
+        assert!(result["content"].as_str().unwrap().ends_with("line 150"));
+    }
+
+    #[tokio::test]
+    async fn line_range() {
+        let lines: Vec<String> = (1..=20).map(|i| format!("line {i}")).collect();
+        let f = tmp_file_with(&lines.join("\n"));
+
+        let tool = FileReadTool::with_defaults();
+        let result = tool
+            .execute(json!({
+                "path": f.path().to_str().unwrap(),
+                "start_line": 5,
+                "end_line": 10,
+            }))
+            .await
+            .unwrap();
+
+        assert_eq!(result["metadata"]["start_line"], 5);
+        assert_eq!(result["metadata"]["end_line"], 10);
+        assert_eq!(result["metadata"]["truncated"], false);
+        assert_eq!(
+            result["content"].as_str().unwrap(),
+            "line 5\nline 6\nline 7\nline 8\nline 9\nline 10"
+        );
+    }
+
+    #[tokio::test]
+    async fn start_line_beyond_file() {
+        let f = tmp_file_with("line 1\nline 2\nline 3");
+
+        let tool = FileReadTool::with_defaults();
+        let result = tool
+            .execute(json!({
+                "path": f.path().to_str().unwrap(),
+                "start_line": 100,
+            }))
+            .await
+            .unwrap();
+
+        assert_eq!(result["metadata"]["total_lines"], 3);
+        assert_eq!(result["content"].as_str().unwrap(), "");
+    }
+
+    #[tokio::test]
+    async fn empty_file() {
+        let f = tmp_file_with("");
+
+        let tool = FileReadTool::with_defaults();
+        let result = tool
+            .execute(json!({ "path": f.path().to_str().unwrap() }))
+            .await
+            .unwrap();
+
+        assert_eq!(result["metadata"]["total_lines"], 0);
+        assert_eq!(result["content"].as_str().unwrap(), "");
+        assert_eq!(result["metadata"]["truncated"], false);
+    }
+
+    #[tokio::test]
+    async fn non_existent_file() {
+        let tool = FileReadTool::with_defaults();
+        let err = tool
+            .execute(json!({ "path": "/tmp/does-not-exist-file-read-test-98765.bin" }))
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("cannot access"));
+    }
+
+    #[tokio::test]
+    async fn non_utf8_file_returns_error() {
+        let mut f = tempfile::NamedTempFile::new().unwrap();
+        f.write_all(&[0x80, 0xFE, 0xFF]).unwrap();
+        f.flush().unwrap();
+
+        let tool = FileReadTool::with_defaults();
+        let err = tool
+            .execute(json!({ "path": f.path().to_str().unwrap() }))
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("not valid UTF-8"));
+    }
+
+    #[tokio::test]
+    async fn max_lines_override() {
+        let lines: Vec<String> = (1..=20).map(|i| format!("line {i}")).collect();
+        let f = tmp_file_with(&lines.join("\n"));
+
+        let tool = FileReadTool::with_defaults();
+        let result = tool
+            .execute(json!({
+                "path": f.path().to_str().unwrap(),
+                "max_lines": 3,
+            }))
+            .await
+            .unwrap();
+
+        assert_eq!(result["metadata"]["end_line"], 3);
+        assert_eq!(result["metadata"]["truncated"], true);
+        assert_eq!(
+            result["content"].as_str().unwrap(),
+            "line 1\nline 2\nline 3"
+        );
+    }
+
+    #[tokio::test]
+    async fn metadata_accuracy() {
+        let content = "hello\nworld\nfoo";
+        let f = tmp_file_with(content);
+
+        let tool = FileReadTool::with_defaults();
+        let result = tool
+            .execute(json!({ "path": f.path().to_str().unwrap() }))
+            .await
+            .unwrap();
+
+        assert_eq!(result["metadata"]["total_lines"], 3);
+        assert_eq!(result["metadata"]["byte_size"], content.len() as u64);
+        assert_eq!(result["metadata"]["truncated"], false);
+        assert_eq!(result["metadata"]["start_line"], 1);
+        assert_eq!(result["metadata"]["end_line"], 3);
+    }
+
+    #[tokio::test]
+    async fn missing_path_parameter() {
+        let tool = FileReadTool::with_defaults();
+        let err = tool.execute(json!({})).await.unwrap_err();
+        assert!(err.to_string().contains("missing 'path'"));
+    }
+
+    #[tokio::test]
+    async fn path_is_directory_returns_error() {
+        let dir = tempfile::tempdir().unwrap();
+
+        let tool = FileReadTool::with_defaults();
+        let err = tool
+            .execute(json!({ "path": dir.path().to_str().unwrap() }))
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("not a regular file"));
+    }
+
+    #[tokio::test]
+    async fn custom_max_lines_in_constructor() {
+        let tool = FileReadTool::new(5);
+        let lines: Vec<String> = (1..=20).map(|i| format!("line {i}")).collect();
+        let f = tmp_file_with(&lines.join("\n"));
+
+        let result = tool
+            .execute(json!({ "path": f.path().to_str().unwrap() }))
+            .await
+            .unwrap();
+
+        assert_eq!(result["metadata"]["end_line"], 5);
+    }
+}

--- a/crates/tools/src/filesystem/read.rs
+++ b/crates/tools/src/filesystem/read.rs
@@ -6,14 +6,19 @@
 //! truncated flag) so the model can decide whether it needs another call
 //! without a separate `file_info` round-trip.
 
+use std::sync::Arc;
+
 use {
     async_trait::async_trait,
     moltis_agents::tool_registry::AgentTool,
     serde_json::{Value, json},
-    tracing::instrument,
+    tracing::{info, instrument, warn},
 };
 
-use crate::error::Error;
+use crate::{
+    approval::{ApprovalAction, ApprovalBroadcaster, ApprovalDecision, ApprovalManager},
+    error::Error,
+};
 
 use super::{canonicalize_or_original, check_allowed_dir};
 
@@ -27,6 +32,8 @@ const MAX_FILE_BYTES: u64 = 20 * 1024 * 1024;
 pub struct FileReadTool {
     max_lines: usize,
     allowed_dirs: Vec<String>,
+    approval_manager: Option<Arc<ApprovalManager>>,
+    broadcaster: Option<Arc<dyn ApprovalBroadcaster>>,
 }
 
 impl FileReadTool {
@@ -35,6 +42,8 @@ impl FileReadTool {
         Self {
             max_lines: max_lines.clamp(1, 10_000),
             allowed_dirs: Vec::new(),
+            approval_manager: None,
+            broadcaster: None,
         }
     }
 
@@ -53,6 +62,8 @@ impl FileReadTool {
         Self {
             max_lines: max_lines.clamp(1, 10_000),
             allowed_dirs,
+            approval_manager: None,
+            broadcaster: None,
         }
     }
 
@@ -60,6 +71,17 @@ impl FileReadTool {
     #[must_use]
     pub fn with_defaults_and_allowed_dirs(allowed_dirs: Vec<String>) -> Self {
         Self::new_with_allowed_dirs(DEFAULT_MAX_LINES, allowed_dirs)
+    }
+
+    /// Attach approval gating to this tool.
+    pub fn with_approval(
+        mut self,
+        manager: Arc<ApprovalManager>,
+        broadcaster: Arc<dyn ApprovalBroadcaster>,
+    ) -> Self {
+        self.approval_manager = Some(manager);
+        self.broadcaster = Some(broadcaster);
+        self
     }
 }
 
@@ -128,7 +150,45 @@ impl AgentTool for FileReadTool {
 
         // --- Resolve & validate path ---
         let resolved = canonicalize_or_original(std::path::Path::new(path));
-        check_allowed_dir(&resolved, &self.allowed_dirs)?;
+
+        // Approval gating: if an approval manager is attached, route
+        // out-of-bounds paths through the approval flow instead of
+        // hard-rejecting.
+        if let Some(ref mgr) = self.approval_manager {
+            let action = mgr.check_path(path, &self.allowed_dirs)?;
+            if action == ApprovalAction::NeedsApproval {
+                info!(path, "filesystem access needs approval, waiting...");
+                let (req_id, rx) = mgr.create_request(path).await;
+
+                if let Some(ref bc) = self.broadcaster
+                    && let Err(e) = bc.broadcast_request(&req_id, path).await
+                {
+                    warn!(error = %e, "failed to broadcast approval request");
+                }
+
+                let decision = mgr.wait_for_decision(rx).await;
+                match decision {
+                    ApprovalDecision::Approved => {
+                        info!(path, "filesystem access approved");
+                    },
+                    ApprovalDecision::Denied => {
+                        return Err(Error::message(format!(
+                            "filesystem access denied by user: {path}"
+                        ))
+                        .into());
+                    },
+                    ApprovalDecision::Timeout => {
+                        return Err(Error::message(format!(
+                            "approval timed out for filesystem access: {path}"
+                        ))
+                        .into());
+                    },
+                }
+            }
+        } else {
+            // No approval manager — hard-reject paths outside allowed_dirs.
+            check_allowed_dir(&resolved, &self.allowed_dirs)?;
+        }
 
         let display_path = resolved.to_string_lossy().to_string();
 

--- a/crates/tools/src/filesystem/read.rs
+++ b/crates/tools/src/filesystem/read.rs
@@ -12,15 +12,15 @@ use {
     async_trait::async_trait,
     moltis_agents::tool_registry::AgentTool,
     serde_json::{Value, json},
-    tracing::{info, instrument, warn},
+    tracing::instrument,
 };
 
 use crate::{
-    approval::{ApprovalAction, ApprovalBroadcaster, ApprovalDecision, ApprovalManager},
+    approval::{ApprovalBroadcaster, ApprovalManager},
     error::Error,
 };
 
-use super::{canonicalize_or_original, check_allowed_dir};
+use super::{canonicalize_or_original, enforce_approval};
 
 /// Default maximum lines per call when no config override is set.
 const DEFAULT_MAX_LINES: usize = 150;
@@ -74,6 +74,7 @@ impl FileReadTool {
     }
 
     /// Attach approval gating to this tool.
+    #[must_use]
     pub fn with_approval(
         mut self,
         manager: Arc<ApprovalManager>,
@@ -102,7 +103,8 @@ impl AgentTool for FileReadTool {
          lines along with metadata (total_lines, byte_size, truncated). By \
          default returns at most 150 lines starting from line 1. Use \
          start_line and end_line to read a specific range, or set max_lines \
-         to override the per-call limit."
+         to override the per-call limit. Line endings are normalized to \
+         LF (\\n) in the returned content."
     }
 
     fn parameters_schema(&self) -> Value {
@@ -145,50 +147,24 @@ impl AgentTool for FileReadTool {
         let max_lines = params
             .get("max_lines")
             .and_then(Value::as_i64)
-            .map(|v| v as usize)
+            .map(|v| (v as usize).clamp(1, 10_000))
             .unwrap_or(self.max_lines);
 
         // --- Resolve & validate path ---
-        let resolved = canonicalize_or_original(std::path::Path::new(path));
+        let Some(resolved) = canonicalize_or_original(std::path::Path::new(path)) else {
+            return Err(Error::message(format!("path '{path}' does not exist")).into());
+        };
 
-        // Approval gating: if an approval manager is attached, route
-        // out-of-bounds paths through the approval flow instead of
-        // hard-rejecting.
-        if let Some(ref mgr) = self.approval_manager {
-            let action = mgr.check_path(path, &self.allowed_dirs)?;
-            if action == ApprovalAction::NeedsApproval {
-                info!(path, "filesystem access needs approval, waiting...");
-                let (req_id, rx) = mgr.create_request(path).await;
-
-                if let Some(ref bc) = self.broadcaster
-                    && let Err(e) = bc.broadcast_request(&req_id, path).await
-                {
-                    warn!(error = %e, "failed to broadcast approval request");
-                }
-
-                let decision = mgr.wait_for_decision(rx).await;
-                match decision {
-                    ApprovalDecision::Approved => {
-                        info!(path, "filesystem access approved");
-                    },
-                    ApprovalDecision::Denied => {
-                        return Err(Error::message(format!(
-                            "filesystem access denied by user: {path}"
-                        ))
-                        .into());
-                    },
-                    ApprovalDecision::Timeout => {
-                        return Err(Error::message(format!(
-                            "approval timed out for filesystem access: {path}"
-                        ))
-                        .into());
-                    },
-                }
-            }
-        } else {
-            // No approval manager — hard-reject paths outside allowed_dirs.
-            check_allowed_dir(&resolved, &self.allowed_dirs)?;
-        }
+        // Approval gating: route out-of-bounds paths through the approval
+        // flow (if configured) or hard-reject.
+        enforce_approval(
+            path,
+            &resolved,
+            &self.allowed_dirs,
+            self.approval_manager.as_ref(),
+            self.broadcaster.as_ref(),
+        )
+        .await?;
 
         let display_path = resolved.to_string_lossy().to_string();
 
@@ -388,7 +364,7 @@ mod tests {
             .execute(json!({ "path": "/tmp/does-not-exist-file-read-test-98765.bin" }))
             .await
             .unwrap_err();
-        assert!(err.to_string().contains("cannot access"));
+        assert!(err.to_string().contains("does not exist"));
     }
 
     #[tokio::test]

--- a/crates/tools/src/filesystem/read.rs
+++ b/crates/tools/src/filesystem/read.rs
@@ -15,6 +15,8 @@ use {
 
 use crate::error::Error;
 
+use super::{canonicalize_or_original, check_allowed_dir};
+
 /// Default maximum lines per call when no config override is set.
 const DEFAULT_MAX_LINES: usize = 150;
 
@@ -24,6 +26,7 @@ const MAX_FILE_BYTES: u64 = 20 * 1024 * 1024;
 /// Read file contents with line-range control and metadata.
 pub struct FileReadTool {
     max_lines: usize,
+    allowed_dirs: Vec<String>,
 }
 
 impl FileReadTool {
@@ -31,12 +34,32 @@ impl FileReadTool {
     pub fn new(max_lines: usize) -> Self {
         Self {
             max_lines: max_lines.clamp(1, 10_000),
+            allowed_dirs: Vec::new(),
         }
     }
 
     #[must_use]
     pub fn with_defaults() -> Self {
         Self::new(DEFAULT_MAX_LINES)
+    }
+
+    /// Create a tool that restricts reads to the given directories.
+    ///
+    /// Paths are canonicalized before checking, so symlinks cannot escape
+    /// the boundary.  An empty `allowed_dirs` permits all paths (permissive
+    /// mode, same as `new`).
+    #[must_use]
+    pub fn new_with_allowed_dirs(max_lines: usize, allowed_dirs: Vec<String>) -> Self {
+        Self {
+            max_lines: max_lines.clamp(1, 10_000),
+            allowed_dirs,
+        }
+    }
+
+    /// Create a default-configuration tool restricted to the given directories.
+    #[must_use]
+    pub fn with_defaults_and_allowed_dirs(allowed_dirs: Vec<String>) -> Self {
+        Self::new_with_allowed_dirs(DEFAULT_MAX_LINES, allowed_dirs)
     }
 }
 
@@ -103,20 +126,19 @@ impl AgentTool for FileReadTool {
             .map(|v| v as usize)
             .unwrap_or(self.max_lines);
 
-        // --- Resolve display path ---
-        let display_path = std::path::Path::new(path)
-            .canonicalize()
-            .unwrap_or_else(|_| std::path::PathBuf::from(path))
-            .to_string_lossy()
-            .to_string();
+        // --- Resolve & validate path ---
+        let resolved = canonicalize_or_original(std::path::Path::new(path));
+        check_allowed_dir(&resolved, &self.allowed_dirs)?;
+
+        let display_path = resolved.to_string_lossy().to_string();
 
         // --- File metadata ---
-        let meta = tokio::fs::metadata(path)
+        let meta = tokio::fs::metadata(&resolved)
             .await
-            .map_err(|e| Error::message(format!("cannot access '{path}': {e}")))?;
+            .map_err(|e| Error::message(format!("cannot access '{display_path}': {e}")))?;
 
         if !meta.is_file() {
-            return Err(Error::message(format!("'{path}' is not a regular file")).into());
+            return Err(Error::message(format!("'{display_path}' is not a regular file")).into());
         }
 
         let byte_size = meta.len();
@@ -125,19 +147,21 @@ impl AgentTool for FileReadTool {
                 "file is too large ({:.1} MB) — maximum is {:.0} MB",
                 byte_size as f64 / (1024.0 * 1024.0),
                 MAX_FILE_BYTES as f64 / (1024.0 * 1024.0),
-            )).into());
+            ))
+            .into());
         }
 
         // --- Read content ---
-        let raw = tokio::fs::read(path)
+        let raw = tokio::fs::read(&resolved)
             .await
-            .map_err(|e| Error::message(format!("failed to read '{path}': {e}")))?;
+            .map_err(|e| Error::message(format!("failed to read '{display_path}': {e}")))?;
 
-        let content = String::from_utf8(raw)
-            .map_err(|e| Error::message(format!(
-                "'{path}' is not valid UTF-8 (first error at byte {})",
+        let content = String::from_utf8(raw).map_err(|e| {
+            Error::message(format!(
+                "'{display_path}' is not valid UTF-8 (first error at byte {})",
                 e.utf8_error().valid_up_to()
-            )))?;
+            ))
+        })?;
 
         // --- Line logic ---
         let lines: Vec<&str> = content.lines().collect();
@@ -208,8 +232,7 @@ impl AgentTool for FileReadTool {
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use std::io::Write;
+    use {super::*, std::io::Write};
 
     fn tmp_file_with(content: &str) -> tempfile::NamedTempFile {
         let mut f = tempfile::NamedTempFile::new().unwrap();
@@ -233,7 +256,12 @@ mod tests {
         assert_eq!(result["metadata"]["start_line"], 1);
         assert_eq!(result["metadata"]["end_line"], 150);
         assert_eq!(result["metadata"]["truncated"], true);
-        assert!(result["content"].as_str().unwrap().starts_with("line 1\nline 2"));
+        assert!(
+            result["content"]
+                .as_str()
+                .unwrap()
+                .starts_with("line 1\nline 2")
+        );
         assert!(result["content"].as_str().unwrap().ends_with("line 150"));
     }
 
@@ -388,5 +416,113 @@ mod tests {
             .unwrap();
 
         assert_eq!(result["metadata"]["end_line"], 5);
+    }
+
+    // --- allowed_dirs containment tests ---
+
+    #[tokio::test]
+    async fn allowed_dirs_path_inside_is_allowed() {
+        let allowed = tempfile::tempdir().unwrap();
+        let file = allowed.path().join("subdir").join("file.txt");
+        std::fs::create_dir_all(file.parent().unwrap()).unwrap();
+        std::fs::write(&file, "hello").unwrap();
+
+        let tool = FileReadTool::new_with_allowed_dirs(100, vec![
+            allowed.path().to_str().unwrap().to_string(),
+        ]);
+        let result = tool
+            .execute(json!({ "path": file.to_str().unwrap() }))
+            .await
+            .unwrap();
+        assert_eq!(result["content"].as_str().unwrap(), "hello");
+    }
+
+    #[tokio::test]
+    async fn allowed_dirs_path_outside_is_rejected() {
+        let allowed = tempfile::tempdir().unwrap();
+        let other = tempfile::tempdir().unwrap();
+        let file = other.path().join("secret.txt");
+        std::fs::write(&file, "secret data").unwrap();
+
+        let tool = FileReadTool::new_with_allowed_dirs(100, vec![
+            allowed.path().to_str().unwrap().to_string(),
+        ]);
+        let err = tool
+            .execute(json!({ "path": file.to_str().unwrap() }))
+            .await
+            .unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("outside the allowed directories"), "{msg}");
+    }
+
+    #[tokio::test]
+    async fn allowed_dirs_empty_allows_everything() {
+        let other = tempfile::tempdir().unwrap();
+        let file = other.path().join("anywhere.txt");
+        std::fs::write(&file, "data").unwrap();
+
+        // Empty allowed_dirs — permissive, same as no restriction.
+        let tool = FileReadTool::new_with_allowed_dirs(100, vec![]);
+        let result = tool
+            .execute(json!({ "path": file.to_str().unwrap() }))
+            .await
+            .unwrap();
+        assert_eq!(result["content"].as_str().unwrap(), "data");
+    }
+
+    #[tokio::test]
+    async fn allowed_dirs_symlink_escape_is_blocked() {
+        let allowed = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+
+        // Create a file outside the allowed dir.
+        let outside_file = outside.path().join("escape.txt");
+        std::fs::write(&outside_file, "escaped!").unwrap();
+
+        // Create a symlink inside the allowed dir pointing outside.
+        let link = allowed.path().join("sneaky_link");
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(&outside_file, &link).unwrap();
+
+        let tool = FileReadTool::new_with_allowed_dirs(100, vec![
+            allowed.path().to_str().unwrap().to_string(),
+        ]);
+        let err = tool
+            .execute(json!({ "path": link.to_str().unwrap() }))
+            .await
+            .unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("outside the allowed directories"), "{msg}");
+    }
+
+    #[tokio::test]
+    async fn with_defaults_and_allowed_dirs_factory() {
+        let allowed = tempfile::tempdir().unwrap();
+        let file = allowed.path().join("test.txt");
+        std::fs::write(&file, "works").unwrap();
+
+        let tool = FileReadTool::with_defaults_and_allowed_dirs(vec![
+            allowed.path().to_str().unwrap().to_string(),
+        ]);
+        let result = tool
+            .execute(json!({ "path": file.to_str().unwrap() }))
+            .await
+            .unwrap();
+        assert_eq!(result["content"].as_str().unwrap(), "works");
+    }
+
+    #[tokio::test]
+    async fn allowed_dirs_default_constructor_is_permissive() {
+        let other = tempfile::tempdir().unwrap();
+        let file = other.path().join("unrestricted.txt");
+        std::fs::write(&file, "ok").unwrap();
+
+        // Plain new() / with_defaults() has no allowed_dirs — should be permissive.
+        let tool = FileReadTool::with_defaults();
+        let result = tool
+            .execute(json!({ "path": file.to_str().unwrap() }))
+            .await
+            .unwrap();
+        assert_eq!(result["content"].as_str().unwrap(), "ok");
     }
 }

--- a/crates/tools/src/lib.rs
+++ b/crates/tools/src/lib.rs
@@ -50,6 +50,7 @@ pub mod cron_tool;
 pub mod embedded_wasm;
 pub mod exec;
 pub mod file_io;
+pub mod filesystem;
 #[cfg(feature = "firecrawl")]
 pub mod firecrawl;
 pub mod image_cache;


### PR DESCRIPTION
# feat(tools): add native file_read and file_info tools with containment and approval gating

## What

Adds two built-in filesystem tools (`file_read`, `file_info`) as native replacements for the MCP filesystem server's read/info operations. Includes directory containment enforcement (`allowed_dirs`) with symlink-escape prevention, and approval gating integration with the existing `ApprovalManager` flow. New module `crates/tools/src/filesystem/` (1,296 lines across 3 files) with 16 new tests.

## Why

The MCP filesystem server is an external process dependency that adds latency, complexity, and a separate security boundary for basic file read operations. Native tools eliminate the inter-process hop, integrate directly with Moltis's existing approval and containment infrastructure, and provide structured metadata (line counts, truncation flags) that help the model make efficient read decisions without round-trips.

## Diff Summary

| File | Change |
|------|--------|
| `crates/tools/src/filesystem/mod.rs` | **New** — 301 lines (containment logic, `check_allowed_dir`, `enforce_approval`, 9 tests) |
| `crates/tools/src/filesystem/read.rs` | **New** — 564 lines (`FileReadTool` with line-range control, metadata, 20 MB cap) |
| `crates/tools/src/filesystem/info.rs` | **New** — 431 lines (`FileInfoTool` with size, type, line count, permissions) |
| `crates/tools/src/lib.rs` | **+1** — `pub mod filesystem` |
| `crates/tools/src/approval.rs` | **+184** — extracted `ApprovalBroadcaster` trait, added `check_path()` with 7 tests |
| `crates/tools/src/exec.rs` | **+3/-4** — re-export `ApprovalBroadcaster` from `approval` module |
| `crates/config/src/schema.rs` | **+36** — `FilesystemToolsConfig` struct (`max_lines`, `max_write_bytes`, `allowed_dirs`) |
| `crates/config/src/validate.rs` | **+8** — filesystem keys in schema map |
| `crates/gateway/src/server.rs` | **+17/-2** — register `FileReadTool` and `FileInfoTool` with approval gating |
| `crates/web/ui/e2e/specs/onboarding.spec.js` | **+5/-1** — updated Matrix auth text assertions |
| `crates/web/ui/e2e/specs/settings-nav.spec.js` | **+1** — added "Projects" to settings nav expectations |

**Total: +1,552 lines added, 9 removed across 11 files.**

## Public API

### `FileReadTool` (`filesystem::read`)

| Method | Purpose |
|--------|---------|
| `new(max_lines)` | Create with custom line limit (clamped 1–10,000) |
| `with_defaults()` | Create with 150-line default |
| `new_with_allowed_dirs(max_lines, allowed_dirs)` | Create with directory containment |
| `with_approval(manager, broadcaster)` | Attach approval gating (builder pattern) |

Parameters: `path` (required), `start_line`, `end_line`, `max_lines`. Returns content with metadata (`total_lines`, `byte_size`, `truncated`). 20 MB file size cap. Line endings normalized to LF.

### `FileInfoTool` (`filesystem::info`)

| Method | Purpose |
|--------|---------|
| `new()` | Create with no restrictions |
| `new_with_allowed_dirs(allowed_dirs)` | Create with directory containment |
| `with_approval(manager, broadcaster)` | Attach approval gating (builder pattern) |

Parameters: `path` (required). Returns `size_bytes`, `type` (file/directory), `line_count` (files under 1 MB), `extension`, `modified` (RFC 3339), `readable`/`writable` booleans.

### `ApprovalBroadcaster` trait (`approval`)

Extracted from `exec.rs` to `approval.rs` so both `ExecTool` and filesystem tools share the same broadcaster interface. No behavioral change.

### `ApprovalManager::check_path()` (`approval`)

New method that integrates `check_allowed_dir` with the existing security-level/mode model. Returns `Proceed`, `NeedsApproval`, or error based on path location relative to `allowed_dirs`.

## Config — `[tools.filesystem]`

| Key | Type | Default | Description |
|-----|------|---------|-------------|
| `max_lines` | usize | 150 | Max lines per `file_read` call |
| `max_write_bytes` | u64 | 20 MB | Max bytes for write ops (phase 2 placeholder) |
| `allowed_dirs` | Vec\<String\> | `[]` (all allowed) | Directory allowlist; empty = permissive |

## Key Design Decisions

- **Canonicalization-first containment**: All paths are canonicalized via `std::fs::canonicalize()` before checking against `allowed_dirs`. This prevents symlink-based escapes (e.g., `/allowed/escape → /etc`).
- **Prefix boundary safety**: Containment checks append a trailing `/` to the allowed-dir prefix so `/tmp/fo` does not match `/tmp/foo/bar`.
- **Approval flow reuse**: Out-of-bounds paths route through the same `ApprovalManager` used by `exec`, with `NeedsApproval` → broadcast → wait for decision. Without an approval manager, out-of-bounds paths are hard-rejected.
- **Default 150-line cap**: Prevents the model from consuming its entire context window on a single large file read. The `truncated` flag in the response tells the model it needs to paginate.
- **20 MB hard cap**: `file_read` refuses files over 20 MB. `file_info` skips line counting for files over 1 MB to avoid loading large binaries.
- **Phase 2 placeholder**: `max_write_bytes` is in the config schema but not yet consumed — write/edit tools will follow in a later PR.

## Containment Tests (`mod.rs`, 9 tests)

| Test | Covers |
|------|--------|
| `empty_allowed_dirs_allows_everything` | Permissive mode when no dirs configured |
| `path_inside_allowed_dir_is_allowed` | Basic containment pass |
| `path_outside_allowed_dir_is_rejected` | Basic containment block |
| `prefix_boundary_prevents_false_match` | `/tmp/fo` vs `/tmp/foo` edge case |
| `canonicalizes_allowed_dir_entry` | Symlink in allowed_dir still resolves |
| `symlink_escape_is_detected` | Symlink pointing outside is blocked |
| `exact_allowed_dir_match_is_allowed` | Path equals allowed dir exactly |
| `multiple_allowed_dirs` | Multi-dir allowlist |
| `non_existent_allowed_dir_is_skipped` | Missing dirs don't break validation |

## Approval Tests (`approval.rs`, 7 new tests)

| Test | Covers |
|------|--------|
| `test_check_path_empty_allowed_dirs` | Empty dirs → Proceed |
| `test_check_path_inside_allowed_dir` | Inside → Proceed |
| `test_check_path_outside_allowed_dir_needs_approval` | Outside + Allowlist/OnMiss → NeedsApproval |
| `test_check_path_deny_security_level` | Deny level → error |
| `test_check_path_full_security_level` | Full level → Proceed |
| `test_check_path_off_mode_outside_allowed` | Off mode → Proceed |
| `test_check_path_always_mode_inside_allowed` | Always mode + inside → Proceed |

## Validation

- `cargo clippy -p moltis-tools -- -D warnings` — clean
- `just format-check` — clean (pinned nightly rustfmt)
- `cargo test -p moltis-tools` — **16 new tests passing** (9 containment + 7 approval path checks)

## Follow-up

- Phase 2: `file_write`, `file_edit`, `file_tree`, `file_list`, `file_search`, `create_directory`, `move_file` tools
- Phase 2: consume `max_write_bytes` in write tool
- Consider adding a `file_glob` or `file_find` tool for pattern-based discovery
