### PR TITLE
[codex] Sanitize OpenAI-compatible MCP tool schemas

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,7 @@ fields need updates in `check_semantic_warnings()`.
 ## Rust Style and Idioms
 
 - **File size limit: 1,500 lines.** CI enforces this via `scripts/check-file-size.sh`. Split large files into modules by domain. Existing oversize files are allowlisted for incremental decomposition.
+- Do not add implementation code to `mod.rs` or `lib.rs`. Keep those files for module wiring, exports, and crate setup, move real logic into dedicated sibling modules.
 - Use traits for behaviour boundaries. Prefer generics for hot paths, `dyn Trait` for heterogeneous/runtime dispatch.
 - Derive `Default` when all fields have sensible defaults.
 - Use concrete types (`struct`/`enum`) over `serde_json::Value` wherever shape is known.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -133,6 +133,7 @@ dependencies = [
  "cfg-if",
  "getrandom 0.3.4",
  "once_cell",
+ "serde",
  "version_check",
  "zerocopy",
 ]
@@ -1056,6 +1057,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitcoin-io"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1153,6 +1169,12 @@ checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
 dependencies = [
  "objc2",
 ]
+
+[[package]]
+name = "borrow-or-share"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc0b364ead1874514c8c2855ab558056ebfeb775653e7ae45ff72f28f8f3166c"
 
 [[package]]
 name = "bs58"
@@ -2963,6 +2985,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "email_address"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e079f19b08ca6239f47f8ba8509c11cf3ea30095831f7fed61441475edd8c449"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "embedded-io"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3184,6 +3215,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
+name = "fancy-regex"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72cf461f865c862bb7dc573f643dd6a2b6842f7c30b07882b56bd148cc2761b8"
+dependencies = [
+ "bit-set",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "fancy_constructor"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3329,6 +3371,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "fluent-uri"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc74ac4d8359ae70623506d512209619e5cf8f347124910440dbc221714b328e"
+dependencies = [
+ "borrow-or-share",
+ "ref-cast",
+ "serde",
+]
+
+[[package]]
 name = "flume"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3379,6 +3432,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fraction"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f158e3ff0a1b334408dc9fb811cd99b446986f4d8b741bb08f9df1604085ae7"
+dependencies = [
+ "lazy_static",
+ "num",
 ]
 
 [[package]]
@@ -5924,6 +5987,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "json_schema_ast"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65ab8ebca795b6b9285f077bf83f37bdf58c5b1c8e17bbe6ac2bffbad99f085b"
+dependencies = [
+ "fancy-regex",
+ "jsonschema",
+ "percent-encoding",
+ "serde_json",
+ "thiserror 2.0.18",
+ "url",
+]
+
+[[package]]
+name = "jsonschema"
+version = "0.45.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "257eb0e588b76827bbddc9e73945a9743693dd2adeaee9da26420f93cfedb798"
+dependencies = [
+ "ahash",
+ "bytecount",
+ "data-encoding",
+ "email_address",
+ "fancy-regex",
+ "fraction",
+ "getrandom 0.3.4",
+ "idna",
+ "itoa",
+ "num-cmp",
+ "num-traits",
+ "percent-encoding",
+ "referencing",
+ "regex",
+ "regex-syntax",
+ "serde",
+ "serde_json",
+ "unicode-general-category",
+ "uuid-simd",
+]
+
+[[package]]
 name = "jsonwebtoken"
 version = "10.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7823,6 +7927,7 @@ dependencies = [
  "futures",
  "genai",
  "http 1.4.0",
+ "json_schema_ast",
  "llama-cpp-2",
  "moltis-agents",
  "moltis-common",
@@ -7830,6 +7935,7 @@ dependencies = [
  "moltis-metrics",
  "moltis-oauth",
  "reqwest 0.12.28",
+ "schemars 1.2.1",
  "secrecy 0.8.0",
  "serde",
  "serde_json",
@@ -8627,6 +8733,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8650,6 +8770,21 @@ dependencies = [
  "rand 0.8.5",
  "smallvec",
  "zeroize",
+]
+
+[[package]]
+name = "num-cmp"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63335b2e2c34fae2fb0aa2cecfd9f0832a1e24b3b32ecec612c3426d46dc8aaa"
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -8691,6 +8826,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "537b596b97c40fcf8056d153049eb22f481c17ebce72a513ec9286e4986d1bb6"
 dependencies = [
  "num-modular",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
@@ -8891,6 +9037,12 @@ checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "outref"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "p256"
@@ -10029,6 +10181,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "referencing"
+version = "0.45.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2f38748ceca8d0b0013e60f534d94a6e23dfd89fd2a88318fc5a2d04fda1010"
+dependencies = [
+ "ahash",
+ "fluent-uri",
+ "getrandom 0.3.4",
+ "hashbrown 0.16.1",
+ "parking_lot 0.12.5",
+ "percent-encoding",
+ "serde_json",
+]
+
+[[package]]
 name = "regalloc2"
 version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10826,8 +10993,21 @@ checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
 dependencies = [
  "dyn-clone",
  "ref-cast",
+ "schemars_derive",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -11049,6 +11229,17 @@ name = "serde_derive"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -13142,6 +13333,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7eec5d1121208364f6793f7d2e222bf75a915c19557537745b195b253dd64217"
 
 [[package]]
+name = "unicode-general-category"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b993bddc193ae5bd0d623b49ec06ac3e9312875fdae725a975c51db1cc1677f"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13289,6 +13486,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "uuid-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b082222b4f6619906941c17eb2297fff4c2fb96cb60164170522942a200bd8"
+dependencies = [
+ "outref",
+ "vsimd",
+]
+
+[[package]]
 name = "uwl"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13352,6 +13559,12 @@ dependencies = [
  "x25519-dalek",
  "zeroize",
 ]
+
+[[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "wacore"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,8 +26,8 @@ default-members = [
   "crates/metrics",
   "crates/msteams",
   "crates/network-filter",
-  "crates/node-host",
   "crates/node-exec-types",
+  "crates/node-host",
   "crates/nostr",
   "crates/oauth",
   "crates/onboarding",
@@ -83,8 +83,8 @@ members = [
   "crates/memory",
   "crates/metrics",
   "crates/msteams",
-  "crates/node-host",
   "crates/node-exec-types",
+  "crates/node-host",
   "crates/nostr",
   "crates/oauth",
   "crates/onboarding",
@@ -152,6 +152,7 @@ axum       = { features = ["ws"], version = "0.8" }
 axum-extra = "0.10"
 # Serialization
 postcard   = { features = ["alloc"], version = "1.1" }
+schemars   = "1.2"
 serde      = { features = ["derive"], version = "1" }
 serde_json = "1"
 # Error handling
@@ -190,13 +191,14 @@ tokio-tungstenite = "0.26"
 toml              = "0.8"
 toml_edit         = "0.22"
 # LLM provider crates (optional, behind feature flags)
-async-openai = { features = ["chat-completion"], version = "0.32" }
-base64       = "0.22"
-bytemuck     = { features = ["derive"], version = "1" }
-bytes        = "1"
-encoding_rs  = "0.8"
-fd-lock      = "4"
-genai        = "0.5"
+async-openai    = { features = ["chat-completion"], version = "0.32" }
+base64          = "0.22"
+bytemuck        = { features = ["derive"], version = "1" }
+bytes           = "1"
+encoding_rs     = "0.8"
+fd-lock         = "4"
+genai           = "0.5"
+json_schema_ast = "0.3.1"
 # GraphQL
 async-graphql      = "7"
 async-graphql-axum = "7"
@@ -297,9 +299,9 @@ grep-regex            = "0.1"
 grep-searcher         = "0.1"
 ignore                = "0.4"
 include_dir           = "0.7"
-pdf-extract           = "0.10"
 json5                 = "0.4"
 notify-debouncer-full = "0.7"
+pdf-extract           = "0.10"
 portable-pty          = "0.9"
 rstest                = "0.25"
 serial_test           = "3"
@@ -320,59 +322,59 @@ tower-service = "0.3"
 zeroize       = { features = ["derive"], version = "1" }
 
 # Workspace crates
-moltis                 = { path = "crates/cli" }
-moltis-agents          = { path = "crates/agents" }
-moltis-auth            = { path = "crates/auth" }
-moltis-auto-reply      = { path = "crates/auto-reply" }
-moltis-browser         = { path = "crates/browser" }
-moltis-caldav          = { path = "crates/caldav" }
-moltis-canvas          = { path = "crates/canvas" }
-moltis-channels        = { path = "crates/channels" }
-moltis-chat            = { path = "crates/chat" }
-moltis-common          = { path = "crates/common" }
-moltis-config          = { path = "crates/config" }
-moltis-cron            = { path = "crates/cron" }
-moltis-discord         = { path = "crates/discord" }
-moltis-gateway         = { default-features = false, path = "crates/gateway" }
-moltis-graphql         = { path = "crates/graphql" }
-moltis-httpd           = { default-features = false, path = "crates/httpd" }
-moltis-matrix          = { path = "crates/matrix" }
-moltis-mcp             = { path = "crates/mcp" }
+moltis                  = { path = "crates/cli" }
+moltis-agents           = { path = "crates/agents" }
+moltis-auth             = { path = "crates/auth" }
+moltis-auto-reply       = { path = "crates/auto-reply" }
+moltis-browser          = { path = "crates/browser" }
+moltis-caldav           = { path = "crates/caldav" }
+moltis-canvas           = { path = "crates/canvas" }
+moltis-channels         = { path = "crates/channels" }
+moltis-chat             = { path = "crates/chat" }
+moltis-common           = { path = "crates/common" }
+moltis-config           = { path = "crates/config" }
+moltis-cron             = { path = "crates/cron" }
+moltis-discord          = { path = "crates/discord" }
+moltis-gateway          = { default-features = false, path = "crates/gateway" }
+moltis-graphql          = { path = "crates/graphql" }
+moltis-httpd            = { default-features = false, path = "crates/httpd" }
+moltis-matrix           = { path = "crates/matrix" }
+moltis-mcp              = { path = "crates/mcp" }
 moltis-mcp-agent-bridge = { path = "crates/mcp-agent-bridge" }
-moltis-media           = { path = "crates/media" }
-moltis-memory          = { path = "crates/memory" }
-moltis-metrics         = { path = "crates/metrics" }
-moltis-msteams         = { path = "crates/msteams" }
-moltis-network-filter  = { default-features = false, path = "crates/network-filter" }
-moltis-node-host       = { path = "crates/node-host" }
-moltis-node-exec-types = { path = "crates/node-exec-types" }
-moltis-nostr           = { path = "crates/nostr" }
-moltis-oauth           = { path = "crates/oauth" }
-moltis-onboarding      = { path = "crates/onboarding" }
-moltis-openclaw-import = { path = "crates/openclaw-import" }
-moltis-plugins         = { path = "crates/plugins" }
-moltis-projects        = { path = "crates/projects" }
-moltis-protocol        = { path = "crates/protocol" }
-moltis-provider-setup  = { path = "crates/provider-setup" }
-moltis-providers       = { features = ["provider-github-copilot", "provider-kimi-code", "provider-openai-codex"], path = "crates/providers" }
-moltis-qmd             = { path = "crates/qmd" }
-moltis-routing         = { path = "crates/routing" }
-moltis-schema-export   = { path = "crates/schema-export" }
-moltis-secret-store    = { default-features = false, path = "crates/secret-store" }
-moltis-service-traits  = { path = "crates/service-traits" }
-moltis-sessions        = { path = "crates/sessions" }
-moltis-skills          = { path = "crates/skills" }
-moltis-slack           = { path = "crates/slack" }
-moltis-swift-bridge    = { path = "crates/swift-bridge" }
-moltis-tailscale       = { path = "crates/tailscale" }
-moltis-telegram        = { path = "crates/telegram" }
-moltis-tls             = { path = "crates/tls" }
-moltis-tools           = { path = "crates/tools" }
-moltis-vault           = { path = "crates/vault" }
-moltis-voice           = { path = "crates/voice" }
-moltis-web             = { default-features = false, path = "crates/web" }
-moltis-webhooks        = { path = "crates/webhooks" }
-moltis-whatsapp        = { path = "crates/whatsapp" }
+moltis-media            = { path = "crates/media" }
+moltis-memory           = { path = "crates/memory" }
+moltis-metrics          = { path = "crates/metrics" }
+moltis-msteams          = { path = "crates/msteams" }
+moltis-network-filter   = { default-features = false, path = "crates/network-filter" }
+moltis-node-exec-types  = { path = "crates/node-exec-types" }
+moltis-node-host        = { path = "crates/node-host" }
+moltis-nostr            = { path = "crates/nostr" }
+moltis-oauth            = { path = "crates/oauth" }
+moltis-onboarding       = { path = "crates/onboarding" }
+moltis-openclaw-import  = { path = "crates/openclaw-import" }
+moltis-plugins          = { path = "crates/plugins" }
+moltis-projects         = { path = "crates/projects" }
+moltis-protocol         = { path = "crates/protocol" }
+moltis-provider-setup   = { path = "crates/provider-setup" }
+moltis-providers        = { features = ["provider-github-copilot", "provider-kimi-code", "provider-openai-codex"], path = "crates/providers" }
+moltis-qmd              = { path = "crates/qmd" }
+moltis-routing          = { path = "crates/routing" }
+moltis-schema-export    = { path = "crates/schema-export" }
+moltis-secret-store     = { default-features = false, path = "crates/secret-store" }
+moltis-service-traits   = { path = "crates/service-traits" }
+moltis-sessions         = { path = "crates/sessions" }
+moltis-skills           = { path = "crates/skills" }
+moltis-slack            = { path = "crates/slack" }
+moltis-swift-bridge     = { path = "crates/swift-bridge" }
+moltis-tailscale        = { path = "crates/tailscale" }
+moltis-telegram         = { path = "crates/telegram" }
+moltis-tls              = { path = "crates/tls" }
+moltis-tools            = { path = "crates/tools" }
+moltis-vault            = { path = "crates/vault" }
+moltis-voice            = { path = "crates/voice" }
+moltis-web              = { default-features = false, path = "crates/web" }
+moltis-webhooks         = { path = "crates/webhooks" }
+moltis-whatsapp         = { path = "crates/whatsapp" }
 
 [profile.release]
 codegen-units = 1

--- a/crates/providers/Cargo.toml
+++ b/crates/providers/Cargo.toml
@@ -23,10 +23,12 @@ async-stream      = { workspace = true }
 async-trait       = { workspace = true }
 futures           = { workspace = true }
 http              = { workspace = true }
+json_schema_ast   = { workspace = true }
 moltis-agents     = { path = "../agents" }
 moltis-common     = { workspace = true }
 moltis-config     = { workspace = true }
 reqwest           = { workspace = true }
+schemars          = { workspace = true }
 secrecy           = { workspace = true }
 serde             = { workspace = true }
 serde_json        = { workspace = true }

--- a/crates/providers/src/openai_compat/mod.rs
+++ b/crates/providers/src/openai_compat/mod.rs
@@ -145,7 +145,13 @@ pub fn sanitize_schema_for_openai_compat(schema: &mut serde_json::Value) {
     }
 
     if let Some(items) = obj.get_mut("items") {
-        sanitize_schema_for_openai_compat(items);
+        if let Some(item_schemas) = items.as_array_mut() {
+            for item_schema in item_schemas {
+                sanitize_schema_for_openai_compat(item_schema);
+            }
+        } else {
+            sanitize_schema_for_openai_compat(items);
+        }
     }
 
     for key in ["anyOf", "oneOf", "allOf", "prefixItems"] {
@@ -1178,8 +1184,8 @@ pub fn parse_responses_completion(resp: &serde_json::Value) -> CompletionRespons
 #[cfg(test)]
 mod tests {
     use super::{
-        parse_responses_completion, parse_tool_calls, sanitize_schema_for_openai_compat,
-        to_responses_api_tools,
+        OPENAI_UNSUPPORTED_SCHEMA_KEYWORDS, parse_responses_completion, parse_tool_calls,
+        sanitize_schema_for_openai_compat, to_responses_api_tools,
     };
 
     #[test]
@@ -1352,6 +1358,19 @@ mod tests {
                     "patternProperties": {
                         "^x-": { "type": "string" }
                     },
+                    "dependentRequired": {
+                        "mode": ["enabled"]
+                    },
+                    "unevaluatedProperties": false,
+                    "unevaluatedItems": false,
+                    "propertyNames": {
+                        "minLength": 1
+                    },
+                    "contains": {
+                        "type": "string"
+                    },
+                    "minContains": 1,
+                    "maxContains": 2,
                     "items": {
                         "not": {
                             "type": "integer"
@@ -1364,19 +1383,47 @@ mod tests {
         sanitize_schema_for_openai_compat(&mut schema);
         let encoded = schema.to_string();
 
-        for keyword in [
-            "\"if\"",
-            "\"then\"",
-            "\"else\"",
-            "\"dependentSchemas\"",
-            "\"patternProperties\"",
-            "\"not\"",
-        ] {
-            assert!(!encoded.contains(keyword), "{keyword} should be removed");
+        for keyword in OPENAI_UNSUPPORTED_SCHEMA_KEYWORDS {
+            assert!(
+                !encoded.contains(&format!("\"{keyword}\"")),
+                "{keyword} should be removed"
+            );
         }
         assert_eq!(
             schema["properties"]["config"]["properties"]["mode"]["type"],
             "string"
         );
+    }
+
+    #[test]
+    fn sanitize_schema_for_openai_compat_recurses_into_array_form_items() {
+        let mut schema = serde_json::json!({
+            "type": "object",
+            "properties": {
+                "tuple": {
+                    "type": "array",
+                    "items": [
+                        {
+                            "type": "string",
+                            "not": { "const": "" }
+                        },
+                        {
+                            "type": "object",
+                            "patternProperties": {
+                                "^x-": { "type": "string" }
+                            }
+                        }
+                    ]
+                }
+            }
+        });
+
+        sanitize_schema_for_openai_compat(&mut schema);
+
+        let tuple_items = schema["properties"]["tuple"]["items"]
+            .as_array()
+            .expect("tuple items should remain an array");
+        assert!(tuple_items[0].get("not").is_none());
+        assert!(tuple_items[1].get("patternProperties").is_none());
     }
 }

--- a/crates/providers/src/openai_compat/mod.rs
+++ b/crates/providers/src/openai_compat/mod.rs
@@ -5,7 +5,18 @@
 
 use std::collections::{HashMap, HashSet};
 
-use {serde::Serialize, tracing::trace};
+use {
+    json_schema_ast::SchemaDocument,
+    schemars::{
+        Schema,
+        transform::{
+            RecursiveTransform, RemoveRefSiblings, ReplaceConstValue, ReplacePrefixItems,
+            ReplaceUnevaluatedProperties, Transform,
+        },
+    },
+    serde::Serialize,
+    tracing::{trace, warn},
+};
 
 use moltis_agents::model::{
     ChatMessage, CompletionResponse, StreamEvent, ToolCall, Usage, UserContent,
@@ -107,74 +118,118 @@ fn make_nullable(schema: &mut serde_json::Value) {
     }
 }
 
-const OPENAI_UNSUPPORTED_SCHEMA_KEYWORDS: &[&str] = &[
-    "not",
-    "if",
-    "then",
-    "else",
-    "dependentSchemas",
-    "dependentRequired",
-    "unevaluatedProperties",
-    "unevaluatedItems",
-    "patternProperties",
-    "propertyNames",
-    "contains",
-    "minContains",
-    "maxContains",
+const OPENAI_ALLOWED_SCHEMA_KEYWORDS: &[&str] = &[
+    "$ref",
+    "$defs",
+    "definitions",
+    "type",
+    "enum",
+    "title",
+    "description",
+    "default",
+    "example",
+    "examples",
+    "format",
+    "pattern",
+    "properties",
+    "required",
+    "items",
+    "additionalProperties",
+    "anyOf",
+    "oneOf",
+    "allOf",
+    "minimum",
+    "maximum",
+    "exclusiveMinimum",
+    "exclusiveMaximum",
+    "multipleOf",
+    "minLength",
+    "maxLength",
+    "minItems",
+    "maxItems",
+    "uniqueItems",
+    "minProperties",
+    "maxProperties",
 ];
 
-/// Recursively strip JSON Schema keywords that OpenAI-compatible tool schemas
-/// reject in strict function-calling mode.
+#[derive(Debug, Clone, Default)]
+struct OpenAiSchemaSubsetTransform;
+
+impl Transform for OpenAiSchemaSubsetTransform {
+    fn transform(&mut self, schema: &mut Schema) {
+        let Some(obj) = schema.as_object_mut() else {
+            return;
+        };
+
+        obj.retain(|key, _| OPENAI_ALLOWED_SCHEMA_KEYWORDS.contains(&key.as_str()));
+    }
+}
+
+fn canonicalize_schema_for_openai_compat(schema: &serde_json::Value) -> serde_json::Value {
+    let document = match SchemaDocument::from_json(schema) {
+        Ok(document) => document,
+        Err(error) => {
+            warn!(
+                error = %error,
+                "openai tool schema failed Draft 2020-12 preflight; using raw schema for best-effort normalization"
+            );
+            return schema.clone();
+        },
+    };
+
+    if let Err(error) = document.root() {
+        warn!(
+            error = %error,
+            "openai tool schema failed canonical AST resolution; using raw schema for best-effort normalization"
+        );
+        return schema.clone();
+    }
+
+    document
+        .canonical_schema_json()
+        .map_or_else(
+            |error| {
+                warn!(
+                    error = %error,
+                    "openai tool schema canonicalization was unavailable; using raw schema for best-effort normalization"
+                );
+                schema.clone()
+            },
+            serde_json::Value::clone,
+        )
+}
+
+/// Validate and normalize a JSON Schema document into the smaller subset used
+/// by OpenAI-compatible function-calling APIs.
 ///
-/// This keeps the schema permissive instead of failing the entire request when
-/// an MCP server advertises a valid draft-2020-12 schema that the provider does
-/// not accept.
+/// The pipeline is:
+/// 1. Validate and canonicalize the raw schema with `json_schema_ast`
+/// 2. Apply recursive schema transforms with `schemars`
+/// 3. Retain only the OpenAI-compatible subset before strict-mode patching
 pub fn sanitize_schema_for_openai_compat(schema: &mut serde_json::Value) {
-    let Some(obj) = schema.as_object_mut() else {
+    let canonical = canonicalize_schema_for_openai_compat(schema);
+
+    let Ok(mut transformed) = Schema::try_from(canonical.clone()) else {
+        *schema = canonical;
         return;
     };
 
-    for keyword in OPENAI_UNSUPPORTED_SCHEMA_KEYWORDS {
-        obj.remove(*keyword);
-    }
+    let mut replace_const = ReplaceConstValue::default();
+    replace_const.transform(&mut transformed);
 
-    if let Some(props) = obj.get_mut("properties").and_then(|p| p.as_object_mut()) {
-        for prop_schema in props.values_mut() {
-            sanitize_schema_for_openai_compat(prop_schema);
-        }
-    }
+    let mut replace_unevaluated_properties = ReplaceUnevaluatedProperties::default();
+    replace_unevaluated_properties.transform(&mut transformed);
 
-    if let Some(items) = obj.get_mut("items") {
-        if let Some(item_schemas) = items.as_array_mut() {
-            for item_schema in item_schemas {
-                sanitize_schema_for_openai_compat(item_schema);
-            }
-        } else {
-            sanitize_schema_for_openai_compat(items);
-        }
-    }
+    let mut replace_prefix_items = ReplacePrefixItems::default();
+    replace_prefix_items.transform(&mut transformed);
 
-    for key in ["anyOf", "oneOf", "allOf", "prefixItems"] {
-        if let Some(variants) = obj.get_mut(key).and_then(|v| v.as_array_mut()) {
-            for variant in variants {
-                sanitize_schema_for_openai_compat(variant);
-            }
-        }
-    }
+    let mut remove_ref_siblings = RemoveRefSiblings::default();
+    remove_ref_siblings.transform(&mut transformed);
 
-    if let Some(additional) = obj.get_mut("additionalProperties")
-        && additional.is_object()
-    {
-        sanitize_schema_for_openai_compat(additional);
-    }
+    let mut subset_transform = RecursiveTransform(OpenAiSchemaSubsetTransform);
+    subset_transform.transform(&mut transformed);
 
-    for key in ["$defs", "definitions"] {
-        if let Some(definitions) = obj.get_mut(key).and_then(|v| v.as_object_mut()) {
-            for definition in definitions.values_mut() {
-                sanitize_schema_for_openai_compat(definition);
-            }
-        }
-    }
+    *schema = transformed.to_value();
 }
 
 /// Recursively patch schema for OpenAI strict mode compliance.
@@ -1184,8 +1239,8 @@ pub fn parse_responses_completion(resp: &serde_json::Value) -> CompletionRespons
 #[cfg(test)]
 mod tests {
     use super::{
-        OPENAI_UNSUPPORTED_SCHEMA_KEYWORDS, parse_responses_completion, parse_tool_calls,
-        sanitize_schema_for_openai_compat, to_responses_api_tools,
+        parse_responses_completion, parse_tool_calls, sanitize_schema_for_openai_compat,
+        to_responses_api_tools,
     };
 
     #[test]
@@ -1371,6 +1426,8 @@ mod tests {
                     },
                     "minContains": 1,
                     "maxContains": 2,
+                    "const": "active",
+                    "x-custom": "remove-me",
                     "items": {
                         "not": {
                             "type": "integer"
@@ -1383,12 +1440,28 @@ mod tests {
         sanitize_schema_for_openai_compat(&mut schema);
         let encoded = schema.to_string();
 
-        for keyword in OPENAI_UNSUPPORTED_SCHEMA_KEYWORDS {
-            assert!(
-                !encoded.contains(&format!("\"{keyword}\"")),
-                "{keyword} should be removed"
-            );
+        for keyword in [
+            "\"if\"",
+            "\"then\"",
+            "\"else\"",
+            "\"dependentSchemas\"",
+            "\"patternProperties\"",
+            "\"dependentRequired\"",
+            "\"unevaluatedProperties\"",
+            "\"unevaluatedItems\"",
+            "\"propertyNames\"",
+            "\"contains\"",
+            "\"minContains\"",
+            "\"maxContains\"",
+            "\"not\"",
+            "\"x-custom\"",
+        ] {
+            assert!(!encoded.contains(keyword), "{keyword} should be removed");
         }
+        assert_eq!(
+            schema["properties"]["config"]["enum"],
+            serde_json::json!(["active"])
+        );
         assert_eq!(
             schema["properties"]["config"]["properties"]["mode"]["type"],
             "string"

--- a/crates/providers/src/openai_compat/mod.rs
+++ b/crates/providers/src/openai_compat/mod.rs
@@ -3,20 +3,11 @@
 //! This module provides reusable functions for parsing OpenAI-style SSE streams
 //! that include tool calls. Used by openai.rs, github_copilot.rs, and kimi_code.rs.
 
+mod schema_normalization;
+
 use std::collections::{HashMap, HashSet};
 
-use {
-    json_schema_ast::SchemaDocument,
-    schemars::{
-        Schema,
-        transform::{
-            RecursiveTransform, RemoveRefSiblings, ReplaceConstValue, ReplacePrefixItems,
-            ReplaceUnevaluatedProperties, Transform,
-        },
-    },
-    serde::Serialize,
-    tracing::{trace, warn},
-};
+use {schema_normalization::sanitize_schema_for_openai_compat, serde::Serialize, tracing::trace};
 
 use moltis_agents::model::{
     ChatMessage, CompletionResponse, StreamEvent, ToolCall, Usage, UserContent,
@@ -116,111 +107,6 @@ fn make_nullable(schema: &mut serde_json::Value) {
             return;
         }
     }
-}
-
-const OPENAI_ALLOWED_SCHEMA_KEYWORDS: &[&str] = &[
-    "$ref",
-    "$defs",
-    "definitions",
-    "type",
-    "enum",
-    "title",
-    "description",
-    "default",
-    "example",
-    "examples",
-    "format",
-    "pattern",
-    "properties",
-    "required",
-    "items",
-    "additionalProperties",
-    "anyOf",
-    "oneOf",
-    "allOf",
-    "minimum",
-    "maximum",
-    "exclusiveMinimum",
-    "exclusiveMaximum",
-    "multipleOf",
-    "minLength",
-    "maxLength",
-    "minItems",
-    "maxItems",
-    "uniqueItems",
-    "minProperties",
-    "maxProperties",
-];
-
-#[derive(Debug, Clone, Default)]
-struct OpenAiSchemaSubsetTransform;
-
-impl Transform for OpenAiSchemaSubsetTransform {
-    fn transform(&mut self, schema: &mut Schema) {
-        let Some(obj) = schema.as_object_mut() else {
-            return;
-        };
-
-        obj.retain(|key, _| OPENAI_ALLOWED_SCHEMA_KEYWORDS.contains(&key.as_str()));
-    }
-}
-
-fn canonicalize_schema_for_openai_compat(schema: &serde_json::Value) -> serde_json::Value {
-    let document = match SchemaDocument::from_json(schema) {
-        Ok(document) => document,
-        Err(error) => {
-            warn!(
-                error = %error,
-                "openai tool schema failed Draft 2020-12 preflight; using raw schema for best-effort normalization"
-            );
-            return schema.clone();
-        },
-    };
-
-    if let Err(error) = document.root() {
-        warn!(
-            error = %error,
-            "openai tool schema failed canonical AST resolution; using raw schema for best-effort normalization"
-        );
-        return schema.clone();
-    }
-
-    document
-        .canonical_schema_json()
-        .map_or_else(
-            |error| {
-                warn!(
-                    error = %error,
-                    "openai tool schema canonicalization was unavailable; using raw schema for best-effort normalization"
-                );
-                schema.clone()
-            },
-            serde_json::Value::clone,
-        )
-}
-
-/// Validate and normalize a JSON Schema document into the OpenAI-compatible
-/// function-calling subset via `json_schema_ast` canonicalization plus
-/// recursive `schemars` transforms.
-pub fn sanitize_schema_for_openai_compat(schema: &mut serde_json::Value) {
-    let canonical = canonicalize_schema_for_openai_compat(schema);
-
-    let Ok(mut transformed) = Schema::try_from(canonical.clone()) else {
-        *schema = canonical;
-        return;
-    };
-    let mut replace_const = ReplaceConstValue::default();
-    replace_const.transform(&mut transformed);
-    let mut replace_unevaluated_properties = ReplaceUnevaluatedProperties::default();
-    replace_unevaluated_properties.transform(&mut transformed);
-    let mut replace_prefix_items = ReplacePrefixItems::default();
-    replace_prefix_items.transform(&mut transformed);
-    let mut remove_ref_siblings = RemoveRefSiblings::default();
-    remove_ref_siblings.transform(&mut transformed);
-    let mut subset_transform = RecursiveTransform(OpenAiSchemaSubsetTransform);
-    subset_transform.transform(&mut transformed);
-
-    *schema = transformed.to_value();
 }
 
 /// Recursively patch schema for OpenAI strict mode compliance.

--- a/crates/providers/src/openai_compat/mod.rs
+++ b/crates/providers/src/openai_compat/mod.rs
@@ -199,13 +199,9 @@ fn canonicalize_schema_for_openai_compat(schema: &serde_json::Value) -> serde_js
         )
 }
 
-/// Validate and normalize a JSON Schema document into the smaller subset used
-/// by OpenAI-compatible function-calling APIs.
-///
-/// The pipeline is:
-/// 1. Validate and canonicalize the raw schema with `json_schema_ast`
-/// 2. Apply recursive schema transforms with `schemars`
-/// 3. Retain only the OpenAI-compatible subset before strict-mode patching
+/// Validate and normalize a JSON Schema document into the OpenAI-compatible
+/// function-calling subset via `json_schema_ast` canonicalization plus
+/// recursive `schemars` transforms.
 pub fn sanitize_schema_for_openai_compat(schema: &mut serde_json::Value) {
     let canonical = canonicalize_schema_for_openai_compat(schema);
 
@@ -213,19 +209,14 @@ pub fn sanitize_schema_for_openai_compat(schema: &mut serde_json::Value) {
         *schema = canonical;
         return;
     };
-
     let mut replace_const = ReplaceConstValue::default();
     replace_const.transform(&mut transformed);
-
     let mut replace_unevaluated_properties = ReplaceUnevaluatedProperties::default();
     replace_unevaluated_properties.transform(&mut transformed);
-
     let mut replace_prefix_items = ReplacePrefixItems::default();
     replace_prefix_items.transform(&mut transformed);
-
     let mut remove_ref_siblings = RemoveRefSiblings::default();
     remove_ref_siblings.transform(&mut transformed);
-
     let mut subset_transform = RecursiveTransform(OpenAiSchemaSubsetTransform);
     subset_transform.transform(&mut transformed);
 

--- a/crates/providers/src/openai_compat/mod.rs
+++ b/crates/providers/src/openai_compat/mod.rs
@@ -107,6 +107,70 @@ fn make_nullable(schema: &mut serde_json::Value) {
     }
 }
 
+const OPENAI_UNSUPPORTED_SCHEMA_KEYWORDS: &[&str] = &[
+    "not",
+    "if",
+    "then",
+    "else",
+    "dependentSchemas",
+    "dependentRequired",
+    "unevaluatedProperties",
+    "unevaluatedItems",
+    "patternProperties",
+    "propertyNames",
+    "contains",
+    "minContains",
+    "maxContains",
+];
+
+/// Recursively strip JSON Schema keywords that OpenAI-compatible tool schemas
+/// reject in strict function-calling mode.
+///
+/// This keeps the schema permissive instead of failing the entire request when
+/// an MCP server advertises a valid draft-2020-12 schema that the provider does
+/// not accept.
+pub fn sanitize_schema_for_openai_compat(schema: &mut serde_json::Value) {
+    let Some(obj) = schema.as_object_mut() else {
+        return;
+    };
+
+    for keyword in OPENAI_UNSUPPORTED_SCHEMA_KEYWORDS {
+        obj.remove(*keyword);
+    }
+
+    if let Some(props) = obj.get_mut("properties").and_then(|p| p.as_object_mut()) {
+        for prop_schema in props.values_mut() {
+            sanitize_schema_for_openai_compat(prop_schema);
+        }
+    }
+
+    if let Some(items) = obj.get_mut("items") {
+        sanitize_schema_for_openai_compat(items);
+    }
+
+    for key in ["anyOf", "oneOf", "allOf", "prefixItems"] {
+        if let Some(variants) = obj.get_mut(key).and_then(|v| v.as_array_mut()) {
+            for variant in variants {
+                sanitize_schema_for_openai_compat(variant);
+            }
+        }
+    }
+
+    if let Some(additional) = obj.get_mut("additionalProperties")
+        && additional.is_object()
+    {
+        sanitize_schema_for_openai_compat(additional);
+    }
+
+    for key in ["$defs", "definitions"] {
+        if let Some(definitions) = obj.get_mut(key).and_then(|v| v.as_object_mut()) {
+            for definition in definitions.values_mut() {
+                sanitize_schema_for_openai_compat(definition);
+            }
+        }
+    }
+}
+
 /// Recursively patch schema for OpenAI strict mode compliance.
 ///
 /// OpenAI's strict mode requires:
@@ -226,6 +290,7 @@ pub fn to_openai_tools(tools: &[serde_json::Value]) -> Vec<serde_json::Value> {
         .filter_map(|t| {
             // Clone parameters and patch for strict mode
             let mut params = t["parameters"].clone();
+            sanitize_schema_for_openai_compat(&mut params);
             patch_schema_for_strict_mode(&mut params);
 
             let name = t["name"].as_str()?.to_string();
@@ -273,6 +338,7 @@ pub fn to_responses_api_tools(tools: &[serde_json::Value]) -> Vec<serde_json::Va
         .filter_map(|t| {
             // Clone parameters and patch for strict mode
             let mut params = t["parameters"].clone();
+            sanitize_schema_for_openai_compat(&mut params);
             patch_schema_for_strict_mode(&mut params);
 
             let name = t["name"].as_str()?.to_string();
@@ -1111,7 +1177,10 @@ pub fn parse_responses_completion(resp: &serde_json::Value) -> CompletionRespons
 
 #[cfg(test)]
 mod tests {
-    use super::{parse_responses_completion, parse_tool_calls};
+    use super::{
+        parse_responses_completion, parse_tool_calls, sanitize_schema_for_openai_compat,
+        to_responses_api_tools,
+    };
 
     #[test]
     fn parse_tool_calls_preserves_native_falsy_types() {
@@ -1206,5 +1275,108 @@ mod tests {
         assert_eq!(result.tool_calls[0].arguments["offset"], 0);
         assert_eq!(result.tool_calls[0].arguments["multiline"], false);
         assert!(result.tool_calls[0].arguments["type"].is_null());
+    }
+
+    #[test]
+    fn responses_tools_strip_nested_not_schemas() {
+        let tools = vec![serde_json::json!({
+            "name": "mcp__attio__list-attribute-definitions",
+            "description": "Attio test tool",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "query": {
+                        "anyOf": [
+                            {
+                                "anyOf": [
+                                    {
+                                        "not": {
+                                            "const": ""
+                                        }
+                                    },
+                                    {
+                                        "type": "string"
+                                    }
+                                ]
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    }
+                }
+            }
+        })];
+
+        let converted = to_responses_api_tools(&tools);
+        let params = &converted[0]["parameters"];
+        let encoded = params.to_string();
+
+        assert_eq!(converted[0]["strict"], true);
+        assert!(!encoded.contains("\"not\""));
+        assert_eq!(params["type"], "object");
+        assert_eq!(params["additionalProperties"], false);
+        assert_eq!(params["required"], serde_json::json!(["query"]));
+    }
+
+    #[test]
+    fn sanitize_schema_for_openai_compat_strips_recursive_unsupported_keywords() {
+        let mut schema = serde_json::json!({
+            "type": "object",
+            "properties": {
+                "config": {
+                    "type": "object",
+                    "properties": {
+                        "mode": { "type": "string" }
+                    },
+                    "if": {
+                        "required": ["mode"]
+                    },
+                    "then": {
+                        "properties": {
+                            "enabled": { "type": "boolean" }
+                        }
+                    },
+                    "else": {
+                        "properties": {
+                            "enabled": { "type": "boolean" }
+                        }
+                    },
+                    "dependentSchemas": {
+                        "mode": {
+                            "properties": {
+                                "extra": { "type": "string" }
+                            }
+                        }
+                    },
+                    "patternProperties": {
+                        "^x-": { "type": "string" }
+                    },
+                    "items": {
+                        "not": {
+                            "type": "integer"
+                        }
+                    }
+                }
+            }
+        });
+
+        sanitize_schema_for_openai_compat(&mut schema);
+        let encoded = schema.to_string();
+
+        for keyword in [
+            "\"if\"",
+            "\"then\"",
+            "\"else\"",
+            "\"dependentSchemas\"",
+            "\"patternProperties\"",
+            "\"not\"",
+        ] {
+            assert!(!encoded.contains(keyword), "{keyword} should be removed");
+        }
+        assert_eq!(
+            schema["properties"]["config"]["properties"]["mode"]["type"],
+            "string"
+        );
     }
 }

--- a/crates/providers/src/openai_compat/mod.rs
+++ b/crates/providers/src/openai_compat/mod.rs
@@ -1484,9 +1484,9 @@ mod tests {
 
         sanitize_schema_for_openai_compat(&mut schema);
 
-        let tuple_items = schema["properties"]["tuple"]["items"]
-            .as_array()
-            .expect("tuple items should remain an array");
+        let Some(tuple_items) = schema["properties"]["tuple"]["items"].as_array() else {
+            panic!("tuple items should remain an array");
+        };
         assert!(tuple_items[0].get("not").is_none());
         assert!(tuple_items[1].get("patternProperties").is_none());
     }

--- a/crates/providers/src/openai_compat/schema_normalization.rs
+++ b/crates/providers/src/openai_compat/schema_normalization.rs
@@ -1,0 +1,116 @@
+use {
+    json_schema_ast::SchemaDocument,
+    schemars::{
+        Schema,
+        transform::{
+            RecursiveTransform, RemoveRefSiblings, ReplaceConstValue, ReplacePrefixItems,
+            ReplaceUnevaluatedProperties, Transform,
+        },
+    },
+    tracing::warn,
+};
+
+const OPENAI_ALLOWED_SCHEMA_KEYWORDS: &[&str] = &[
+    "$ref",
+    "$defs",
+    "definitions",
+    "type",
+    "enum",
+    "title",
+    "description",
+    "default",
+    "example",
+    "examples",
+    "format",
+    "pattern",
+    "properties",
+    "required",
+    "items",
+    "additionalProperties",
+    "anyOf",
+    "oneOf",
+    "allOf",
+    "minimum",
+    "maximum",
+    "exclusiveMinimum",
+    "exclusiveMaximum",
+    "multipleOf",
+    "minLength",
+    "maxLength",
+    "minItems",
+    "maxItems",
+    "uniqueItems",
+    "minProperties",
+    "maxProperties",
+];
+
+#[derive(Debug, Clone, Default)]
+struct OpenAiSchemaSubsetTransform;
+
+impl Transform for OpenAiSchemaSubsetTransform {
+    fn transform(&mut self, schema: &mut Schema) {
+        let Some(obj) = schema.as_object_mut() else {
+            return;
+        };
+
+        obj.retain(|key, _| OPENAI_ALLOWED_SCHEMA_KEYWORDS.contains(&key.as_str()));
+    }
+}
+
+fn canonicalize_schema_for_openai_compat(schema: &serde_json::Value) -> serde_json::Value {
+    let document = match SchemaDocument::from_json(schema) {
+        Ok(document) => document,
+        Err(error) => {
+            warn!(
+                error = %error,
+                "openai tool schema failed Draft 2020-12 preflight; using raw schema for best-effort normalization"
+            );
+            return schema.clone();
+        },
+    };
+
+    if let Err(error) = document.root() {
+        warn!(
+            error = %error,
+            "openai tool schema failed canonical AST resolution; using raw schema for best-effort normalization"
+        );
+        return schema.clone();
+    }
+
+    document
+        .canonical_schema_json()
+        .map_or_else(
+            |error| {
+                warn!(
+                    error = %error,
+                    "openai tool schema canonicalization was unavailable; using raw schema for best-effort normalization"
+                );
+                schema.clone()
+            },
+            serde_json::Value::clone,
+        )
+}
+
+/// Validate and normalize a JSON Schema document into the OpenAI-compatible
+/// function-calling subset via `json_schema_ast` canonicalization plus
+/// recursive `schemars` transforms.
+pub(crate) fn sanitize_schema_for_openai_compat(schema: &mut serde_json::Value) {
+    let canonical = canonicalize_schema_for_openai_compat(schema);
+
+    let Ok(mut transformed) = Schema::try_from(canonical.clone()) else {
+        *schema = canonical;
+        return;
+    };
+    let mut replace_const = ReplaceConstValue::default();
+    replace_const.transform(&mut transformed);
+    let mut replace_unevaluated_properties = ReplaceUnevaluatedProperties::default();
+    replace_unevaluated_properties.transform(&mut transformed);
+    let mut replace_prefix_items = ReplacePrefixItems::default();
+    replace_prefix_items.transform(&mut transformed);
+    let mut remove_ref_siblings = RemoveRefSiblings::default();
+    remove_ref_siblings.transform(&mut transformed);
+    let mut subset_transform = RecursiveTransform(OpenAiSchemaSubsetTransform);
+    subset_transform.transform(&mut transformed);
+
+    *schema = transformed.to_value();
+}

--- a/crates/web/ui/e2e/specs/settings-nav.spec.js
+++ b/crates/web/ui/e2e/specs/settings-nav.spec.js
@@ -40,10 +40,14 @@ function isRetryableNavigationError(error) {
 }
 
 async function mockChannelsStatus(page, { channels, senders = [], allowRetryOwnership = false, label }) {
+	const firstMarker = channels
+		.map((channel) => String(channel.name || channel.account_id || channel.details || "").trim())
+		.find(Boolean);
 	let lastError = null;
 	for (let attempt = 0; attempt < 3; attempt++) {
 		try {
 			await expect.poll(() => new URL(page.url()).pathname).toBe("/settings/channels");
+			await expect(page.getByRole("heading", { name: "Channels", exact: true })).toBeVisible();
 			await page.waitForFunction(() => !!document.querySelector('script[type="module"][src*="js/app.js"]'));
 			await page.evaluate(
 				async ({ channels, senders, allowRetryOwnership, label }) => {
@@ -91,6 +95,26 @@ async function mockChannelsStatus(page, { channels, senders = [], allowRetryOwne
 				},
 				{ channels, senders, allowRetryOwnership, label },
 			);
+			if (channels.length === 0) {
+				await expect(page.getByText("No channels connected.", { exact: false })).toBeVisible();
+			} else {
+				await expect
+					.poll(
+						async () => {
+							const cardCount = await page
+								.locator(".provider-card")
+								.count()
+								.catch(() => 0);
+							const pageText = await page
+								.locator("#pageContent")
+								.innerText()
+								.catch(() => "");
+							return cardCount >= channels.length && (!firstMarker || pageText.includes(firstMarker));
+						},
+						{ timeout: 10_000 },
+					)
+					.toBe(true);
+			}
 			return;
 		} catch (error) {
 			lastError = error;


### PR DESCRIPTION
## Summary

Fixes #694.

Moltis was forwarding MCP tool schemas straight into the OpenAI-compatible tool serializer, then only applying strict-mode rewrites. That still left unsupported JSON Schema keywords like `not`, `if/then/else`, and related draft-2020-12 constructs in the payload, which causes OpenAI/Codex to reject the entire request before any MCP tool can run.

This change adds an OpenAI-compat schema sanitizer in `crates/providers/src/openai_compat/mod.rs` and runs it before the existing strict-mode patching for both Chat Completions and Responses/Codex tool formats. It also adds regression tests for the Attio-style nested `not` shape and recursive stripping of adjacent unsupported keywords.

## Validation

### Completed

- [x] `cargo test -p moltis-providers openai_compat::tests -- --nocapture`
- [x] `cargo +nightly-2025-11-30 fmt --all -- --check`
- [x] `cargo clippy -p moltis-providers --lib -- -D warnings`

### Remaining

- [ ] `just lint` (started, but stopped after exceeding the repo's 5-minute command budget)

## Manual QA

1. Connect the Attio MCP server.
2. Use an OpenAI-compatible provider such as OpenAI Codex.
3. Trigger an Attio tool call such as listing contacts or attribute definitions.
4. Confirm the request no longer fails with `invalid_function_parameters` complaining about a nested `not` schema.