### PR TITLE
fix(web): show Clear button for main session in modal

### DIFF
--- a/crates/web/src/assets/js/page-chat.js
+++ b/crates/web/src/assets/js/page-chat.js
@@ -1294,7 +1294,6 @@ registerPrefix(
 						showSelectors=${false}
 						showName=${false}
 						showStop=${false}
-						showClear=${false}
 						actionButtonClass=${"provider-btn provider-btn-secondary provider-btn-sm"}
 						onBeforeShare=${() => closeChatMore?.()}
 						onBeforeDelete=${() => closeChatMore?.()}

--- a/crates/web/ui/e2e/specs/sessions.spec.js
+++ b/crates/web/ui/e2e/specs/sessions.spec.js
@@ -338,21 +338,21 @@ test.describe("Session management", () => {
 		expect(pageErrors).toEqual([]);
 	});
 
-	test("main session hides delete while non-main sessions show delete in more controls", async ({ page }) => {
+	test("main session shows clear but hides delete, non-main shows delete but hides clear", async ({ page }) => {
 		const pageErrors = watchPageErrors(page);
 		await page.goto("/");
 		await waitForWsConnected(page);
 		await expectPageContentMounted(page);
 
 		await openChatMoreModal(page);
-		await expect(page.locator('#chatMoreModal button[title="Clear session"]')).toBeHidden();
+		await expect(page.locator('#sessionHeaderModalTopMount button[title="Clear session"]')).toBeVisible();
 		await expect(page.locator('#chatMoreModal button[title="Delete session"]')).toHaveCount(0);
 		await closeChatMoreModal(page);
 
 		await createSession(page);
 
 		await openChatMoreModal(page);
-		await expect(page.locator('#chatMoreModal button[title="Clear session"]')).toHaveCount(0);
+		await expect(page.locator('#sessionHeaderModalTopMount button[title="Clear session"]')).toHaveCount(0);
 		await expect(page.locator('#chatMoreModal button[title="Delete session"]')).toBeVisible();
 		await closeChatMoreModal(page);
 


### PR DESCRIPTION
## Summary

- Show the **Clear** button for the main session in the "More controls" modal top bar
- The button was hidden because `showClear=${false}` was explicitly set on the modal top mount, while the only other mount where `showClear` defaults to `true` (sessionControlsSection) is hidden for the main session — leaving no way to clear it without editing HTML manually

Closes #671

## Validation

### Completed
- [x] `biome check --write` passes
- [x] Verified `showClear && isMain` guard in `SessionHeader` restricts the button to the main session only

### Remaining
- [ ] `cargo +nightly-2025-11-30 fmt --all -- --check`
- [ ] `just lint`
- [ ] `just test`
- [ ] `./scripts/local-validate.sh`

## Manual QA

1. Start Moltis, open the web UI
2. On the **main** session, click the "More controls" (⋯) button
3. Verify a **Clear** button appears in the modal header bar
4. Click Clear — the main session messages should be cleared
5. Switch to a non-main session, open "More controls" — verify **no** Clear button appears in the top bar (the session controls section below handles non-main sessions)