### PR TITLE
Update sandbox_image to use docker.io path

### DIFF
--- a/crates/browser/src/types.rs
+++ b/crates/browser/src/types.rs
@@ -452,7 +452,7 @@ pub struct BrowserConfig {
 }
 
 fn default_sandbox_image() -> String {
-    "browserless/chrome".to_string()
+    "docker.io/browserless/chrome".to_string()
 }
 
 fn default_container_prefix() -> String {

--- a/crates/config/src/schema.rs
+++ b/crates/config/src/schema.rs
@@ -2492,7 +2492,7 @@ pub struct BrowserConfig {
 }
 
 fn default_sandbox_image() -> String {
-    "browserless/chrome".to_string()
+    "docker.io/browserless/chrome".to_string()
 }
 
 const fn default_low_memory_threshold_mb() -> u64 {

--- a/docs/src/browser-automation.md
+++ b/docs/src/browser-automation.md
@@ -64,7 +64,7 @@ navigation_timeout_ms = 30000  # Page load timeout
 # chrome_args = ["--disable-extensions"]  # Extra args
 
 # Sandbox image (browser sandbox mode follows session sandbox mode)
-sandbox_image = "browserless/chrome"  # Container image for sandboxed sessions
+sandbox_image = "docker.io/browserless/chrome"  # Container image for sandboxed sessions
 # allowed_domains = ["example.com", "*.trusted.org"]  # Restrict navigation
 
 # Container connectivity (for Moltis-in-Docker setups)
@@ -297,7 +297,7 @@ When the session is sandboxed, Chrome runs inside a Docker container with:
 
 ```toml
 [tools.browser]
-sandbox_image = "browserless/chrome"  # Container image for sandboxed sessions
+sandbox_image = "docker.io/browserless/chrome"  # Container image for sandboxed sessions
 ```
 
 Requirements:


### PR DESCRIPTION
We need a fully-qualified image name in order for it to work on podman without further configuration.