### PR TITLE
feat(auth): disable terminal option + comprehensive auth hardening

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6801,6 +6801,7 @@ dependencies = [
  "axum",
  "base64 0.22.1",
  "dashmap 6.1.0",
+ "hmac",
  "moltis-config",
  "moltis-tools",
  "moltis-vault",

--- a/crates/auth/Cargo.toml
+++ b/crates/auth/Cargo.toml
@@ -15,6 +15,7 @@ async-trait       = { workspace = true }
 axum              = { workspace = true }
 base64            = { workspace = true }
 dashmap           = { workspace = true }
+hmac              = { workspace = true }
 moltis-config     = { workspace = true }
 moltis-tools      = { workspace = true }
 moltis-vault      = { optional = true, workspace = true }

--- a/crates/auth/src/credential_store.rs
+++ b/crates/auth/src/credential_store.rs
@@ -33,6 +33,22 @@ pub enum AuthMethod {
 #[derive(Debug, Clone)]
 pub struct AuthIdentity {
     pub method: AuthMethod,
+    /// Scopes granted to this identity. Empty for full access (password,
+    /// passkey, loopback). Populated for API keys with scope restrictions.
+    pub scopes: Vec<String>,
+}
+
+impl AuthIdentity {
+    /// Returns `true` if this identity has the given scope, or has
+    /// unrestricted access (password/passkey/loopback or unscooped API key).
+    pub fn has_scope(&self, scope: &str) -> bool {
+        // Non-API-key methods always have full access.
+        if self.method != AuthMethod::ApiKey {
+            return true;
+        }
+        // API keys with empty scopes have full access (legacy behavior).
+        self.scopes.is_empty() || self.scopes.iter().any(|s| s == scope)
+    }
 }
 
 /// A registered passkey entry (for listing in the UI).
@@ -161,6 +177,12 @@ pub struct CredentialStore {
 }
 
 impl CredentialStore {
+    // ── Sessions ─────────────────────────────────────────────────────────
+
+    /// Maximum number of concurrent active sessions. Oldest sessions are
+    /// evicted when the cap is reached.
+    const MAX_SESSIONS: i64 = 10;
+
     /// Open a database at the given path, reset all auth, and close it.
     pub async fn reset_from_db_path(db_path: &std::path::Path) -> anyhow::Result<()> {
         let db_url = format!("sqlite:{}", db_path.display());
@@ -276,7 +298,8 @@ impl CredentialStore {
                 key_prefix TEXT    NOT NULL,
                 created_at TEXT    NOT NULL DEFAULT (datetime('now')),
                 revoked_at TEXT,
-                scopes     TEXT
+                scopes     TEXT,
+                key_salt   TEXT
             )",
         )
         .execute(&self.pool)
@@ -287,6 +310,18 @@ impl CredentialStore {
                 token      TEXT PRIMARY KEY,
                 created_at TEXT NOT NULL DEFAULT (datetime('now')),
                 expires_at TEXT NOT NULL
+            )",
+        )
+        .execute(&self.pool)
+        .await?;
+
+        sqlx::query(
+            "CREATE TABLE IF NOT EXISTS auth_audit_log (
+                id         INTEGER PRIMARY KEY AUTOINCREMENT,
+                event_type TEXT    NOT NULL,
+                client_ip  TEXT,
+                detail     TEXT,
+                created_at TEXT    NOT NULL DEFAULT (datetime('now'))
             )",
         )
         .execute(&self.pool)
@@ -491,10 +526,30 @@ impl CredentialStore {
         Ok(())
     }
 
-    // ── Sessions ─────────────────────────────────────────────────────────
-
     /// Create a new session token (30-day expiry).
+    ///
+    /// Enforces a cap of [`MAX_SESSIONS`] active (non-expired) sessions.
+    /// When the cap is reached, the oldest sessions are deleted to make room.
     pub async fn create_session(&self) -> anyhow::Result<String> {
+        // Clean up expired sessions first.
+        sqlx::query("DELETE FROM auth_sessions WHERE expires_at <= datetime('now')")
+            .execute(&self.pool)
+            .await?;
+
+        // Evict oldest sessions if we're at the cap.
+        let count: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM auth_sessions")
+            .fetch_one(&self.pool)
+            .await?;
+        if count.0 >= Self::MAX_SESSIONS {
+            let to_delete = count.0 - Self::MAX_SESSIONS + 1;
+            sqlx::query(
+                "DELETE FROM auth_sessions WHERE token IN (SELECT token FROM auth_sessions ORDER BY created_at ASC LIMIT ?)",
+            )
+            .bind(to_delete)
+            .execute(&self.pool)
+            .await?;
+        }
+
         let token = generate_token();
         sqlx::query(
             "INSERT INTO auth_sessions (token, expires_at) VALUES (?, datetime('now', '+30 days'))",
@@ -536,7 +591,8 @@ impl CredentialStore {
     // ── API Keys ─────────────────────────────────────────────────────────
 
     /// Generate a new API key with optional scopes. Returns (id, raw_key).
-    /// The raw key is only shown once — we store only its SHA-256 hash.
+    /// The raw key is only shown once — we store its HMAC-SHA256 hash with
+    /// a per-key random salt.
     ///
     /// If `scopes` is None or empty, the key will have no access until scopes are set.
     pub async fn create_api_key(
@@ -546,7 +602,8 @@ impl CredentialStore {
     ) -> anyhow::Result<(i64, String)> {
         let raw_key = format!("mk_{}", generate_token());
         let prefix = &raw_key[..raw_key.len().min(11)]; // "mk_" + 8 chars
-        let hash = sha256_hex(&raw_key);
+        let salt = generate_token();
+        let hash = hmac_sha256_hex(&raw_key, &salt);
 
         // Store scopes as JSON array, or NULL for full access
         let scopes_json = scopes
@@ -554,12 +611,13 @@ impl CredentialStore {
             .map(|s| serde_json::to_string(s).unwrap_or_default());
 
         let result = sqlx::query(
-            "INSERT INTO api_keys (label, key_hash, key_prefix, scopes) VALUES (?, ?, ?, ?)",
+            "INSERT INTO api_keys (label, key_hash, key_prefix, scopes, key_salt) VALUES (?, ?, ?, ?, ?)",
         )
         .bind(label)
         .bind(&hash)
         .bind(prefix)
         .bind(&scopes_json)
+        .bind(&salt)
         .execute(&self.pool)
         .await?;
         Ok((result.last_insert_rowid(), raw_key))
@@ -602,24 +660,36 @@ impl CredentialStore {
 
     /// Verify a raw API key. Returns `Some(ApiKeyVerification)` if valid,
     /// `None` if invalid or revoked.
+    ///
+    /// Supports both salted (HMAC-SHA256) and legacy unsalted (SHA-256) keys.
     pub async fn verify_api_key(
         &self,
         raw_key: &str,
     ) -> anyhow::Result<Option<ApiKeyVerification>> {
-        let hash = sha256_hex(raw_key);
-        let row: Option<(i64, Option<String>)> = sqlx::query_as(
-            "SELECT id, scopes FROM api_keys WHERE key_hash = ? AND revoked_at IS NULL",
+        // Fetch all active keys and verify against each.
+        // The key set is small (typically <10), so this is acceptable.
+        let rows: Vec<(i64, String, Option<String>, Option<String>)> = sqlx::query_as(
+            "SELECT id, key_hash, scopes, key_salt FROM api_keys WHERE revoked_at IS NULL",
         )
-        .bind(&hash)
-        .fetch_optional(&self.pool)
+        .fetch_all(&self.pool)
         .await?;
 
-        Ok(row.map(|(key_id, scopes_json)| {
-            let scopes = scopes_json
-                .and_then(|s| serde_json::from_str::<Vec<String>>(&s).ok())
-                .unwrap_or_default();
-            ApiKeyVerification { key_id, scopes }
-        }))
+        for (key_id, stored_hash, scopes_json, salt) in rows {
+            let matches = if let Some(ref s) = salt {
+                // Salted key: HMAC-SHA256.
+                hmac_sha256_hex(raw_key, s) == stored_hash
+            } else {
+                // Legacy unsalted key: plain SHA-256.
+                sha256_hex(raw_key) == stored_hash
+            };
+            if matches {
+                let scopes = scopes_json
+                    .and_then(|s| serde_json::from_str::<Vec<String>>(&s).ok())
+                    .unwrap_or_default();
+                return Ok(Some(ApiKeyVerification { key_id, scopes }));
+            }
+        }
+        Ok(None)
     }
 
     // ── Environment Variables ─────────────────────────────────────────────
@@ -1347,6 +1417,31 @@ impl CredentialStore {
             .await?;
         Ok(row.is_some())
     }
+
+    // ── Audit log ─────────────────────────────────────────────────────────
+
+    /// Record an authentication event for audit purposes.
+    pub async fn audit_log(&self, event_type: &str, client_ip: Option<&str>, detail: Option<&str>) {
+        let result = sqlx::query(
+            "INSERT INTO auth_audit_log (event_type, client_ip, detail) VALUES (?, ?, ?)",
+        )
+        .bind(event_type)
+        .bind(client_ip)
+        .bind(detail)
+        .execute(&self.pool)
+        .await;
+        if let Err(e) = result {
+            // Best-effort — never fail the auth flow because of logging.
+            tracing::debug!(error = %e, "failed to write audit log");
+        }
+
+        // Prune entries older than 90 days to prevent unbounded growth.
+        let _ = sqlx::query(
+            "DELETE FROM auth_audit_log WHERE created_at < datetime('now', '-90 days')",
+        )
+        .execute(&self.pool)
+        .await;
+    }
 }
 
 // ── EnvVarProvider impl ─────────────────────────────────────────────────────
@@ -1399,6 +1494,17 @@ fn sha256_hex(input: &str) -> String {
     let mut hasher = Sha256::new();
     hasher.update(input.as_bytes());
     format!("{:x}", hasher.finalize())
+}
+
+fn hmac_sha256_hex(input: &str, salt: &str) -> String {
+    use hmac::{Hmac, Mac};
+    type HmacSha256 = Hmac<Sha256>;
+    // HMAC-SHA256 accepts any key length, so this never fails in practice.
+    let Ok(mut mac) = HmacSha256::new_from_slice(salt.as_bytes()) else {
+        return sha256_hex(input);
+    };
+    mac.update(input.as_bytes());
+    format!("{:x}", mac.finalize().into_bytes())
 }
 
 // ── Legacy compat ────────────────────────────────────────────────────────────

--- a/crates/auth/src/credential_store.rs
+++ b/crates/auth/src/credential_store.rs
@@ -18,6 +18,12 @@ use {
 #[cfg(feature = "vault")]
 use moltis_vault::Vault;
 
+/// Pre-computed Argon2 hash used for constant-time dummy verification when no
+/// password is set. This prevents timing side channels that would reveal
+/// whether a password exists. The actual value doesn't matter — it will
+/// never match any real input.
+const DUMMY_ARGON2_HASH: &str = "$argon2id$v=19$m=19456,t=2,p=1$AAAAAAAAAAAAAAAAAAAAAA$AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+
 // ── Types ────────────────────────────────────────────────────────────────────
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -491,13 +497,22 @@ impl CredentialStore {
     }
 
     /// Verify a password against the stored hash.
+    ///
+    /// When no password is set, a dummy Argon2 verification is performed
+    /// to prevent timing side channels that would reveal whether a password
+    /// exists.
     pub async fn verify_password(&self, password: &str) -> anyhow::Result<bool> {
         let row: Option<(String,)> =
             sqlx::query_as("SELECT password_hash FROM auth_password WHERE id = 1")
                 .fetch_optional(&self.pool)
                 .await?;
-        let Some((hash,)) = row else {
-            return Ok(false);
+        let hash = match row {
+            Some((h,)) => h,
+            None => {
+                // Perform dummy verification to avoid timing leak.
+                let _ = verify_password(password, DUMMY_ARGON2_HASH);
+                return Ok(false);
+            },
         };
         Ok(verify_password(password, &hash))
     }

--- a/crates/config/src/schema.rs
+++ b/crates/config/src/schema.rs
@@ -841,6 +841,14 @@ pub struct ServerConfig {
     /// Defaults to `https://esm.sh/shiki@3.2.1?bundle` when unset.
     /// Set to an alternative CDN or a self-hosted URL to override.
     pub shiki_cdn_url: Option<String>,
+    /// Enable or disable the host terminal in the web UI.
+    ///
+    /// Defaults to `true`. Set to `false` to prevent the web UI from
+    /// offering an unsandboxed shell. The `MOLTIS_TERMINAL_DISABLED`
+    /// environment variable (set to `1` or `true`) takes precedence over
+    /// this field and cannot be changed from the web UI config editor.
+    #[serde(default = "default_terminal_enabled")]
+    pub terminal_enabled: bool,
 }
 
 fn default_log_buffer_size() -> usize {
@@ -849,6 +857,10 @@ fn default_log_buffer_size() -> usize {
 
 fn default_db_pool_max_connections() -> u32 {
     5
+}
+
+fn default_terminal_enabled() -> bool {
+    true
 }
 
 impl Default for ServerConfig {
@@ -862,7 +874,23 @@ impl Default for ServerConfig {
             update_releases_url: None,
             db_pool_max_connections: default_db_pool_max_connections(),
             shiki_cdn_url: None,
+            terminal_enabled: default_terminal_enabled(),
         }
+    }
+}
+
+impl ServerConfig {
+    /// Returns whether the web UI terminal is enabled, accounting for the
+    /// `MOLTIS_TERMINAL_DISABLED` env-var override. When the env var is set
+    /// to `"1"` or `"true"` (case-insensitive), the terminal is disabled
+    /// regardless of the config file value.
+    pub fn is_terminal_enabled(&self) -> bool {
+        if let Ok(val) = std::env::var("MOLTIS_TERMINAL_DISABLED")
+            && (val.eq_ignore_ascii_case("true") || val == "1")
+        {
+            return false;
+        }
+        self.terminal_enabled
     }
 }
 
@@ -3763,5 +3791,27 @@ enabled = true
             serialized.contains("wire_api = \"responses\""),
             "non-default wire_api should be serialized"
         );
+    }
+
+    #[test]
+    fn terminal_enabled_defaults_to_true() {
+        let cfg: MoltisConfig = toml::from_str("").unwrap();
+        assert!(cfg.server.terminal_enabled);
+        assert!(cfg.server.is_terminal_enabled());
+    }
+
+    #[test]
+    fn terminal_enabled_parsed_from_config() {
+        let cfg: MoltisConfig = toml::from_str("[server]\nterminal_enabled = false\n").unwrap();
+        assert!(!cfg.server.terminal_enabled);
+    }
+
+    #[test]
+    fn terminal_disabled_via_config_reflects_in_helper() {
+        let cfg: MoltisConfig = toml::from_str("[server]\nterminal_enabled = false\n").unwrap();
+        // When the env var is not set, the helper returns the config value.
+        // (We cannot test the env-var override here because workspace lints
+        // deny unsafe code, and `std::env::set_var` is unsafe.)
+        assert!(!cfg.server.is_terminal_enabled());
     }
 }

--- a/crates/config/src/schema.rs
+++ b/crates/config/src/schema.rs
@@ -3797,7 +3797,8 @@ enabled = true
     fn terminal_enabled_defaults_to_true() {
         let cfg: MoltisConfig = toml::from_str("").unwrap();
         assert!(cfg.server.terminal_enabled);
-        assert!(cfg.server.is_terminal_enabled());
+        // Note: is_terminal_enabled() is NOT tested here because it reads
+        // the MOLTIS_TERMINAL_DISABLED env var, which may be set in CI.
     }
 
     #[test]

--- a/crates/config/src/template.rs
+++ b/crates/config/src/template.rs
@@ -25,6 +25,11 @@ bind = "127.0.0.1"                # Address to bind to ("0.0.0.0" for all interf
 port = {port}                           # Port number (auto-generated for this installation)
 http_request_logs = false              # Enable verbose Axum HTTP request/response logs (debugging)
 ws_request_logs = false                # Enable WebSocket RPC request/response logs (debugging)
+terminal_enabled = true                   # Enable interactive host terminal in Settings > Terminal
+                                          # Set to false to disable the unsandboxed shell in the web UI.
+                                          # NOTE: this can be re-enabled via the web UI config editor.
+                                          # For hard lockdown, set MOLTIS_TERMINAL_DISABLED=1 (env var
+                                          # takes precedence and cannot be changed from the web UI).
 update_releases_url = "https://www.moltis.org/releases.json"    # Releases manifest URL for update checks (override to use a custom URL)
 
 # ══════════════════════════════════════════════════════════════════════════════

--- a/crates/config/src/validate.rs
+++ b/crates/config/src/validate.rs
@@ -392,6 +392,7 @@ fn build_schema_map() -> KnownKeys {
                 ("update_releases_url", Leaf),
                 ("db_pool_max_connections", Leaf),
                 ("shiki_cdn_url", Leaf),
+                ("terminal_enabled", Leaf),
             ])),
         ),
         ("providers", MapWithFields {
@@ -3256,5 +3257,22 @@ allow = ["web_search"]
             .filter(|d| d.category == "security" && d.path == "agents.presets")
             .count();
         assert_eq!(count, 1, "expected exactly one rolled-up warning");
+    }
+
+    #[test]
+    fn server_terminal_enabled_is_known_field() {
+        let toml = r#"
+[server]
+terminal_enabled = false
+"#;
+        let result = validate_toml_str(toml);
+        let unknown = result
+            .diagnostics
+            .iter()
+            .find(|d| d.category == "unknown-field" && d.path.contains("terminal_enabled"));
+        assert!(
+            unknown.is_none(),
+            "terminal_enabled should be a known field, got: {unknown:?}"
+        );
     }
 }

--- a/crates/gateway/migrations/20260412180000_api_keys_salt.sql
+++ b/crates/gateway/migrations/20260412180000_api_keys_salt.sql
@@ -1,0 +1,3 @@
+-- Add per-key salt for HMAC-SHA256 key hashing.
+-- Legacy keys (key_salt IS NULL) fall back to plain SHA-256 verification.
+ALTER TABLE api_keys ADD COLUMN key_salt TEXT;

--- a/crates/gateway/migrations/20260412180100_auth_audit_log.sql
+++ b/crates/gateway/migrations/20260412180100_auth_audit_log.sql
@@ -1,0 +1,12 @@
+-- Audit log for authentication events (login attempts, key creation, etc.).
+CREATE TABLE IF NOT EXISTS auth_audit_log (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    event_type TEXT    NOT NULL,  -- login_success, login_failure, setup, key_created, key_revoked, password_changed, auth_reset
+    client_ip  TEXT,
+    detail     TEXT,
+    created_at TEXT    NOT NULL DEFAULT (datetime('now'))
+);
+
+-- Keep the audit log from growing without bounds; older entries can be
+-- pruned by a periodic cleanup task.
+CREATE INDEX IF NOT EXISTS idx_auth_audit_log_created ON auth_audit_log (created_at);

--- a/crates/gateway/src/auth.rs
+++ b/crates/gateway/src/auth.rs
@@ -1,7 +1,14 @@
 pub use moltis_auth::*;
 
-/// Generate a random 6-digit numeric setup code.
+/// Generate a random 8-character alphanumeric setup code (~48 bits of entropy).
+///
+/// Uses uppercase + digits only (no ambiguous chars like 0/O, 1/I/L) for easy
+/// reading from a terminal.
 pub fn generate_setup_code() -> String {
     use rand::Rng;
-    rand::rng().random_range(100_000..1_000_000).to_string()
+    const CHARSET: &[u8] = b"ABCDEFGHJKMNPQRSTUVWXYZ23456789";
+    let mut rng = rand::rng();
+    (0..8)
+        .map(|_| CHARSET[rng.random_range(0..CHARSET.len())] as char)
+        .collect()
 }

--- a/crates/gateway/src/server.rs
+++ b/crates/gateway/src/server.rs
@@ -3542,7 +3542,11 @@ pub async fn prepare_gateway_core(
         if !credential_store.is_setup_complete() && !credential_store.is_auth_disabled() {
             let code = std::env::var("MOLTIS_E2E_SETUP_CODE")
                 .unwrap_or_else(|_| auth::generate_setup_code());
-            state.inner.write().await.setup_code = Some(Secret::new(code.clone()));
+            {
+                let mut inner = state.inner.write().await;
+                inner.setup_code = Some(Secret::new(code.clone()));
+                inner.setup_code_created_at = Some(std::time::Instant::now());
+            }
             Some(code)
         } else {
             None

--- a/crates/gateway/src/state.rs
+++ b/crates/gateway/src/state.rs
@@ -261,6 +261,8 @@ pub struct GatewayInner {
     /// One-time setup code displayed at startup, required during initial setup.
     /// Cleared after successful setup.
     pub setup_code: Option<secrecy::Secret<String>>,
+    /// When the setup code was created (for 30-minute expiry).
+    pub setup_code_created_at: Option<Instant>,
     /// Auto-update availability state from GitHub releases.
     pub update: crate::update_check::UpdateAvailability,
     /// Last error per run_id (short-lived, for send_sync to retrieve).
@@ -309,6 +311,7 @@ impl GatewayInner {
             discovered_hooks: Vec::new(),
             disabled_hooks: HashSet::new(),
             setup_code: None,
+            setup_code_created_at: None,
             update: crate::update_check::UpdateAvailability::default(),
             run_errors: HashMap::new(),
             #[cfg(feature = "metrics")]

--- a/crates/httpd/src/auth_middleware.rs
+++ b/crates/httpd/src/auth_middleware.rs
@@ -56,6 +56,7 @@ pub async fn check_auth(
         return if is_local {
             AuthResult::Allowed(AuthIdentity {
                 method: AuthMethod::Loopback,
+                scopes: Vec::new(),
             })
         } else {
             AuthResult::SetupRequired
@@ -66,6 +67,7 @@ pub async fn check_auth(
         return if is_local {
             AuthResult::Allowed(AuthIdentity {
                 method: AuthMethod::Loopback,
+                scopes: Vec::new(),
             })
         } else {
             AuthResult::SetupRequired
@@ -78,15 +80,17 @@ pub async fn check_auth(
     {
         return AuthResult::Allowed(AuthIdentity {
             method: AuthMethod::Password,
+            scopes: Vec::new(),
         });
     }
 
     // Check Bearer API key.
     if let Some(key) = bearer_token(headers)
-        && store.verify_api_key(key).await.ok().flatten().is_some()
+        && let Some(verification) = store.verify_api_key(key).await.ok().flatten()
     {
         return AuthResult::Allowed(AuthIdentity {
             method: AuthMethod::ApiKey,
+            scopes: verification.scopes,
         });
     }
 
@@ -151,6 +155,7 @@ pub async fn auth_gate(
                 // render without full auth (#310, #350).
                 request.extensions_mut().insert(AuthIdentity {
                     method: AuthMethod::Loopback,
+                    scopes: Vec::new(),
                 });
                 next.run(request).await
             } else {
@@ -185,6 +190,7 @@ pub async fn auth_gate(
                     debug!(path, remote = %addr, "auth bypass: local request during onboarding");
                     request.extensions_mut().insert(AuthIdentity {
                         method: AuthMethod::Loopback,
+                        scopes: Vec::new(),
                     });
                     return next.run(request).await;
                 }
@@ -344,6 +350,36 @@ where
     }
 }
 
+// ── RequireAdmin extractor ───────────────────────────────────────────────────
+
+/// Axum extractor that requires the `operator.admin` scope.
+///
+/// Use on routes that modify server configuration, restart the process,
+/// or manage credentials. Returns 403 if the authenticated identity lacks
+/// the required scope.
+pub struct RequireAdmin(pub AuthIdentity);
+
+impl<S> FromRequestParts<S> for RequireAdmin
+where
+    S: Send + Sync,
+    Arc<CredentialStore>: FromRef<S>,
+    Arc<GatewayState>: FromRef<S>,
+{
+    type Rejection = (StatusCode, &'static str);
+
+    async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
+        let AuthSession(identity) = AuthSession::from_request_parts(parts, state).await?;
+        if identity.has_scope("operator.admin") {
+            Ok(RequireAdmin(identity))
+        } else {
+            Err((
+                StatusCode::FORBIDDEN,
+                "insufficient scope: operator.admin required",
+            ))
+        }
+    }
+}
+
 // ── Helpers ─────────────────────────────────────────────────────────────────
 
 /// Extract the Cookie header value.
@@ -428,6 +464,7 @@ mod tests {
             check_auth(&store, &headers, true).await,
             AuthResult::Allowed(AuthIdentity {
                 method: AuthMethod::Loopback,
+                ..
             })
         ));
         assert!(matches!(

--- a/crates/httpd/src/auth_routes.rs
+++ b/crates/httpd/src/auth_routes.rs
@@ -206,13 +206,35 @@ async fn setup_handler(
         return (StatusCode::FORBIDDEN, "setup already completed").into_response();
     }
 
+    let client_ip = crate::request_throttle::resolve_client_ip(
+        &headers,
+        addr,
+        state.gateway_state.behind_proxy,
+    );
+    const SETUP_ACCOUNT: &str = "__setup__";
+
+    if let Some(block) = state.login_guard.check(client_ip, SETUP_ACCOUNT) {
+        return blocked_response(block);
+    }
+
     // Validate setup code if one was generated at startup.
     {
         let inner = state.gateway_state.inner.read().await;
-        if let Some(ref expected) = inner.setup_code
-            && body.setup_code.as_deref() != Some(expected.expose_secret().as_str())
-        {
-            return (StatusCode::FORBIDDEN, "invalid or missing setup code").into_response();
+        if let Some(ref expected) = inner.setup_code {
+            // Expire setup code after 30 minutes.
+            if let Some(created_at) = inner.setup_code_created_at
+                && created_at.elapsed() > std::time::Duration::from_secs(30 * 60)
+            {
+                return (
+                    StatusCode::GONE,
+                    "setup code has expired — restart the server to generate a new one",
+                )
+                    .into_response();
+            }
+            if body.setup_code.as_deref() != Some(expected.expose_secret().as_str()) {
+                state.login_guard.record_failure(client_ip, SETUP_ACCOUNT);
+                return (StatusCode::FORBIDDEN, "invalid or missing setup code").into_response();
+            }
         }
     }
 
@@ -229,10 +251,10 @@ async fn setup_handler(
                 .into_response();
         }
     } else {
-        if password.len() < 8 {
+        if password.len() < 12 {
             return (
                 StatusCode::BAD_REQUEST,
-                "password must be at least 8 characters",
+                "password must be at least 12 characters",
             )
                 .into_response();
         }
@@ -333,9 +355,14 @@ async fn login_handler(
         return blocked_response(block);
     }
 
+    let ip_str = client_ip.to_string();
     match state.credential_store.verify_password(&body.password).await {
         Ok(true) => {
             state.login_guard.record_success(client_ip);
+            state
+                .credential_store
+                .audit_log("login_success", Some(&ip_str), None)
+                .await;
             // Best-effort vault unseal on successful login.
             #[cfg(feature = "vault")]
             if let Some(ref vault) = state.gateway_state.vault {
@@ -365,6 +392,10 @@ async fn login_handler(
             state
                 .login_guard
                 .record_failure(client_ip, PASSWORD_ACCOUNT);
+            state
+                .credential_store
+                .audit_log("login_failure", Some(&ip_str), None)
+                .await;
             (StatusCode::UNAUTHORIZED, "invalid password").into_response()
         },
         Err(e) => (
@@ -404,7 +435,11 @@ async fn reset_auth_handler(
                 .await;
             let code = moltis_gateway::auth::generate_setup_code();
             tracing::info!("setup code: {code} (enter this in the browser to set your password)");
-            state.gateway_state.inner.write().await.setup_code = Some(secrecy::Secret::new(code));
+            {
+                let mut inner = state.gateway_state.inner.write().await;
+                inner.setup_code = Some(secrecy::Secret::new(code));
+                inner.setup_code_created_at = Some(std::time::Instant::now());
+            }
             let bp = state.gateway_state.behind_proxy;
             clear_session_response(&headers, bp, state.gateway_state.tls_active || bp)
         },
@@ -425,10 +460,10 @@ async fn change_password_handler(
     State(state): State<AuthState>,
     Json(body): Json<ChangePasswordRequest>,
 ) -> impl IntoResponse {
-    if body.new_password.len() < 8 {
+    if body.new_password.len() < 12 {
         return (
             StatusCode::BAD_REQUEST,
-            "new password must be at least 8 characters",
+            "new password must be at least 12 characters",
         )
             .into_response();
     }

--- a/crates/httpd/src/auth_routes.rs
+++ b/crates/httpd/src/auth_routes.rs
@@ -458,6 +458,8 @@ struct ChangePasswordRequest {
 async fn change_password_handler(
     _session: AuthSession,
     State(state): State<AuthState>,
+    ConnectInfo(addr): ConnectInfo<SocketAddr>,
+    headers: axum::http::HeaderMap,
     Json(body): Json<ChangePasswordRequest>,
 ) -> impl IntoResponse {
     if body.new_password.len() < 12 {
@@ -515,6 +517,17 @@ async fn change_password_handler(
         };
     }
 
+    let client_ip = crate::request_throttle::resolve_client_ip(
+        &headers,
+        addr,
+        state.gateway_state.behind_proxy,
+    );
+    const PASSWORD_CHANGE_ACCOUNT: &str = "__password_change__";
+
+    if let Some(block) = state.login_guard.check(client_ip, PASSWORD_CHANGE_ACCOUNT) {
+        return blocked_response(block);
+    }
+
     let current_password = body.current_password.unwrap_or_default();
     match state
         .credential_store
@@ -522,6 +535,7 @@ async fn change_password_handler(
         .await
     {
         Ok(()) => {
+            state.login_guard.record_success(client_ip);
             // Best-effort vault password rotation.
             #[cfg(feature = "vault")]
             if let Some(ref vault) = state.gateway_state.vault {
@@ -542,6 +556,9 @@ async fn change_password_handler(
         Err(e) => {
             let msg = e.to_string();
             if msg.contains("incorrect") {
+                state
+                    .login_guard
+                    .record_failure(client_ip, PASSWORD_CHANGE_ACCOUNT);
                 (StatusCode::FORBIDDEN, msg).into_response()
             } else {
                 (StatusCode::INTERNAL_SERVER_ERROR, msg).into_response()
@@ -593,7 +610,17 @@ async fn create_api_key_handler(
         .create_api_key(body.label.trim(), body.scopes.as_deref())
         .await
     {
-        Ok((id, key)) => Json(serde_json::json!({ "id": id, "key": key })).into_response(),
+        Ok((id, key)) => {
+            state
+                .credential_store
+                .audit_log(
+                    "key_created",
+                    None,
+                    Some(&format!("id={id}, label={}", body.label.trim())),
+                )
+                .await;
+            Json(serde_json::json!({ "id": id, "key": key })).into_response()
+        },
         Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
     }
 }
@@ -604,7 +631,13 @@ async fn revoke_api_key_handler(
     axum::extract::Path(id): axum::extract::Path<i64>,
 ) -> impl IntoResponse {
     match state.credential_store.revoke_api_key(id).await {
-        Ok(()) => Json(serde_json::json!({ "ok": true })).into_response(),
+        Ok(()) => {
+            state
+                .credential_store
+                .audit_log("key_revoked", None, Some(&format!("id={id}")))
+                .await;
+            Json(serde_json::json!({ "ok": true })).into_response()
+        },
         Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
     }
 }

--- a/crates/httpd/src/auth_routes.rs
+++ b/crates/httpd/src/auth_routes.rs
@@ -19,6 +19,7 @@ use moltis_gateway::{
 
 use crate::{
     auth_middleware::{AuthResult, AuthSession, SESSION_COOKIE, check_auth},
+    login_guard::LoginGuard,
     server::is_local_connection,
 };
 
@@ -28,6 +29,7 @@ pub struct AuthState {
     pub credential_store: Arc<CredentialStore>,
     pub webauthn_registry: Option<SharedWebAuthnRegistry>,
     pub gateway_state: Arc<GatewayState>,
+    pub login_guard: LoginGuard,
 }
 
 impl axum::extract::FromRef<AuthState> for Arc<CredentialStore> {
@@ -95,6 +97,37 @@ fn vault_routes() -> axum::Router<AuthState> {
 #[cfg(not(feature = "vault"))]
 fn vault_routes() -> axum::Router<AuthState> {
     axum::Router::new()
+}
+
+// ── Brute-force block response ────────────────────────────────────────────────
+
+fn blocked_response(reason: crate::login_guard::BlockReason) -> axum::response::Response {
+    use crate::login_guard::BlockReason;
+    let (message, retry_after) = match reason {
+        BlockReason::IpBanned { retry_after } => (
+            "too many failed attempts from this address — try again later",
+            retry_after,
+        ),
+        BlockReason::AccountLocked { retry_after } => (
+            "account temporarily locked due to suspicious activity — try again later",
+            retry_after,
+        ),
+    };
+    let retry_secs = retry_after.as_secs().max(1);
+    let mut resp = (
+        StatusCode::TOO_MANY_REQUESTS,
+        Json(serde_json::json!({
+            "code": "LOGIN_BLOCKED",
+            "error": message,
+            "retry_after_seconds": retry_secs,
+        })),
+    )
+        .into_response();
+    if let Ok(val) = retry_secs.to_string().parse() {
+        resp.headers_mut()
+            .insert(axum::http::header::RETRY_AFTER, val);
+    }
+    resp
 }
 
 // ── Status ───────────────────────────────────────────────────────────────────
@@ -285,11 +318,24 @@ struct LoginRequest {
 
 async fn login_handler(
     State(state): State<AuthState>,
+    ConnectInfo(addr): ConnectInfo<SocketAddr>,
     headers: axum::http::HeaderMap,
     Json(body): Json<LoginRequest>,
 ) -> impl IntoResponse {
+    let client_ip = crate::request_throttle::resolve_client_ip(
+        &headers,
+        addr,
+        state.gateway_state.behind_proxy,
+    );
+    const PASSWORD_ACCOUNT: &str = "__password__";
+
+    if let Some(block) = state.login_guard.check(client_ip, PASSWORD_ACCOUNT) {
+        return blocked_response(block);
+    }
+
     match state.credential_store.verify_password(&body.password).await {
         Ok(true) => {
+            state.login_guard.record_success(client_ip);
             // Best-effort vault unseal on successful login.
             #[cfg(feature = "vault")]
             if let Some(ref vault) = state.gateway_state.vault {
@@ -315,7 +361,12 @@ async fn login_handler(
                     .into_response(),
             }
         },
-        Ok(false) => (StatusCode::UNAUTHORIZED, "invalid password").into_response(),
+        Ok(false) => {
+            state
+                .login_guard
+                .record_failure(client_ip, PASSWORD_ACCOUNT);
+            (StatusCode::UNAUTHORIZED, "invalid password").into_response()
+        },
         Err(e) => (
             StatusCode::INTERNAL_SERVER_ERROR,
             format!("auth error: {e}"),
@@ -802,10 +853,22 @@ struct PasskeyAuthFinishRequest {
 
 async fn passkey_auth_finish_handler(
     State(state): State<AuthState>,
+    ConnectInfo(addr): ConnectInfo<SocketAddr>,
     Host(host): Host,
     headers: axum::http::HeaderMap,
     Json(body): Json<PasskeyAuthFinishRequest>,
 ) -> impl IntoResponse {
+    let client_ip = crate::request_throttle::resolve_client_ip(
+        &headers,
+        addr,
+        state.gateway_state.behind_proxy,
+    );
+    const PASSKEY_ACCOUNT: &str = "__passkey__";
+
+    if let Some(block) = state.login_guard.check(client_ip, PASSKEY_ACCOUNT) {
+        return blocked_response(block);
+    }
+
     let Some(ref registry) = state.webauthn_registry else {
         return (StatusCode::NOT_IMPLEMENTED, "passkeys not configured").into_response();
     };
@@ -818,14 +881,20 @@ async fn passkey_auth_finish_handler(
     };
 
     match wa.finish_authentication(&body.challenge_id, &body.credential) {
-        Ok(_result) => match state.credential_store.create_session().await {
-            Ok(token) => {
-                let bp = state.gateway_state.behind_proxy;
-                session_response(token, &headers, bp, state.gateway_state.tls_active || bp)
-            },
-            Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
+        Ok(_result) => {
+            state.login_guard.record_success(client_ip);
+            match state.credential_store.create_session().await {
+                Ok(token) => {
+                    let bp = state.gateway_state.behind_proxy;
+                    session_response(token, &headers, bp, state.gateway_state.tls_active || bp)
+                },
+                Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
+            }
         },
-        Err(e) => (StatusCode::UNAUTHORIZED, e.to_string()).into_response(),
+        Err(e) => {
+            state.login_guard.record_failure(client_ip, PASSKEY_ACCOUNT);
+            (StatusCode::UNAUTHORIZED, e.to_string()).into_response()
+        },
     }
 }
 

--- a/crates/httpd/src/lib.rs
+++ b/crates/httpd/src/lib.rs
@@ -11,6 +11,7 @@ pub mod auth_middleware;
 pub mod auth_routes;
 pub mod channel_webhook_middleware;
 pub mod env_routes;
+pub mod login_guard;
 pub mod request_throttle;
 pub mod server;
 pub mod ssh_routes;

--- a/crates/httpd/src/login_guard.rs
+++ b/crates/httpd/src/login_guard.rs
@@ -1,0 +1,451 @@
+//! Brute-force protection for authentication endpoints.
+//!
+//! Provides two complementary defences:
+//!
+//! 1. **IP ban** — after [`IP_BAN_THRESHOLD`] consecutive failures from a single
+//!    IP address the IP is banned with exponential back-off
+//!    (5 min → 15 min → 1 hour → 24 hours, capped).
+//!
+//! 2. **Account lockout** — after [`ACCOUNT_LOCKOUT_IP_THRESHOLD`] *distinct* IPs
+//!    fail for the same account within [`ACCOUNT_LOCKOUT_WINDOW`] the account is
+//!    locked for [`ACCOUNT_LOCKOUT_DURATION`].
+//!
+//! Both layers are in-memory ([`DashMap`]) and cleaned up periodically.
+
+use std::{
+    collections::HashSet,
+    net::IpAddr,
+    sync::{
+        Arc,
+        atomic::{AtomicU64, Ordering},
+    },
+    time::{Duration, Instant},
+};
+
+use dashmap::DashMap;
+
+// ── Tuning constants ─────────────────────────────────────────────────────────
+
+/// Consecutive failures from a single IP before it is banned.
+const IP_BAN_THRESHOLD: u32 = 10;
+
+/// Base ban duration (first offence).
+const IP_BAN_BASE: Duration = Duration::from_secs(5 * 60); // 5 minutes
+
+/// Maximum ban duration after repeated escalations.
+const IP_BAN_CAP: Duration = Duration::from_secs(24 * 60 * 60); // 24 hours
+
+/// Number of distinct IPs that must fail for the same account
+/// within [`ACCOUNT_LOCKOUT_WINDOW`] to trigger a lockout.
+const ACCOUNT_LOCKOUT_IP_THRESHOLD: usize = 3;
+
+/// Sliding window for counting distinct IPs per account.
+const ACCOUNT_LOCKOUT_WINDOW: Duration = Duration::from_secs(15 * 60); // 15 minutes
+
+/// How long a locked-out account stays locked.
+const ACCOUNT_LOCKOUT_DURATION: Duration = Duration::from_secs(15 * 60); // 15 minutes
+
+/// Run cleanup every N `record_failure` calls.
+const CLEANUP_EVERY: u64 = 128;
+
+// ── Per-IP state ─────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone)]
+struct IpRecord {
+    /// Consecutive failures (reset on success).
+    consecutive_failures: u32,
+    /// Number of bans this IP has accumulated (drives escalation).
+    ban_count: u32,
+    /// If banned, when the ban expires.
+    banned_until: Option<Instant>,
+    /// When the last failure was recorded (for staleness cleanup).
+    last_failure_at: Instant,
+}
+
+// ── Per-account state ────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone)]
+struct AccountRecord {
+    /// `(ip, first_failure_time)` pairs within the window.
+    recent_ips: Vec<(IpAddr, Instant)>,
+    /// If locked, when the lockout expires.
+    locked_until: Option<Instant>,
+}
+
+// ── Why a login attempt was rejected ─────────────────────────────────────────
+
+/// Reason a login attempt was blocked before credentials were checked.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BlockReason {
+    /// The source IP is temporarily banned.
+    IpBanned { retry_after: Duration },
+    /// The target account is temporarily locked.
+    AccountLocked { retry_after: Duration },
+}
+
+// ── LoginGuard ───────────────────────────────────────────────────────────────
+
+/// Thread-safe, in-memory brute-force guard.
+///
+/// Call [`check`] before verifying credentials and [`record_failure`] /
+/// [`record_success`] after the outcome is known.
+#[derive(Clone)]
+pub struct LoginGuard {
+    ips: Arc<DashMap<IpAddr, IpRecord>>,
+    /// Keyed by "account identifier" — for password auth this is a fixed
+    /// sentinel (`"__password__"`) because moltis has a single admin account.
+    accounts: Arc<DashMap<String, AccountRecord>>,
+    calls: Arc<AtomicU64>,
+}
+
+impl LoginGuard {
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            ips: Arc::new(DashMap::new()),
+            accounts: Arc::new(DashMap::new()),
+            calls: Arc::new(AtomicU64::new(0)),
+        }
+    }
+
+    /// Check whether the request should be blocked *before* credential
+    /// verification.  Returns `None` if the attempt is allowed.
+    pub fn check(&self, ip: IpAddr, account: &str) -> Option<BlockReason> {
+        self.check_at(ip, account, Instant::now())
+    }
+
+    fn check_at(&self, ip: IpAddr, account: &str, now: Instant) -> Option<BlockReason> {
+        // Check IP ban first.
+        if let Some(rec) = self.ips.get(&ip)
+            && let Some(until) = rec.banned_until
+            && now < until
+        {
+            return Some(BlockReason::IpBanned {
+                retry_after: until.duration_since(now),
+            });
+        }
+
+        // Check account lockout.
+        if let Some(rec) = self.accounts.get(account)
+            && let Some(until) = rec.locked_until
+            && now < until
+        {
+            return Some(BlockReason::AccountLocked {
+                retry_after: until.duration_since(now),
+            });
+        }
+
+        None
+    }
+
+    /// Record a failed authentication attempt.
+    pub fn record_failure(&self, ip: IpAddr, account: &str) {
+        self.record_failure_at(ip, account, Instant::now());
+    }
+
+    fn record_failure_at(&self, ip: IpAddr, account: &str, now: Instant) {
+        // ── Update per-IP record ─────────────────────────────────────────
+        let mut ip_entry = self.ips.entry(ip).or_insert_with(|| IpRecord {
+            consecutive_failures: 0,
+            ban_count: 0,
+            banned_until: None,
+            last_failure_at: now,
+        });
+
+        ip_entry.consecutive_failures += 1;
+        ip_entry.last_failure_at = now;
+
+        if ip_entry.consecutive_failures >= IP_BAN_THRESHOLD {
+            ip_entry.ban_count += 1;
+            let multiplier = 1u32 << ip_entry.ban_count.saturating_sub(1).min(10);
+            let ban_duration = (IP_BAN_BASE * multiplier).min(IP_BAN_CAP);
+            ip_entry.banned_until = Some(now + ban_duration);
+            // Reset counter so the next window starts fresh after the ban.
+            ip_entry.consecutive_failures = 0;
+        }
+        drop(ip_entry);
+
+        // ── Update per-account record ────────────────────────────────────
+        let mut acct_entry =
+            self.accounts
+                .entry(account.to_owned())
+                .or_insert_with(|| AccountRecord {
+                    recent_ips: Vec::new(),
+                    locked_until: None,
+                });
+
+        // Prune IPs outside the window.
+        acct_entry
+            .recent_ips
+            .retain(|&(_, t)| now.duration_since(t) < ACCOUNT_LOCKOUT_WINDOW);
+
+        // Add this IP if not already tracked in the current window.
+        if !acct_entry
+            .recent_ips
+            .iter()
+            .any(|&(recorded_ip, _)| recorded_ip == ip)
+        {
+            acct_entry.recent_ips.push((ip, now));
+        }
+
+        let distinct_ips: HashSet<IpAddr> =
+            acct_entry.recent_ips.iter().map(|&(ip, _)| ip).collect();
+        if distinct_ips.len() >= ACCOUNT_LOCKOUT_IP_THRESHOLD {
+            acct_entry.locked_until = Some(now + ACCOUNT_LOCKOUT_DURATION);
+            acct_entry.recent_ips.clear();
+        }
+        drop(acct_entry);
+
+        // Periodic cleanup.
+        let calls = self.calls.fetch_add(1, Ordering::Relaxed) + 1;
+        if calls.is_multiple_of(CLEANUP_EVERY) {
+            self.cleanup(now);
+        }
+    }
+
+    /// Record a successful authentication — clears IP failure counter.
+    pub fn record_success(&self, ip: IpAddr) {
+        if let Some(mut rec) = self.ips.get_mut(&ip) {
+            rec.consecutive_failures = 0;
+            // Clear the ban if it's expired (or let it ride if still active —
+            // a successful login means the request wasn't blocked, so the ban
+            // must have already expired).
+            rec.banned_until = None;
+        }
+    }
+
+    fn cleanup(&self, now: Instant) {
+        // Remove expired IP records. Keep if:
+        // - actively banned, OR
+        // - has recent failures (within the lockout window).
+        self.ips.retain(|_, rec| {
+            if let Some(until) = rec.banned_until
+                && now < until
+            {
+                return true;
+            }
+            // Keep if there were recent failures (could still contribute
+            // to a ban if more arrive soon).
+            rec.consecutive_failures > 0
+                && now.duration_since(rec.last_failure_at) < ACCOUNT_LOCKOUT_WINDOW
+        });
+
+        // Remove expired account lockouts with no recent IPs.
+        self.accounts.retain(|_, rec| {
+            rec.recent_ips
+                .retain(|&(_, t)| now.duration_since(t) < ACCOUNT_LOCKOUT_WINDOW);
+            if !rec.recent_ips.is_empty() {
+                return true;
+            }
+            match rec.locked_until {
+                Some(until) => now < until,
+                None => false,
+            }
+        });
+    }
+}
+
+impl Default for LoginGuard {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use std::net::Ipv4Addr;
+
+    use super::*;
+
+    fn ip(last: u8) -> IpAddr {
+        IpAddr::V4(Ipv4Addr::new(10, 0, 0, last))
+    }
+
+    #[test]
+    fn allows_initial_attempt() {
+        let guard = LoginGuard::new();
+        assert!(guard.check(ip(1), "admin").is_none());
+    }
+
+    #[test]
+    fn bans_ip_after_threshold() {
+        let guard = LoginGuard::new();
+        let now = Instant::now();
+
+        // 10 failures should trigger ban.
+        for i in 0..IP_BAN_THRESHOLD {
+            assert!(
+                guard.check_at(ip(1), "admin", now).is_none(),
+                "attempt {i} should be allowed"
+            );
+            guard.record_failure_at(ip(1), "admin", now);
+        }
+
+        // Next attempt is blocked.
+        let block = guard.check_at(ip(1), "admin", now);
+        assert!(
+            matches!(block, Some(BlockReason::IpBanned { .. })),
+            "expected IP ban, got {block:?}"
+        );
+
+        // A different IP is not affected.
+        assert!(guard.check_at(ip(2), "admin", now).is_none());
+    }
+
+    #[test]
+    fn ip_ban_expires() {
+        let guard = LoginGuard::new();
+        let now = Instant::now();
+
+        for _ in 0..IP_BAN_THRESHOLD {
+            guard.record_failure_at(ip(1), "admin", now);
+        }
+        assert!(guard.check_at(ip(1), "admin", now).is_some());
+
+        // After ban duration + 1 second, should be allowed again.
+        let after = now + IP_BAN_BASE + Duration::from_secs(1);
+        assert!(guard.check_at(ip(1), "admin", after).is_none());
+    }
+
+    #[test]
+    fn ip_ban_escalates() {
+        let guard = LoginGuard::new();
+        let mut now = Instant::now();
+
+        // First ban: 5 minutes.
+        for _ in 0..IP_BAN_THRESHOLD {
+            guard.record_failure_at(ip(1), "admin", now);
+        }
+        if let Some(BlockReason::IpBanned { retry_after }) = guard.check_at(ip(1), "admin", now) {
+            assert!(
+                retry_after <= IP_BAN_BASE,
+                "first ban should be ~5min, got {retry_after:?}"
+            );
+        } else {
+            panic!("expected ban");
+        }
+
+        // Advance past first ban.
+        now += IP_BAN_BASE + Duration::from_secs(1);
+
+        // Second ban: 10 minutes.
+        for _ in 0..IP_BAN_THRESHOLD {
+            guard.record_failure_at(ip(1), "admin", now);
+        }
+        if let Some(BlockReason::IpBanned { retry_after }) = guard.check_at(ip(1), "admin", now) {
+            assert!(
+                retry_after > IP_BAN_BASE,
+                "second ban should be escalated, got {retry_after:?}"
+            );
+        } else {
+            panic!("expected escalated ban");
+        }
+    }
+
+    #[test]
+    fn success_clears_ip_state() {
+        let guard = LoginGuard::new();
+        let now = Instant::now();
+
+        for _ in 0..(IP_BAN_THRESHOLD - 1) {
+            guard.record_failure_at(ip(1), "admin", now);
+        }
+
+        // One more failure would ban — but success resets.
+        guard.record_success(ip(1));
+        guard.record_failure_at(ip(1), "admin", now);
+        assert!(
+            guard.check_at(ip(1), "admin", now).is_none(),
+            "counter should have reset on success"
+        );
+    }
+
+    #[test]
+    fn account_locks_after_distinct_ips() {
+        let guard = LoginGuard::new();
+        let now = Instant::now();
+
+        // Failures from 3 distinct IPs targeting the same account.
+        guard.record_failure_at(ip(1), "admin", now);
+        guard.record_failure_at(ip(2), "admin", now);
+        assert!(
+            guard.check_at(ip(4), "admin", now).is_none(),
+            "should not be locked after 2 IPs"
+        );
+
+        guard.record_failure_at(ip(3), "admin", now);
+
+        // Account is now locked — even a new IP is blocked.
+        let block = guard.check_at(ip(4), "admin", now);
+        assert!(
+            matches!(block, Some(BlockReason::AccountLocked { .. })),
+            "expected account lockout, got {block:?}"
+        );
+    }
+
+    #[test]
+    fn account_lockout_expires() {
+        let guard = LoginGuard::new();
+        let now = Instant::now();
+
+        guard.record_failure_at(ip(1), "admin", now);
+        guard.record_failure_at(ip(2), "admin", now);
+        guard.record_failure_at(ip(3), "admin", now);
+
+        assert!(guard.check_at(ip(4), "admin", now).is_some());
+
+        let after = now + ACCOUNT_LOCKOUT_DURATION + Duration::from_secs(1);
+        assert!(guard.check_at(ip(4), "admin", after).is_none());
+    }
+
+    #[test]
+    fn account_lockout_requires_ips_within_window() {
+        let guard = LoginGuard::new();
+        let now = Instant::now();
+
+        // IP 1 fails at t=0.
+        guard.record_failure_at(ip(1), "admin", now);
+
+        // IP 2 fails after the window expires — IP 1 should be pruned.
+        let later = now + ACCOUNT_LOCKOUT_WINDOW + Duration::from_secs(1);
+        guard.record_failure_at(ip(2), "admin", later);
+        guard.record_failure_at(ip(3), "admin", later);
+
+        // Only 2 IPs in window (ip(1) expired), so no lockout.
+        assert!(guard.check_at(ip(4), "admin", later).is_none());
+    }
+
+    #[test]
+    fn ip_ban_checked_before_account_lockout() {
+        let guard = LoginGuard::new();
+        let now = Instant::now();
+
+        // Ban IP first.
+        for _ in 0..IP_BAN_THRESHOLD {
+            guard.record_failure_at(ip(1), "admin", now);
+        }
+
+        let block = guard.check_at(ip(1), "admin", now);
+        assert!(
+            matches!(block, Some(BlockReason::IpBanned { .. })),
+            "IP ban should take precedence"
+        );
+    }
+
+    #[test]
+    fn cleanup_removes_stale_entries() {
+        let guard = LoginGuard::new();
+        let now = Instant::now();
+
+        guard.record_failure_at(ip(1), "admin", now);
+
+        // Well past all windows and bans.
+        let far_future = now + Duration::from_secs(100_000);
+        guard.cleanup(far_future);
+
+        assert!(guard.ips.is_empty());
+        assert!(guard.accounts.is_empty());
+    }
+}

--- a/crates/httpd/src/request_throttle.rs
+++ b/crates/httpd/src/request_throttle.rs
@@ -284,7 +284,7 @@ fn rate_limited_response(path: String, retry_after: Duration) -> Response {
     response
 }
 
-fn resolve_client_ip(headers: &HeaderMap, addr: SocketAddr, behind_proxy: bool) -> IpAddr {
+pub fn resolve_client_ip(headers: &HeaderMap, addr: SocketAddr, behind_proxy: bool) -> IpAddr {
     if behind_proxy && let Some(ip) = extract_forwarded_ip(headers) {
         return ip;
     }

--- a/crates/httpd/src/server.rs
+++ b/crates/httpd/src/server.rs
@@ -373,6 +373,10 @@ where
             header::HeaderName::from_static("referrer-policy"),
             HeaderValue::from_static("strict-origin-when-cross-origin"),
         ))
+        .layer(SetResponseHeaderLayer::overriding(
+            header::HeaderName::from_static("permissions-policy"),
+            HeaderValue::from_static("camera=(), microphone=(self), geolocation=(), payment=()"),
+        ))
         .layer(PropagateRequestIdLayer::x_request_id())
         .layer(cors);
 
@@ -656,6 +660,16 @@ pub fn finalize_gateway_app(
         app_state.clone(),
         crate::request_throttle::throttle_gate,
     ));
+    // HSTS: instruct browsers to always use HTTPS once they've connected securely.
+    let router = if app_state.gateway.is_secure() {
+        use axum::http::{HeaderValue, header};
+        router.layer(SetResponseHeaderLayer::overriding(
+            header::STRICT_TRANSPORT_SECURITY,
+            HeaderValue::from_static("max-age=31536000; includeSubDomains"),
+        ))
+    } else {
+        router
+    };
     let router = apply_middleware_stack(router, cors, http_request_logs);
     router.with_state(app_state)
 }

--- a/crates/httpd/src/server.rs
+++ b/crates/httpd/src/server.rs
@@ -454,6 +454,7 @@ fn build_gateway_base_internal(
             credential_store: Arc::clone(cred_store),
             webauthn_registry: webauthn_registry.clone(),
             gateway_state: Arc::clone(&state),
+            login_guard: crate::login_guard::LoginGuard::new(),
         };
         router = router.nest("/api/auth", auth_router().with_state(auth_state));
     }
@@ -556,6 +557,7 @@ fn build_gateway_base_internal(
             credential_store: Arc::clone(cred_store),
             webauthn_registry: webauthn_registry.clone(),
             gateway_state: Arc::clone(&state),
+            login_guard: crate::login_guard::LoginGuard::new(),
         };
         router = router.nest("/api/auth", auth_router().with_state(auth_state));
     }

--- a/crates/httpd/src/server.rs
+++ b/crates/httpd/src/server.rs
@@ -2617,6 +2617,12 @@ pub async fn start_gateway(
     if banner.sandbox_backend_name == "none" {
         lines.push("⚠ no container runtime found; commands run on host".into());
     }
+    // Warn when TLS is off and the server is not localhost-only.
+    if !tls_active && !is_localhost {
+        lines.push(
+            "⚠ TLS is disabled on a non-localhost bind address; session cookies will be sent over unencrypted HTTP".into(),
+        );
+    }
     // Display setup code if one was generated.
     if let Some(ref code) = banner.setup_code_display {
         lines.extend(startup_setup_code_lines(code));
@@ -2835,8 +2841,8 @@ async fn ws_upgrade_handler(
     let remote_ip = extract_ws_client_ip(&headers, addr).filter(|ip| is_public_ip(ip));
 
     let is_local = is_local_connection(&headers, addr, state.gateway.behind_proxy);
-    let header_authenticated =
-        websocket_header_authenticated(&headers, state.gateway.credential_store.as_ref(), is_local)
+    let header_identity =
+        websocket_header_authenticate(&headers, state.gateway.credential_store.as_ref(), is_local)
             .await;
     ws.on_upgrade(move |socket| {
         handle_connection(
@@ -2846,7 +2852,7 @@ async fn ws_upgrade_handler(
             addr,
             accept_language,
             remote_ip,
-            header_authenticated,
+            header_identity,
             is_local,
         )
     })
@@ -2939,19 +2945,17 @@ fn is_public_ip(ip: &str) -> bool {
 
 pub(crate) use moltis_auth::locality::is_local_connection;
 
-async fn websocket_header_authenticated(
+async fn websocket_header_authenticate(
     headers: &axum::http::HeaderMap,
     credential_store: Option<&Arc<auth::CredentialStore>>,
     is_local: bool,
-) -> bool {
-    let Some(store) = credential_store else {
-        return false;
-    };
+) -> Option<auth::AuthIdentity> {
+    let store = credential_store?;
 
-    matches!(
-        crate::auth_middleware::check_auth(store, headers, is_local).await,
-        crate::auth_middleware::AuthResult::Allowed(_)
-    )
+    match crate::auth_middleware::check_auth(store, headers, is_local).await {
+        crate::auth_middleware::AuthResult::Allowed(identity) => Some(identity),
+        _ => None,
+    }
 }
 
 /// Resolve the machine's primary outbound IP address.

--- a/crates/httpd/src/tools_routes.rs
+++ b/crates/httpd/src/tools_routes.rs
@@ -6,7 +6,10 @@
 //! They are protected by auth middleware, but also have explicit checks to ensure
 //! they never work without authentication on non-localhost connections.
 
-use axum::{Json, extract::State, http::StatusCode, response::IntoResponse};
+use {
+    axum::{Json, extract::State, http::StatusCode, response::IntoResponse},
+    moltis_gateway::auth::AuthIdentity,
+};
 
 const CONFIG_AUTH_REQUIRED: &str = "CONFIG_AUTH_REQUIRED";
 const CONFIG_READ_FAILED: &str = "CONFIG_READ_FAILED";
@@ -29,8 +32,27 @@ fn config_error(code: &str, error: impl Into<String>) -> serde_json::Value {
 /// - Running on localhost (loopback interface only), OR
 /// - User is authenticated via session or API key
 ///
+/// When `require_admin` is true, API keys must have the `operator.admin`
+/// scope (password/passkey/loopback always have full access).
+///
 /// This is a defense-in-depth check on top of the auth middleware.
-async fn require_config_access(state: &crate::server::AppState) -> Result<(), impl IntoResponse> {
+async fn require_config_access(
+    state: &crate::server::AppState,
+    identity: Option<&AuthIdentity>,
+    require_admin: bool,
+) -> Result<(), impl IntoResponse> {
+    if require_admin
+        && let Some(id) = identity
+        && !id.has_scope("operator.admin")
+    {
+        return Err((
+            StatusCode::FORBIDDEN,
+            Json(config_error(
+                "INSUFFICIENT_SCOPE",
+                "operator.admin scope required",
+            )),
+        ));
+    }
     let gw = &state.gateway;
 
     // On localhost with no password set, allow access (backward compat for initial setup)
@@ -85,7 +107,7 @@ async fn require_config_access(state: &crate::server::AppState) -> Result<(), im
 /// Get the current configuration as TOML.
 pub async fn config_get(State(state): State<crate::server::AppState>) -> impl IntoResponse {
     // Extra security check for config access
-    if let Err(resp) = require_config_access(&state).await {
+    if let Err(resp) = require_config_access(&state, None, false).await {
         return resp.into_response();
     }
 
@@ -125,7 +147,7 @@ pub async fn config_validate(
     Json(body): Json<serde_json::Value>,
 ) -> impl IntoResponse {
     // Extra security check for config access
-    if let Err(resp) = require_config_access(&state).await {
+    if let Err(resp) = require_config_access(&state, None, false).await {
         return resp.into_response();
     }
 
@@ -166,7 +188,7 @@ pub async fn config_validate(
 /// Preserves the current port from the existing config.
 pub async fn config_template(State(state): State<crate::server::AppState>) -> impl IntoResponse {
     // Extra security check for config access
-    if let Err(resp) = require_config_access(&state).await {
+    if let Err(resp) = require_config_access(&state, None, false).await {
         return resp.into_response();
     }
 
@@ -182,11 +204,12 @@ pub async fn config_template(State(state): State<crate::server::AppState>) -> im
 
 /// Save configuration from TOML.
 pub async fn config_save(
+    identity: Option<axum::Extension<AuthIdentity>>,
     State(state): State<crate::server::AppState>,
     Json(body): Json<serde_json::Value>,
 ) -> impl IntoResponse {
-    // Extra security check for config access
-    if let Err(resp) = require_config_access(&state).await {
+    let id_ref = identity.as_ref().map(|axum::Extension(id)| id);
+    if let Err(resp) = require_config_access(&state, id_ref, true).await {
         return resp.into_response();
     }
 
@@ -239,9 +262,12 @@ pub async fn config_save(
 ///
 /// Before restarting, the saved config is loaded from disk and validated. If the config
 /// is invalid the restart is refused so the server doesn't crash on startup.
-pub async fn restart(State(state): State<crate::server::AppState>) -> impl IntoResponse {
-    // Extra security check for config access (restart is a privileged operation)
-    if let Err(resp) = require_config_access(&state).await {
+pub async fn restart(
+    identity: Option<axum::Extension<AuthIdentity>>,
+    State(state): State<crate::server::AppState>,
+) -> impl IntoResponse {
+    let id_ref = identity.as_ref().map(|axum::Extension(id)| id);
+    if let Err(resp) = require_config_access(&state, id_ref, true).await {
         return resp.into_response();
     }
 

--- a/crates/httpd/src/ws.rs
+++ b/crates/httpd/src/ws.rs
@@ -7,10 +7,13 @@ use {
     tracing::{debug, info, warn},
 };
 
-use moltis_protocol::{
-    ConnectParams, ConnectParamsV4, ErrorShape, EventFrame, Extensions, Features, GatewayFrame,
-    HANDSHAKE_TIMEOUT_MS, HelloAuth, HelloOk, KNOWN_EVENTS, MAX_PAYLOAD_BYTES, PROTOCOL_VERSION,
-    Policy, ResponseFrame, ServerInfo, error_codes, roles, scopes,
+use {
+    moltis_gateway::auth::{AuthIdentity, AuthMethod},
+    moltis_protocol::{
+        ConnectParams, ConnectParamsV4, ErrorShape, EventFrame, Extensions, Features, GatewayFrame,
+        HANDSHAKE_TIMEOUT_MS, HelloAuth, HelloOk, KNOWN_EVENTS, MAX_PAYLOAD_BYTES,
+        PROTOCOL_VERSION, Policy, ResponseFrame, ServerInfo, error_codes, roles, scopes,
+    },
 };
 
 use moltis_gateway::{
@@ -38,7 +41,7 @@ pub async fn handle_connection(
     remote_addr: SocketAddr,
     accept_language: Option<String>,
     remote_ip: Option<String>,
-    header_authenticated: bool,
+    header_identity: Option<AuthIdentity>,
     is_local: bool,
 ) {
     let conn_id = uuid::Uuid::new_v4().to_string();
@@ -141,9 +144,14 @@ pub async fn handle_connection(
     //   - TCP source IP loopback check
     //
     // See CVE-2026-25253 for the analogous OpenClaw vulnerability.
-    let mut authenticated = header_authenticated;
+    let mut authenticated = header_identity.is_some();
     // Scopes from API key verification (if any).
-    let mut api_key_scopes: Option<Vec<String>> = None;
+    // When authenticated via HTTP header (cookie/bearer), scopes come from
+    // the AuthIdentity. API-key scopes are non-empty; password/loopback
+    // scopes are empty (= full access).
+    let mut api_key_scopes: Option<Vec<String>> = header_identity
+        .filter(|id| id.method == AuthMethod::ApiKey)
+        .map(|id| id.scopes);
     // Device token verification result (if any).
     let mut device_token_device_id: Option<String> = None;
 
@@ -242,7 +250,7 @@ pub async fn handle_connection(
         warn!(
             conn_id = %conn_id,
             is_local,
-            header_authenticated,
+            authenticated,
             setup_complete,
             has_api_key,
             has_password,

--- a/crates/httpd/tests/auth_middleware.rs
+++ b/crates/httpd/tests/auth_middleware.rs
@@ -324,7 +324,7 @@ async fn setup_not_complete_passes_through() {
 #[tokio::test]
 async fn unauthenticated_returns_401() {
     let (addr, store) = start_auth_server().await;
-    store.set_initial_password("testpass123").await.unwrap();
+    store.set_initial_password("testpass12345").await.unwrap();
 
     let resp = reqwest::get(format!("http://{addr}/api/bootstrap"))
         .await
@@ -339,7 +339,7 @@ async fn unauthenticated_returns_401() {
 #[tokio::test]
 async fn session_cookie_auth_succeeds() {
     let (addr, store) = start_auth_server().await;
-    store.set_initial_password("testpass123").await.unwrap();
+    store.set_initial_password("testpass12345").await.unwrap();
     let token = store.create_session().await.unwrap();
 
     let client = reqwest::Client::new();
@@ -357,7 +357,7 @@ async fn session_cookie_auth_succeeds() {
 #[tokio::test]
 async fn api_key_auth_succeeds() {
     let (addr, store) = start_auth_server().await;
-    store.set_initial_password("testpass123").await.unwrap();
+    store.set_initial_password("testpass12345").await.unwrap();
     let (_id, raw_key) = store.create_api_key("test", None).await.unwrap();
 
     let client = reqwest::Client::new();
@@ -375,7 +375,7 @@ async fn api_key_auth_succeeds() {
 #[tokio::test]
 async fn images_endpoint_returns_401() {
     let (addr, store) = start_auth_server().await;
-    store.set_initial_password("testpass123").await.unwrap();
+    store.set_initial_password("testpass12345").await.unwrap();
 
     let resp = reqwest::get(format!("http://{addr}/api/images/cached"))
         .await
@@ -388,7 +388,7 @@ async fn images_endpoint_returns_401() {
 #[tokio::test]
 async fn public_routes_accessible_without_auth() {
     let (addr, store) = start_auth_server().await;
-    store.set_initial_password("testpass123").await.unwrap();
+    store.set_initial_password("testpass12345").await.unwrap();
 
     // /health is always public.
     let resp = reqwest::get(format!("http://{addr}/health")).await.unwrap();
@@ -434,7 +434,7 @@ async fn public_routes_accessible_without_auth() {
 #[tokio::test]
 async fn graphql_requires_auth_when_enabled() {
     let (addr, store) = start_auth_server().await;
-    store.set_initial_password("testpass123").await.unwrap();
+    store.set_initial_password("testpass12345").await.unwrap();
 
     let client = reqwest::Client::builder()
         .redirect(reqwest::redirect::Policy::none())
@@ -460,7 +460,7 @@ async fn graphql_requires_auth_when_enabled() {
 #[tokio::test]
 async fn graphql_runtime_toggle_applies_immediately() {
     let (addr, store, state) = start_auth_server_with_state().await;
-    store.set_initial_password("testpass123").await.unwrap();
+    store.set_initial_password("testpass12345").await.unwrap();
     let token = store.create_session().await.unwrap();
 
     let client = reqwest::Client::new();
@@ -502,7 +502,7 @@ async fn graphql_runtime_toggle_applies_immediately() {
 #[tokio::test]
 async fn graphql_status_includes_uptime_ms() {
     let (addr, store) = start_auth_server().await;
-    store.set_initial_password("testpass123").await.unwrap();
+    store.set_initial_password("testpass12345").await.unwrap();
     let token = store.create_session().await.unwrap();
 
     let client = reqwest::Client::new();
@@ -571,7 +571,7 @@ async fn graphql_websocket_upgrade_not_supported_on_legacy_path() {
 #[tokio::test]
 async fn invalid_session_cookie_returns_401() {
     let (addr, store) = start_auth_server().await;
-    store.set_initial_password("testpass123").await.unwrap();
+    store.set_initial_password("testpass12345").await.unwrap();
 
     let client = reqwest::Client::new();
     let resp = client
@@ -588,7 +588,7 @@ async fn invalid_session_cookie_returns_401() {
 #[tokio::test]
 async fn reset_auth_removes_all_authentication() {
     let (addr, store) = start_auth_server().await;
-    store.set_initial_password("testpass123").await.unwrap();
+    store.set_initial_password("testpass12345").await.unwrap();
     let token = store.create_session().await.unwrap();
 
     // Protected endpoint requires auth.
@@ -642,7 +642,7 @@ async fn reset_auth_removes_all_authentication() {
 #[tokio::test]
 async fn reenable_auth_after_reset() {
     let (addr, store, state) = start_auth_server_with_state().await;
-    store.set_initial_password("testpass123").await.unwrap();
+    store.set_initial_password("testpass12345").await.unwrap();
     let token = store.create_session().await.unwrap();
 
     // Reset auth.
@@ -670,7 +670,7 @@ async fn reenable_auth_after_reset() {
     let resp = client
         .post(format!("http://{addr}/api/auth/setup"))
         .header("Content-Type", "application/json")
-        .body(r#"{"password":"newpass123"}"#)
+        .body(r#"{"password":"newpass12345678"}"#)
         .send()
         .await
         .unwrap();
@@ -681,7 +681,7 @@ async fn reenable_auth_after_reset() {
         .post(format!("http://{addr}/api/auth/setup"))
         .header("Content-Type", "application/json")
         .body(format!(
-            r#"{{"password":"newpass123","setup_code":"{code}"}}"#
+            r#"{{"password":"newpass12345678","setup_code":"{code}"}}"#
         ))
         .send()
         .await
@@ -708,7 +708,7 @@ async fn reenable_auth_after_reset() {
 #[tokio::test]
 async fn reset_auth_requires_session() {
     let (addr, store) = start_auth_server().await;
-    store.set_initial_password("testpass123").await.unwrap();
+    store.set_initial_password("testpass12345").await.unwrap();
 
     let client = reqwest::Client::new();
     let resp = client
@@ -724,7 +724,7 @@ async fn reset_auth_requires_session() {
 #[tokio::test]
 async fn revoked_api_key_returns_401() {
     let (addr, store) = start_auth_server().await;
-    store.set_initial_password("testpass123").await.unwrap();
+    store.set_initial_password("testpass12345").await.unwrap();
     let (id, raw_key) = store.create_api_key("test", None).await.unwrap();
     store.revoke_api_key(id).await.unwrap();
 
@@ -751,7 +751,7 @@ async fn setup_without_code_when_required_returns_403() {
     let resp = client
         .post(format!("http://{addr}/api/auth/setup"))
         .header("Content-Type", "application/json")
-        .body(r#"{"password":"testpass123"}"#)
+        .body(r#"{"password":"testpass12345"}"#)
         .send()
         .await
         .unwrap();
@@ -769,7 +769,7 @@ async fn setup_with_wrong_code_returns_403() {
     let resp = client
         .post(format!("http://{addr}/api/auth/setup"))
         .header("Content-Type", "application/json")
-        .body(r#"{"password":"testpass123","setup_code":"999999"}"#)
+        .body(r#"{"password":"testpass12345","setup_code":"999999"}"#)
         .send()
         .await
         .unwrap();
@@ -787,7 +787,7 @@ async fn setup_with_correct_code_succeeds() {
     let resp = client
         .post(format!("http://{addr}/api/auth/setup"))
         .header("Content-Type", "application/json")
-        .body(r#"{"password":"testpass123","setup_code":"123456"}"#)
+        .body(r#"{"password":"testpass12345","setup_code":"123456"}"#)
         .send()
         .await
         .unwrap();
@@ -802,7 +802,7 @@ async fn setup_with_correct_code_succeeds() {
 #[tokio::test]
 async fn setup_code_not_required_when_already_setup() {
     let (addr, store, _state) = start_auth_server_with_state().await;
-    store.set_initial_password("testpass123").await.unwrap();
+    store.set_initial_password("testpass12345").await.unwrap();
 
     let resp = reqwest::get(format!("http://{addr}/api/auth/status"))
         .await
@@ -834,7 +834,7 @@ async fn status_reports_setup_code_required() {
 #[tokio::test]
 async fn setup_code_not_required_when_auth_disabled() {
     let (addr, store, _state) = start_auth_server_with_state().await;
-    store.set_initial_password("testpass123").await.unwrap();
+    store.set_initial_password("testpass12345").await.unwrap();
     let token = store.create_session().await.unwrap();
 
     // Reset auth to disable it.
@@ -898,7 +898,7 @@ async fn localhost_set_password_without_current() {
     let resp = client
         .post(format!("http://{addr}/api/auth/password/change"))
         .header("Content-Type", "application/json")
-        .body(r#"{"new_password":"newpass123"}"#)
+        .body(r#"{"new_password":"newpass12345678"}"#)
         .send()
         .await
         .unwrap();
@@ -906,7 +906,7 @@ async fn localhost_set_password_without_current() {
 
     // Password should now be set.
     assert!(store.has_password().await.unwrap());
-    assert!(store.verify_password("newpass123").await.unwrap());
+    assert!(store.verify_password("newpass12345678").await.unwrap());
 
     // After adding a password, localhost bypass should stop applying.
     let status = reqwest::get(format!("http://{addr}/api/auth/status"))
@@ -928,7 +928,7 @@ async fn localhost_set_password_without_current() {
 #[tokio::test]
 async fn upload_endpoint_requires_auth() {
     let (addr, store) = start_auth_server().await;
-    store.set_initial_password("testpass123").await.unwrap();
+    store.set_initial_password("testpass12345").await.unwrap();
 
     // Unauthenticated POST should get 401.
     let client = reqwest::Client::new();
@@ -960,7 +960,7 @@ async fn upload_endpoint_requires_auth() {
 #[tokio::test]
 async fn media_endpoint_requires_auth() {
     let (addr, store) = start_auth_server().await;
-    store.set_initial_password("testpass123").await.unwrap();
+    store.set_initial_password("testpass12345").await.unwrap();
 
     // Unauthenticated GET should get 401.
     let resp = reqwest::get(format!("http://{addr}/api/sessions/main/media/test.png"))
@@ -985,7 +985,7 @@ async fn media_endpoint_requires_auth() {
 #[tokio::test]
 async fn localhost_with_password_requires_login() {
     let (addr, store, _state) = start_localhost_server().await;
-    store.set_initial_password("testpass123").await.unwrap();
+    store.set_initial_password("testpass12345").await.unwrap();
 
     let resp = reqwest::get(format!("http://{addr}/api/auth/status"))
         .await
@@ -1087,7 +1087,7 @@ async fn proxied_no_password_auth_status_accessible() {
 #[tokio::test]
 async fn proxied_with_password_requires_auth() {
     let (addr, store, _state) = start_proxied_server().await;
-    store.set_initial_password("testpass123").await.unwrap();
+    store.set_initial_password("testpass12345").await.unwrap();
 
     let resp = reqwest::get(format!("http://{addr}/api/bootstrap"))
         .await
@@ -1115,7 +1115,7 @@ async fn proxied_with_password_requires_auth() {
 #[tokio::test]
 async fn login_cookie_includes_domain_for_localhost_subdomain() {
     let (addr, store, _state) = start_localhost_server().await;
-    store.set_initial_password("testpass123").await.unwrap();
+    store.set_initial_password("testpass12345").await.unwrap();
 
     let client = reqwest::Client::builder()
         .redirect(reqwest::redirect::Policy::none())
@@ -1126,7 +1126,7 @@ async fn login_cookie_includes_domain_for_localhost_subdomain() {
         .post(format!("http://{addr}/api/auth/login"))
         .header("Host", "moltis.localhost:18080")
         .header("Content-Type", "application/json")
-        .body(r#"{"password":"testpass123"}"#)
+        .body(r#"{"password":"testpass12345"}"#)
         .send()
         .await
         .unwrap();
@@ -1152,7 +1152,7 @@ async fn login_cookie_includes_domain_for_localhost_subdomain() {
 #[tokio::test]
 async fn login_cookie_includes_domain_for_plain_localhost() {
     let (addr, store, _state) = start_localhost_server().await;
-    store.set_initial_password("testpass123").await.unwrap();
+    store.set_initial_password("testpass12345").await.unwrap();
 
     let client = reqwest::Client::builder()
         .redirect(reqwest::redirect::Policy::none())
@@ -1163,7 +1163,7 @@ async fn login_cookie_includes_domain_for_plain_localhost() {
         .post(format!("http://{addr}/api/auth/login"))
         .header("Host", "localhost:18080")
         .header("Content-Type", "application/json")
-        .body(r#"{"password":"testpass123"}"#)
+        .body(r#"{"password":"testpass12345"}"#)
         .send()
         .await
         .unwrap();
@@ -1188,7 +1188,7 @@ async fn login_cookie_includes_domain_for_plain_localhost() {
 #[tokio::test]
 async fn login_cookie_omits_domain_for_external_host() {
     let (addr, store, _state) = start_localhost_server().await;
-    store.set_initial_password("testpass123").await.unwrap();
+    store.set_initial_password("testpass12345").await.unwrap();
 
     let client = reqwest::Client::builder()
         .redirect(reqwest::redirect::Policy::none())
@@ -1199,7 +1199,7 @@ async fn login_cookie_omits_domain_for_external_host() {
         .post(format!("http://{addr}/api/auth/login"))
         .header("Host", "mybox.example.com:443")
         .header("Content-Type", "application/json")
-        .body(r#"{"password":"testpass123"}"#)
+        .body(r#"{"password":"testpass12345"}"#)
         .send()
         .await
         .unwrap();
@@ -1223,7 +1223,7 @@ async fn login_cookie_omits_domain_for_external_host() {
 #[tokio::test]
 async fn login_endpoint_rate_limited_after_repeated_failures() {
     let (addr, store) = start_auth_server().await;
-    store.set_initial_password("testpass123").await.unwrap();
+    store.set_initial_password("testpass12345").await.unwrap();
 
     let client = reqwest::Client::new();
 
@@ -1269,7 +1269,7 @@ async fn login_endpoint_rate_limited_after_repeated_failures() {
 #[tokio::test]
 async fn api_endpoint_rate_limited_after_high_request_volume() {
     let (addr, store) = start_auth_server().await;
-    store.set_initial_password("testpass123").await.unwrap();
+    store.set_initial_password("testpass12345").await.unwrap();
 
     let client = reqwest::Client::new();
 
@@ -1432,7 +1432,7 @@ async fn setup_required_page_accessible_for_remote() {
 #[tokio::test]
 async fn setup_required_redirects_to_login_after_setup() {
     let (addr, store, _state) = start_proxied_server().await;
-    store.set_initial_password("testpass123").await.unwrap();
+    store.set_initial_password("testpass12345").await.unwrap();
 
     let client = reqwest::Client::builder()
         .redirect(reqwest::redirect::Policy::none())
@@ -1467,7 +1467,7 @@ async fn setup_required_redirects_to_login_after_setup() {
 #[tokio::test]
 async fn onboarding_requires_auth_after_setup() {
     let (addr, store, _state) = start_proxied_server().await;
-    store.set_initial_password("testpass123").await.unwrap();
+    store.set_initial_password("testpass12345").await.unwrap();
 
     let client = reqwest::Client::builder()
         .redirect(reqwest::redirect::Policy::none())
@@ -1503,7 +1503,7 @@ async fn onboarding_requires_auth_after_setup() {
 #[tokio::test]
 async fn onboarding_accessible_with_session_after_setup() {
     let (addr, store, _state) = start_proxied_server().await;
-    store.set_initial_password("testpass123").await.unwrap();
+    store.set_initial_password("testpass12345").await.unwrap();
     let token = store.create_session().await.unwrap();
 
     let client = reqwest::Client::builder()
@@ -1537,7 +1537,7 @@ async fn onboarding_accessible_with_session_after_setup() {
 #[tokio::test]
 async fn onboarding_remains_accessible_after_auth_reset_when_onboarded() {
     let (addr, store, _state) = start_server_with_onboarding(true, true).await;
-    store.set_initial_password("testpass123").await.unwrap();
+    store.set_initial_password("testpass12345").await.unwrap();
     store.reset_all().await.unwrap();
 
     let client = reqwest::Client::builder()
@@ -1570,7 +1570,7 @@ async fn onboarding_remains_accessible_after_auth_reset_when_onboarded() {
 #[tokio::test]
 async fn setup_endpoint_rejected_after_setup_complete() {
     let (addr, store, _state) = start_proxied_server().await;
-    store.set_initial_password("testpass123").await.unwrap();
+    store.set_initial_password("testpass12345").await.unwrap();
     let token = store.create_session().await.unwrap();
 
     let client = reqwest::Client::new();
@@ -1596,7 +1596,7 @@ async fn setup_endpoint_rejected_after_setup_complete() {
 #[tokio::test]
 async fn authenticated_api_endpoint_not_rate_limited() {
     let (addr, store) = start_auth_server().await;
-    store.set_initial_password("testpass123").await.unwrap();
+    store.set_initial_password("testpass12345").await.unwrap();
     let token = store.create_session().await.unwrap();
 
     let client = reqwest::Client::new();
@@ -1634,7 +1634,7 @@ async fn password_change_initializes_vault() {
     let resp = client
         .post(format!("http://{addr}/api/auth/password/change"))
         .header("Content-Type", "application/json")
-        .body(r#"{"new_password":"newpass123"}"#)
+        .body(r#"{"new_password":"newpass12345678"}"#)
         .send()
         .await
         .unwrap();
@@ -1659,7 +1659,7 @@ async fn password_change_initializes_vault() {
 
     // Password should be set.
     assert!(store.has_password().await.unwrap());
-    assert!(store.verify_password("newpass123").await.unwrap());
+    assert!(store.verify_password("newpass12345678").await.unwrap());
 }
 
 /// Setting a password via /api/auth/password/change when the vault is already
@@ -1681,7 +1681,7 @@ async fn password_change_on_initialized_vault_no_recovery_key() {
     let resp = client
         .post(format!("http://{addr}/api/auth/password/change"))
         .header("Content-Type", "application/json")
-        .body(r#"{"new_password":"newpass123"}"#)
+        .body(r#"{"new_password":"newpass12345678"}"#)
         .send()
         .await
         .unwrap();
@@ -1705,7 +1705,7 @@ async fn password_change_on_initialized_vault_no_recovery_key() {
 #[tokio::test]
 async fn sealed_vault_allows_bootstrap() {
     let (addr, _store, _state, vault) = start_localhost_server_with_vault().await;
-    let _rk = vault.initialize("testpass123").await.unwrap();
+    let _rk = vault.initialize("testpass12345").await.unwrap();
     vault.seal().await;
 
     let blocked_resp = reqwest::get(format!("http://{addr}/api/skills"))
@@ -1735,7 +1735,7 @@ async fn sealed_vault_allows_session_history() {
         )
         .await
         .unwrap();
-    let _rk = vault.initialize("testpass123").await.unwrap();
+    let _rk = vault.initialize("testpass12345").await.unwrap();
     vault.seal().await;
 
     let blocked_resp = reqwest::get(format!("http://{addr}/api/skills"))
@@ -1881,7 +1881,7 @@ async fn start_server_with_onboarding(
 #[tokio::test]
 async fn local_api_during_onboarding_bypasses_auth() {
     let (addr, store, _state) = start_server_with_onboarding(false, false).await;
-    store.set_initial_password("testpass123").await.unwrap();
+    store.set_initial_password("testpass12345").await.unwrap();
 
     let resp = reqwest::get(format!("http://{addr}/api/bootstrap"))
         .await
@@ -1899,7 +1899,7 @@ async fn local_api_during_onboarding_bypasses_auth() {
 #[tokio::test]
 async fn local_api_after_onboarding_requires_auth() {
     let (addr, store, _state) = start_server_with_onboarding(true, false).await;
-    store.set_initial_password("testpass123").await.unwrap();
+    store.set_initial_password("testpass12345").await.unwrap();
 
     let resp = reqwest::get(format!("http://{addr}/api/bootstrap"))
         .await
@@ -1917,7 +1917,7 @@ async fn local_api_after_onboarding_requires_auth() {
 #[tokio::test]
 async fn remote_api_during_onboarding_requires_auth() {
     let (addr, store, _state) = start_server_with_onboarding(false, true).await;
-    store.set_initial_password("testpass123").await.unwrap();
+    store.set_initial_password("testpass12345").await.unwrap();
 
     let resp = reqwest::get(format!("http://{addr}/api/bootstrap"))
         .await
@@ -1936,7 +1936,7 @@ async fn remote_api_during_onboarding_requires_auth() {
 #[tokio::test]
 async fn local_privileged_api_during_onboarding_requires_auth() {
     let (addr, store, _state) = start_server_with_onboarding(false, false).await;
-    store.set_initial_password("testpass123").await.unwrap();
+    store.set_initial_password("testpass12345").await.unwrap();
 
     // /api/config is not in the onboarding bypass allowlist.
     let resp = reqwest::get(format!("http://{addr}/api/config"))

--- a/crates/web/src/assets/js/page-settings.js
+++ b/crates/web/src/assets/js/page-settings.js
@@ -5555,7 +5555,16 @@ function SettingsPage() {
 					}
 					${
 						ps
-							? html`<${PageSection} key=${`${section}:${subPath}`} initFn=${ps.init} teardownFn=${ps.teardown} subPath=${subPath} />`
+							? section === "terminal" && gon.get("terminal_enabled") !== true
+								? html`<div class="flex-1 flex flex-col min-w-0 p-4 gap-3 overflow-y-auto">
+									<h2 class="text-base font-medium text-[var(--text-strong)]">Terminal</h2>
+									<div class="text-xs text-[var(--muted)] max-w-form">
+										The host terminal has been disabled by the server administrator.
+										To re-enable it, set <code>terminal_enabled = true</code> under <code>[server]</code> in the configuration file,
+										or remove the <code>MOLTIS_TERMINAL_DISABLED</code> environment variable if it is set.
+									</div>
+								</div>`
+								: html`<${PageSection} key=${`${section}:${subPath}`} initFn=${ps.init} teardownFn=${ps.teardown} subPath=${subPath} />`
 							: null
 					}
 					${section === "identity" ? html`<${IdentitySection} />` : null}

--- a/crates/web/src/templates.rs
+++ b/crates/web/src/templates.rs
@@ -65,6 +65,7 @@ pub(crate) struct GonData {
     heartbeat_runs: Vec<moltis_cron::types::CronRunRecord>,
     voice_enabled: bool,
     graphql_enabled: bool,
+    terminal_enabled: bool,
     git_branch: Option<String>,
     mem: MemSnapshot,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -454,6 +455,7 @@ pub(crate) async fn build_gon_data(gw: &GatewayState) -> GonData {
         heartbeat_runs,
         voice_enabled: cfg!(feature = "voice"),
         graphql_enabled: cfg!(feature = "graphql"),
+        terminal_enabled: gw.config.server.is_terminal_enabled(),
         git_branch: detect_git_branch(),
         mem: collect_mem_snapshot(),
         deploy_platform: gw.deploy_platform.clone(),

--- a/crates/web/src/terminal.rs
+++ b/crates/web/src/terminal.rs
@@ -36,6 +36,7 @@ const TERMINAL_WINDOWS_LIST_FAILED: &str = "TERMINAL_WINDOWS_LIST_FAILED";
 const TERMINAL_TMUX_UNAVAILABLE: &str = "TERMINAL_TMUX_UNAVAILABLE";
 const TERMINAL_WINDOW_NAME_INVALID: &str = "TERMINAL_WINDOW_NAME_INVALID";
 const TERMINAL_WINDOW_CREATE_FAILED: &str = "TERMINAL_WINDOW_CREATE_FAILED";
+const TERMINAL_DISABLED: &str = "TERMINAL_DISABLED";
 
 // ── Data structures ──────────────────────────────────────────────────────────
 
@@ -841,7 +842,17 @@ fn host_terminal_windows_payload(
 
 // ── HTTP handlers ────────────────────────────────────────────────────────────
 
-pub async fn api_terminal_windows_handler() -> impl IntoResponse {
+pub async fn api_terminal_windows_handler(State(state): State<AppState>) -> impl IntoResponse {
+    if !state.gateway.config.server.is_terminal_enabled() {
+        return (
+            StatusCode::FORBIDDEN,
+            Json(terminal_error(
+                TERMINAL_DISABLED,
+                "terminal has been disabled by the server administrator",
+            )),
+        )
+            .into_response();
+    }
     if !host_terminal_tmux_available() {
         return Json(serde_json::json!({
             "ok": true,
@@ -881,8 +892,19 @@ pub async fn api_terminal_windows_handler() -> impl IntoResponse {
 }
 
 pub async fn api_terminal_windows_create_handler(
+    State(state): State<AppState>,
     Json(payload): Json<HostTerminalCreateWindowRequest>,
 ) -> impl IntoResponse {
+    if !state.gateway.config.server.is_terminal_enabled() {
+        return (
+            StatusCode::FORBIDDEN,
+            Json(terminal_error(
+                TERMINAL_DISABLED,
+                "terminal has been disabled by the server administrator",
+            )),
+        )
+            .into_response();
+    }
     if !host_terminal_tmux_available() {
         return (
             StatusCode::CONFLICT,
@@ -965,6 +987,14 @@ pub async fn api_terminal_ws_upgrade_handler(
     ConnectInfo(addr): ConnectInfo<SocketAddr>,
     State(state): State<AppState>,
 ) -> impl IntoResponse {
+    if !state.gateway.config.server.is_terminal_enabled() {
+        return (
+            StatusCode::FORBIDDEN,
+            "terminal has been disabled by the server administrator",
+        )
+            .into_response();
+    }
+
     // CSWSH protection: only same-origin browser upgrades are allowed.
     if let Some(origin) = headers
         .get(axum::http::header::ORIGIN)

--- a/crates/web/ui/e2e/specs/terminal-disabled.spec.js
+++ b/crates/web/ui/e2e/specs/terminal-disabled.spec.js
@@ -1,0 +1,43 @@
+const { expect, test } = require("../base-test");
+const { navigateAndWait, waitForWsConnected, watchPageErrors } = require("../helpers");
+
+test.describe("Terminal disabled state", () => {
+	test("shows disabled message when terminal_enabled is false in gon", async ({ page }) => {
+		var errors = watchPageErrors(page);
+
+		// Override gon before the page loads.
+		await page.addInitScript(() => {
+			Object.defineProperty(window, "__MOLTIS__", {
+				configurable: true,
+				writable: true,
+				value: { terminal_enabled: false },
+			});
+		});
+
+		await navigateAndWait(page, "/settings/terminal");
+		await waitForWsConnected(page);
+
+		// The disabled message should be visible.
+		await expect(page.getByText("host terminal has been disabled")).toBeVisible({ timeout: 10_000 });
+
+		// The xterm container should NOT be present.
+		await expect(page.locator("#terminalOutput")).not.toBeVisible();
+
+		expect(errors).toHaveLength(0);
+	});
+
+	test("shows terminal when terminal_enabled is true in gon", async ({ page }) => {
+		var errors = watchPageErrors(page);
+
+		await navigateAndWait(page, "/settings/terminal");
+		await waitForWsConnected(page);
+
+		// The disabled message should NOT be visible (terminal_enabled defaults to true).
+		await expect(page.getByText("host terminal has been disabled")).not.toBeVisible();
+
+		// The terminal container or status should be present.
+		await expect(page.locator(".terminal-page")).toBeVisible({ timeout: 10_000 });
+
+		expect(errors).toHaveLength(0);
+	});
+});


### PR DESCRIPTION
## Summary

Closes #681 — adds a terminal disable option and comprehensively hardens the remote access security surface.

### Terminal disable (issue #681)
- `server.terminal_enabled` config flag (default `true`) and `MOLTIS_TERMINAL_DISABLED` env var override
- All 3 terminal API routes return 403 when disabled; UI shows administrator message
- Env var takes precedence over config, cannot be changed from the web UI config editor

### Brute-force protection
- New `LoginGuard` module with two complementary defences:
  - **IP ban**: 10 consecutive failures → ban with escalating duration (5min → 15min → 1hr → 24hr cap)
  - **Account lockout**: 3 distinct IPs fail same account within 15 min → lock for 15 min
- Covers password login, passkey auth, setup code, and password change endpoints
- Returns 429 + Retry-After header with descriptive JSON error

### Security headers
- **HSTS**: `Strict-Transport-Security: max-age=31536000; includeSubDomains` when TLS is active
- **Permissions-Policy**: restricts camera, geolocation, payment; allows microphone for voice

### Session management
- Max 10 concurrent sessions with LRU eviction; expired sessions cleaned eagerly

### API key hardening
- New keys use **HMAC-SHA256 with per-key random salt** (migration adds `key_salt` column)
- Legacy unsalted SHA-256 keys continue to verify (backward compatible)
- **Scope enforcement**: `config_save` and `restart` require `operator.admin` scope
- `AuthIdentity` now carries scopes through the full auth pipeline
- `RequireAdmin` extractor added for future route-level scope enforcement

### WebSocket scope enforcement
- `websocket_header_authenticate` returns full `AuthIdentity` (not just bool)
- API key scopes from Bearer header auth are now enforced on WS RPC dispatch
- A read-only API key can no longer make write calls through the WebSocket

### Password policy
- Minimum length increased from 8 to 12 characters (NIST guidelines)

### Setup code hardening
- Entropy increased from 6-digit numeric (~20 bits) to 8-char alphanumeric (~48 bits)
- Uses unambiguous charset (no 0/O/1/I/L) for easy terminal reading
- Auto-expires after 30 minutes (returns 410 Gone)

### Timing side channel fix
- `verify_password` now performs dummy Argon2 verification when no password is set
- Response times are indistinguishable regardless of whether a password exists

### Audit logging
- New `auth_audit_log` table records events with client IP and detail
- Logs: login_success, login_failure, key_created, key_revoked
- Auto-prunes entries older than 90 days

### Startup warning
- Banner warns when TLS is disabled on a non-localhost bind address

## Validation

### Completed
- [x] `cargo +nightly-2025-11-30 fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] All unit tests pass (768+ across modified crates)
- [x] `biome check --write` on changed JS
- [x] `taplo fmt` on changed TOML
- [x] `build_schema_map()` updated in `validate.rs`
- [x] Config template updated with documentation
- [x] E2E spec added for terminal disabled/enabled rendering

### Remaining
- [ ] `./scripts/local-validate.sh` (full CI gate)

## Manual QA

1. **Terminal disable**: Set `terminal_enabled = false` in `[server]` → terminal tab shows disabled message, API returns 403
2. **Env var override**: Set `MOLTIS_TERMINAL_DISABLED=1` → terminal disabled regardless of config
3. **Brute-force**: Send 10 wrong passwords → IP banned, returns 429 with Retry-After
4. **Account lockout**: Send wrong passwords from 3 IPs → account locked for 15 min
5. **Password minimum**: Try setting an 8-char password → rejected with "at least 12 characters"
6. **Setup code**: Wait 30 min after startup → setup code returns 410 Gone
7. **API key scopes**: Create key with `operator.read` scope → config save returns 403
8. **Session cap**: Create 11 sessions → oldest session is evicted
9. **HSTS**: Enable TLS → `Strict-Transport-Security` header present in responses