### PR TITLE
[codex] Fix tool-call compatibility regressions

### DIFF
--- a/crates/agents/src/runner.rs
+++ b/crates/agents/src/runner.rs
@@ -87,6 +87,26 @@ fn sanitize_tool_name(name: &str) -> Cow<'_, str> {
     }
 }
 
+fn legacy_public_tool_alias(name: &str) -> Option<&str> {
+    name.strip_suffix("_wasm").filter(|base| !base.is_empty())
+}
+
+fn resolve_tool_lookup<'a>(
+    tools: &ToolRegistry,
+    name: &'a str,
+) -> (
+    Option<Arc<dyn crate::tool_registry::AgentTool>>,
+    Cow<'a, str>,
+) {
+    if let Some(alias) = legacy_public_tool_alias(name)
+        && let Some(tool) = tools.get(alias)
+    {
+        return (Some(tool), Cow::Owned(alias.to_string()));
+    }
+
+    (tools.get(name), Cow::Borrowed(name))
+}
+
 const MALFORMED_TOOL_RETRY_PROMPT: &str = "Your tool call was malformed. Retry with exact format:\n\
      ```tool_call\n{\"tool\": \"name\", \"arguments\": {...}}\n```";
 const EMPTY_TOOL_NAME_RETRY_PROMPT: &str = "Your structured tool call had an empty tool name. Retry the same tool call using the intended tool's exact name and the same arguments.";
@@ -1299,14 +1319,17 @@ pub async fn run_agent_loop_with_context(
                 if *sanitized != tc.name {
                     debug!(original = %tc.name, sanitized = %sanitized, "sanitized mangled tool name");
                 }
-                let tool = tools.get(&sanitized);
+                let (tool, resolved_name) = resolve_tool_lookup(tools, sanitized.as_ref());
+                if resolved_name.as_ref() != sanitized.as_ref() {
+                    debug!(original = %sanitized, resolved = %resolved_name, "resolved legacy tool alias");
+                }
                 let mut args = tc.arguments.clone();
 
                 // Dispatch BeforeToolCall hook — may block or modify arguments.
                 let hook_registry = hook_registry.clone();
                 let session_key = session_key_for_hooks.clone();
                 let channel_for_hooks = channel_for_hooks.clone();
-                let tc_name = sanitized.to_string();
+                let tc_name = resolved_name.to_string();
                 let _tc_id = tc.id.clone();
 
                 if let Some(ref ctx) = tool_context
@@ -1342,7 +1365,7 @@ pub async fn run_agent_loop_with_context(
                     if let Some(cb) = on_event {
                         cb(RunnerEvent::ToolCallStart {
                             id: tc.id.clone(),
-                            name: tc.name.clone(),
+                            name: tc_name.clone(),
                             arguments: args.clone(),
                         });
                     }
@@ -2218,13 +2241,16 @@ pub async fn run_agent_loop_streaming(
                 if *sanitized != tc.name {
                     debug!(original = %tc.name, sanitized = %sanitized, "sanitized mangled tool name");
                 }
-                let tool = tools.get(&sanitized);
+                let (tool, resolved_name) = resolve_tool_lookup(tools, sanitized.as_ref());
+                if resolved_name.as_ref() != sanitized.as_ref() {
+                    debug!(original = %sanitized, resolved = %resolved_name, "resolved legacy tool alias");
+                }
                 let mut args = tc.arguments.clone();
 
                 let hook_registry = hook_registry.clone();
                 let session_key = session_key_for_hooks.clone();
                 let channel_for_hooks = channel_for_hooks.clone();
-                let tc_name = sanitized.to_string();
+                let tc_name = resolved_name.to_string();
 
                 if let Some(ref ctx) = tool_context
                     && let (Some(args_obj), Some(ctx_obj)) = (args.as_object_mut(), ctx.as_object())
@@ -2256,7 +2282,7 @@ pub async fn run_agent_loop_streaming(
                     if let Some(cb) = on_event {
                         cb(RunnerEvent::ToolCallStart {
                             id: tc.id.clone(),
-                            name: tc.name.clone(),
+                            name: tc_name.clone(),
                             arguments: args.clone(),
                         });
                     }
@@ -7290,6 +7316,54 @@ mod tests {
         // "functions_" with no trailing name should produce an empty string,
         // which is handled by find_empty_tool_name_call / EMPTY_TOOL_NAME_RETRY_PROMPT.
         assert_eq!(sanitize_tool_name("functions_"), "");
+    }
+
+    #[test]
+    fn legacy_public_tool_alias_strips_wasm_suffix() {
+        assert_eq!(
+            legacy_public_tool_alias("web_search_wasm"),
+            Some("web_search")
+        );
+        assert_eq!(legacy_public_tool_alias("calc_wasm"), Some("calc"));
+        assert_eq!(legacy_public_tool_alias("web_search"), None);
+    }
+
+    #[test]
+    fn resolve_tool_lookup_prefers_public_alias_when_both_exist() {
+        let mut tools = ToolRegistry::new();
+        tools.register(Box::new(LargeResultTool {
+            tool_name: "web_search",
+            payload: "public".into(),
+        }));
+        tools.register_wasm(
+            Box::new(LargeResultTool {
+                tool_name: "web_search_wasm",
+                payload: "legacy".into(),
+            }),
+            [0x11; 32],
+        );
+
+        let (tool, resolved_name) = resolve_tool_lookup(&tools, "web_search_wasm");
+        let tool = tool.expect("resolved tool should exist");
+        assert_eq!(resolved_name, "web_search");
+        assert_eq!(tool.name(), "web_search");
+    }
+
+    #[test]
+    fn resolve_tool_lookup_falls_back_to_legacy_name_when_no_public_tool_exists() {
+        let mut tools = ToolRegistry::new();
+        tools.register_wasm(
+            Box::new(LargeResultTool {
+                tool_name: "web_search_wasm",
+                payload: "legacy".into(),
+            }),
+            [0x22; 32],
+        );
+
+        let (tool, resolved_name) = resolve_tool_lookup(&tools, "web_search_wasm");
+        let tool = tool.expect("legacy tool should exist");
+        assert_eq!(resolved_name, "web_search_wasm");
+        assert_eq!(tool.name(), "web_search_wasm");
     }
 
     // ── Auto-continue tests ──────────────────────────────────────────

--- a/crates/agents/src/tool_arg_validator.rs
+++ b/crates/agents/src/tool_arg_validator.rs
@@ -154,18 +154,14 @@ pub fn validate_tool_args(schema: &Value, args: &Value) -> Result<(), ToolArgErr
             if actual_val.is_null() {
                 continue;
             }
-            let Some(expected_type) = prop_schema
-                .as_object()
-                .and_then(|o| o.get("type"))
-                .and_then(Value::as_str)
-            else {
+            let Some(expected_type) = prop_schema.as_object().and_then(|o| o.get("type")) else {
                 continue; // No declared type → nothing to check.
             };
             let actual_type = value_type_name(actual_val);
             if !type_matches(expected_type, actual_val) {
                 type_mismatches.push(TypeMismatch {
                     field: field.clone(),
-                    expected: expected_type.to_string(),
+                    expected: expected_type_name(expected_type),
                     actual: actual_type.to_string(),
                 });
             }
@@ -183,7 +179,18 @@ pub fn validate_tool_args(schema: &Value, args: &Value) -> Result<(), ToolArgErr
     })
 }
 
-fn type_matches(expected: &str, value: &Value) -> bool {
+fn type_matches(expected: &Value, value: &Value) -> bool {
+    match expected {
+        Value::String(expected) => type_matches_single(expected, value),
+        Value::Array(expected_types) => expected_types
+            .iter()
+            .filter_map(Value::as_str)
+            .any(|expected| type_matches_single(expected, value)),
+        _ => true,
+    }
+}
+
+fn type_matches_single(expected: &str, value: &Value) -> bool {
     match expected {
         "string" => value.is_string(),
         "number" => value.is_number(),
@@ -202,6 +209,21 @@ fn type_matches(expected: &str, value: &Value) -> bool {
         "null" => value.is_null(),
         // Unknown/complex types (unions, $ref, etc.): don't claim a mismatch.
         _ => true,
+    }
+}
+
+fn expected_type_name(expected: &Value) -> String {
+    match expected {
+        Value::String(single) => single.clone(),
+        Value::Array(types) => {
+            let labels: Vec<&str> = types.iter().filter_map(Value::as_str).collect();
+            if labels.is_empty() {
+                "unknown".to_string()
+            } else {
+                labels.join(" | ")
+            }
+        },
+        _ => "unknown".to_string(),
     }
 }
 
@@ -386,6 +408,56 @@ mod tests {
         let err = validate_tool_args(&schema, &json!({"timeout": 30.5})).unwrap_err();
         assert_eq!(err.type_mismatches.len(), 1);
         assert_eq!(err.type_mismatches[0].field, "timeout");
+    }
+
+    #[test]
+    fn union_type_array_accepts_any_matching_type() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "schedule": { "type": ["object", "string", "integer"] },
+                "maybe_null": { "type": ["string", "null"] }
+            },
+            "required": ["schedule"]
+        });
+
+        assert!(
+            validate_tool_args(
+                &schema,
+                &json!({"schedule": {"kind": "at"}, "maybe_null": "ok"})
+            )
+            .is_ok()
+        );
+        assert!(
+            validate_tool_args(
+                &schema,
+                &json!({"schedule": "0 9 * * *", "maybe_null": null})
+            )
+            .is_ok()
+        );
+        assert!(
+            validate_tool_args(
+                &schema,
+                &json!({"schedule": 1_700_000_000_000u64, "maybe_null": "ok"})
+            )
+            .is_ok()
+        );
+    }
+
+    #[test]
+    fn union_type_array_reports_mismatch_when_nothing_matches() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "schedule": { "type": ["object", "string", "integer"] }
+            },
+            "required": ["schedule"]
+        });
+
+        let err = validate_tool_args(&schema, &json!({"schedule": false})).unwrap_err();
+        assert_eq!(err.type_mismatches.len(), 1);
+        assert_eq!(err.type_mismatches[0].expected, "object | string | integer");
+        assert_eq!(err.type_mismatches[0].actual, "boolean");
     }
 
     #[test]

--- a/crates/agents/src/tool_registry.rs
+++ b/crates/agents/src/tool_registry.rs
@@ -168,12 +168,16 @@ impl ToolRegistry {
     }
 
     pub fn list_schemas(&self) -> Vec<serde_json::Value> {
-        let mut schemas: Vec<serde_json::Value> =
-            self.tools.values().map(entry_to_schema).collect();
+        let mut schemas: Vec<serde_json::Value> = self
+            .tools
+            .iter()
+            .filter(|(name, _)| is_public_tool_name(name))
+            .map(|(_, entry)| entry_to_schema(entry))
+            .collect();
 
         let activated = self.activated.lock().unwrap_or_else(|e| e.into_inner());
         for (name, entry) in activated.iter() {
-            if !self.tools.contains_key(name) {
+            if !self.tools.contains_key(name) && is_public_tool_name(name) {
                 schemas.push(entry_to_schema(entry));
             }
         }
@@ -193,10 +197,15 @@ impl ToolRegistry {
 
     /// List registered tool names (static + activated).
     pub fn list_names(&self) -> Vec<String> {
-        let mut names: Vec<String> = self.tools.keys().cloned().collect();
+        let mut names: Vec<String> = self
+            .tools
+            .keys()
+            .filter(|name| is_public_tool_name(name))
+            .cloned()
+            .collect();
         let activated = self.activated.lock().unwrap_or_else(|e| e.into_inner());
         for name in activated.keys() {
-            if !self.tools.contains_key(name) {
+            if !self.tools.contains_key(name) && is_public_tool_name(name) {
                 names.push(name.clone());
             }
         }
@@ -284,6 +293,10 @@ impl ToolRegistry {
             activated: Arc::new(Mutex::new(HashMap::new())),
         }
     }
+}
+
+fn is_public_tool_name(name: &str) -> bool {
+    !name.ends_with("_wasm")
 }
 
 fn entry_to_schema(e: &ToolEntry) -> serde_json::Value {
@@ -467,16 +480,6 @@ mod tests {
             .expect("mcp tool should exist");
         assert_eq!(mcp["source"], "mcp");
         assert_eq!(mcp["mcpServer"], "github");
-
-        let wasm = schemas
-            .iter()
-            .find(|s| s["name"] == "calc_wasm")
-            .expect("wasm tool should exist");
-        assert_eq!(wasm["source"], "wasm");
-        assert_eq!(
-            wasm["componentHash"],
-            "abababababababababababababababababababababababababababababababab"
-        );
     }
 
     #[test]
@@ -491,6 +494,30 @@ mod tests {
 
         let names = registry.list_names();
         assert_eq!(names, vec!["exec".to_string(), "web_fetch".to_string()]);
+    }
+
+    #[test]
+    fn test_wasm_suffix_tools_are_hidden_from_public_lists() {
+        let mut registry = ToolRegistry::new();
+        registry.register(Box::new(DummyTool {
+            name: "exec".to_string(),
+        }));
+        registry.register_wasm(
+            Box::new(DummyTool {
+                name: "web_search_wasm".to_string(),
+            }),
+            [0xAB; 32],
+        );
+
+        assert_eq!(registry.list_names(), vec!["exec".to_string()]);
+        assert!(registry.get("web_search_wasm").is_some());
+
+        let schemas = registry.list_schemas();
+        assert!(
+            schemas
+                .iter()
+                .all(|schema| schema["name"] != "web_search_wasm")
+        );
     }
 
     #[test]

--- a/crates/tools/src/cron_tool.rs
+++ b/crates/tools/src/cron_tool.rs
@@ -674,6 +674,24 @@ impl AgentTool for CronTool {
     }
 
     fn parameters_schema(&self) -> Value {
+        let duration_like = |description: &str| {
+            json!({
+                "description": description,
+                "anyOf": [
+                    { "type": "integer" },
+                    { "type": "string" }
+                ]
+            })
+        };
+        let absolute_time_like = |description: &str| {
+            json!({
+                "description": description,
+                "anyOf": [
+                    { "type": "integer" },
+                    { "type": "string" }
+                ]
+            })
+        };
         json!({
             "type": "object",
             "properties": {
@@ -688,33 +706,59 @@ impl AgentTool for CronTool {
                     "properties": {
                         "name": { "type": "string", "description": "Human-readable job name" },
                         "schedule": {
-                            "type": "object",
                             "description": "Schedule object. For one-off jobs use {kind:'at', delay_ms} where delay_ms is milliseconds from now (e.g. 600000 for 10 min) — never compute at_ms yourself. For recurring use {kind:'every', every_ms} or {kind:'cron', expr, tz?}.",
-                            "properties": {
-                                "kind": { "type": "string", "enum": ["at", "every", "cron"] },
-                                "delay_ms": { "type": "integer", "description": "Milliseconds from now to run the job (server resolves to absolute time). Preferred over at_ms." },
-                                "at_ms": { "type": "integer", "description": "Absolute epoch milliseconds. Use delay_ms instead unless you have an exact timestamp." },
-                                "every_ms": { "type": "integer", "description": "Used when kind='every'" },
-                                "anchor_ms": { "type": "integer", "description": "Optional anchor when kind='every'" },
-                                "expr": { "type": "string", "description": "Cron expression used when kind='cron'" },
-                                "tz": { "type": "string", "description": "Optional timezone used when kind='cron'" }
-                            },
-                            "required": ["kind"]
+                            "anyOf": [
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "kind": { "type": "string", "enum": ["at", "every", "cron"] },
+                                        "delay_ms": duration_like("Milliseconds from now to run the job. Accepts integer milliseconds or a duration string like '10m'. Preferred over at_ms."),
+                                        "at_ms": absolute_time_like("Absolute epoch milliseconds or ISO-8601 timestamp. Use delay_ms instead unless you have an exact timestamp."),
+                                        "every_ms": duration_like("Recurring interval when kind='every'. Accepts integer milliseconds or a duration string like '15m'."),
+                                        "anchor_ms": absolute_time_like("Optional anchor when kind='every'. Accepts epoch milliseconds or ISO-8601 timestamp."),
+                                        "expr": { "type": "string", "description": "Cron expression used when kind='cron'" },
+                                        "tz": { "type": "string", "description": "Optional timezone used when kind='cron'" }
+                                    },
+                                    "required": ["kind"]
+                                },
+                                {
+                                    "type": "string",
+                                    "description": "Shorthand schedule string. Interpreted as a cron expression."
+                                },
+                                {
+                                    "type": "integer",
+                                    "description": "Shorthand absolute epoch milliseconds for a one-off job."
+                                }
+                            ]
                         },
                         "payload": {
-                            "type": "object",
                             "description": "What to do. Use {kind:'systemEvent', text} for main-session reminders or {kind:'agentTurn', message, model?, timeout_secs?, deliver?, channel?, to?}. `payload.model` selects the LLM for that job. This tool also accepts a shorthand message string at runtime.",
-                            "properties": {
-                                "kind": { "type": "string", "enum": ["systemEvent", "agentTurn"] },
-                                "text": { "type": "string" },
-                                "message": { "type": "string" },
-                                "model": { "type": "string" },
-                                "timeout_secs": { "type": "integer" },
-                                "deliver": { "type": "boolean", "description": "Set to true to deliver the agent output to a channel (e.g. Telegram) after the run. Requires channel and to." },
-                                "channel": { "type": "string", "description": "Channel account identifier for delivery (e.g. the Telegram bot username like 'my_telegram_bot'). Required when deliver=true." },
-                                "to": { "type": "string", "description": "Recipient chat ID for delivery (e.g. '123456789' for Telegram). Required when deliver=true." }
-                            },
-                            "required": ["kind"]
+                            "anyOf": [
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "kind": { "type": "string", "enum": ["systemEvent", "agentTurn"] },
+                                        "text": { "type": "string" },
+                                        "message": { "type": "string" },
+                                        "model": { "type": "string" },
+                                        "timeout_secs": {
+                                            "description": "Optional timeout in seconds. Accepts an integer number of seconds or a duration string like '2m'.",
+                                            "anyOf": [
+                                                { "type": "integer" },
+                                                { "type": "string" }
+                                            ]
+                                        },
+                                        "deliver": { "type": "boolean", "description": "Set to true to deliver the agent output to a channel (e.g. Telegram) after the run. Requires channel and to." },
+                                        "channel": { "type": "string", "description": "Channel account identifier for delivery (e.g. the Telegram bot username like 'my_telegram_bot'). Required when deliver=true." },
+                                        "to": { "type": "string", "description": "Recipient chat ID for delivery (e.g. '123456789' for Telegram). Required when deliver=true." }
+                                    },
+                                    "required": ["kind"]
+                                },
+                                {
+                                    "type": "string",
+                                    "description": "Shorthand payload message string."
+                                }
+                            ]
                         },
                         "sessionTarget": { "type": "string", "enum": ["main", "isolated"], "default": "isolated" },
                         "sandbox": {
@@ -1053,6 +1097,63 @@ mod tests {
 
         assert_eq!(updated["schedule"]["kind"], "cron");
         assert_eq!(updated["schedule"]["expr"], "*/15 * * * *");
+    }
+
+    #[test]
+    fn test_parameters_schema_advertises_flexible_schedule_inputs() {
+        let tool = make_tool();
+        let schema = tool.parameters_schema();
+        let schedule = &schema["properties"]["job"]["properties"]["schedule"];
+
+        assert!(schedule.get("anyOf").is_some());
+
+        let object_variant = schedule["anyOf"]
+            .as_array()
+            .and_then(|variants| variants.iter().find(|variant| variant["type"] == "object"))
+            .expect("schedule object variant should exist");
+
+        assert!(
+            object_variant["properties"]["delay_ms"]
+                .get("anyOf")
+                .is_some()
+        );
+        assert!(object_variant["properties"]["at_ms"].get("anyOf").is_some());
+        assert!(
+            object_variant["properties"]["every_ms"]
+                .get("anyOf")
+                .is_some()
+        );
+        assert!(
+            object_variant["properties"]["anchor_ms"]
+                .get("anyOf")
+                .is_some()
+        );
+    }
+
+    #[test]
+    fn test_parameters_schema_advertises_shorthand_payload_string() {
+        let tool = make_tool();
+        let schema = tool.parameters_schema();
+        let payload = &schema["properties"]["job"]["properties"]["payload"];
+
+        let string_variant = payload["anyOf"]
+            .as_array()
+            .and_then(|variants| variants.iter().find(|variant| variant["type"] == "string"))
+            .expect("payload string variant should exist");
+        assert_eq!(
+            string_variant["description"],
+            "Shorthand payload message string."
+        );
+
+        let object_variant = payload["anyOf"]
+            .as_array()
+            .and_then(|variants| variants.iter().find(|variant| variant["type"] == "object"))
+            .expect("payload object variant should exist");
+        assert!(
+            object_variant["properties"]["timeout_secs"]
+                .get("anyOf")
+                .is_some()
+        );
     }
 
     #[tokio::test]

--- a/crates/tools/src/cron_tool.rs
+++ b/crates/tools/src/cron_tool.rs
@@ -676,20 +676,14 @@ impl AgentTool for CronTool {
     fn parameters_schema(&self) -> Value {
         let duration_like = |description: &str| {
             json!({
-                "description": description,
-                "anyOf": [
-                    { "type": "integer" },
-                    { "type": "string" }
-                ]
+                "type": ["integer", "string"],
+                "description": description
             })
         };
         let absolute_time_like = |description: &str| {
             json!({
-                "description": description,
-                "anyOf": [
-                    { "type": "integer" },
-                    { "type": "string" }
-                ]
+                "type": ["integer", "string"],
+                "description": description
             })
         };
         json!({
@@ -706,59 +700,36 @@ impl AgentTool for CronTool {
                     "properties": {
                         "name": { "type": "string", "description": "Human-readable job name" },
                         "schedule": {
+                            "type": ["object", "string", "integer"],
                             "description": "Schedule object. For one-off jobs use {kind:'at', delay_ms} where delay_ms is milliseconds from now (e.g. 600000 for 10 min) — never compute at_ms yourself. For recurring use {kind:'every', every_ms} or {kind:'cron', expr, tz?}.",
-                            "anyOf": [
-                                {
-                                    "type": "object",
-                                    "properties": {
-                                        "kind": { "type": "string", "enum": ["at", "every", "cron"] },
-                                        "delay_ms": duration_like("Milliseconds from now to run the job. Accepts integer milliseconds or a duration string like '10m'. Preferred over at_ms."),
-                                        "at_ms": absolute_time_like("Absolute epoch milliseconds or ISO-8601 timestamp. Use delay_ms instead unless you have an exact timestamp."),
-                                        "every_ms": duration_like("Recurring interval when kind='every'. Accepts integer milliseconds or a duration string like '15m'."),
-                                        "anchor_ms": absolute_time_like("Optional anchor when kind='every'. Accepts epoch milliseconds or ISO-8601 timestamp."),
-                                        "expr": { "type": "string", "description": "Cron expression used when kind='cron'" },
-                                        "tz": { "type": "string", "description": "Optional timezone used when kind='cron'" }
-                                    },
-                                    "required": ["kind"]
-                                },
-                                {
-                                    "type": "string",
-                                    "description": "Shorthand schedule string. Interpreted as a cron expression."
-                                },
-                                {
-                                    "type": "integer",
-                                    "description": "Shorthand absolute epoch milliseconds for a one-off job."
-                                }
-                            ]
+                            "properties": {
+                                "kind": { "type": "string", "enum": ["at", "every", "cron"] },
+                                "delay_ms": duration_like("Milliseconds from now to run the job. Accepts integer milliseconds or a duration string like '10m'. Preferred over at_ms."),
+                                "at_ms": absolute_time_like("Absolute epoch milliseconds or ISO-8601 timestamp. Use delay_ms instead unless you have an exact timestamp."),
+                                "every_ms": duration_like("Recurring interval when kind='every'. Accepts integer milliseconds or a duration string like '15m'."),
+                                "anchor_ms": absolute_time_like("Optional anchor when kind='every'. Accepts epoch milliseconds or ISO-8601 timestamp."),
+                                "expr": { "type": "string", "description": "Cron expression used when kind='cron'" },
+                                "tz": { "type": "string", "description": "Optional timezone used when kind='cron'" }
+                            },
+                            "required": ["kind"]
                         },
                         "payload": {
+                            "type": ["object", "string"],
                             "description": "What to do. Use {kind:'systemEvent', text} for main-session reminders or {kind:'agentTurn', message, model?, timeout_secs?, deliver?, channel?, to?}. `payload.model` selects the LLM for that job. This tool also accepts a shorthand message string at runtime.",
-                            "anyOf": [
-                                {
-                                    "type": "object",
-                                    "properties": {
-                                        "kind": { "type": "string", "enum": ["systemEvent", "agentTurn"] },
-                                        "text": { "type": "string" },
-                                        "message": { "type": "string" },
-                                        "model": { "type": "string" },
-                                        "timeout_secs": {
-                                            "description": "Optional timeout in seconds. Accepts an integer number of seconds or a duration string like '2m'.",
-                                            "anyOf": [
-                                                { "type": "integer" },
-                                                { "type": "string" }
-                                            ]
-                                        },
-                                        "deliver": { "type": "boolean", "description": "Set to true to deliver the agent output to a channel (e.g. Telegram) after the run. Requires channel and to." },
-                                        "channel": { "type": "string", "description": "Channel account identifier for delivery (e.g. the Telegram bot username like 'my_telegram_bot'). Required when deliver=true." },
-                                        "to": { "type": "string", "description": "Recipient chat ID for delivery (e.g. '123456789' for Telegram). Required when deliver=true." }
-                                    },
-                                    "required": ["kind"]
+                            "properties": {
+                                "kind": { "type": "string", "enum": ["systemEvent", "agentTurn"] },
+                                "text": { "type": "string" },
+                                "message": { "type": "string" },
+                                "model": { "type": "string" },
+                                "timeout_secs": {
+                                    "type": ["integer", "string"],
+                                    "description": "Optional timeout in seconds. Accepts an integer number of seconds or a duration string like '2m'."
                                 },
-                                {
-                                    "type": "string",
-                                    "description": "Shorthand payload message string."
-                                }
-                            ]
+                                "deliver": { "type": "boolean", "description": "Set to true to deliver the agent output to a channel (e.g. Telegram) after the run. Requires channel and to." },
+                                "channel": { "type": "string", "description": "Channel account identifier for delivery (e.g. the Telegram bot username like 'my_telegram_bot'). Required when deliver=true." },
+                                "to": { "type": "string", "description": "Recipient chat ID for delivery (e.g. '123456789' for Telegram). Required when deliver=true." }
+                            },
+                            "required": ["kind"]
                         },
                         "sessionTarget": { "type": "string", "enum": ["main", "isolated"], "default": "isolated" },
                         "sandbox": {
@@ -1105,28 +1076,22 @@ mod tests {
         let schema = tool.parameters_schema();
         let schedule = &schema["properties"]["job"]["properties"]["schedule"];
 
-        assert!(schedule.get("anyOf").is_some());
-
-        let object_variant = schedule["anyOf"]
-            .as_array()
-            .and_then(|variants| variants.iter().find(|variant| variant["type"] == "object"))
-            .expect("schedule object variant should exist");
-
-        assert!(
-            object_variant["properties"]["delay_ms"]
-                .get("anyOf")
-                .is_some()
+        assert_eq!(schedule["type"], json!(["object", "string", "integer"]));
+        assert_eq!(
+            schedule["properties"]["delay_ms"]["type"],
+            json!(["integer", "string"])
         );
-        assert!(object_variant["properties"]["at_ms"].get("anyOf").is_some());
-        assert!(
-            object_variant["properties"]["every_ms"]
-                .get("anyOf")
-                .is_some()
+        assert_eq!(
+            schedule["properties"]["at_ms"]["type"],
+            json!(["integer", "string"])
         );
-        assert!(
-            object_variant["properties"]["anchor_ms"]
-                .get("anyOf")
-                .is_some()
+        assert_eq!(
+            schedule["properties"]["every_ms"]["type"],
+            json!(["integer", "string"])
+        );
+        assert_eq!(
+            schedule["properties"]["anchor_ms"]["type"],
+            json!(["integer", "string"])
         );
     }
 
@@ -1136,23 +1101,10 @@ mod tests {
         let schema = tool.parameters_schema();
         let payload = &schema["properties"]["job"]["properties"]["payload"];
 
-        let string_variant = payload["anyOf"]
-            .as_array()
-            .and_then(|variants| variants.iter().find(|variant| variant["type"] == "string"))
-            .expect("payload string variant should exist");
+        assert_eq!(payload["type"], json!(["object", "string"]));
         assert_eq!(
-            string_variant["description"],
-            "Shorthand payload message string."
-        );
-
-        let object_variant = payload["anyOf"]
-            .as_array()
-            .and_then(|variants| variants.iter().find(|variant| variant["type"] == "object"))
-            .expect("payload object variant should exist");
-        assert!(
-            object_variant["properties"]["timeout_secs"]
-                .get("anyOf")
-                .is_some()
+            payload["properties"]["timeout_secs"]["type"],
+            json!(["integer", "string"])
         );
     }
 
@@ -1306,16 +1258,16 @@ mod tests {
     }
 
     #[test]
-    fn test_parameters_schema_has_no_one_of() {
-        fn contains_one_of(value: &Value) -> bool {
+    fn test_parameters_schema_has_no_one_of_or_any_of() {
+        fn contains_disallowed_union(value: &Value) -> bool {
             match value {
                 Value::Object(obj) => {
-                    if obj.contains_key("oneOf") {
+                    if obj.contains_key("oneOf") || obj.contains_key("anyOf") {
                         return true;
                     }
-                    obj.values().any(contains_one_of)
+                    obj.values().any(contains_disallowed_union)
                 },
-                Value::Array(items) => items.iter().any(contains_one_of),
+                Value::Array(items) => items.iter().any(contains_disallowed_union),
                 _ => false,
             }
         }
@@ -1323,8 +1275,8 @@ mod tests {
         let tool = make_tool();
         let schema = tool.parameters_schema();
         assert!(
-            !contains_one_of(&schema),
-            "cron tool schema must avoid oneOf for OpenAI Responses API compatibility"
+            !contains_disallowed_union(&schema),
+            "cron tool schema must avoid oneOf/anyOf for native tool-calling compatibility"
         );
     }
 

--- a/crates/tools/src/cron_tool.rs
+++ b/crates/tools/src/cron_tool.rs
@@ -674,13 +674,7 @@ impl AgentTool for CronTool {
     }
 
     fn parameters_schema(&self) -> Value {
-        let duration_like = |description: &str| {
-            json!({
-                "type": ["integer", "string"],
-                "description": description
-            })
-        };
-        let absolute_time_like = |description: &str| {
+        let time_field = |description: &str| {
             json!({
                 "type": ["integer", "string"],
                 "description": description
@@ -704,10 +698,10 @@ impl AgentTool for CronTool {
                             "description": "Schedule object. For one-off jobs use {kind:'at', delay_ms} where delay_ms is milliseconds from now (e.g. 600000 for 10 min) — never compute at_ms yourself. For recurring use {kind:'every', every_ms} or {kind:'cron', expr, tz?}.",
                             "properties": {
                                 "kind": { "type": "string", "enum": ["at", "every", "cron"] },
-                                "delay_ms": duration_like("Milliseconds from now to run the job. Accepts integer milliseconds or a duration string like '10m'. Preferred over at_ms."),
-                                "at_ms": absolute_time_like("Absolute epoch milliseconds or ISO-8601 timestamp. Use delay_ms instead unless you have an exact timestamp."),
-                                "every_ms": duration_like("Recurring interval when kind='every'. Accepts integer milliseconds or a duration string like '15m'."),
-                                "anchor_ms": absolute_time_like("Optional anchor when kind='every'. Accepts epoch milliseconds or ISO-8601 timestamp."),
+                                "delay_ms": time_field("Milliseconds from now to run the job. Accepts integer milliseconds or a duration string like '10m'. Preferred over at_ms."),
+                                "at_ms": time_field("Absolute epoch milliseconds or ISO-8601 timestamp. Use delay_ms instead unless you have an exact timestamp."),
+                                "every_ms": time_field("Recurring interval when kind='every'. Accepts integer milliseconds or a duration string like '15m'."),
+                                "anchor_ms": time_field("Optional anchor when kind='every'. Accepts epoch milliseconds or ISO-8601 timestamp."),
                                 "expr": { "type": "string", "description": "Cron expression used when kind='cron'" },
                                 "tz": { "type": "string", "description": "Optional timezone used when kind='cron'" }
                             },


### PR DESCRIPTION
## Summary
Fix recent tool-call regressions that were breaking updated Moltis instances, especially for cron reminders and legacy internal WASM tool names.

This PR:
- hides internal `*_wasm` tools from the model-facing tool inventory
- simplifies the `cron` tool schema to use plain JSON Schema `type` unions instead of nested `anyOf`
- teaches the local tool-arg validator to understand `type: [...]` unions
- preserves compatibility with older sessions/tool calls by resolving legacy names like `web_search_wasm` to stable public tools when available, while still falling back to the legacy name if needed

Root cause:
- internal WASM-backed tool variants leaked into the public inventory, so models could call implementation-detail tool names directly
- the cron runtime accepted flexible string inputs, but the published schema shape was hostile to native tool calling and could lead models to emit the wrong argument types

## Validation
### Completed
- [x] `cargo +nightly-2025-11-30 fmt --all`
- [x] `cargo test -p moltis-agents tool_registry`
- [x] `cargo test -p moltis-tools cron_tool`
- [x] `cargo test -p moltis-agents tool_arg_validator`
- [x] `cargo test -p moltis-agents`
- [x] `cargo test -p moltis-tools cron_tool`

### Remaining
- [ ] `just lint`
- [ ] `just test`
- [ ] `./scripts/local-validate.sh <PR_NUMBER>`

## Manual QA
1. Start Moltis with the updated branch.
2. Verify tool inventory does not expose `web_search_wasm`, `web_fetch_wasm`, or `calc_wasm`.
3. Ask Codex/ChatGPT to create a reminder using relative time like "in 10 minutes" and confirm the cron call succeeds.
4. Verify a legacy tool call name such as `web_search_wasm` still resolves successfully through the stable public tool path after update.
5. Verify `web_search` still returns the normal config/runtime error if no Brave key is configured, rather than failing through a leaked internal tool path.