### PR TITLE
[codex] add web UI for local whisper setup

### DIFF
--- a/crates/config/src/schema/tests.rs
+++ b/crates/config/src/schema/tests.rs
@@ -746,3 +746,24 @@ fn terminal_disabled_via_config_reflects_in_helper() {
     // deny unsafe code, and `std::env::set_var` is unsafe.)
     assert!(!cfg.server.is_terminal_enabled());
 }
+
+#[test]
+fn voice_openai_and_whisper_base_url_parse_from_toml() {
+    let toml_str = r#"
+[voice.tts.openai]
+base_url = "http://127.0.0.1:8003/v1"
+
+[voice.stt.whisper]
+base_url = "http://127.0.0.1:8001/v1"
+"#;
+    let config: MoltisConfig = toml::from_str(toml_str).unwrap();
+
+    assert_eq!(
+        config.voice.tts.openai.base_url.as_deref(),
+        Some("http://127.0.0.1:8003/v1")
+    );
+    assert_eq!(
+        config.voice.stt.whisper.base_url.as_deref(),
+        Some("http://127.0.0.1:8001/v1")
+    );
+}

--- a/crates/config/src/schema/voice.rs
+++ b/crates/config/src/schema/voice.rs
@@ -79,6 +79,8 @@ pub struct VoiceOpenAiConfig {
         deserialize_with = "crate::schema::deserialize_option_secret"
     )]
     pub api_key: Option<Secret<String>>,
+    /// Override the OpenAI TTS endpoint for compatible local servers.
+    pub base_url: Option<String>,
     /// Voice to use for TTS (alloy, echo, fable, onyx, nova, shimmer).
     pub voice: Option<String>,
     /// Model to use for TTS (tts-1, tts-1-hd).
@@ -271,6 +273,8 @@ pub struct VoiceWhisperConfig {
         deserialize_with = "crate::schema::deserialize_option_secret"
     )]
     pub api_key: Option<Secret<String>>,
+    /// Override the Whisper endpoint for compatible local servers.
+    pub base_url: Option<String>,
     /// Model to use (whisper-1).
     pub model: Option<String>,
     /// Language hint (ISO 639-1 code).

--- a/crates/config/src/validate/schema_map.rs
+++ b/crates/config/src/validate/schema_map.rs
@@ -569,6 +569,7 @@ pub(super) fn build_schema_map() -> KnownKeys {
                             "openai",
                             Struct(HashMap::from([
                                 ("api_key", Leaf),
+                                ("base_url", Leaf),
                                 ("voice", Leaf),
                                 ("model", Leaf),
                             ])),
@@ -604,6 +605,7 @@ pub(super) fn build_schema_map() -> KnownKeys {
                             "whisper",
                             Struct(HashMap::from([
                                 ("api_key", Leaf),
+                                ("base_url", Leaf),
                                 ("model", Leaf),
                                 ("language", Leaf),
                             ])),

--- a/crates/gateway/src/methods/voice.rs
+++ b/crates/gateway/src/methods/voice.rs
@@ -991,6 +991,16 @@ pub(super) fn apply_voice_provider_settings(
     provider: &str,
     params: &serde_json::Value,
 ) {
+    let get_nullable_string = |key: &str| -> Option<Option<String>> {
+        params.get(key).map(|value| {
+            value
+                .as_str()
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .map(ToOwned::to_owned)
+        })
+    };
+
     let get_string = |key: &str| -> Option<String> {
         params
             .get(key)
@@ -1002,8 +1012,8 @@ pub(super) fn apply_voice_provider_settings(
 
     match provider {
         "openai" | "openai-tts" => {
-            if let Some(base_url) = get_string("baseUrl") {
-                cfg.voice.tts.openai.base_url = Some(base_url);
+            if let Some(base_url) = get_nullable_string("baseUrl") {
+                cfg.voice.tts.openai.base_url = base_url;
             }
             if let Some(voice) = get_string("voice") {
                 cfg.voice.tts.openai.voice = Some(voice);
@@ -1013,8 +1023,12 @@ pub(super) fn apply_voice_provider_settings(
             }
         },
         "whisper" => {
-            if let Some(base_url) = get_string("baseUrl") {
-                cfg.voice.stt.whisper.base_url = Some(base_url);
+            if let Some(base_url) = get_nullable_string("baseUrl") {
+                cfg.voice.stt.whisper.base_url = base_url;
+                if cfg.voice.stt.whisper.base_url.is_some() {
+                    cfg.voice.stt.provider = Some(VoiceSttProvider::Whisper);
+                    cfg.voice.stt.enabled = true;
+                }
             }
         },
         "elevenlabs" => {
@@ -1292,6 +1306,33 @@ mod tests {
             config.voice.stt.whisper.base_url.as_deref(),
             Some("http://127.0.0.1:8001/v1")
         );
+        assert_eq!(config.voice.stt.provider, Some(VoiceSttProvider::Whisper));
+        assert!(config.voice.stt.enabled);
+    }
+
+    #[test]
+    fn apply_voice_provider_settings_clears_base_urls_when_requested() {
+        let mut config = moltis_config::MoltisConfig::default();
+        config.voice.tts.openai.base_url = Some("http://127.0.0.1:8003/v1".to_string());
+        config.voice.stt.whisper.base_url = Some("http://127.0.0.1:8001/v1".to_string());
+
+        apply_voice_provider_settings(
+            &mut config,
+            "openai",
+            &serde_json::json!({
+                "baseUrl": "",
+            }),
+        );
+        apply_voice_provider_settings(
+            &mut config,
+            "whisper",
+            &serde_json::json!({
+                "baseUrl": "",
+            }),
+        );
+
+        assert_eq!(config.voice.tts.openai.base_url, None);
+        assert_eq!(config.voice.stt.whisper.base_url, None);
     }
 
     #[tokio::test]

--- a/crates/gateway/src/methods/voice.rs
+++ b/crates/gateway/src/methods/voice.rs
@@ -339,6 +339,33 @@ pub(super) struct VoiceProvidersResponse {
     stt: Vec<VoiceProviderInfo>,
 }
 
+fn openai_provider_base_url(config: &moltis_config::MoltisConfig) -> Option<&str> {
+    config
+        .providers
+        .get("openai")
+        .and_then(|provider| provider.base_url.as_deref())
+}
+
+fn openai_tts_base_url(config: &moltis_config::MoltisConfig) -> Option<&str> {
+    config
+        .voice
+        .tts
+        .openai
+        .base_url
+        .as_deref()
+        .or_else(|| openai_provider_base_url(config))
+}
+
+fn whisper_base_url(config: &moltis_config::MoltisConfig) -> Option<&str> {
+    config
+        .voice
+        .stt
+        .whisper
+        .base_url
+        .as_deref()
+        .or_else(|| openai_provider_base_url(config))
+}
+
 /// Detect all available voice providers with their availability status.
 pub(super) async fn detect_voice_providers(
     config: &moltis_config::MoltisConfig,
@@ -361,6 +388,7 @@ pub(super) async fn detect_voice_providers(
         .get("openai")
         .and_then(|p| p.api_key.as_ref())
         .map(|k| k.expose_secret().to_string());
+    let llm_openai_base_url = openai_provider_base_url(config);
     let llm_groq_key = config
         .providers
         .get("groq")
@@ -404,18 +432,16 @@ pub(super) async fn detect_voice_providers(
             "tts",
             "cloud",
             config.voice.tts.openai.api_key.is_some()
-                || config
-                    .providers
-                    .get("openai")
-                    .and_then(|provider| provider.base_url.as_ref())
-                    .is_some()
+                || config.voice.tts.openai.base_url.is_some()
                 || env_openai_key.is_some()
-                || llm_openai_key.is_some(),
+                || llm_openai_key.is_some()
+                || llm_openai_base_url.is_some(),
             config.voice.tts.provider == "openai" && config.voice.tts.enabled,
             key_source(
-                config.voice.tts.openai.api_key.is_some(),
+                config.voice.tts.openai.api_key.is_some()
+                    || config.voice.tts.openai.base_url.is_some(),
                 env_openai_key.is_some(),
-                llm_openai_key.is_some(),
+                llm_openai_key.is_some() || llm_openai_base_url.is_some(),
             ),
             None,
             None,
@@ -484,14 +510,17 @@ pub(super) async fn detect_voice_providers(
             "stt",
             "cloud",
             config.voice.stt.whisper.api_key.is_some()
+                || config.voice.stt.whisper.base_url.is_some()
                 || env_openai_key.is_some()
-                || llm_openai_key.is_some(),
+                || llm_openai_key.is_some()
+                || llm_openai_base_url.is_some(),
             config.voice.stt.provider == Some(VoiceSttProvider::Whisper)
                 && config.voice.stt.enabled,
             key_source(
-                config.voice.stt.whisper.api_key.is_some(),
+                config.voice.stt.whisper.api_key.is_some()
+                    || config.voice.stt.whisper.base_url.is_some(),
                 env_openai_key.is_some(),
-                llm_openai_key.is_some(),
+                llm_openai_key.is_some() || llm_openai_base_url.is_some(),
             ),
             None,
             None,
@@ -694,10 +723,12 @@ fn enrich_voice_provider(
             serde_json::json!({
                 "voiceChoices": ["alloy", "echo", "fable", "onyx", "nova", "shimmer"],
                 "modelChoices": ["tts-1", "tts-1-hd"],
+                "baseUrl": true,
                 "customVoice": true,
                 "customModel": true,
             }),
             serde_json::json!({
+                "baseUrl": openai_tts_base_url(config),
                 "voice": config.voice.tts.openai.voice,
                 "model": config.voice.tts.openai.model,
             }),
@@ -705,6 +736,15 @@ fn enrich_voice_provider(
                 config.voice.tts.openai.voice.clone(),
                 config.voice.tts.openai.model.clone(),
             ),
+        ),
+        VoiceProviderId::Whisper => (
+            serde_json::json!({
+                "baseUrl": true,
+            }),
+            serde_json::json!({
+                "baseUrl": whisper_base_url(config),
+            }),
+            None,
         ),
         VoiceProviderId::Elevenlabs => (
             serde_json::json!({
@@ -962,11 +1002,19 @@ pub(super) fn apply_voice_provider_settings(
 
     match provider {
         "openai" | "openai-tts" => {
+            if let Some(base_url) = get_string("baseUrl") {
+                cfg.voice.tts.openai.base_url = Some(base_url);
+            }
             if let Some(voice) = get_string("voice") {
                 cfg.voice.tts.openai.voice = Some(voice);
             }
             if let Some(model) = get_string("model") {
                 cfg.voice.tts.openai.model = Some(model);
+            }
+        },
+        "whisper" => {
+            if let Some(base_url) = get_string("baseUrl") {
+                cfg.voice.stt.whisper.base_url = Some(base_url);
             }
         },
         "elevenlabs" => {
@@ -1215,5 +1263,55 @@ mod tests {
             .count();
 
         assert_eq!(enabled_count, 0);
+    }
+
+    #[test]
+    fn apply_voice_provider_settings_stores_base_urls() {
+        let mut config = moltis_config::MoltisConfig::default();
+
+        apply_voice_provider_settings(
+            &mut config,
+            "openai",
+            &serde_json::json!({
+                "baseUrl": "http://127.0.0.1:8003/v1",
+            }),
+        );
+        apply_voice_provider_settings(
+            &mut config,
+            "whisper",
+            &serde_json::json!({
+                "baseUrl": "http://127.0.0.1:8001/v1",
+            }),
+        );
+
+        assert_eq!(
+            config.voice.tts.openai.base_url.as_deref(),
+            Some("http://127.0.0.1:8003/v1")
+        );
+        assert_eq!(
+            config.voice.stt.whisper.base_url.as_deref(),
+            Some("http://127.0.0.1:8001/v1")
+        );
+    }
+
+    #[tokio::test]
+    async fn detect_voice_providers_marks_whisper_available_when_base_url_configured() {
+        let mut config = moltis_config::MoltisConfig::default();
+        config.voice.stt.whisper.base_url = Some("http://127.0.0.1:8001/v1".to_string());
+
+        let detected = detect_voice_providers(&config).await;
+        let Some(stt) = detected["stt"].as_array() else {
+            panic!("stt list missing");
+        };
+        let Some(whisper) = stt.iter().find(|provider| provider["id"] == "whisper") else {
+            panic!("whisper provider missing");
+        };
+
+        assert_eq!(whisper["available"], serde_json::json!(true));
+        assert_eq!(whisper["keySource"], serde_json::json!("config"));
+        assert_eq!(
+            whisper["settings"]["baseUrl"],
+            serde_json::json!("http://127.0.0.1:8001/v1")
+        );
     }
 }

--- a/crates/gateway/src/voice.rs
+++ b/crates/gateway/src/voice.rs
@@ -64,8 +64,28 @@ fn resolve_openai_key(
 }
 
 #[cfg(feature = "voice")]
-fn resolve_openai_base_url(cfg: &moltis_config::MoltisConfig) -> Option<String> {
+fn resolve_openai_provider_base_url(cfg: &moltis_config::MoltisConfig) -> Option<String> {
     cfg.providers.get("openai").and_then(|p| p.base_url.clone())
+}
+
+#[cfg(feature = "voice")]
+fn resolve_openai_tts_base_url(cfg: &moltis_config::MoltisConfig) -> Option<String> {
+    cfg.voice
+        .tts
+        .openai
+        .base_url
+        .clone()
+        .or_else(|| resolve_openai_provider_base_url(cfg))
+}
+
+#[cfg(feature = "voice")]
+fn resolve_openai_whisper_base_url(cfg: &moltis_config::MoltisConfig) -> Option<String> {
+    cfg.voice
+        .stt
+        .whisper
+        .base_url
+        .clone()
+        .or_else(|| resolve_openai_provider_base_url(cfg))
 }
 
 // ── TTS Service ─────────────────────────────────────────────────────────────
@@ -117,7 +137,7 @@ impl LiveTtsService {
             },
             openai: moltis_voice::OpenAiTtsConfig {
                 api_key: resolve_openai_key(cfg.voice.tts.openai.api_key.as_ref(), &cfg),
-                base_url: resolve_openai_base_url(&cfg),
+                base_url: resolve_openai_tts_base_url(&cfg),
                 voice: cfg.voice.tts.openai.voice.clone(),
                 model: cfg.voice.tts.openai.model.clone(),
                 speed: None,
@@ -535,7 +555,7 @@ impl LiveSttService {
                 let key = resolve_openai_key(cfg.voice.stt.whisper.api_key.as_ref(), &cfg);
                 let provider = WhisperStt::with_options(
                     key,
-                    resolve_openai_base_url(&cfg),
+                    resolve_openai_whisper_base_url(&cfg),
                     cfg.voice.stt.whisper.model.clone(),
                     cfg.voice.stt.whisper.language.clone(),
                 );
@@ -626,7 +646,8 @@ impl LiveSttService {
         vec![
             (
                 SttProviderId::Whisper,
-                cfg.voice.stt.whisper.api_key.is_some() || resolve_openai_base_url(&cfg).is_some(),
+                cfg.voice.stt.whisper.api_key.is_some()
+                    || resolve_openai_whisper_base_url(&cfg).is_some(),
             ),
             (SttProviderId::Groq, cfg.voice.stt.groq.api_key.is_some()),
             (
@@ -907,13 +928,13 @@ mod tests {
     }
 
     #[test]
-    fn test_live_stt_openai_provider_base_url_counts_as_configured() {
+    fn test_live_stt_whisper_base_url_counts_as_configured() {
         let _guard = VoiceConfigTestGuard::with_config(
             r#"
 [server]
 port = 18080
 
-[providers.openai]
+[voice.stt.whisper]
 base_url = "http://127.0.0.1:8001/"
 "#,
         );
@@ -927,6 +948,42 @@ base_url = "http://127.0.0.1:8001/"
         assert_eq!(
             LiveSttService::resolve_provider(None),
             Some(SttProviderId::Whisper)
+        );
+    }
+
+    #[test]
+    fn test_resolve_openai_tts_base_url_prefers_voice_specific_value() {
+        let mut cfg = moltis_config::MoltisConfig::default();
+        cfg.voice.tts.openai.base_url = Some("http://127.0.0.1:8003".to_string());
+        cfg.providers.providers.insert(
+            "openai".to_string(),
+            moltis_config::schema::ProviderEntry {
+                base_url: Some("http://127.0.0.1:8001".to_string()),
+                ..moltis_config::schema::ProviderEntry::default()
+            },
+        );
+
+        assert_eq!(
+            resolve_openai_tts_base_url(&cfg).as_deref(),
+            Some("http://127.0.0.1:8003")
+        );
+    }
+
+    #[test]
+    fn test_resolve_openai_whisper_base_url_prefers_voice_specific_value() {
+        let mut cfg = moltis_config::MoltisConfig::default();
+        cfg.voice.stt.whisper.base_url = Some("http://127.0.0.1:8002".to_string());
+        cfg.providers.providers.insert(
+            "openai".to_string(),
+            moltis_config::schema::ProviderEntry {
+                base_url: Some("http://127.0.0.1:8001".to_string()),
+                ..moltis_config::schema::ProviderEntry::default()
+            },
+        );
+
+        assert_eq!(
+            resolve_openai_whisper_base_url(&cfg).as_deref(),
+            Some("http://127.0.0.1:8002")
         );
     }
 

--- a/crates/gateway/src/voice.rs
+++ b/crates/gateway/src/voice.rs
@@ -970,6 +970,23 @@ base_url = "http://127.0.0.1:8001/"
     }
 
     #[test]
+    fn test_resolve_openai_tts_base_url_falls_back_to_provider_value() {
+        let mut cfg = moltis_config::MoltisConfig::default();
+        cfg.providers.providers.insert(
+            "openai".to_string(),
+            moltis_config::schema::ProviderEntry {
+                base_url: Some("http://127.0.0.1:8001".to_string()),
+                ..moltis_config::schema::ProviderEntry::default()
+            },
+        );
+
+        assert_eq!(
+            resolve_openai_tts_base_url(&cfg).as_deref(),
+            Some("http://127.0.0.1:8001")
+        );
+    }
+
+    #[test]
     fn test_resolve_openai_whisper_base_url_prefers_voice_specific_value() {
         let mut cfg = moltis_config::MoltisConfig::default();
         cfg.voice.stt.whisper.base_url = Some("http://127.0.0.1:8002".to_string());
@@ -984,6 +1001,23 @@ base_url = "http://127.0.0.1:8001/"
         assert_eq!(
             resolve_openai_whisper_base_url(&cfg).as_deref(),
             Some("http://127.0.0.1:8002")
+        );
+    }
+
+    #[test]
+    fn test_resolve_openai_whisper_base_url_falls_back_to_provider_value() {
+        let mut cfg = moltis_config::MoltisConfig::default();
+        cfg.providers.providers.insert(
+            "openai".to_string(),
+            moltis_config::schema::ProviderEntry {
+                base_url: Some("http://127.0.0.1:8001".to_string()),
+                ..moltis_config::schema::ProviderEntry::default()
+            },
+        );
+
+        assert_eq!(
+            resolve_openai_whisper_base_url(&cfg).as_deref(),
+            Some("http://127.0.0.1:8001")
         );
     }
 

--- a/crates/httpd/src/server/runtime.rs
+++ b/crates/httpd/src/server/runtime.rs
@@ -1,4 +1,4 @@
-use {super::*, axum::routing::get};
+use super::*;
 
 pub(super) struct FinalizeGatewayArgs<'a> {
     pub bind: &'a str,
@@ -150,7 +150,7 @@ pub(super) async fn finalize_prepared_gateway(
             let ca_clone = Arc::clone(&ca_bytes);
             app = app.route(
                 "/certs/ca.pem",
-                get(move || {
+                axum::routing::get(move || {
                     let data = Arc::clone(&ca_clone);
                     async move {
                         (

--- a/crates/web/src/assets/js/onboarding-view.js
+++ b/crates/web/src/assets/js/onboarding-view.js
@@ -56,7 +56,6 @@ import {
 	toggleVoiceProvider,
 	transcribeAudio,
 	VOICE_COUNTERPART_IDS,
-	voiceProviderSupportsBaseUrl,
 } from "./voice-utils.js";
 import { connectWs } from "./ws-connect.js";
 
@@ -1811,7 +1810,7 @@ function OnboardingVoiceRow({
 			keyInputRef.current.focus();
 		}
 	}, [isConfiguring]);
-	var supportsBaseUrl = voiceProviderSupportsBaseUrl(provider.id);
+	var supportsBaseUrl = provider.capabilities?.baseUrl === true;
 	var keySourceLabel =
 		provider.keySource === "env" ? "(from env)" : provider.keySource === "llm_provider" ? "(from LLM provider)" : "";
 
@@ -2044,9 +2043,12 @@ function VoiceStep({ onNext, onBack }) {
 
 	function onSaveKey(e) {
 		e.preventDefault();
+		var provider = [...allProviders.stt, ...allProviders.tts].find((candidate) => candidate.id === configuring);
 		var trimmedApiKey = apiKey.trim();
 		var trimmedBaseUrl = baseUrl.trim();
-		if (!(trimmedApiKey || trimmedBaseUrl)) {
+		var hadBaseUrl = typeof provider?.settings?.baseUrl === "string" && provider.settings.baseUrl.trim().length > 0;
+		var shouldSaveBaseUrl = provider?.capabilities?.baseUrl === true && (trimmedBaseUrl.length > 0 || hadBaseUrl);
+		if (!(trimmedApiKey || shouldSaveBaseUrl)) {
 			setError("API key or base URL is required.");
 			return;
 		}
@@ -2054,8 +2056,8 @@ function VoiceStep({ onNext, onBack }) {
 		setSaving(true);
 		var providerId = configuring;
 		var req = trimmedApiKey
-			? saveVoiceKey(providerId, trimmedApiKey, { baseUrl: trimmedBaseUrl || undefined })
-			: saveVoiceSettings(providerId, { baseUrl: trimmedBaseUrl });
+			? saveVoiceKey(providerId, trimmedApiKey, { baseUrl: shouldSaveBaseUrl ? trimmedBaseUrl : undefined })
+			: saveVoiceSettings(providerId, shouldSaveBaseUrl ? { baseUrl: trimmedBaseUrl } : undefined);
 		req.then(async (res) => {
 			if (res?.ok) {
 				// Auto-enable in onboarding: toggle on for each type this provider appears in.

--- a/crates/web/src/assets/js/onboarding-view.js
+++ b/crates/web/src/assets/js/onboarding-view.js
@@ -51,10 +51,12 @@ import {
 	decodeBase64Safe,
 	fetchVoiceProviders,
 	saveVoiceKey,
+	saveVoiceSettings,
 	testTts,
 	toggleVoiceProvider,
 	transcribeAudio,
 	VOICE_COUNTERPART_IDS,
+	voiceProviderSupportsBaseUrl,
 } from "./voice-utils.js";
 import { connectWs } from "./ws-connect.js";
 
@@ -1790,6 +1792,8 @@ function OnboardingVoiceRow({
 	configuring,
 	apiKey,
 	setApiKey,
+	baseUrl,
+	setBaseUrl,
 	saving,
 	error,
 	onSaveKey,
@@ -1807,6 +1811,7 @@ function OnboardingVoiceRow({
 			keyInputRef.current.focus();
 		}
 	}, [isConfiguring]);
+	var supportsBaseUrl = voiceProviderSupportsBaseUrl(provider.id);
 	var keySourceLabel =
 		provider.keySource === "env" ? "(from env)" : provider.keySource === "llm_provider" ? "(from LLM provider)" : "";
 
@@ -1897,6 +1902,23 @@ function OnboardingVoiceRow({
 						placeholder=${provider.keyPlaceholder || "API key"} />
 				</div>
 				${
+					supportsBaseUrl
+						? html`<div>
+					<label class="text-xs text-[var(--muted)] mb-1 block">Base URL</label>
+					<input
+						type="text"
+						class="provider-key-input w-full"
+						data-field="baseUrl"
+						value=${baseUrl}
+						onInput=${(e) => setBaseUrl(e.target.value)}
+						placeholder="http://localhost:8000/v1" />
+					<div class="text-xs text-[var(--muted)] mt-1">
+						Use this for a local or OpenAI-compatible server. Leave the API key blank if the endpoint does not require one.
+					</div>
+				</div>`
+						: null
+				}
+				${
 					provider.keyUrl
 						? html`<div class="text-xs text-[var(--muted)]">
 					Get your key at <a href=${provider.keyUrl} target="_blank" class="text-[var(--accent)] underline">${provider.keyUrlLabel || provider.keyUrl}</a>
@@ -1922,6 +1944,7 @@ function VoiceStep({ onNext, onBack }) {
 	var [allProviders, setAllProviders] = useState({ tts: [], stt: [] });
 	var [configuring, setConfiguring] = useState(null); // provider id with open key form
 	var [apiKey, setApiKey] = useState("");
+	var [baseUrl, setBaseUrl] = useState("");
 	var [saving, setSaving] = useState(false);
 	var [error, setError] = useState(null);
 	var [voiceTesting, setVoiceTesting] = useState(null); // { id, type, phase }
@@ -2005,27 +2028,35 @@ function VoiceStep({ onNext, onBack }) {
 	}
 
 	function onStartConfigure(providerId) {
+		var provider = [...allProviders.stt, ...allProviders.tts].find((candidate) => candidate.id === providerId);
 		setConfiguring(providerId);
 		setApiKey("");
+		setBaseUrl(provider?.settings?.baseUrl || "");
 		setError(null);
 	}
 
 	function onCancelConfigure() {
 		setConfiguring(null);
 		setApiKey("");
+		setBaseUrl("");
 		setError(null);
 	}
 
 	function onSaveKey(e) {
 		e.preventDefault();
-		if (!apiKey.trim()) {
-			setError("API key is required.");
+		var trimmedApiKey = apiKey.trim();
+		var trimmedBaseUrl = baseUrl.trim();
+		if (!(trimmedApiKey || trimmedBaseUrl)) {
+			setError("API key or base URL is required.");
 			return;
 		}
 		setError(null);
 		setSaving(true);
 		var providerId = configuring;
-		saveVoiceKey(providerId, apiKey.trim()).then(async (res) => {
+		var req = trimmedApiKey
+			? saveVoiceKey(providerId, trimmedApiKey, { baseUrl: trimmedBaseUrl || undefined })
+			: saveVoiceSettings(providerId, { baseUrl: trimmedBaseUrl });
+		req.then(async (res) => {
 			if (res?.ok) {
 				// Auto-enable in onboarding: toggle on for each type this provider appears in.
 				// IDs differ between TTS and STT (e.g. "elevenlabs" vs "elevenlabs-stt"),
@@ -2048,6 +2079,7 @@ function VoiceStep({ onNext, onBack }) {
 				setSaving(false);
 				setConfiguring(null);
 				setApiKey("");
+				setBaseUrl("");
 				fetchProviders();
 			} else {
 				setSaving(false);
@@ -2261,6 +2293,8 @@ function VoiceStep({ onNext, onBack }) {
 						configuring=${configuring}
 						apiKey=${apiKey}
 						setApiKey=${setApiKey}
+						baseUrl=${baseUrl}
+						setBaseUrl=${setBaseUrl}
 						saving=${saving}
 						error=${configuring === prov.id ? error : null}
 						onSaveKey=${onSaveKey}
@@ -2289,6 +2323,8 @@ function VoiceStep({ onNext, onBack }) {
 						configuring=${configuring}
 						apiKey=${apiKey}
 						setApiKey=${setApiKey}
+						baseUrl=${baseUrl}
+						setBaseUrl=${setBaseUrl}
 						saving=${saving}
 						error=${configuring === prov.id ? error : null}
 						onSaveKey=${onSaveKey}

--- a/crates/web/src/assets/js/page-settings.js
+++ b/crates/web/src/assets/js/page-settings.js
@@ -39,9 +39,11 @@ import {
 	decodeBase64Safe,
 	fetchVoiceProviders,
 	saveVoiceKey,
+	saveVoiceSettings,
 	testTts,
 	toggleVoiceProvider,
 	transcribeAudio,
+	voiceProviderSupportsBaseUrl,
 } from "./voice-utils.js";
 
 var identity = signal(null);
@@ -4489,6 +4491,7 @@ function LocalProviderInstructions({ providerId, voxtralReqs }) {
 // Add Voice Provider Modal
 function AddVoiceProviderModal({ unconfiguredProviders, voxtralReqs, onSaved }) {
 	var [apiKey, setApiKey] = useState("");
+	var [baseUrlValue, setBaseUrlValue] = useState("");
 	var [voiceValue, setVoiceValue] = useState("");
 	var [modelValue, setModelValue] = useState("");
 	var [languageCodeValue, setLanguageCodeValue] = useState("");
@@ -4503,12 +4506,14 @@ function AddVoiceProviderModal({ unconfiguredProviders, voxtralReqs, onSaved }) 
 		: null;
 	var isElevenLabsProvider = selectedProvider === "elevenlabs" || selectedProvider === "elevenlabs-stt";
 	var supportsTtsVoiceSettings = providerMeta?.type === "tts";
+	var supportsBaseUrl = voiceProviderSupportsBaseUrl(selectedProvider);
 
 	function onClose() {
 		voiceShowAddModal.value = false;
 		voiceSelectedProvider.value = null;
 		voiceSelectedProviderData.value = null;
 		setApiKey("");
+		setBaseUrlValue("");
 		setVoiceValue("");
 		setModelValue("");
 		setLanguageCodeValue("");
@@ -4517,30 +4522,25 @@ function AddVoiceProviderModal({ unconfiguredProviders, voxtralReqs, onSaved }) 
 
 	function onSaveKey() {
 		var hasApiKey = apiKey.trim().length > 0;
-		var hasSettings = supportsTtsVoiceSettings && (voiceValue.trim() || modelValue.trim() || languageCodeValue.trim());
+		var hasBaseUrl = supportsBaseUrl && baseUrlValue.trim().length > 0;
+		var hasSettings =
+			(supportsTtsVoiceSettings && (voiceValue.trim() || modelValue.trim() || languageCodeValue.trim())) || hasBaseUrl;
 		if (!(hasApiKey || hasSettings)) {
-			setError("Provide an API key or at least one voice setting.");
+			setError("Provide an API key, base URL, or at least one provider setting.");
 			return;
 		}
 		setError("");
 		setSaving(true);
 
-		var voiceOpts = supportsTtsVoiceSettings
-			? {
-					voice: voiceValue.trim() || undefined,
-					model: modelValue.trim() || undefined,
-					languageCode: languageCodeValue.trim() || undefined,
-				}
-			: undefined;
+		var voiceOpts = {
+			baseUrl: baseUrlValue.trim() || undefined,
+			voice: supportsTtsVoiceSettings ? voiceValue.trim() || undefined : undefined,
+			model: supportsTtsVoiceSettings ? modelValue.trim() || undefined : undefined,
+			languageCode: supportsTtsVoiceSettings ? languageCodeValue.trim() || undefined : undefined,
+		};
 		var req = hasApiKey
 			? saveVoiceKey(selectedProvider, apiKey.trim(), voiceOpts)
-			: sendRpc("voice.config.save_settings", {
-					provider: selectedProvider,
-					voice: voiceOpts?.voice,
-					voiceId: voiceOpts?.voice,
-					model: voiceOpts?.model,
-					languageCode: voiceOpts?.languageCode,
-				});
+			: saveVoiceSettings(selectedProvider, voiceOpts);
 		req
 			.then((res) => {
 				setSaving(false);
@@ -4561,6 +4561,7 @@ function AddVoiceProviderModal({ unconfiguredProviders, voxtralReqs, onSaved }) 
 		voiceSelectedProvider.value = providerId;
 		voiceSelectedProviderData.value = null;
 		setApiKey("");
+		setBaseUrlValue("");
 		setVoiceValue("");
 		setModelValue("");
 		setLanguageCodeValue("");
@@ -4570,6 +4571,7 @@ function AddVoiceProviderModal({ unconfiguredProviders, voxtralReqs, onSaved }) 
 	useEffect(() => {
 		var settings = voiceSelectedProviderData.value?.settings;
 		if (!settings) return;
+		setBaseUrlValue(settings.baseUrl || "");
 		setVoiceValue(settings.voiceId || settings.voice || "");
 		setModelValue(settings.model || "");
 		setLanguageCodeValue(settings.languageCode || "");
@@ -4618,9 +4620,28 @@ function AddVoiceProviderModal({ unconfiguredProviders, voxtralReqs, onSaved }) 
 					<input type="password" class="provider-key-input" style="width:100%;"
 						value=${apiKey} onInput=${(e) => setApiKey(e.target.value)}
 						placeholder=${providerMeta.keyPlaceholder || "Leave blank to keep existing key"} />
-					<div class="text-xs text-[var(--muted)]">
+					${
+						providerMeta.keyUrl
+							? html`<div class="text-xs text-[var(--muted)]">
 						Get your API key at <a href=${providerMeta.keyUrl} target="_blank" rel="noopener" class="hover:underline text-[var(--accent)]">${providerMeta.keyUrlLabel}</a>
+					</div>`
+							: null
+					}
+
+					${
+						supportsBaseUrl
+							? html`<div class="flex flex-col gap-2" style="margin-top:8px;">
+					<label class="text-xs text-[var(--muted)]">Base URL</label>
+					<input type="text" class="provider-key-input" style="width:100%;"
+						data-field="baseUrl"
+						value=${baseUrlValue} onInput=${(e) => setBaseUrlValue(e.target.value)}
+						placeholder="http://localhost:8000/v1" />
+					<div class="text-xs text-[var(--muted)]">
+						Use this for a local or OpenAI-compatible server. Leave the API key blank if your endpoint does not require one.
 					</div>
+				</div>`
+							: null
+					}
 
 					${
 						supportsTtsVoiceSettings

--- a/crates/web/src/assets/js/page-settings.js
+++ b/crates/web/src/assets/js/page-settings.js
@@ -43,7 +43,6 @@ import {
 	testTts,
 	toggleVoiceProvider,
 	transcribeAudio,
-	voiceProviderSupportsBaseUrl,
 } from "./voice-utils.js";
 
 var identity = signal(null);
@@ -4506,7 +4505,7 @@ function AddVoiceProviderModal({ unconfiguredProviders, voxtralReqs, onSaved }) 
 		: null;
 	var isElevenLabsProvider = selectedProvider === "elevenlabs" || selectedProvider === "elevenlabs-stt";
 	var supportsTtsVoiceSettings = providerMeta?.type === "tts";
-	var supportsBaseUrl = voiceProviderSupportsBaseUrl(selectedProvider);
+	var supportsBaseUrl = providerMeta?.capabilities?.baseUrl === true;
 
 	function onClose() {
 		voiceShowAddModal.value = false;
@@ -4522,7 +4521,10 @@ function AddVoiceProviderModal({ unconfiguredProviders, voxtralReqs, onSaved }) 
 
 	function onSaveKey() {
 		var hasApiKey = apiKey.trim().length > 0;
-		var hasBaseUrl = supportsBaseUrl && baseUrlValue.trim().length > 0;
+		var trimmedBaseUrl = baseUrlValue.trim();
+		var hadBaseUrl =
+			typeof providerMeta?.settings?.baseUrl === "string" && providerMeta.settings.baseUrl.trim().length > 0;
+		var hasBaseUrl = supportsBaseUrl && (trimmedBaseUrl.length > 0 || hadBaseUrl);
 		var hasSettings =
 			(supportsTtsVoiceSettings && (voiceValue.trim() || modelValue.trim() || languageCodeValue.trim())) || hasBaseUrl;
 		if (!(hasApiKey || hasSettings)) {
@@ -4533,7 +4535,7 @@ function AddVoiceProviderModal({ unconfiguredProviders, voxtralReqs, onSaved }) 
 		setSaving(true);
 
 		var voiceOpts = {
-			baseUrl: baseUrlValue.trim() || undefined,
+			baseUrl: hasBaseUrl ? trimmedBaseUrl : undefined,
 			voice: supportsTtsVoiceSettings ? voiceValue.trim() || undefined : undefined,
 			model: supportsTtsVoiceSettings ? modelValue.trim() || undefined : undefined,
 			languageCode: supportsTtsVoiceSettings ? languageCodeValue.trim() || undefined : undefined,
@@ -4614,10 +4616,10 @@ function AddVoiceProviderModal({ unconfiguredProviders, voxtralReqs, onSaved }) 
 			return html`<${Modal} show=${voiceShowAddModal.value} onClose=${onClose} title="Add ${providerMeta.name}">
 				<div class="channel-form">
 					<div class="text-sm text-[var(--text-strong)]">${providerMeta.name}</div>
-					<div class="text-xs text-[var(--muted)]" style="margin-bottom:12px;">${providerMeta.description}</div>
+					<div class="mb-3 text-xs text-[var(--muted)]">${providerMeta.description}</div>
 
 					<label class="text-xs text-[var(--muted)]">API Key</label>
-					<input type="password" class="provider-key-input" style="width:100%;"
+					<input type="password" class="provider-key-input w-full"
 						value=${apiKey} onInput=${(e) => setApiKey(e.target.value)}
 						placeholder=${providerMeta.keyPlaceholder || "Leave blank to keep existing key"} />
 					${
@@ -4630,9 +4632,9 @@ function AddVoiceProviderModal({ unconfiguredProviders, voxtralReqs, onSaved }) 
 
 					${
 						supportsBaseUrl
-							? html`<div class="flex flex-col gap-2" style="margin-top:8px;">
+							? html`<div class="mt-2 flex flex-col gap-2">
 					<label class="text-xs text-[var(--muted)]">Base URL</label>
-					<input type="text" class="provider-key-input" style="width:100%;"
+					<input type="text" class="provider-key-input w-full"
 						data-field="baseUrl"
 						value=${baseUrlValue} onInput=${(e) => setBaseUrlValue(e.target.value)}
 						placeholder="http://localhost:8000/v1" />
@@ -4651,13 +4653,13 @@ function AddVoiceProviderModal({ unconfiguredProviders, voxtralReqs, onSaved }) 
 					${isElevenLabsProvider && elevenlabsCatalog.warning ? html`<div class="text-xs text-[var(--muted)]">${elevenlabsCatalog.warning}</div>` : null}
 					${
 						isElevenLabsProvider && elevenlabsCatalog.voices.length > 0
-							? html`<select class="provider-key-input" style="width:100%;" onChange=${(e) => setVoiceValue(e.target.value)}>
+							? html`<select class="provider-key-input w-full" onChange=${(e) => setVoiceValue(e.target.value)}>
 						<option value="">Pick a voice from your account...</option>
 						${elevenlabsCatalog.voices.map((v) => html`<option value=${v.id}>${v.name} (${v.id})</option>`)}
 					</select>`
 							: null
 					}
-					<input type="text" class="provider-key-input" style="width:100%;"
+					<input type="text" class="provider-key-input w-full"
 						value=${voiceValue} onInput=${(e) => setVoiceValue(e.target.value)}
 						list=${isElevenLabsProvider ? "elevenlabs-voice-options" : undefined}
 						placeholder="voice id / name (optional)" />
@@ -4672,13 +4674,13 @@ function AddVoiceProviderModal({ unconfiguredProviders, voxtralReqs, onSaved }) 
 					<label class="text-xs text-[var(--muted)]">Model</label>
 					${
 						isElevenLabsProvider && elevenlabsCatalog.models.length > 0
-							? html`<select class="provider-key-input" style="width:100%;" onChange=${(e) => setModelValue(e.target.value)}>
+							? html`<select class="provider-key-input w-full" onChange=${(e) => setModelValue(e.target.value)}>
 						<option value="">Pick a model...</option>
 						${elevenlabsCatalog.models.map((m) => html`<option value=${m.id}>${m.name} (${m.id})</option>`)}
 					</select>`
 							: null
 					}
-					<input type="text" class="provider-key-input" style="width:100%;"
+					<input type="text" class="provider-key-input w-full"
 						value=${modelValue} onInput=${(e) => setModelValue(e.target.value)}
 						list=${isElevenLabsProvider ? "elevenlabs-model-options" : undefined}
 						placeholder="model (optional)" />
@@ -4694,7 +4696,7 @@ function AddVoiceProviderModal({ unconfiguredProviders, voxtralReqs, onSaved }) 
 						selectedProvider === "google" || selectedProvider === "google-tts"
 							? html`<div class="flex flex-col gap-2">
 							<label class="text-xs text-[var(--muted)]">Language Code</label>
-							<input type="text" class="provider-key-input" style="width:100%;"
+							<input type="text" class="provider-key-input w-full"
 								value=${languageCodeValue} onInput=${(e) => setLanguageCodeValue(e.target.value)}
 								placeholder="en-US (optional)" />
 						</div>`

--- a/crates/web/src/assets/js/voice-utils.js
+++ b/crates/web/src/assets/js/voice-utils.js
@@ -47,7 +47,7 @@ export function saveVoiceKey(providerId, apiKey, opts) {
 	}
 	if (opts?.model) payload.model = opts.model;
 	if (opts?.languageCode) payload.languageCode = opts.languageCode;
-	if (opts?.baseUrl) payload.baseUrl = opts.baseUrl;
+	if (typeof opts?.baseUrl === "string") payload.baseUrl = opts.baseUrl;
 	return sendRpc("voice.config.save_key", payload);
 }
 
@@ -64,17 +64,8 @@ export function saveVoiceSettings(providerId, opts) {
 	}
 	if (opts?.model) payload.model = opts.model;
 	if (opts?.languageCode) payload.languageCode = opts.languageCode;
-	if (opts?.baseUrl) payload.baseUrl = opts.baseUrl;
+	if (typeof opts?.baseUrl === "string") payload.baseUrl = opts.baseUrl;
 	return sendRpc("voice.config.save_settings", payload);
-}
-
-/**
- * Providers that support an OpenAI-compatible base URL override.
- * @param {string} providerId
- * @returns {boolean}
- */
-export function voiceProviderSupportsBaseUrl(providerId) {
-	return providerId === "openai" || providerId === "openai-tts" || providerId === "whisper";
 }
 
 /**

--- a/crates/web/src/assets/js/voice-utils.js
+++ b/crates/web/src/assets/js/voice-utils.js
@@ -37,7 +37,7 @@ export function toggleVoiceProvider(providerId, enabled, type) {
  * Save an API key (and optional settings) for a voice provider.
  * @param {string} providerId
  * @param {string} apiKey
- * @param {object} [opts] - Optional TTS settings: voice, model, languageCode
+ * @param {object} [opts] - Optional settings: voice, model, languageCode, baseUrl
  */
 export function saveVoiceKey(providerId, apiKey, opts) {
 	var payload = { provider: providerId, api_key: apiKey };
@@ -47,7 +47,34 @@ export function saveVoiceKey(providerId, apiKey, opts) {
 	}
 	if (opts?.model) payload.model = opts.model;
 	if (opts?.languageCode) payload.languageCode = opts.languageCode;
+	if (opts?.baseUrl) payload.baseUrl = opts.baseUrl;
 	return sendRpc("voice.config.save_key", payload);
+}
+
+/**
+ * Save non-secret voice provider settings.
+ * @param {string} providerId
+ * @param {object} [opts] - Optional settings: voice, model, languageCode, baseUrl
+ */
+export function saveVoiceSettings(providerId, opts) {
+	var payload = { provider: providerId };
+	if (opts?.voice) {
+		payload.voice = opts.voice;
+		payload.voiceId = opts.voice;
+	}
+	if (opts?.model) payload.model = opts.model;
+	if (opts?.languageCode) payload.languageCode = opts.languageCode;
+	if (opts?.baseUrl) payload.baseUrl = opts.baseUrl;
+	return sendRpc("voice.config.save_settings", payload);
+}
+
+/**
+ * Providers that support an OpenAI-compatible base URL override.
+ * @param {string} providerId
+ * @returns {boolean}
+ */
+export function voiceProviderSupportsBaseUrl(providerId) {
+	return providerId === "openai" || providerId === "openai-tts" || providerId === "whisper";
 }
 
 /**

--- a/crates/web/ui/e2e/specs/onboarding.spec.js
+++ b/crates/web/ui/e2e/specs/onboarding.spec.js
@@ -832,4 +832,99 @@ test.describe("Onboarding wizard", () => {
 
 		expect(pageErrors).toEqual([]);
 	});
+
+	test("voice onboarding saves whisper base URL without requiring an API key", async ({ page }) => {
+		const pageErrors = watchPageErrors(page);
+		await page.goto("/onboarding");
+		await page.waitForLoadState("networkidle");
+
+		await expect.poll(() => new URL(page.url()).pathname, { timeout: 15_000 }).toMatch(/^\/(?:onboarding|chats\/.+)$/);
+		if (/^\/chats\//.test(new URL(page.url()).pathname)) {
+			expect(pageErrors).toEqual([]);
+			return;
+		}
+
+		const reachedVoice = await moveToVoiceStep(page);
+		if (!reachedVoice) {
+			test.skip(true, "voice step not reachable in this onboarding run");
+			return;
+		}
+
+		const whisperRow = page
+			.locator(".onboarding-card .rounded-md.border")
+			.filter({ has: page.getByText("OpenAI Whisper", { exact: true }) })
+			.first();
+		if (!(await isVisible(whisperRow))) {
+			test.skip(true, "OpenAI Whisper row not available in this onboarding run");
+			return;
+		}
+
+		await page.evaluate(async () => {
+			const onboardingScript = document.querySelector('script[type="module"][src*="js/onboarding-app.js"]');
+			if (!onboardingScript) throw new Error("onboarding-app.js script not found");
+			const appUrl = new URL(onboardingScript.src, window.location.origin).href;
+			const marker = "js/onboarding-app.js";
+			const markerIdx = appUrl.indexOf(marker);
+			if (markerIdx < 0) throw new Error("onboarding-app.js marker not found in script URL");
+			const prefix = appUrl.slice(0, markerIdx);
+			const state = await import(`${prefix}js/state.js`);
+			const wsOpen = typeof WebSocket !== "undefined" ? WebSocket.OPEN : 1;
+			window.__voiceOnboardingSaveSettingsRequest = null;
+			state.setConnected(true);
+			state.setWs({
+				readyState: wsOpen,
+				send(raw) {
+					const req = JSON.parse(raw || "{}");
+					const resolver = state.pending[req.id];
+					if (!resolver) return;
+					if (req.method === "voice.config.save_settings") {
+						window.__voiceOnboardingSaveSettingsRequest = req.params || null;
+						resolver({ ok: true, payload: { ok: true } });
+					} else if (req.method === "voice.provider.toggle") {
+						resolver({ ok: true, payload: { ok: true } });
+					} else if (req.method === "voice.providers.all") {
+						resolver({
+							ok: true,
+							payload: {
+								stt: [
+									{
+										id: "whisper",
+										name: "OpenAI Whisper",
+										type: "stt",
+										category: "cloud",
+										description: "Best accuracy, handles accents and background noise",
+										available: true,
+										enabled: true,
+										keySource: "config",
+										settings: { baseUrl: "http://127.0.0.1:8001/v1" },
+										capabilities: { baseUrl: true },
+									},
+								],
+								tts: [],
+							},
+						});
+					} else {
+						resolver({
+							ok: false,
+							error: { message: `unexpected rpc in onboarding voice test: ${req.method}` },
+						});
+					}
+					delete state.pending[req.id];
+				},
+			});
+		});
+
+		await whisperRow.getByRole("button", { name: "Configure", exact: true }).click();
+		await whisperRow.locator('input[data-field="baseUrl"]').fill("http://127.0.0.1:8001/v1");
+		await whisperRow.getByRole("button", { name: "Save", exact: true }).click();
+
+		await expect.poll(() => page.evaluate(() => window.__voiceOnboardingSaveSettingsRequest)).not.toBeNull();
+
+		const sentRequest = await page.evaluate(() => window.__voiceOnboardingSaveSettingsRequest);
+		expect(sentRequest).toMatchObject({
+			provider: "whisper",
+			baseUrl: "http://127.0.0.1:8001/v1",
+		});
+		expect(pageErrors).toEqual([]);
+	});
 });

--- a/crates/web/ui/e2e/specs/settings-nav.spec.js
+++ b/crates/web/ui/e2e/specs/settings-nav.spec.js
@@ -295,6 +295,89 @@ test.describe("Settings navigation", () => {
 		expect(pageErrors).toEqual([]);
 	});
 
+	test("voice settings can clear an existing whisper base URL", async ({ page }) => {
+		const pageErrors = watchPageErrors(page);
+		await navigateAndWait(page, "/settings/voice");
+		await waitForWsConnected(page);
+
+		const whisperRow = page
+			.locator(".provider-card")
+			.filter({ has: page.getByText("OpenAI Whisper", { exact: true }) })
+			.first();
+		await expect(whisperRow).toBeVisible();
+
+		await page.evaluate(async () => {
+			const appScript = document.querySelector('script[type="module"][src*="js/app.js"]');
+			if (!appScript) throw new Error("app.js script not found");
+			const appUrl = new URL(appScript.src, window.location.origin).href;
+			const marker = "js/app.js";
+			const markerIdx = appUrl.indexOf(marker);
+			if (markerIdx < 0) throw new Error("app.js marker not found in script URL");
+			const prefix = appUrl.slice(0, markerIdx);
+			const state = await import(`${prefix}js/state.js`);
+			const wsOpen = typeof WebSocket !== "undefined" ? WebSocket.OPEN : 1;
+			window.__voiceSettingsClearBaseUrlRequest = null;
+			state.setConnected(true);
+			state.setWs({
+				readyState: wsOpen,
+				send(raw) {
+					const req = JSON.parse(raw || "{}");
+					const resolver = state.pending[req.id];
+					if (!resolver) return;
+					if (req.method === "voice.config.save_settings") {
+						window.__voiceSettingsClearBaseUrlRequest = req.params || null;
+						resolver({ ok: true, payload: { ok: true } });
+					} else if (req.method === "voice.providers.all") {
+						resolver({
+							ok: true,
+							payload: {
+								stt: [
+									{
+										id: "whisper",
+										name: "OpenAI Whisper",
+										type: "stt",
+										category: "cloud",
+										description: "Best accuracy, handles accents and background noise",
+										available: true,
+										enabled: false,
+										keySource: "config",
+										settings: { baseUrl: "http://127.0.0.1:8001/v1" },
+										capabilities: { baseUrl: true },
+									},
+								],
+								tts: [],
+							},
+						});
+					} else {
+						resolver({
+							ok: false,
+							error: { message: `unexpected rpc in voice settings clear-base-url test: ${req.method}` },
+						});
+					}
+					delete state.pending[req.id];
+				},
+			});
+		});
+
+		await whisperRow.getByRole("button", { name: "Configure", exact: true }).click();
+		const modal = page
+			.locator(".modal-box")
+			.filter({ has: page.getByText("OpenAI Whisper", { exact: false }) })
+			.last();
+		await expect(modal).toBeVisible();
+		await modal.locator('input[data-field="baseUrl"]').fill("");
+		await modal.getByRole("button", { name: "Save", exact: true }).click();
+
+		await expect.poll(() => page.evaluate(() => window.__voiceSettingsClearBaseUrlRequest)).not.toBeNull();
+
+		const sentRequest = await page.evaluate(() => window.__voiceSettingsClearBaseUrlRequest);
+		expect(sentRequest).toMatchObject({
+			provider: "whisper",
+			baseUrl: "",
+		});
+		expect(pageErrors).toEqual([]);
+	});
+
 	test("remote access page shows tailscale and ngrok cards", async ({ page }) => {
 		const pageErrors = watchPageErrors(page);
 		await page.route("**/api/auth/status", async (route) => {

--- a/crates/web/ui/e2e/specs/settings-nav.spec.js
+++ b/crates/web/ui/e2e/specs/settings-nav.spec.js
@@ -212,6 +212,89 @@ test.describe("Settings navigation", () => {
 		});
 	}
 
+	test("voice settings saves whisper base URL without requiring an API key", async ({ page }) => {
+		const pageErrors = watchPageErrors(page);
+		await navigateAndWait(page, "/settings/voice");
+		await waitForWsConnected(page);
+
+		const whisperRow = page
+			.locator(".provider-card")
+			.filter({ has: page.getByText("OpenAI Whisper", { exact: true }) })
+			.first();
+		await expect(whisperRow).toBeVisible();
+
+		await page.evaluate(async () => {
+			const appScript = document.querySelector('script[type="module"][src*="js/app.js"]');
+			if (!appScript) throw new Error("app.js script not found");
+			const appUrl = new URL(appScript.src, window.location.origin).href;
+			const marker = "js/app.js";
+			const markerIdx = appUrl.indexOf(marker);
+			if (markerIdx < 0) throw new Error("app.js marker not found in script URL");
+			const prefix = appUrl.slice(0, markerIdx);
+			const state = await import(`${prefix}js/state.js`);
+			const wsOpen = typeof WebSocket !== "undefined" ? WebSocket.OPEN : 1;
+			window.__voiceSettingsSaveSettingsRequest = null;
+			state.setConnected(true);
+			state.setWs({
+				readyState: wsOpen,
+				send(raw) {
+					const req = JSON.parse(raw || "{}");
+					const resolver = state.pending[req.id];
+					if (!resolver) return;
+					if (req.method === "voice.config.save_settings") {
+						window.__voiceSettingsSaveSettingsRequest = req.params || null;
+						resolver({ ok: true, payload: { ok: true } });
+					} else if (req.method === "voice.providers.all") {
+						resolver({
+							ok: true,
+							payload: {
+								stt: [
+									{
+										id: "whisper",
+										name: "OpenAI Whisper",
+										type: "stt",
+										category: "cloud",
+										description: "Best accuracy, handles accents and background noise",
+										available: true,
+										enabled: false,
+										keySource: "config",
+										settings: { baseUrl: "http://127.0.0.1:8001/v1" },
+										capabilities: { baseUrl: true },
+									},
+								],
+								tts: [],
+							},
+						});
+					} else {
+						resolver({
+							ok: false,
+							error: { message: `unexpected rpc in voice settings test: ${req.method}` },
+						});
+					}
+					delete state.pending[req.id];
+				},
+			});
+		});
+
+		await whisperRow.getByRole("button", { name: "Configure", exact: true }).click();
+		const modal = page
+			.locator(".modal-box")
+			.filter({ has: page.getByText("OpenAI Whisper", { exact: false }) })
+			.last();
+		await expect(modal).toBeVisible();
+		await modal.locator('input[data-field="baseUrl"]').fill("http://127.0.0.1:8001/v1");
+		await modal.getByRole("button", { name: "Save", exact: true }).click();
+
+		await expect.poll(() => page.evaluate(() => window.__voiceSettingsSaveSettingsRequest)).not.toBeNull();
+
+		const sentRequest = await page.evaluate(() => window.__voiceSettingsSaveSettingsRequest);
+		expect(sentRequest).toMatchObject({
+			provider: "whisper",
+			baseUrl: "http://127.0.0.1:8001/v1",
+		});
+		expect(pageErrors).toEqual([]);
+	});
+
 	test("remote access page shows tailscale and ngrok cards", async ({ page }) => {
 		const pageErrors = watchPageErrors(page);
 		await page.route("**/api/auth/status", async (route) => {

--- a/crates/web/ui/e2e/specs/settings-nav.spec.js
+++ b/crates/web/ui/e2e/specs/settings-nav.spec.js
@@ -316,6 +316,8 @@ test.describe("Settings navigation", () => {
 			const prefix = appUrl.slice(0, markerIdx);
 			const state = await import(`${prefix}js/state.js`);
 			const wsOpen = typeof WebSocket !== "undefined" ? WebSocket.OPEN : 1;
+			window.__voiceSettingsCurrentBaseUrl = null;
+			window.__voiceSettingsRequests = [];
 			window.__voiceSettingsClearBaseUrlRequest = null;
 			state.setConnected(true);
 			state.setWs({
@@ -325,7 +327,12 @@ test.describe("Settings navigation", () => {
 					const resolver = state.pending[req.id];
 					if (!resolver) return;
 					if (req.method === "voice.config.save_settings") {
-						window.__voiceSettingsClearBaseUrlRequest = req.params || null;
+						window.__voiceSettingsRequests.push(req.params || null);
+						window.__voiceSettingsCurrentBaseUrl =
+							typeof req.params?.baseUrl === "string" ? req.params.baseUrl : window.__voiceSettingsCurrentBaseUrl;
+						if (req.params?.baseUrl === "") {
+							window.__voiceSettingsClearBaseUrlRequest = req.params || null;
+						}
 						resolver({ ok: true, payload: { ok: true } });
 					} else if (req.method === "voice.providers.all") {
 						resolver({
@@ -341,7 +348,7 @@ test.describe("Settings navigation", () => {
 										available: true,
 										enabled: false,
 										keySource: "config",
-										settings: { baseUrl: "http://127.0.0.1:8001/v1" },
+										settings: { baseUrl: window.__voiceSettingsCurrentBaseUrl || "" },
 										capabilities: { baseUrl: true },
 									},
 								],
@@ -360,7 +367,18 @@ test.describe("Settings navigation", () => {
 		});
 
 		await whisperRow.getByRole("button", { name: "Configure", exact: true }).click();
-		const modal = page
+		let modal = page
+			.locator(".modal-box")
+			.filter({ has: page.getByText("OpenAI Whisper", { exact: false }) })
+			.last();
+		await expect(modal).toBeVisible();
+		await modal.locator('input[data-field="baseUrl"]').fill("http://127.0.0.1:8001/v1");
+		await modal.getByRole("button", { name: "Save", exact: true }).click();
+
+		await expect.poll(() => page.evaluate(() => window.__voiceSettingsRequests.length)).toBeGreaterThan(0);
+
+		await whisperRow.getByRole("button", { name: "Configure", exact: true }).click();
+		modal = page
 			.locator(".modal-box")
 			.filter({ has: page.getByText("OpenAI Whisper", { exact: false }) })
 			.last();


### PR DESCRIPTION
## Summary

- add onboarding and Settings UI for local/OpenAI-compatible Whisper and OpenAI TTS endpoints via a `Base URL` field
- persist `voice.tts.openai.base_url` and `voice.stt.whisper.base_url` in config, expose them in provider metadata, and let provider detection treat them as configured
- add focused config, gateway, and Playwright coverage for the new local setup flow

Fixes #570.

## Validation

### Completed

- [x] `biome check --write crates/web/src/assets/js/voice-utils.js crates/web/src/assets/js/page-settings.js crates/web/src/assets/js/onboarding-view.js crates/web/ui/e2e/specs/onboarding.spec.js crates/web/ui/e2e/specs/settings-nav.spec.js`
- [x] `cargo +nightly-2025-11-30 fmt --all -- --check`
- [x] `cargo test -p moltis-config voice_openai_and_whisper_base_url_parse_from_toml -- --nocapture`
- [x] `cargo test -p moltis-gateway base_url -- --nocapture`
- [x] `npx playwright test e2e/specs/onboarding.spec.js -g "voice onboarding saves whisper base URL without requiring an API key"`
- [x] `npx playwright test e2e/specs/settings-nav.spec.js -g "voice settings saves whisper base URL without requiring an API key"`
- [x] `just lint`

### Remaining

- [ ] None

## Manual QA

1. Open onboarding, reach the Voice step, configure `OpenAI Whisper` with only `Base URL`, save, and confirm the provider enables successfully.
2. Open `Settings -> Voice`, configure `OpenAI Whisper` with only `Base URL`, save, and confirm the value is retained when reopening the modal.
3. Configure a local OpenAI-compatible TTS endpoint and confirm `OpenAI TTS` accepts `Base URL` in the same modal flow.
