### PR TITLE
refactor(nodes): define NodeInfoProvider trait for decoupling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7387,7 +7387,9 @@ dependencies = [
 name = "moltis-node-exec-types"
 version = "0.1.0"
 dependencies = [
+ "moltis-metrics",
  "serde",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,15 +60,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
-name = "adobe-cmap-parser"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae8abfa9a4688de8fc9f42b3f013b6fffec18ed8a554f5f113577e0b9b3212a3"
-dependencies = [
- "pom",
-]
-
-[[package]]
 name = "aead"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -690,37 +681,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-utility"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a34a3b57207a7a1007832416c3e4862378c8451b4e8e093e436f48c2d3d2c151"
-dependencies = [
- "futures-util",
- "gloo-timers",
- "tokio",
- "wasm-bindgen-futures",
-]
-
-[[package]]
-name = "async-wsocket"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c92385c7c8b3eb2de1b78aeca225212e4c9a69a78b802832759b108681a5069"
-dependencies = [
- "async-utility",
- "futures",
- "futures-util",
- "js-sys",
- "tokio",
- "tokio-rustls 0.26.4",
- "tokio-socks",
- "tokio-tungstenite 0.26.2",
- "url",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
 name = "asynk-strim"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -738,12 +698,6 @@ checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
 dependencies = [
  "num-traits",
 ]
-
-[[package]]
-name = "atomic-destructor"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef49f5882e4b6afaac09ad239a4f8c70a24b8f2b0897edb1f706008efd109cf4"
 
 [[package]]
 name = "atomic-polyfill"
@@ -999,12 +953,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bech32"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32637268377fc7b10a8c6d51de3e7fba1ce5dd371a96e342b34e6078db558e7f"
-
-[[package]]
 name = "benchmarks"
 version = "0.1.0"
 dependencies = [
@@ -1043,34 +991,6 @@ name = "binstring"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0669d5a35b64fdb5ab7fb19cae13148b6b5cbdf4b8247faf54ece47f699c8cef"
-
-[[package]]
-name = "bip39"
-version = "2.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90dbd31c98227229239363921e60fcf5e558e43ec69094d46fc4996f08d1d5bc"
-dependencies = [
- "bitcoin_hashes",
- "serde",
- "unicode-normalization",
-]
-
-[[package]]
-name = "bitcoin-io"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dee39a0ee5b4095224a0cfc6bf4cc1baf0f9624b96b367e53b66d974e51d953"
-
-[[package]]
-name = "bitcoin_hashes"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26ec84b80c482df901772e931a9a681e26a1b9ee2302edeff23cb30328745c8b"
-dependencies = [
- "bitcoin-io",
- "hex-conservative",
- "serde",
-]
 
 [[package]]
 name = "bitflags"
@@ -1386,12 +1306,6 @@ checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
 dependencies = [
  "nom 7.1.3",
 ]
-
-[[package]]
-name = "cff-parser"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31f5b6e9141c036f3ff4ce7b2f7e432b0f00dee416ddcd4f17741d189ddc2e9d"
 
 [[package]]
 name = "cfg-if"
@@ -2856,15 +2770,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
-name = "ecb"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a8bfa975b1aec2145850fcaa1c6fe269a16578c44705a532ae3edc92b8881c7"
-dependencies = [
- "cipher 0.4.4",
-]
-
-[[package]]
 name = "ecdsa"
 version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2984,15 +2889,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "encoding_rs_io"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cc3c5651fb62ab8aa3103998dade57efdd028544bd300516baa31840c252a83"
-dependencies = [
- "encoding_rs",
-]
-
-[[package]]
 name = "endian-type"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3096,15 +2992,6 @@ dependencies = [
  "cfg-if",
  "home",
  "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "euclid"
-version = "0.20.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bb7ef65b3777a325d1eeefefab5b6d4959da54747e33bd6258e789640f307ad"
-dependencies = [
- "num-traits",
 ]
 
 [[package]]
@@ -4605,19 +4492,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
-name = "globset"
-version = "0.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3"
-dependencies = [
- "aho-corasick",
- "bstr",
- "log",
- "regex-automata",
- "regex-syntax",
-]
-
-[[package]]
 name = "gloo-timers"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4640,43 +4514,6 @@ dependencies = [
  "serde_json",
  "wasm-bindgen",
  "web-sys",
-]
-
-[[package]]
-name = "grep-matcher"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36d7b71093325ab22d780b40d7df3066ae4aebb518ba719d38c697a8228a8023"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "grep-regex"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce0c256c3ad82bcc07b812c15a45ec1d398122e8e15124f96695234db7112ef"
-dependencies = [
- "bstr",
- "grep-matcher",
- "log",
- "regex-automata",
- "regex-syntax",
-]
-
-[[package]]
-name = "grep-searcher"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac63295322dc48ebb20a25348147905d816318888e64f531bfc2a2bc0577dc34"
-dependencies = [
- "bstr",
- "encoding_rs",
- "encoding_rs_io",
- "grep-matcher",
- "log",
- "memchr",
- "memmap2",
 ]
 
 [[package]]
@@ -4904,15 +4741,6 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
-
-[[package]]
-name = "hex-conservative"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fda06d18ac606267c40c04e41b9947729bf8b9efe74bd4e82b61a5f26a510b9f"
-dependencies = [
- "arrayvec",
-]
 
 [[package]]
 name = "hkdf"
@@ -5477,22 +5305,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ignore"
-version = "0.4.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3d782a365a015e0f5c04902246139249abf769125006fbe7649e2ee88169b4a"
-dependencies = [
- "crossbeam-deque",
- "globset",
- "log",
- "memchr",
- "regex-automata",
- "same-file",
- "walkdir",
- "winapi-util",
-]
-
-[[package]]
 name = "image"
 version = "0.25.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5650,9 +5462,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
 dependencies = [
  "cfg-if",
- "js-sys",
- "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
@@ -6217,40 +6026,6 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
-
-[[package]]
-name = "lopdf"
-version = "0.38.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7184fdea2bc3cd272a1acec4030c321a8f9875e877b3f92a53f2f6033fdc289"
-dependencies = [
- "aes 0.8.4",
- "bitflags 2.10.0",
- "cbc",
- "ecb",
- "encoding_rs",
- "flate2",
- "getrandom 0.3.4",
- "indexmap 2.13.0",
- "itoa",
- "log",
- "md-5",
- "nom 8.0.0",
- "nom_locate",
- "rand 0.9.2",
- "rangemap",
- "sha2",
- "stringprep",
- "thiserror 2.0.18",
- "ttf-parser",
- "weezl",
-]
-
-[[package]]
-name = "lru"
-version = "0.16.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593"
 
 [[package]]
 name = "lru-slab"
@@ -7026,7 +6801,6 @@ dependencies = [
  "axum",
  "base64 0.22.1",
  "dashmap 6.1.0",
- "hmac",
  "moltis-config",
  "moltis-tools",
  "moltis-vault",
@@ -7313,7 +7087,7 @@ dependencies = [
  "moltis-metrics",
  "moltis-msteams",
  "moltis-network-filter",
- "moltis-nostr",
+ "moltis-node-exec-types",
  "moltis-oauth",
  "moltis-onboarding",
  "moltis-openclaw-import",
@@ -7610,6 +7384,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "moltis-node-exec-types"
+version = "0.1.0"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "moltis-node-host"
 version = "0.1.0"
 dependencies = [
@@ -7628,26 +7409,6 @@ dependencies = [
  "url",
  "uuid",
  "which 8.0.0",
-]
-
-[[package]]
-name = "moltis-nostr"
-version = "0.1.0"
-dependencies = [
- "async-trait",
- "moltis-channels",
- "moltis-common",
- "moltis-config",
- "moltis-metrics",
- "nostr-sdk",
- "secrecy 0.8.0",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
- "time",
- "tokio",
- "tokio-util",
- "tracing",
 ]
 
 [[package]]
@@ -8038,12 +7799,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "futures",
- "globset",
- "grep-matcher",
- "grep-regex",
- "grep-searcher",
  "html2text",
- "ignore",
  "image",
  "ipnet",
  "mockito",
@@ -8058,7 +7814,6 @@ dependencies = [
  "moltis-providers",
  "moltis-sessions",
  "moltis-skills",
- "pdf-extract",
  "regex",
  "reqwest 0.12.28",
  "rstest",
@@ -8068,7 +7823,6 @@ dependencies = [
  "sha2",
  "shell-words",
  "sqlx",
- "tar",
  "tempfile",
  "thiserror 2.0.18",
  "time",
@@ -8325,12 +8079,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "negentropy"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0efe882e02d206d8d279c20eb40e03baf7cb5136a1476dc084a324fbc3ec42d"
-
-[[package]]
 name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8447,95 +8195,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2de2bc5b451bfedaef92c90b8939a8fff5770bdcc1fafd6239d086aab8fa6b29"
 dependencies = [
  "nom 8.0.0",
-]
-
-[[package]]
-name = "nom_locate"
-version = "5.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b577e2d69827c4740cba2b52efaad1c4cc7c73042860b199710b3575c68438d"
-dependencies = [
- "bytecount",
- "memchr",
- "nom 8.0.0",
-]
-
-[[package]]
-name = "nostr"
-version = "0.44.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3aa5e3b6a278ed061835fe1ee293b71641e6bf8b401cfe4e1834bbf4ef0a34e1"
-dependencies = [
- "aes 0.8.4",
- "base64 0.22.1",
- "bech32",
- "bip39",
- "bitcoin_hashes",
- "cbc",
- "chacha20 0.9.1",
- "chacha20poly1305",
- "getrandom 0.2.17",
- "hex",
- "instant",
- "scrypt",
- "secp256k1",
- "serde",
- "serde_json",
- "unicode-normalization",
- "url",
-]
-
-[[package]]
-name = "nostr-database"
-version = "0.44.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7462c9d8ae5ef6a28d66a192d399ad2530f1f2130b13186296dbb11bdef5b3d1"
-dependencies = [
- "lru",
- "nostr",
- "tokio",
-]
-
-[[package]]
-name = "nostr-gossip"
-version = "0.44.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ade30de16869618919c6b5efc8258f47b654a98b51541eb77f85e8ec5e3c83a6"
-dependencies = [
- "nostr",
-]
-
-[[package]]
-name = "nostr-relay-pool"
-version = "0.44.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b1073ccfbaea5549fb914a9d52c68dab2aecda61535e5143dd73e95445a804b"
-dependencies = [
- "async-utility",
- "async-wsocket",
- "atomic-destructor",
- "hex",
- "lru",
- "negentropy",
- "nostr",
- "nostr-database",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "nostr-sdk"
-version = "0.44.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "471732576710e779b64f04c55e3f8b5292f865fea228436daf19694f0bf70393"
-dependencies = [
- "async-utility",
- "nostr",
- "nostr-database",
- "nostr-gossip",
- "nostr-relay-pool",
- "tokio",
- "tracing",
 ]
 
 [[package]]
@@ -8974,23 +8633,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pdf-extract"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e28ba1758a3d3f361459645780e09570b573fc3c82637449e9963174c813a98"
-dependencies = [
- "adobe-cmap-parser",
- "cff-parser",
- "encoding_rs",
- "euclid",
- "log",
- "lopdf",
- "postscript",
- "type1-encoding-parser",
- "unicode-normalization",
-]
-
-[[package]]
 name = "pem"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9301,12 +8943,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pom"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60f6ce597ecdcc9a098e7fddacb1065093a3d66446fa16c675e7e71d1b5c28e6"
-
-[[package]]
 name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9354,12 +8990,6 @@ dependencies = [
  "heapless 0.7.17",
  "serde",
 ]
-
-[[package]]
-name = "postscript"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78451badbdaebaf17f053fd9152b3ffb33b516104eacb45e7864aaa9c712f306"
 
 [[package]]
 name = "potential_utf"
@@ -9856,12 +9486,6 @@ checksum = "f703f4665700daf5512dcca5f43afa6af89f09db47fb56be587f80636bda2d41"
 dependencies = [
  "rand_core 0.9.5",
 ]
-
-[[package]]
-name = "rangemap"
-version = "1.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "973443cf09a9c8656b574a866ab68dfa19f0867d0340648c7d2f6a71b8a8ea68"
 
 [[package]]
 name = "raw-cpuid"
@@ -10741,15 +10365,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a50f4cf475b65d88e057964e0e9bb1f0aa9bbb2036dc65c64596b42932536984"
 
 [[package]]
-name = "salsa20"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
-dependencies = [
- "cipher 0.4.4",
-]
-
-[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10807,18 +10422,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
-name = "scrypt"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0516a385866c09368f0b5bcd1caff3366aace790fcd46e2bb032697bb172fd1f"
-dependencies = [
- "password-hash",
- "pbkdf2",
- "salsa20",
- "sha2",
-]
-
-[[package]]
 name = "sdd"
 version = "3.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10858,26 +10461,6 @@ dependencies = [
  "der 0.4.5",
  "pem 0.8.3",
  "thiserror 1.0.69",
-]
-
-[[package]]
-name = "secp256k1"
-version = "0.29.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9465315bc9d4566e1724f0fffcbcc446268cb522e60f9a27bcded6b19c108113"
-dependencies = [
- "rand 0.8.5",
- "secp256k1-sys",
- "serde",
-]
-
-[[package]]
-name = "secp256k1-sys"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4387882333d3aa8cb20530a17c69a3752e97837832f34f6dccc760e715001d9"
-dependencies = [
- "cc",
 ]
 
 [[package]]
@@ -12472,12 +12055,8 @@ checksum = "7a9daff607c6d2bf6c16fd681ccb7eecc83e4e2cdc1ca067ffaadfca5de7f084"
 dependencies = [
  "futures-util",
  "log",
- "rustls 0.23.36",
- "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.26.4",
  "tungstenite 0.26.2",
- "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -12941,12 +12520,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
-name = "ttf-parser"
-version = "0.25.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
-
-[[package]]
 name = "tungstenite"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12979,8 +12552,6 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.9.2",
- "rustls 0.23.36",
- "rustls-pki-types",
  "sha1",
  "thiserror 2.0.18",
  "utf-8",
@@ -13001,15 +12572,6 @@ dependencies = [
  "sha1",
  "thiserror 2.0.18",
  "utf-8",
-]
-
-[[package]]
-name = "type1-encoding-parser"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa10c302f5a53b7ad27fd42a3996e23d096ba39b5b8dd6d9e683a05b01bee749"
-dependencies = [
- "pom",
 ]
 
 [[package]]
@@ -14239,12 +13801,6 @@ checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
 dependencies = [
  "rustls-pki-types",
 ]
-
-[[package]]
-name = "weezl"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
 name = "whatsapp-rust"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7387,6 +7387,8 @@ dependencies = [
 name = "moltis-node-exec-types"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
+ "async-trait",
  "moltis-metrics",
  "serde",
  "tracing",
@@ -7813,6 +7815,7 @@ dependencies = [
  "moltis-media",
  "moltis-metrics",
  "moltis-network-filter",
+ "moltis-node-exec-types",
  "moltis-providers",
  "moltis-sessions",
  "moltis-skills",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ default-members = [
   "crates/msteams",
   "crates/network-filter",
   "crates/node-host",
+  "crates/node-exec-types",
   "crates/nostr",
   "crates/oauth",
   "crates/onboarding",
@@ -82,6 +83,7 @@ members = [
   "crates/metrics",
   "crates/msteams",
   "crates/node-host",
+  "crates/node-exec-types",
   "crates/nostr",
   "crates/oauth",
   "crates/onboarding",
@@ -341,6 +343,7 @@ moltis-metrics         = { path = "crates/metrics" }
 moltis-msteams         = { path = "crates/msteams" }
 moltis-network-filter  = { default-features = false, path = "crates/network-filter" }
 moltis-node-host       = { path = "crates/node-host" }
+moltis-node-exec-types = { path = "crates/node-exec-types" }
 moltis-nostr           = { path = "crates/nostr" }
 moltis-oauth           = { path = "crates/oauth" }
 moltis-onboarding      = { path = "crates/onboarding" }

--- a/crates/gateway/Cargo.toml
+++ b/crates/gateway/Cargo.toml
@@ -36,6 +36,7 @@ moltis-memory          = { workspace = true }
 moltis-metrics         = { optional = true, workspace = true }
 moltis-msteams         = { workspace = true }
 moltis-network-filter  = { features = ["proxy", "service"], optional = true, workspace = true }
+moltis-node-exec-types = { workspace = true }
 moltis-nostr           = { optional = true, workspace = true }
 moltis-oauth           = { workspace = true }
 moltis-onboarding      = { workspace = true }

--- a/crates/gateway/src/node_exec.rs
+++ b/crates/gateway/src/node_exec.rs
@@ -31,20 +31,9 @@ use crate::{
 // Re-export core node execution types from the dedicated crate.
 pub use moltis_node_exec_types::{
     BLOCKED_ENV_PREFIXES, NodeExecResult, SAFE_ENV_ALLOWLIST, SAFE_ENV_PREFIX_ALLOWLIST,
-    SSH_ID_PREFIX, SSH_TARGET_ID_PREFIX,
+    SSH_ID_PREFIX, SSH_TARGET_ID_PREFIX, filter_env, is_safe_env, is_valid_env_key, ssh_node_id,
+    ssh_stored_node_id, ssh_target_matches,
 };
-
-pub(crate) fn ssh_node_id(target: &str) -> String {
-    format!("{SSH_ID_PREFIX}{target}")
-}
-
-fn ssh_stored_node_id(id: i64) -> String {
-    format!("{SSH_TARGET_ID_PREFIX}{id}")
-}
-
-pub(crate) fn ssh_target_matches(node_ref: &str, target: &str) -> bool {
-    node_ref == "ssh" || node_ref == target || node_ref.strip_prefix(SSH_ID_PREFIX) == Some(target)
-}
 
 pub(crate) fn ssh_node_info(target: &str) -> moltis_tools::nodes::NodeInfo {
     moltis_tools::nodes::NodeInfo {
@@ -509,43 +498,6 @@ fn ssh_destination_args(target: &str, remote_command: String) -> [String; 3] {
 fn ssh_config_quote_path(path: &Path) -> String {
     let value = path.to_string_lossy();
     format!("\"{}\"", value.replace('\\', "\\\\").replace('"', "\\\""))
-}
-
-/// Filter environment variables to the safe allowlist.
-fn filter_env(env: &HashMap<String, String>) -> HashMap<String, String> {
-    env.iter()
-        .filter(|(key, _)| is_safe_env(key) && is_valid_env_key(key))
-        .map(|(k, v)| (k.clone(), v.clone()))
-        .collect()
-}
-
-fn is_safe_env(key: &str) -> bool {
-    // Block dangerous prefixes first.
-    for prefix in BLOCKED_ENV_PREFIXES {
-        if key.starts_with(prefix) {
-            return false;
-        }
-    }
-
-    // Allow exact matches.
-    if SAFE_ENV_ALLOWLIST.contains(&key) {
-        return true;
-    }
-
-    // Allow prefix matches.
-    for prefix in SAFE_ENV_PREFIX_ALLOWLIST {
-        if key.starts_with(prefix) {
-            return true;
-        }
-    }
-
-    false
-}
-
-fn is_valid_env_key(key: &str) -> bool {
-    let mut chars = key.chars();
-    matches!(chars.next(), Some(ch) if ch.is_ascii_alphabetic() || ch == '_')
-        && chars.all(|ch| ch.is_ascii_alphanumeric() || ch == '_')
 }
 
 fn parse_exec_result(value: &serde_json::Value) -> anyhow::Result<NodeExecResult> {

--- a/crates/gateway/src/node_exec.rs
+++ b/crates/gateway/src/node_exec.rs
@@ -30,13 +30,13 @@ use crate::{
 
 // Re-export core node execution types from the dedicated crate.
 pub use moltis_node_exec_types::{
-    BLOCKED_ENV_PREFIXES, NodeExecResult, SAFE_ENV_ALLOWLIST, SAFE_ENV_PREFIX_ALLOWLIST,
-    SSH_ID_PREFIX, SSH_TARGET_ID_PREFIX, filter_env, is_safe_env, is_valid_env_key, ssh_node_id,
-    ssh_stored_node_id, ssh_target_matches,
+    BLOCKED_ENV_PREFIXES, NodeExecResult, NodeInfo, NodeInfoProvider, NodeProviderInfo,
+    SAFE_ENV_ALLOWLIST, SAFE_ENV_PREFIX_ALLOWLIST, SSH_ID_PREFIX, SSH_TARGET_ID_PREFIX, filter_env,
+    is_safe_env, is_valid_env_key, ssh_node_id, ssh_stored_node_id, ssh_target_matches,
 };
 
-pub(crate) fn ssh_node_info(target: &str) -> moltis_tools::nodes::NodeInfo {
-    moltis_tools::nodes::NodeInfo {
+pub(crate) fn ssh_node_info(target: &str) -> NodeInfo {
+    NodeInfo {
         node_id: ssh_node_id(target),
         display_name: Some(format!("SSH: {target}")),
         platform: "ssh".to_string(),
@@ -57,12 +57,12 @@ pub(crate) fn ssh_node_info(target: &str) -> moltis_tools::nodes::NodeInfo {
     }
 }
 
-fn ssh_target_node_info(target: &SshResolvedTarget) -> moltis_tools::nodes::NodeInfo {
+fn ssh_target_node_info(target: &SshResolvedTarget) -> NodeInfo {
     let auth_service = match target.auth_mode {
         SshAuthMode::System => "ssh-system",
         SshAuthMode::Managed => "ssh-managed",
     };
-    moltis_tools::nodes::NodeInfo {
+    NodeInfo {
         node_id: ssh_stored_node_id(target.id),
         display_name: Some(format!("SSH: {}", target.label)),
         platform: "ssh".to_string(),
@@ -660,8 +660,8 @@ impl moltis_tools::exec::NodeExecProvider for GatewayNodeExecProvider {
 // ── Node info provider ──────────────────────────────────────────────────────
 
 /// Convert a `NodeSession` into a serializable `NodeInfo`.
-fn node_to_info(n: &crate::nodes::NodeSession) -> moltis_tools::nodes::NodeInfo {
-    moltis_tools::nodes::NodeInfo {
+fn node_to_info(n: &crate::nodes::NodeSession) -> NodeInfo {
+    NodeInfo {
         node_id: n.node_id.clone(),
         display_name: n.display_name.clone(),
         platform: n.platform.clone(),
@@ -683,7 +683,7 @@ fn node_to_info(n: &crate::nodes::NodeSession) -> moltis_tools::nodes::NodeInfo 
         providers: n
             .providers
             .iter()
-            .map(|p| moltis_tools::nodes::NodeProviderInfo {
+            .map(|p| NodeProviderInfo {
                 provider: p.provider.clone(),
                 models: p.models.clone(),
             })
@@ -691,7 +691,7 @@ fn node_to_info(n: &crate::nodes::NodeSession) -> moltis_tools::nodes::NodeInfo 
     }
 }
 
-/// Bridge that implements [`moltis_tools::nodes::NodeInfoProvider`] by
+/// Bridge that implements [`NodeInfoProvider`] by
 /// reading from the `NodeRegistry` and session metadata in `GatewayState`.
 pub struct GatewayNodeInfoProvider {
     state: Arc<GatewayState>,
@@ -708,8 +708,8 @@ impl GatewayNodeInfoProvider {
 }
 
 #[async_trait]
-impl moltis_tools::nodes::NodeInfoProvider for GatewayNodeInfoProvider {
-    async fn list_nodes(&self) -> Vec<moltis_tools::nodes::NodeInfo> {
+impl NodeInfoProvider for GatewayNodeInfoProvider {
+    async fn list_nodes(&self) -> Vec<NodeInfo> {
         let inner = self.state.inner.read().await;
         let mut nodes: Vec<_> = inner.nodes.list().iter().map(|n| node_to_info(n)).collect();
         drop(inner);
@@ -743,7 +743,7 @@ impl moltis_tools::nodes::NodeInfoProvider for GatewayNodeInfoProvider {
         nodes
     }
 
-    async fn describe_node(&self, node_ref: &str) -> Option<moltis_tools::nodes::NodeInfo> {
+    async fn describe_node(&self, node_ref: &str) -> Option<NodeInfo> {
         if let Some(store) = self.state.credential_store.as_ref() {
             match store.resolve_ssh_target(node_ref).await {
                 Ok(Some(target)) => return Some(ssh_target_node_info(&target)),

--- a/crates/gateway/src/node_exec.rs
+++ b/crates/gateway/src/node_exec.rs
@@ -19,7 +19,6 @@ use std::{
 use {
     async_trait::async_trait,
     secrecy::ExposeSecret,
-    serde::{Deserialize, Serialize},
     tokio::{io::AsyncReadExt, process::Command},
     tracing::warn,
 };
@@ -29,41 +28,11 @@ use crate::{
     state::GatewayState,
 };
 
-/// Result of a remote command execution on a node.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct NodeExecResult {
-    pub stdout: String,
-    pub stderr: String,
-    pub exit_code: i32,
-}
-
-/// Environment variables that are safe to forward to a remote node.
-const SAFE_ENV_ALLOWLIST: &[&str] = &["TERM", "LANG", "COLORTERM", "NO_COLOR", "FORCE_COLOR"];
-
-/// Environment variable prefixes that are safe to forward.
-const SAFE_ENV_PREFIX_ALLOWLIST: &[&str] = &["LC_"];
-
-/// Environment variable patterns that must NEVER be forwarded to a remote node.
-const BLOCKED_ENV_PREFIXES: &[&str] = &[
-    "DYLD_",
-    "LD_",
-    "NODE_OPTIONS",
-    "PYTHON",
-    "PERL",
-    "RUBYOPT",
-    "SHELLOPTS",
-    "PS4",
-    // Security-sensitive keys
-    "MOLTIS_",
-    "OPENAI_",
-    "ANTHROPIC_",
-    "AWS_",
-    "GOOGLE_",
-    "AZURE_",
-];
-
-const SSH_ID_PREFIX: &str = "ssh:";
-const SSH_TARGET_ID_PREFIX: &str = "ssh:target:";
+// Re-export core node execution types from the dedicated crate.
+pub use moltis_node_exec_types::{
+    BLOCKED_ENV_PREFIXES, NodeExecResult, SAFE_ENV_ALLOWLIST, SAFE_ENV_PREFIX_ALLOWLIST,
+    SSH_ID_PREFIX, SSH_TARGET_ID_PREFIX,
+};
 
 pub(crate) fn ssh_node_id(target: &str) -> String {
     format!("{SSH_ID_PREFIX}{target}")

--- a/crates/gateway/src/server.rs
+++ b/crates/gateway/src/server.rs
@@ -3966,7 +3966,7 @@ pub async fn prepare_gateway_core(
 
         // Register node info tools (list, describe, select).
         {
-            let node_info_provider: Arc<dyn moltis_tools::nodes::NodeInfoProvider> =
+            let node_info_provider: Arc<dyn moltis_node_exec_types::NodeInfoProvider> =
                 Arc::new(crate::node_exec::GatewayNodeInfoProvider::new(
                     Arc::clone(&state),
                     config.tools.exec.ssh_target.clone(),

--- a/crates/node-exec-types/Cargo.toml
+++ b/crates/node-exec-types/Cargo.toml
@@ -5,6 +5,8 @@ edition.workspace    = true
 repository.workspace = true
 
 [dependencies]
+anyhow         = { workspace = true }
+async-trait    = { workspace = true }
 moltis-metrics = { optional = true, workspace = true }
 serde          = { workspace = true, features = ["derive"] }
 tracing        = { workspace = true }

--- a/crates/node-exec-types/Cargo.toml
+++ b/crates/node-exec-types/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name                 = "moltis-node-exec-types"
+version.workspace    = true
+edition.workspace    = true
+repository.workspace = true
+
+[dependencies]
+moltis-metrics = { optional = true, workspace = true }
+serde          = { workspace = true, features = ["derive"] }
+tracing        = { workspace = true }
+
+[features]
+default = []
+metrics = ["dep:moltis-metrics"]
+
+[lints]
+workspace = true

--- a/crates/node-exec-types/src/lib.rs
+++ b/crates/node-exec-types/src/lib.rs
@@ -3,7 +3,10 @@
 //! This crate contains the shared types and constants used by the gateway
 //! and other crates for remote node execution.
 
-use serde::{Deserialize, Serialize};
+use {
+    serde::{Deserialize, Serialize},
+    std::collections::HashMap,
+};
 
 /// Result of a remote command execution on a node.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -43,3 +46,57 @@ pub const SSH_ID_PREFIX: &str = "ssh:";
 
 /// SSH target ID prefix.
 pub const SSH_TARGET_ID_PREFIX: &str = "ssh:target:";
+
+/// Generate a node ID for an SSH target.
+pub fn ssh_node_id(target: &str) -> String {
+    format!("{SSH_ID_PREFIX}{target}")
+}
+
+/// Generate a stored node ID from a database ID.
+pub fn ssh_stored_node_id(id: i64) -> String {
+    format!("{SSH_TARGET_ID_PREFIX}{id}")
+}
+
+/// Check if a node reference matches an SSH target.
+pub fn ssh_target_matches(node_ref: &str, target: &str) -> bool {
+    node_ref == "ssh" || node_ref == target || node_ref.strip_prefix(SSH_ID_PREFIX) == Some(target)
+}
+
+/// Filter environment variables to only include safe ones.
+pub fn filter_env(env: &HashMap<String, String>) -> HashMap<String, String> {
+    env.iter()
+        .filter(|(key, _)| is_safe_env(key) && is_valid_env_key(key))
+        .map(|(k, v)| (k.clone(), v.clone()))
+        .collect()
+}
+
+/// Check if an environment variable key is safe to forward.
+pub fn is_safe_env(key: &str) -> bool {
+    // Block dangerous prefixes first.
+    for prefix in BLOCKED_ENV_PREFIXES {
+        if key.starts_with(prefix) {
+            return false;
+        }
+    }
+
+    // Allow exact matches.
+    if SAFE_ENV_ALLOWLIST.contains(&key) {
+        return true;
+    }
+
+    // Allow prefix matches.
+    for prefix in SAFE_ENV_PREFIX_ALLOWLIST {
+        if key.starts_with(prefix) {
+            return true;
+        }
+    }
+
+    false
+}
+
+/// Check if an environment variable key has valid format.
+pub fn is_valid_env_key(key: &str) -> bool {
+    let mut chars = key.chars();
+    matches!(chars.next(), Some(ch) if ch.is_ascii_alphabetic() || ch == '_')
+        && chars.all(|ch| ch.is_ascii_alphanumeric() || ch == '_')
+}

--- a/crates/node-exec-types/src/lib.rs
+++ b/crates/node-exec-types/src/lib.rs
@@ -1,0 +1,45 @@
+//! Core types and constants for node execution.
+//!
+//! This crate contains the shared types and constants used by the gateway
+//! and other crates for remote node execution.
+
+use serde::{Deserialize, Serialize};
+
+/// Result of a remote command execution on a node.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct NodeExecResult {
+    pub stdout: String,
+    pub stderr: String,
+    pub exit_code: i32,
+}
+
+/// Environment variables that are safe to forward to a remote node.
+pub const SAFE_ENV_ALLOWLIST: &[&str] = &["TERM", "LANG", "COLORTERM", "NO_COLOR", "FORCE_COLOR"];
+
+/// Environment variable prefixes that are safe to forward.
+pub const SAFE_ENV_PREFIX_ALLOWLIST: &[&str] = &["LC_"];
+
+/// Environment variable patterns that must NEVER be forwarded to a remote node.
+pub const BLOCKED_ENV_PREFIXES: &[&str] = &[
+    "DYLD_",
+    "LD_",
+    "NODE_OPTIONS",
+    "PYTHON",
+    "PERL",
+    "RUBYOPT",
+    "SHELLOPTS",
+    "PS4",
+    // Security-sensitive keys
+    "MOLTIS_",
+    "OPENAI_",
+    "ANTHROPIC_",
+    "AWS_",
+    "GOOGLE_",
+    "AZURE_",
+];
+
+/// SSH node ID prefix.
+pub const SSH_ID_PREFIX: &str = "ssh:";
+
+/// SSH target ID prefix.
+pub const SSH_TARGET_ID_PREFIX: &str = "ssh:target:";

--- a/crates/node-exec-types/src/lib.rs
+++ b/crates/node-exec-types/src/lib.rs
@@ -8,6 +8,9 @@ use {
     std::collections::HashMap,
 };
 
+// Re-export the async_trait macro for trait implementations
+pub use async_trait::async_trait;
+
 /// Result of a remote command execution on a node.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct NodeExecResult {
@@ -99,4 +102,75 @@ pub fn is_valid_env_key(key: &str) -> bool {
     let mut chars = key.chars();
     matches!(chars.next(), Some(ch) if ch.is_ascii_alphabetic() || ch == '_')
         && chars.all(|ch| ch.is_ascii_alphanumeric() || ch == '_')
+}
+
+// ── Node info types ─────────────────────────────────────────────────────────
+
+/// Serializable summary of a connected node, returned by the list/describe tools.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NodeInfo {
+    pub node_id: String,
+    pub display_name: Option<String>,
+    pub platform: String,
+    pub capabilities: Vec<String>,
+    pub commands: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub remote_ip: Option<String>,
+    // Telemetry
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mem_total: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mem_available: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cpu_count: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cpu_usage: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub uptime_secs: Option<u64>,
+    pub services: Vec<String>,
+    pub telemetry_stale: bool,
+    // P1 fields (populated when provider discovery / richer telemetry lands)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub disk_total: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub disk_available: Option<u64>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub runtimes: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub providers: Vec<NodeProviderInfo>,
+}
+
+/// A provider discovered on a remote node (e.g. ollama, openai env key).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NodeProviderInfo {
+    pub provider: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub models: Vec<String>,
+}
+
+// ── Provider trait ──────────────────────────────────────────────────────────
+
+/// Abstraction that the gateway implements to supply node data to the tools
+/// crate without a direct dependency.
+///
+/// Follows the same pattern as [`crate::exec::NodeExecProvider`].
+#[async_trait]
+pub trait NodeInfoProvider: Send + Sync {
+    /// List all currently connected nodes.
+    async fn list_nodes(&self) -> Vec<NodeInfo>;
+
+    /// Describe a single node by id or display name.
+    async fn describe_node(&self, node_ref: &str) -> Option<NodeInfo>;
+
+    /// Assign (or clear) a node for a chat session.
+    /// `node_ref` is an id or display name; `None` clears the assignment.
+    async fn set_session_node(
+        &self,
+        session_key: &str,
+        node_ref: Option<&str>,
+    ) -> anyhow::Result<Option<String>>;
+
+    /// Resolve a node reference (id or display name) to a canonical node_id.
+    async fn resolve_node_id(&self, node_ref: &str) -> Option<String>;
 }

--- a/crates/tools/Cargo.toml
+++ b/crates/tools/Cargo.toml
@@ -29,6 +29,7 @@ ignore                = { optional = true, workspace = true }
 image                 = { workspace = true }
 ipnet                 = { workspace = true }
 moltis-agents         = { workspace = true }
+moltis-node-exec-types = { workspace = true }
 pdf-extract           = { optional = true, workspace = true }
 moltis-browser        = { workspace = true }
 moltis-common         = { workspace = true }

--- a/crates/tools/src/nodes.rs
+++ b/crates/tools/src/nodes.rs
@@ -5,83 +5,12 @@
 
 use std::sync::Arc;
 
-use {
-    async_trait::async_trait,
-    serde::{Deserialize, Serialize},
-};
+use async_trait::async_trait;
 
 use moltis_agents::tool_registry::AgentTool;
 
-// ── Domain types ────────────────────────────────────────────────────────────
-
-/// Serializable summary of a connected node, returned by the list/describe tools.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct NodeInfo {
-    pub node_id: String,
-    pub display_name: Option<String>,
-    pub platform: String,
-    pub capabilities: Vec<String>,
-    pub commands: Vec<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub remote_ip: Option<String>,
-    // Telemetry
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub mem_total: Option<u64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub mem_available: Option<u64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub cpu_count: Option<u32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub cpu_usage: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub uptime_secs: Option<u64>,
-    pub services: Vec<String>,
-    pub telemetry_stale: bool,
-    // P1 fields (populated when provider discovery / richer telemetry lands)
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub disk_total: Option<u64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub disk_available: Option<u64>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub runtimes: Vec<String>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub providers: Vec<NodeProviderInfo>,
-}
-
-/// A provider discovered on a remote node (e.g. ollama, openai env key).
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct NodeProviderInfo {
-    pub provider: String,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub models: Vec<String>,
-}
-
-// ── Provider trait ──────────────────────────────────────────────────────────
-
-/// Abstraction that the gateway implements to supply node data to the tools
-/// crate without a direct dependency.
-///
-/// Follows the same pattern as [`crate::exec::NodeExecProvider`].
-#[async_trait]
-pub trait NodeInfoProvider: Send + Sync {
-    /// List all currently connected nodes.
-    async fn list_nodes(&self) -> Vec<NodeInfo>;
-
-    /// Describe a single node by id or display name.
-    async fn describe_node(&self, node_ref: &str) -> Option<NodeInfo>;
-
-    /// Assign (or clear) a node for a chat session.
-    /// `node_ref` is an id or display name; `None` clears the assignment.
-    async fn set_session_node(
-        &self,
-        session_key: &str,
-        node_ref: Option<&str>,
-    ) -> anyhow::Result<Option<String>>;
-
-    /// Resolve a node reference (id or display name) to a canonical node_id.
-    async fn resolve_node_id(&self, node_ref: &str) -> Option<String>;
-}
+// Re-export core node types and trait from the dedicated crate.
+pub use moltis_node_exec_types::{NodeInfo, NodeInfoProvider, NodeProviderInfo};
 
 // ── NodesListTool ───────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Introduces a trait interface for node information retrieval in `moltis-node-exec-types`. This allows the node execution logic to depend on an abstraction rather than the concrete `GatewayState`.

## What changed

- **Moved** `NodeInfo`, `NodeProviderInfo`, and `NodeInfoProvider` trait from `crates/tools/src/nodes.rs` to `crates/node-exec-types/src/lib.rs` (single source of truth)
- **Updated** `crates/tools/src/nodes.rs` to re-export types from `moltis-node-exec-types` instead of defining duplicates
- **Updated** gateway references from `moltis_tools::nodes::*` to `moltis_node_exec_types::*`
- **Added** `anyhow` and `async-trait` dependencies to `moltis-node-exec-types` (required by trait)

## Security Note

This PR only adds an interface (Trait). It does not change any execution logic. This is a prerequisite for safely moving the remaining provider logic.

## Prior PRs in this sequence

- #683 — Types & Constants (commit 154b7dfd)
- #685 — Pure Helper Functions (commit 2bc4500e)
- **#687 (this PR)** — Trait Abstractions

## Verification

- [x] `cargo check -p moltis-node-exec-types`
- [x] `cargo check -p moltis-tools`
- [x] `cargo check -p moltis-gateway`
- [x] `just format-check`
- [x] `cargo test` (19 node-related tests pass across tools + gateway)
- [x] No logic changes — purely mechanical import path refactor
