### PR TITLE
fix(sandbox): mask /proc and /sys host metadata in Docker/Podman

### DIFF
--- a/crates/tools/src/sandbox/docker.rs
+++ b/crates/tools/src/sandbox/docker.rs
@@ -181,14 +181,33 @@ impl DockerSandbox {
     /// non-prebuilt images need a writable root for `apt-get` provisioning.
     pub(crate) fn hardening_args(is_prebuilt: bool) -> Vec<String> {
         let mut args = vec![
+            // --- Capability / privilege ---
             "--cap-drop".to_string(),
             "ALL".to_string(),
             "--security-opt".to_string(),
             "no-new-privileges".to_string(),
+            // --- Writable tmpfs mounts ---
             "--tmpfs".to_string(),
             "/tmp:rw,nosuid,size=256m".to_string(),
             "--tmpfs".to_string(),
             "/run:rw,nosuid,size=64m".to_string(),
+            // --- Host metadata isolation ---
+            // Give the container its own hostname so /proc/sys/kernel/hostname
+            // and the `hostname` command do not reveal the host identity.
+            "--hostname".to_string(),
+            "sandbox".to_string(),
+            // Mask /sys subtrees that expose host hardware identifiers
+            // (serial numbers, BIOS/UEFI data, disk models, LUKS UUIDs).
+            // Empty read-only tmpfs overlays hide the underlying sysfs entries
+            // and work identically on Docker and Podman.
+            "--tmpfs".to_string(),
+            "/sys/firmware:ro,nosuid".to_string(),
+            "--tmpfs".to_string(),
+            "/sys/class/dmi:ro,nosuid".to_string(),
+            "--tmpfs".to_string(),
+            "/sys/devices/virtual/dmi:ro,nosuid".to_string(),
+            "--tmpfs".to_string(),
+            "/sys/class/block:ro,nosuid".to_string(),
         ];
         if is_prebuilt {
             args.push("--read-only".to_string());

--- a/crates/tools/src/sandbox/tests/core.rs
+++ b/crates/tools/src/sandbox/tests/core.rs
@@ -26,6 +26,13 @@ fn test_docker_hardening_args_prebuilt() {
     // Verify tmpfs mounts are present
     assert!(args.contains(&"/tmp:rw,nosuid,size=256m".to_string()));
     assert!(args.contains(&"/run:rw,nosuid,size=64m".to_string()));
+    // Host metadata isolation
+    assert!(args.contains(&"--hostname".to_string()));
+    assert!(args.contains(&"sandbox".to_string()));
+    assert!(args.contains(&"/sys/firmware:ro,nosuid".to_string()));
+    assert!(args.contains(&"/sys/class/dmi:ro,nosuid".to_string()));
+    assert!(args.contains(&"/sys/devices/virtual/dmi:ro,nosuid".to_string()));
+    assert!(args.contains(&"/sys/class/block:ro,nosuid".to_string()));
 }
 
 #[test]
@@ -39,6 +46,10 @@ fn test_docker_hardening_args_not_prebuilt() {
     assert!(!args.contains(&"--read-only".to_string()));
     // tmpfs mounts still present
     assert!(args.contains(&"/tmp:rw,nosuid,size=256m".to_string()));
+    // Host metadata isolation still present
+    assert!(args.contains(&"--hostname".to_string()));
+    assert!(args.contains(&"/sys/firmware:ro,nosuid".to_string()));
+    assert!(args.contains(&"/sys/class/block:ro,nosuid".to_string()));
 }
 
 #[test]

--- a/crates/tools/src/sandbox/tests/core.rs
+++ b/crates/tools/src/sandbox/tests/core.rs
@@ -26,9 +26,12 @@ fn test_docker_hardening_args_prebuilt() {
     // Verify tmpfs mounts are present
     assert!(args.contains(&"/tmp:rw,nosuid,size=256m".to_string()));
     assert!(args.contains(&"/run:rw,nosuid,size=64m".to_string()));
-    // Host metadata isolation
-    assert!(args.contains(&"--hostname".to_string()));
-    assert!(args.contains(&"sandbox".to_string()));
+    // Host metadata isolation — assert flag-value adjacency for --hostname
+    let hostname_pos = args
+        .iter()
+        .position(|a| a == "--hostname")
+        .expect("--hostname flag missing");
+    assert_eq!(args[hostname_pos + 1], "sandbox", "--hostname value should be 'sandbox'");
     assert!(args.contains(&"/sys/firmware:ro,nosuid".to_string()));
     assert!(args.contains(&"/sys/class/dmi:ro,nosuid".to_string()));
     assert!(args.contains(&"/sys/devices/virtual/dmi:ro,nosuid".to_string()));
@@ -46,9 +49,15 @@ fn test_docker_hardening_args_not_prebuilt() {
     assert!(!args.contains(&"--read-only".to_string()));
     // tmpfs mounts still present
     assert!(args.contains(&"/tmp:rw,nosuid,size=256m".to_string()));
-    // Host metadata isolation still present
-    assert!(args.contains(&"--hostname".to_string()));
+    // Host metadata isolation still present — all 4 sysfs masks + hostname
+    let hostname_pos = args
+        .iter()
+        .position(|a| a == "--hostname")
+        .expect("--hostname flag missing");
+    assert_eq!(args[hostname_pos + 1], "sandbox", "--hostname value should be 'sandbox'");
     assert!(args.contains(&"/sys/firmware:ro,nosuid".to_string()));
+    assert!(args.contains(&"/sys/class/dmi:ro,nosuid".to_string()));
+    assert!(args.contains(&"/sys/devices/virtual/dmi:ro,nosuid".to_string()));
     assert!(args.contains(&"/sys/class/block:ro,nosuid".to_string()));
 }
 

--- a/docs/src/sandbox.md
+++ b/docs/src/sandbox.md
@@ -119,10 +119,20 @@ hardening flags by default:
 | `--tmpfs /tmp:rw,nosuid,size=256m` | Writable tmpfs for temp files (noexec on real root) |
 | `--tmpfs /run:rw,nosuid,size=64m` | Writable tmpfs for runtime files |
 | `--read-only` | Read-only root filesystem (prebuilt images only) |
+| `--hostname sandbox` | Prevents host hostname leakage |
+| `--tmpfs /sys/firmware:ro,nosuid` | Masks BIOS/UEFI firmware data |
+| `--tmpfs /sys/class/dmi:ro,nosuid` | Masks system serial numbers and identifiers |
+| `--tmpfs /sys/devices/virtual/dmi:ro,nosuid` | Masks DMI attributes |
+| `--tmpfs /sys/class/block:ro,nosuid` | Masks block device info (disk models, LUKS UUIDs) |
 
 The `--read-only` flag is applied only to prebuilt sandbox images (where
 packages are already baked in). Non-prebuilt images need a writable root
 filesystem for `apt-get` provisioning on first start.
+
+The `/sys` tmpfs overlays prevent host hardware metadata (serial numbers, disk
+models, LUKS UUIDs) from being visible inside the container. Note that
+`tools.fs.deny_paths` only restricts Moltis file-access tools — these kernel
+filesystem masks prevent leakage via shell commands as well.
 
 ## WASM Sandbox (Wasmtime + WASI)
 


### PR DESCRIPTION
## Summary

- Add host metadata isolation to Docker/Podman sandbox `hardening_args()` to prevent containers from leaking hostname, BIOS serial numbers, disk models, and LUKS UUIDs via `/proc` and `/sys`
- New flags: `--hostname sandbox`, tmpfs overlays on `/sys/firmware`, `/sys/class/dmi`, `/sys/devices/virtual/dmi`, `/sys/class/block`
- Works identically on Docker and Podman; Apple Container unaffected (separate VM kernel)

Closes #705

## Validation

### Completed
- [x] `cargo test -p moltis-tools --lib sandbox::tests::core` — all 28 tests pass
- [x] `cargo +nightly-2025-11-30 fmt --all -- --check` — clean
- [x] `just lint` — clean

### Remaining
- [ ] `./scripts/local-validate.sh`
- [ ] Manual QA with Docker: `cat /proc/sys/kernel/hostname` should show `sandbox`
- [ ] Manual QA with Docker: `ls /sys/firmware/` should be empty
- [ ] Manual QA with Docker: `ls /sys/class/dmi/` should be empty
- [ ] Manual QA with Docker: `ls /sys/class/block/` should be empty
- [ ] Manual QA with Podman: same checks as Docker

## Manual QA

1. Start a sandbox session with Docker backend
2. Run `hostname` — should print `sandbox`, not the host hostname
3. Run `cat /sys/class/dmi/id/product_serial` — should fail (empty dir)
4. Run `ls /sys/class/block/` — should be empty (no disk model/LUKS leakage)
5. Repeat with Podman backend