### PR TITLE
docs(compaction): add compaction command to comparison table

### DIFF
--- a/docs/src/memory-comparison.md
+++ b/docs/src/memory-comparison.md
@@ -207,7 +207,6 @@ context. The implementation differs:
 
 ## What OpenClaw Has That Moltis Does Not (Yet)
 
-- **Manual `/compact` command** with user-specified instructions
 - **CLI memory commands** (`status`, `index`, `search`) for debugging
 - **Session pruning** (cache-TTL based trimming of old tool results)
 - **Gemini and Voyage embedding providers**

--- a/docs/src/memory-comparison.md
+++ b/docs/src/memory-comparison.md
@@ -113,7 +113,7 @@ memory paths and the file watcher to re-index.
 |---------|--------|----------|
 | **Session storage** | SQLite database | JSONL files (append-only, tree structure) |
 | **Auto-compaction** | Yes, near context window limit | Yes, near context window limit |
-| **Manual compaction** | Not yet | `/compact` command with optional instructions |
+| **Manual compaction** | `/compact` (uses [configured compaction strategy](compaction.md#the-four-modes)) | `/compact` command with optional instructions |
 | **Pre-compaction memory flush** | Silent turn via `MemoryWriter` trait | Silent turn via `write_file` tool |
 | **Flush visibility** | Completely hidden from user | Hidden via `NO_REPLY` convention |
 | **Session export to memory** | Markdown files in `memory/sessions/` | Optional (`sessionMemory` experimental flag) |


### PR DESCRIPTION
## Summary

I was going through the documentation and noticed this table seemed outdated (since `/compact` is now available).