### PR TITLE
fix(graphql): make sessionKey required for all chat operations

### DIFF
--- a/apps/ios/GraphQL/Schema/schema.graphqls
+++ b/apps/ios/GraphQL/Schema/schema.graphqls
@@ -99,23 +99,23 @@ type ChatMutation {
 	"""
 	Send a chat message.
 	"""
-	send(message: String!, sessionKey: String, model: String): BoolResult!
+	send(message: String!, sessionKey: String!, model: String): BoolResult!
 	"""
 	Abort active chat response.
 	"""
-	abort(sessionKey: String): BoolResult!
+	abort(sessionKey: String!): BoolResult!
 	"""
 	Cancel queued chat messages.
 	"""
-	cancelQueued(sessionKey: String): BoolResult!
+	cancelQueued(sessionKey: String!): BoolResult!
 	"""
 	Clear chat history for session.
 	"""
-	clear(sessionKey: String): BoolResult!
+	clear(sessionKey: String!): BoolResult!
 	"""
 	Compact chat messages.
 	"""
-	compact(sessionKey: String): BoolResult!
+	compact(sessionKey: String!): BoolResult!
 	"""
 	Inject a message into chat history.
 	"""
@@ -126,19 +126,19 @@ type ChatQuery {
 	"""
 	Get chat history for a session.
 	"""
-	history(sessionKey: String): JSON!
+	history(sessionKey: String!): JSON!
 	"""
 	Get chat context data.
 	"""
-	context(sessionKey: String): JSON!
+	context(sessionKey: String!): JSON!
 	"""
 	Get rendered system prompt.
 	"""
-	rawPrompt(sessionKey: String): ChatRawPrompt!
+	rawPrompt(sessionKey: String!): ChatRawPrompt!
 	"""
 	Get full context with rendering (OpenAI messages format).
 	"""
-	fullContext(sessionKey: String): JSON!
+	fullContext(sessionKey: String!): JSON!
 }
 
 type ChatRawPrompt {
@@ -1141,7 +1141,7 @@ type SubscriptionRoot {
 	"""
 	Chat events (streaming tokens, completion, abort).
 	"""
-	chatEvent(sessionKey: String): GenericEvent!
+	chatEvent(sessionKey: String!): GenericEvent!
 	"""
 	Session change events (patch, switch, delete).
 	"""

--- a/crates/graphql/src/mutations/mod.rs
+++ b/crates/graphql/src/mutations/mod.rs
@@ -256,7 +256,7 @@ impl ChatMutation {
         &self,
         ctx: &Context<'_>,
         message: String,
-        session_key: Option<String>,
+        session_key: String,
         model: Option<String>,
     ) -> Result<BoolResult> {
         let s = services!(ctx);
@@ -268,7 +268,7 @@ impl ChatMutation {
     }
 
     /// Abort active chat response.
-    async fn abort(&self, ctx: &Context<'_>, session_key: Option<String>) -> Result<BoolResult> {
+    async fn abort(&self, ctx: &Context<'_>, session_key: String) -> Result<BoolResult> {
         let s = services!(ctx);
         from_service(
             s.chat
@@ -278,11 +278,7 @@ impl ChatMutation {
     }
 
     /// Cancel queued chat messages.
-    async fn cancel_queued(
-        &self,
-        ctx: &Context<'_>,
-        session_key: Option<String>,
-    ) -> Result<BoolResult> {
+    async fn cancel_queued(&self, ctx: &Context<'_>, session_key: String) -> Result<BoolResult> {
         let s = services!(ctx);
         from_service(
             s.chat
@@ -292,7 +288,7 @@ impl ChatMutation {
     }
 
     /// Clear chat history for session.
-    async fn clear(&self, ctx: &Context<'_>, session_key: Option<String>) -> Result<BoolResult> {
+    async fn clear(&self, ctx: &Context<'_>, session_key: String) -> Result<BoolResult> {
         let s = services!(ctx);
         from_service(
             s.chat
@@ -302,7 +298,7 @@ impl ChatMutation {
     }
 
     /// Compact chat messages.
-    async fn compact(&self, ctx: &Context<'_>, session_key: Option<String>) -> Result<BoolResult> {
+    async fn compact(&self, ctx: &Context<'_>, session_key: String) -> Result<BoolResult> {
         let s = services!(ctx);
         from_service(
             s.chat

--- a/crates/graphql/src/queries/mod.rs
+++ b/crates/graphql/src/queries/mod.rs
@@ -226,7 +226,7 @@ pub struct ChatQuery;
 #[Object]
 impl ChatQuery {
     /// Get chat history for a session.
-    async fn history(&self, ctx: &Context<'_>, session_key: Option<String>) -> Result<Json> {
+    async fn history(&self, ctx: &Context<'_>, session_key: String) -> Result<Json> {
         let s = services!(ctx);
         // Messages contain deeply nested tool calls, images, etc.
         from_service_json(
@@ -237,7 +237,7 @@ impl ChatQuery {
     }
 
     /// Get chat context data.
-    async fn context(&self, ctx: &Context<'_>, session_key: Option<String>) -> Result<Json> {
+    async fn context(&self, ctx: &Context<'_>, session_key: String) -> Result<Json> {
         let s = services!(ctx);
         // Dynamic context shape (system prompt, tools, etc.).
         from_service_json(
@@ -248,11 +248,7 @@ impl ChatQuery {
     }
 
     /// Get rendered system prompt.
-    async fn raw_prompt(
-        &self,
-        ctx: &Context<'_>,
-        session_key: Option<String>,
-    ) -> Result<ChatRawPrompt> {
+    async fn raw_prompt(&self, ctx: &Context<'_>, session_key: String) -> Result<ChatRawPrompt> {
         let s = services!(ctx);
         from_service(
             s.chat
@@ -262,7 +258,7 @@ impl ChatQuery {
     }
 
     /// Get full context with rendering (OpenAI messages format).
-    async fn full_context(&self, ctx: &Context<'_>, session_key: Option<String>) -> Result<Json> {
+    async fn full_context(&self, ctx: &Context<'_>, session_key: String) -> Result<Json> {
         let s = services!(ctx);
         // OpenAI messages format — deeply nested, dynamic.
         from_service_json(

--- a/crates/graphql/src/subscriptions/mod.rs
+++ b/crates/graphql/src/subscriptions/mod.rs
@@ -32,10 +32,10 @@ impl SubscriptionRoot {
         Ok(async_stream::stream! {
             while let Ok((event_name, payload)) = rx.recv().await {
                 if event_name == "chat" {
-                    if let Some(event_sk) = payload.get("sessionKey").and_then(|v| v.as_str())
-                        && event_sk != session_key
-                    {
-                        continue;
+                    match payload.get("sessionKey").and_then(|v| v.as_str()) {
+                        Some(event_sk) if event_sk != session_key => continue,
+                        None => continue,
+                        _ => {}
                     }
                     yield GenericEvent::from(payload);
                 }

--- a/crates/graphql/src/subscriptions/mod.rs
+++ b/crates/graphql/src/subscriptions/mod.rs
@@ -25,16 +25,15 @@ impl SubscriptionRoot {
     async fn chat_event(
         &self,
         ctx: &Context<'_>,
-        session_key: Option<String>,
+        session_key: String,
     ) -> Result<impl Stream<Item = GenericEvent>> {
         let c = ctx.data::<Arc<GqlContext>>()?;
         let mut rx = c.subscribe();
         Ok(async_stream::stream! {
             while let Ok((event_name, payload)) = rx.recv().await {
                 if event_name == "chat" {
-                    if let Some(ref sk) = session_key
-                        && let Some(event_sk) = payload.get("sessionKey").and_then(|v| v.as_str())
-                        && event_sk != sk
+                    if let Some(event_sk) = payload.get("sessionKey").and_then(|v| v.as_str())
+                        && event_sk != session_key
                     {
                         continue;
                     }

--- a/crates/graphql/tests/integration.rs
+++ b/crates/graphql/tests/integration.rs
@@ -1128,36 +1128,68 @@ async fn chat_history_query_forwards_session_key() {
     assert_eq!(params["sessionKey"], "sess1");
 }
 
-#[tokio::test]
-async fn chat_send_requires_session_key() {
+/// Helper: assert that a query/mutation missing a required arg returns a GraphQL error.
+async fn assert_requires_session_key(query: &str, label: &str) {
     let mock = MockDispatch::new();
     let (schema, _) = build_test_schema(mock);
-
-    let res = schema
-        .execute(Request::new(
-            r#"mutation { chat { send(message: "Hello") { ok } } }"#,
-        ))
-        .await;
-
+    let res = schema.execute(Request::new(query)).await;
     assert!(
         !res.errors.is_empty(),
-        "send without sessionKey should fail"
+        "{label} without sessionKey should fail"
     );
 }
 
 #[tokio::test]
+async fn chat_send_requires_session_key() {
+    assert_requires_session_key(
+        r#"mutation { chat { send(message: "Hello") { ok } } }"#,
+        "send",
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn chat_abort_requires_session_key() {
+    assert_requires_session_key(r#"mutation { chat { abort { ok } } }"#, "abort").await;
+}
+
+#[tokio::test]
+async fn chat_cancel_queued_requires_session_key() {
+    assert_requires_session_key(
+        r#"mutation { chat { cancelQueued { ok } } }"#,
+        "cancelQueued",
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn chat_clear_requires_session_key() {
+    assert_requires_session_key(r#"mutation { chat { clear { ok } } }"#, "clear").await;
+}
+
+#[tokio::test]
+async fn chat_compact_requires_session_key() {
+    assert_requires_session_key(r#"mutation { chat { compact { ok } } }"#, "compact").await;
+}
+
+#[tokio::test]
 async fn chat_history_requires_session_key() {
-    let mock = MockDispatch::new();
-    let (schema, _) = build_test_schema(mock);
+    assert_requires_session_key(r#"query { chat { history } }"#, "history").await;
+}
 
-    let res = schema
-        .execute(Request::new(r#"query { chat { history } }"#))
-        .await;
+#[tokio::test]
+async fn chat_context_requires_session_key() {
+    assert_requires_session_key(r#"query { chat { context } }"#, "context").await;
+}
 
-    assert!(
-        !res.errors.is_empty(),
-        "history without sessionKey should fail"
-    );
+#[tokio::test]
+async fn chat_raw_prompt_requires_session_key() {
+    assert_requires_session_key(r#"query { chat { rawPrompt { prompt } } }"#, "rawPrompt").await;
+}
+
+#[tokio::test]
+async fn chat_full_context_requires_session_key() {
+    assert_requires_session_key(r#"query { chat { fullContext } }"#, "fullContext").await;
 }
 
 #[tokio::test]
@@ -1166,10 +1198,8 @@ async fn chat_event_subscription_requires_session_key() {
     let (schema, _) = build_test_schema(mock);
 
     let mut stream = schema.execute_stream(Request::new(r#"subscription { chatEvent { data } }"#));
-    let resp = timeout(Duration::from_millis(100), stream.next())
-        .await
-        .expect("timeout")
-        .expect("subscription response");
+    // Validation errors are synchronous — the stream yields immediately then terminates.
+    let resp = stream.next().await.expect("subscription response");
 
     assert!(
         !resp.errors.is_empty(),
@@ -1438,11 +1468,16 @@ async fn chat_event_subscription_filters_by_session_key() {
     ));
     let _ = timeout(Duration::from_millis(20), stream.next()).await;
 
+    // Different session — should be skipped.
     tx.send((
         "chat".to_string(),
         json!({ "sessionKey": "other", "text": "skip" }),
     ))
     .expect("broadcast other");
+    // No sessionKey in payload — should be dropped.
+    tx.send(("chat".to_string(), json!({ "text": "no-key" })))
+        .expect("broadcast no-key");
+    // Matching session — should be delivered.
     tx.send((
         "chat".to_string(),
         json!({ "sessionKey": "s1", "text": "deliver" }),

--- a/crates/graphql/tests/integration.rs
+++ b/crates/graphql/tests/integration.rs
@@ -1129,6 +1129,55 @@ async fn chat_history_query_forwards_session_key() {
 }
 
 #[tokio::test]
+async fn chat_send_requires_session_key() {
+    let mock = MockDispatch::new();
+    let (schema, _) = build_test_schema(mock);
+
+    let res = schema
+        .execute(Request::new(
+            r#"mutation { chat { send(message: "Hello") { ok } } }"#,
+        ))
+        .await;
+
+    assert!(
+        !res.errors.is_empty(),
+        "send without sessionKey should fail"
+    );
+}
+
+#[tokio::test]
+async fn chat_history_requires_session_key() {
+    let mock = MockDispatch::new();
+    let (schema, _) = build_test_schema(mock);
+
+    let res = schema
+        .execute(Request::new(r#"query { chat { history } }"#))
+        .await;
+
+    assert!(
+        !res.errors.is_empty(),
+        "history without sessionKey should fail"
+    );
+}
+
+#[tokio::test]
+async fn chat_event_subscription_requires_session_key() {
+    let mock = MockDispatch::new();
+    let (schema, _) = build_test_schema(mock);
+
+    let mut stream = schema.execute_stream(Request::new(r#"subscription { chatEvent { data } }"#));
+    let resp = timeout(Duration::from_millis(100), stream.next())
+        .await
+        .expect("timeout")
+        .expect("subscription response");
+
+    assert!(
+        !resp.errors.is_empty(),
+        "chatEvent without sessionKey should fail"
+    );
+}
+
+#[tokio::test]
 async fn agents_update_identity_mutation_returns_ok_on_success() {
     let mock = MockDispatch::new();
     mock.set_response(


### PR DESCRIPTION
## Summary

- Make `sessionKey` a required `String!` parameter on all GraphQL chat mutations (`send`, `abort`, `cancelQueued`, `clear`, `compact`), queries (`history`, `context`, `rawPrompt`, `fullContext`), and the `chatEvent` subscription
- Regenerate iOS companion app GraphQL schema to match
- Add 3 integration tests verifying omitting `sessionKey` returns a GraphQL error

Closes #542

## Validation

### Completed
- [x] `cargo check --workspace` passes
- [x] `cargo +nightly-2025-11-30 fmt --all -- --check` passes
- [x] `cargo clippy -p moltis-graphql --all-targets -- -D warnings` passes
- [x] `cargo test -p moltis-graphql` — 27/27 tests pass (3 new)
- [x] iOS schema regenerated via `cargo run -p moltis-schema-export`
- [x] Verified iOS app uses RPC (not GraphQL) for chat ops — no Swift code changes needed

### Remaining
- [ ] `./scripts/local-validate.sh`
- [ ] iOS build: `just ios-build`

## Manual QA

1. Open GraphQL playground
2. Try `mutation { chat { send(message: "hi") { ok } } }` — should fail with missing `sessionKey` error
3. Try `mutation { chat { send(message: "hi", sessionKey: "main") { ok } } }` — should succeed
4. Subscribe `subscription { chatEvent(sessionKey: "main") { data } }` and send a message — events should arrive for the correct session

🤖 Generated with [Claude Code](https://claude.com/claude-code)