### PR TITLE
fix(whatsapp): upgrade whatsapp-rust ecosystem 0.2 → 0.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8421,6 +8421,7 @@ dependencies = [
  "moltis-media",
  "moltis-metrics",
  "postcard",
+ "qrcode",
  "rand 0.10.0",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -110,7 +110,7 @@ dependencies = [
  "aes 0.8.4",
  "cipher 0.4.4",
  "ctr",
- "ghash",
+ "ghash 0.5.1",
  "subtle",
 ]
 
@@ -1648,6 +1648,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmov"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
+
+[[package]]
 name = "coarsetime"
 version = "0.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2221,6 +2227,15 @@ dependencies = [
  "dispatch2",
  "nix 0.31.1",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
 ]
 
 [[package]]
@@ -3758,7 +3773,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
 dependencies = [
  "opaque-debug",
- "polyval",
+ "polyval 0.6.2",
+]
+
+[[package]]
+name = "ghash"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eecf2d5dc9b66b732b97707a0210906b1d30523eb773193ab777c0c84b3e8d5"
+dependencies = [
+ "polyval 0.7.1",
 ]
 
 [[package]]
@@ -9454,7 +9478,7 @@ checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
 dependencies = [
  "cpufeatures 0.2.17",
  "opaque-debug",
- "universal-hash",
+ "universal-hash 0.5.1",
 ]
 
 [[package]]
@@ -9466,7 +9490,18 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
  "opaque-debug",
- "universal-hash",
+ "universal-hash 0.5.1",
+]
+
+[[package]]
+name = "polyval"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dfc63250416fea14f5749b90725916a6c903f599d51cb635aa7a52bfd03eede"
+dependencies = [
+ "cpubits",
+ "cpufeatures 0.3.0",
+ "universal-hash 0.6.1",
 ]
 
 [[package]]
@@ -9681,7 +9716,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools 0.14.0",
  "log",
  "multimap",
@@ -9725,26 +9760,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
 dependencies = [
  "prost 0.14.3",
-]
-
-[[package]]
-name = "protobuf"
-version = "3.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d65a1d4ddae7d8b5de68153b48f6aa3bba8cb002b243dbdbc55a5afbc98f99f4"
-dependencies = [
- "once_cell",
- "protobuf-support",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "protobuf-support"
-version = "3.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e36c2f31e0a47f9280fb347ef5e461ffcd2c52dd520d8e216b52f93b0b0d7d6"
-dependencies = [
- "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -13221,6 +13236,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "typed-builder"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31aa81521b70f94402501d848ccc0ecaa8f93c8eb6999eb9747e72287757ffda"
+dependencies = [
+ "typed-builder-macro",
+]
+
+[[package]]
+name = "typed-builder-macro"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "076a02dc54dd46795c2e9c8282ed40bcfb1e22747e955de9389a1de28190fb26"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
 name = "typemap_rev"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13375,6 +13410,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "universal-hash"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4987bdc12753382e0bec4a65c50738ffaabc998b9cdd1f952fb5f39b0048a96"
+dependencies = [
+ "crypto-common 0.2.1",
+ "ctutils",
+]
+
+[[package]]
 name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13394,9 +13439,9 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "ureq"
-version = "3.2.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdc97a28575b85cfedf2a7e7d3cc64b3e11bd8ac766666318003abbacc7a21fc"
+checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
 dependencies = [
  "base64 0.22.1",
  "cookie_store",
@@ -13407,15 +13452,15 @@ dependencies = [
  "serde",
  "serde_json",
  "ureq-proto",
- "utf-8",
+ "utf8-zero",
  "webpki-roots 1.0.6",
 ]
 
 [[package]]
 name = "ureq-proto"
-version = "0.5.3"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d81f9efa9df032be5934a46a068815a10a042b494b6a58cb0a1a97bb5467ed6f"
+checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
 dependencies = [
  "base64 0.22.1",
  "http 1.4.0",
@@ -13447,6 +13492,12 @@ name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
+name = "utf8-zero"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
 
 [[package]]
 name = "utf8_iter"
@@ -13555,20 +13606,23 @@ checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "wacore"
-version = "0.2.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c38f75041655201a01725a43d99da2f258de6e9e17033b167f99d458070c4f1"
+checksum = "5292fb723da7505e90cfd7a828dd397802b98e0f819a2bc058a6b3a9f2345306"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
  "anyhow",
  "async-channel 2.5.0",
+ "async-lock",
  "async-trait",
  "base64 0.22.1",
  "bytes",
  "chrono",
  "ctr",
+ "event-listener 5.4.1",
  "flate2",
+ "futures",
  "hex",
  "hkdf",
  "hmac",
@@ -13577,27 +13631,33 @@ dependencies = [
  "once_cell",
  "pbkdf2",
  "prost 0.14.3",
- "protobuf",
- "rand 0.9.4",
- "rand_core 0.9.5",
+ "rand 0.10.0",
  "serde",
  "serde-big-array",
+ "serde_json",
+ "sha1",
  "sha2",
  "thiserror 2.0.18",
+ "typed-builder",
  "wacore-appstate",
  "wacore-binary",
+ "wacore-derive",
  "wacore-libsignal",
+ "wacore-noise",
  "waproto",
 ]
 
 [[package]]
 name = "wacore-appstate"
-version = "0.2.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8128197fd310dbc350cf7d417666d31591a84fa2d42b3b5692e48da9e0500ea"
+checksum = "ab29b1c5198e16e2619868cc3e48c32f0bcecec936fd20d09460a8f7e374604d"
 dependencies = [
  "anyhow",
+ "bytemuck",
+ "hex",
  "hkdf",
+ "log",
  "prost 0.14.3",
  "serde",
  "serde-big-array",
@@ -13611,12 +13671,11 @@ dependencies = [
 
 [[package]]
 name = "wacore-binary"
-version = "0.2.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d560076c8483f9197ca0e2c46e98e3cb01fc30c089114704b851b3f73b6b94d6"
+checksum = "127a3a6e7554ce002092f1711aa927b0efa3d3fb1ee83506525565c626e68834"
 dependencies = [
  "flate2",
- "indexmap 2.13.0",
  "phf 0.13.1",
  "phf_codegen 0.13.1",
  "serde",
@@ -13624,10 +13683,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "wacore-libsignal"
-version = "0.2.0"
+name = "wacore-derive"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02751fcbb54d2abb19b61261217e444f06889fdd85b8f035b2a420d7636a92ee"
+checksum = "3f9546a14730f112eca3bc2e4cbd815df88046fa78530f110c3665492604e770"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "wacore-libsignal"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c89676f7e09708d6b3a58e02bfea42000e3d7bffbc1bf67d0c8bf58ddbdf6373"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -13639,14 +13709,13 @@ dependencies = [
  "curve25519-dalek",
  "derive_more 2.1.1",
  "displaydoc",
- "ghash",
+ "ghash 0.6.0",
  "hex",
  "hkdf",
  "hmac",
- "itertools 0.14.0",
  "log",
  "prost 0.14.3",
- "rand 0.9.4",
+ "rand 0.10.0",
  "serde",
  "sha1",
  "sha2",
@@ -13655,6 +13724,26 @@ dependencies = [
  "uuid",
  "waproto",
  "x25519-dalek",
+]
+
+[[package]]
+name = "wacore-noise"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e1c5a0ef2ddaf0f7c5a227649c09de5f354571d95feea4dbac55f2b31c2da53"
+dependencies = [
+ "aes-gcm",
+ "anyhow",
+ "bytes",
+ "hkdf",
+ "log",
+ "prost 0.14.3",
+ "rand 0.10.0",
+ "sha2",
+ "thiserror 2.0.18",
+ "wacore-binary",
+ "wacore-libsignal",
+ "waproto",
 ]
 
 [[package]]
@@ -13684,9 +13773,9 @@ dependencies = [
 
 [[package]]
 name = "waproto"
-version = "0.2.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0fac064a4b1d339d7343612c0544739118e23969464f3e215eae2813e4f65d0"
+checksum = "b8fb5d942027d97e5ca1e542a9915388742cc5efab4802910ecc2fd1f430cefe"
 dependencies = [
  "prost 0.14.3",
  "prost-build",
@@ -14478,25 +14567,24 @@ checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
 name = "whatsapp-rust"
-version = "0.2.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af27e10258392b3d8accee86ec80815673815e07ea5fc53897eba73aacb372b6"
+checksum = "b5b79e16847fe6e7ea8d103b4b575b1a1b77bd57cb4c292f7c50616b72a74374"
 dependencies = [
  "anyhow",
  "async-channel 2.5.0",
+ "async-lock",
  "async-trait",
  "base64 0.22.1",
  "bytes",
  "chrono",
- "dashmap 6.1.0",
  "env_logger",
+ "event-listener 5.4.1",
+ "futures",
  "hex",
- "indexmap 2.13.0",
  "log",
- "moka",
  "prost 0.14.3",
- "rand 0.9.4",
- "rand_core 0.9.5",
+ "rand 0.10.0",
  "scopeguard",
  "serde",
  "serde_json",
@@ -14511,9 +14599,9 @@ dependencies = [
 
 [[package]]
 name = "whatsapp-rust-tokio-transport"
-version = "0.2.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0da5151ff392012ef834b8820785d03e44b78f6139e60a3b02614bfbc477d17a"
+checksum = "0aca6e068f01d56f7d360a04aeb16d34a3edb623e7d43e7cd857682a186c0130"
 dependencies = [
  "anyhow",
  "async-channel 2.5.0",
@@ -14532,9 +14620,9 @@ dependencies = [
 
 [[package]]
 name = "whatsapp-rust-ureq-http-client"
-version = "0.2.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "063d5d6d08711de6cade6903cefeebd708070e5979c984ac025d0271f655b97f"
+checksum = "45ae9349f172ab8e50031ef5c429bb56ffdd677fbfeb22ed09fff3ce3b62c135"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8427,6 +8427,7 @@ dependencies = [
  "sled",
  "tempfile",
  "thiserror 2.0.18",
+ "time",
  "tokio",
  "tokio-util",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -220,12 +220,12 @@ sysinfo            = "0.34"
 teloxide           = { features = ["macros"], version = "0.13" }
 # WhatsApp (sqlite-storage disabled to avoid libsqlite3-sys conflict with sqlx;
 # re-enable once sqlx 0.9 stabilises).
-wacore                         = "0.2"
-wacore-binary                  = "0.2"
-waproto                        = "0.2"
-whatsapp-rust                  = { default-features = false, features = ["tokio-native", "tokio-transport", "ureq-client"], version = "0.2" }
-whatsapp-rust-tokio-transport  = "0.2"
-whatsapp-rust-ureq-http-client = "0.2"
+wacore                         = { default-features = false, version = "0.5" }
+wacore-binary                  = { default-features = false, version = "0.5" }
+waproto                        = "0.5"
+whatsapp-rust                  = { default-features = false, features = ["tokio-native", "tokio-runtime", "tokio-transport", "ureq-client"], version = "0.5" }
+whatsapp-rust-tokio-transport  = "0.5"
+whatsapp-rust-ureq-http-client = "0.5"
 # QR code rendering
 qrcode = "0.14"
 # TLS / certificate generation

--- a/crates/config/src/schema/runtime.rs
+++ b/crates/config/src/schema/runtime.rs
@@ -205,7 +205,7 @@ pub struct ChannelToolPolicyOverride {
 #[serde(default)]
 pub struct ChannelsConfig {
     /// Which channel types are offered in the web UI (onboarding + channels page).
-    /// Defaults to `["telegram", "msteams", "discord", "slack", "matrix", "nostr"]`. Add `"whatsapp"` to opt in.
+    /// Defaults to `["telegram", "whatsapp", "msteams", "discord", "slack", "matrix", "nostr"]`.
     #[serde(
         default = "default_channels_offered",
         skip_serializing_if = "Vec::is_empty"
@@ -286,6 +286,7 @@ impl ChannelsConfig {
 fn default_channels_offered() -> Vec<String> {
     vec![
         "telegram".into(),
+        "whatsapp".into(),
         "msteams".into(),
         "discord".into(),
         "slack".into(),

--- a/crates/config/src/schema/tests.rs
+++ b/crates/config/src/schema/tests.rs
@@ -376,6 +376,7 @@ fn channels_config_defaults_offered() {
     let config = ChannelsConfig::default();
     assert_eq!(config.offered, vec![
         "telegram".to_string(),
+        "whatsapp".to_string(),
         "msteams".to_string(),
         "discord".to_string(),
         "slack".to_string(),
@@ -389,6 +390,7 @@ fn channels_config_empty_toml_defaults_offered() {
     let config: ChannelsConfig = toml::from_str("").unwrap();
     assert_eq!(config.offered, vec![
         "telegram".to_string(),
+        "whatsapp".to_string(),
         "msteams".to_string(),
         "discord".to_string(),
         "slack".to_string(),

--- a/crates/config/src/template.rs
+++ b/crates/config/src/template.rs
@@ -851,9 +851,8 @@ reset_on_exit = true              # Reset serve/funnel when gateway shuts down
 
 [channels]
 # Which channel types appear in the web UI's "+ Add Channel" menu.
-# Default: ["telegram", "msteams", "discord", "slack", "matrix", "nostr"]
-# Add "whatsapp" to enable it in the UI.
-# offered = ["telegram", "msteams", "discord", "slack", "matrix", "nostr", "whatsapp"]
+# Default: ["telegram", "whatsapp", "msteams", "discord", "slack", "matrix", "nostr"]
+# offered = ["telegram", "whatsapp", "msteams", "discord", "slack", "matrix", "nostr"]
 
 # WhatsApp linked-device accounts
 # [channels.whatsapp.my-bot]

--- a/crates/gateway/src/channel_events/dispatch.rs
+++ b/crates/gateway/src/channel_events/dispatch.rs
@@ -38,7 +38,7 @@ pub(in crate::channel_events) async fn dispatch_to_chat(
             "sessionKey": &session_key,
         });
         broadcast(state, "chat", payload, BroadcastOpts {
-            drop_if_slow: true,
+            drop_if_slow: false,
             ..Default::default()
         })
         .await;

--- a/crates/gateway/src/channel_events/sink.rs
+++ b/crates/gateway/src/channel_events/sink.rs
@@ -46,8 +46,12 @@ pub(super) async fn emit(
             payload
         };
 
+        // QR code events are large and frequent — drop them if the client
+        // is slow.  Pairing result events (complete/failed) are critical
+        // one-shots that must not be lost.
+        let droppable = matches!(event, ChannelEvent::PairingQrCode { .. });
         broadcast(state, "channel", payload, BroadcastOpts {
-            drop_if_slow: true,
+            drop_if_slow: droppable,
             ..Default::default()
         })
         .await;

--- a/crates/gateway/src/state.rs
+++ b/crates/gateway/src/state.rs
@@ -325,6 +325,7 @@ impl GatewayInner {
             channel_command_mode_sessions: HashSet::new(),
             channels_offered: vec![
                 "telegram".into(),
+                "whatsapp".into(),
                 "discord".into(),
                 "slack".into(),
                 "matrix".into(),
@@ -978,6 +979,7 @@ mod tests {
         let inner = state.inner.read().await;
         assert_eq!(inner.channels_offered, vec![
             "telegram".to_owned(),
+            "whatsapp".to_owned(),
             "discord".to_owned(),
             "slack".to_owned(),
             "matrix".to_owned(),

--- a/crates/web/src/assets/js/onboarding-view.js
+++ b/crates/web/src/assets/js/onboarding-view.js
@@ -3342,6 +3342,27 @@ function WhatsAppForm({ onConnected, error, setError }) {
 		};
 	}, []);
 
+	// Poll channels.status as a fallback in case the WebSocket QR event was missed.
+	useEffect(() => {
+		if (!pairingStarted || qrData) return undefined;
+		var id = accountId.trim();
+		var timer = setInterval(async () => {
+			try {
+				var res = await sendRpc("channels.status");
+				if (!res?.ok) return;
+				var ch = (res.result?.channels || []).find(
+					(c) => c.type === "whatsapp" && c.account_id === id,
+				);
+				if (ch?.extra?.qr_data && !qrData) {
+					setQrData(ch.extra.qr_data);
+				}
+			} catch (_e) {
+				/* ignore */
+			}
+		}, 2000);
+		return () => clearInterval(timer);
+	}, [pairingStarted, qrData]);
+
 	useEffect(() => {
 		if (!qrSvg) {
 			setQrSvgUrl(null);

--- a/crates/web/src/assets/js/onboarding-view.js
+++ b/crates/web/src/assets/js/onboarding-view.js
@@ -3462,6 +3462,9 @@ function WhatsAppForm({ onConnected, error, setError }) {
 			<div class="text-xs text-[var(--muted)] text-center">
 				Scan the QR code from your terminal, or open WhatsApp > Settings > Linked Devices > Link a Device.
 			</div>
+ttt<div class="text-xs text-[var(--muted)] text-center">
+ttttOnly new messages will be processed. Past conversations are not synced.
+ttt</div>
 		</div>`;
 	}
 
@@ -3473,6 +3476,7 @@ function WhatsAppForm({ onConnected, error, setError }) {
 			<span>3. Open WhatsApp > Settings > Linked Devices > Link a Device</span>
 			<span>4. Scan the QR code to connect</span>
 		</div>
+ttt<span class="mt-1">Only new messages will be processed — past conversations are not synced.</span>
 		<div>
 			<label class="text-xs text-[var(--muted)] mb-1 block">Account ID</label>
 			<input type="text" class="provider-key-input w-full"

--- a/crates/web/src/assets/js/onboarding-view.js
+++ b/crates/web/src/assets/js/onboarding-view.js
@@ -3355,9 +3355,7 @@ function WhatsAppForm({ onConnected, error, setError }) {
 			try {
 				var res = await sendRpc("channels.status");
 				if (!res?.ok) return;
-				var ch = (res.payload?.channels || []).find(
-					(c) => c.type === "whatsapp" && c.account_id === id,
-				);
+				var ch = (res.payload?.channels || []).find((c) => c.type === "whatsapp" && c.account_id === id);
 				if (!ch) return;
 				if (ch.status === "connected") {
 					onConnected(id, "whatsapp");

--- a/crates/web/src/assets/js/onboarding-view.js
+++ b/crates/web/src/assets/js/onboarding-view.js
@@ -3394,11 +3394,7 @@ function WhatsAppForm({ onConnected, error, setError }) {
 
 	function onStartPairing(e) {
 		e.preventDefault();
-		var id = accountId.trim();
-		if (!id) {
-			setError("Account ID is required.");
-			return;
-		}
+		var id = accountId.trim() || "main";
 		var advancedPatch = parseChannelConfigPatch(advancedConfig);
 		if (!advancedPatch.ok) {
 			setError(advancedPatch.error);
@@ -3476,19 +3472,18 @@ function WhatsAppForm({ onConnected, error, setError }) {
 	return html`<form onSubmit=${onStartPairing} class="flex flex-col gap-3">
 		<div class="rounded-md border border-[var(--border)] bg-[var(--surface2)] p-3 text-xs text-[var(--muted)] flex flex-col gap-1">
 			<span class="font-medium text-[var(--text-strong)]">Link your WhatsApp</span>
-			<span>1. Choose an account ID below (any name you like)</span>
-			<span>2. Click "Start Pairing" to generate a QR code</span>
-			<span>3. Open WhatsApp > Settings > Linked Devices > Link a Device</span>
-			<span>4. Scan the QR code to connect</span>
+			<span>1. Click "Start Pairing" to generate a QR code</span>
+			<span>2. Open WhatsApp > Settings > Linked Devices > Link a Device</span>
+			<span>3. Scan the QR code to connect</span>
 			<span class="mt-1 italic">Only new messages will be processed — past conversations are not synced.</span>
 		</div>
 		<div>
-			<label class="text-xs text-[var(--muted)] mb-1 block">Account ID</label>
+			<label class="text-xs text-[var(--muted)] mb-1 block">Account ID (optional)</label>
 			<input type="text" class="provider-key-input w-full"
 				value=${accountId} onInput=${(e) => setAccountId(e.target.value)}
-				placeholder="e.g. my-whatsapp"
+				placeholder="main"
 				autocomplete="off" autocapitalize="none" autocorrect="off" spellcheck="false"
-				name="whatsapp_account_id" autofocus />
+				name="whatsapp_account_id" />
 		</div>
 		<div>
 			<label class="text-xs text-[var(--muted)] mb-1 block">DM Policy</label>

--- a/crates/web/src/assets/js/onboarding-view.js
+++ b/crates/web/src/assets/js/onboarding-view.js
@@ -3350,7 +3350,7 @@ function WhatsAppForm({ onConnected, error, setError }) {
 			try {
 				var res = await sendRpc("channels.status");
 				if (!res?.ok) return;
-				var ch = (res.result?.channels || []).find(
+				var ch = (res.payload?.channels || []).find(
 					(c) => c.type === "whatsapp" && c.account_id === id,
 				);
 				if (ch?.extra?.qr_data && !qrData) {

--- a/crates/web/src/assets/js/onboarding-view.js
+++ b/crates/web/src/assets/js/onboarding-view.js
@@ -3342,9 +3342,10 @@ function WhatsAppForm({ onConnected, error, setError }) {
 		};
 	}, []);
 
-	// Poll channels.status as a fallback in case the WebSocket QR event was missed.
+	// Poll channels.status as a fallback for both QR code display and
+	// connection detection (WebSocket events may be missed).
 	useEffect(() => {
-		if (!pairingStarted || qrData) return undefined;
+		if (!pairingStarted) return undefined;
 		var id = accountId.trim();
 		var timer = setInterval(async () => {
 			try {
@@ -3353,7 +3354,12 @@ function WhatsAppForm({ onConnected, error, setError }) {
 				var ch = (res.payload?.channels || []).find(
 					(c) => c.type === "whatsapp" && c.account_id === id,
 				);
-				if (ch?.extra?.qr_data && !qrData) {
+				if (!ch) return;
+				if (ch.status === "connected") {
+					onConnected(id, "whatsapp");
+					return;
+				}
+				if (ch.extra?.qr_data && !qrData) {
 					setQrData(ch.extra.qr_data);
 					if (ch.extra.qr_svg) setQrSvg(ch.extra.qr_svg);
 				}

--- a/crates/web/src/assets/js/onboarding-view.js
+++ b/crates/web/src/assets/js/onboarding-view.js
@@ -3622,7 +3622,7 @@ function NostrForm({ onConnected, error, setError }) {
 }
 
 function ChannelStep({ onNext, onBack }) {
-	var offeredList = getGon("channels_offered") || ["telegram", "discord", "slack", "matrix"];
+	var offeredList = getGon("channels_offered") || ["telegram", "whatsapp", "discord", "slack", "matrix"];
 	var offered = new Set(offeredList);
 	var singleType = offeredList.length === 1 ? offeredList[0] : null;
 

--- a/crates/web/src/assets/js/onboarding-view.js
+++ b/crates/web/src/assets/js/onboarding-view.js
@@ -3359,6 +3359,11 @@ function WhatsAppForm({ onConnected, error, setError }) {
 					onConnected(id, "whatsapp");
 					return;
 				}
+				// QR cleared + not connected = pairing succeeded, connecting.
+				if (qrData && !ch.extra?.qr_data) {
+					onConnected(id, "whatsapp");
+					return;
+				}
 				if (ch.extra?.qr_data && !qrData) {
 					setQrData(ch.extra.qr_data);
 					if (ch.extra.qr_svg) setQrSvg(ch.extra.qr_svg);

--- a/crates/web/src/assets/js/onboarding-view.js
+++ b/crates/web/src/assets/js/onboarding-view.js
@@ -3462,9 +3462,9 @@ function WhatsAppForm({ onConnected, error, setError }) {
 			<div class="text-xs text-[var(--muted)] text-center">
 				Scan the QR code from your terminal, or open WhatsApp > Settings > Linked Devices > Link a Device.
 			</div>
-ttt<div class="text-xs text-[var(--muted)] text-center">
-ttttOnly new messages will be processed. Past conversations are not synced.
-ttt</div>
+			<div class="text-xs text-[var(--muted)] text-center italic">
+				Only new messages will be processed. Past conversations are not synced.
+			</div>
 		</div>`;
 	}
 
@@ -3475,8 +3475,8 @@ ttt</div>
 			<span>2. Click "Start Pairing" to generate a QR code</span>
 			<span>3. Open WhatsApp > Settings > Linked Devices > Link a Device</span>
 			<span>4. Scan the QR code to connect</span>
+			<span class="mt-1 italic">Only new messages will be processed — past conversations are not synced.</span>
 		</div>
-ttt<span class="mt-1">Only new messages will be processed — past conversations are not synced.</span>
 		<div>
 			<label class="text-xs text-[var(--muted)] mb-1 block">Account ID</label>
 			<input type="text" class="provider-key-input w-full"

--- a/crates/web/src/assets/js/onboarding-view.js
+++ b/crates/web/src/assets/js/onboarding-view.js
@@ -3355,6 +3355,7 @@ function WhatsAppForm({ onConnected, error, setError }) {
 				);
 				if (ch?.extra?.qr_data && !qrData) {
 					setQrData(ch.extra.qr_data);
+					if (ch.extra.qr_svg) setQrSvg(ch.extra.qr_svg);
 				}
 			} catch (_e) {
 				/* ignore */

--- a/crates/web/src/assets/js/onboarding-view.js
+++ b/crates/web/src/assets/js/onboarding-view.js
@@ -57,7 +57,7 @@ import {
 	transcribeAudio,
 	VOICE_COUNTERPART_IDS,
 } from "./voice-utils.js";
-import { connectWs } from "./ws-connect.js";
+import { connectWs, subscribeEvents } from "./ws-connect.js";
 
 var wsStarted = false;
 function ensureWsConnected() {
@@ -65,6 +65,9 @@ function ensureWsConnected() {
 	wsStarted = true;
 	connectWs({
 		backoff: { factor: 2, max: 10000 },
+		onConnected: () => {
+			subscribeEvents(["channel"]);
+		},
 		onFrame: (frame) => {
 			if (frame.type !== "event") return;
 			var listeners = eventListeners[frame.event] || [];

--- a/crates/web/src/assets/js/onboarding-view.js
+++ b/crates/web/src/assets/js/onboarding-view.js
@@ -3334,6 +3334,7 @@ function WhatsAppForm({ onConnected, error, setError }) {
 	var [qrSvgUrl, setQrSvgUrl] = useState(null);
 	var [pairingError, setPairingError] = useState(null);
 	var unsubRef = useRef(null);
+	var hadQrRef = useRef(false);
 
 	// Clean up event subscription on unmount.
 	useEffect(() => {
@@ -3346,7 +3347,7 @@ function WhatsAppForm({ onConnected, error, setError }) {
 	// connection detection (WebSocket events may be missed).
 	useEffect(() => {
 		if (!pairingStarted) return undefined;
-		var id = accountId.trim();
+		var id = accountId.trim() || "main";
 		var timer = setInterval(async () => {
 			try {
 				var res = await sendRpc("channels.status");
@@ -3360,11 +3361,12 @@ function WhatsAppForm({ onConnected, error, setError }) {
 					return;
 				}
 				// QR cleared + not connected = pairing succeeded, connecting.
-				if (qrData && !ch.extra?.qr_data) {
+				if (hadQrRef.current && !ch.extra?.qr_data) {
 					onConnected(id, "whatsapp");
 					return;
 				}
-				if (ch.extra?.qr_data && !qrData) {
+				if (ch.extra?.qr_data) {
+					hadQrRef.current = true;
 					setQrData(ch.extra.qr_data);
 					if (ch.extra.qr_svg) setQrSvg(ch.extra.qr_svg);
 				}
@@ -3373,7 +3375,7 @@ function WhatsAppForm({ onConnected, error, setError }) {
 			}
 		}, 2000);
 		return () => clearInterval(timer);
-	}, [pairingStarted, qrData]);
+	}, [pairingStarted]);
 
 	useEffect(() => {
 		if (!qrSvg) {

--- a/crates/web/src/assets/js/page-channels.js
+++ b/crates/web/src/assets/js/page-channels.js
@@ -1852,7 +1852,7 @@ function AddWhatsAppModal() {
 							? html`<div class="text-sm text-[var(--error)]">${waPairingError.value}</div>`
 							: html`<${QrCodeDisplay} data=${waQrData.value} svg=${waQrSvg.value} />`
 					}
-          <div class="text-xs text-[var(--muted)]">QR code refreshes automatically. Keep this window open.</div>
+          <div class="text-xs text-[var(--muted)]">QR code refreshes automatically. Keep this window open.<br/>Only new messages will be processed — past conversations are not synced.</div>
         </div>
       `
 					: html`

--- a/crates/web/src/assets/js/page-channels.js
+++ b/crates/web/src/assets/js/page-channels.js
@@ -1748,6 +1748,7 @@ function AddWhatsAppModal() {
 	var allowlistItems = useSignal([]);
 	var accountDraft = useSignal("");
 	var advancedConfigPatch = useSignal("");
+	var qrPollRef = useRef(null);
 
 	function onStartPairing(e) {
 		e.preventDefault();
@@ -1783,6 +1784,27 @@ function AddWhatsAppModal() {
 			saving.value = false;
 			if (res?.ok) {
 				pairingStarted.value = true;
+				// Poll channels.status as fallback if WebSocket QR event is missed.
+				if (qrPollRef.current) clearInterval(qrPollRef.current);
+				qrPollRef.current = setInterval(async () => {
+					if (waQrData.value) {
+						clearInterval(qrPollRef.current);
+						qrPollRef.current = null;
+						return;
+					}
+					try {
+						var st = await sendRpc("channels.status");
+						if (!st?.ok) return;
+						var ch = (st.result?.channels || []).find(
+							(c) => c.type === "whatsapp" && c.account_id === accountId,
+						);
+						if (ch?.extra?.qr_data && !waQrData.value) {
+							waQrData.value = ch.extra.qr_data;
+						}
+					} catch (_e) {
+						/* ignore */
+					}
+				}, 2000);
 			} else {
 				error.value = (res?.error && (res.error.message || res.error.detail)) || "Failed to start pairing.";
 			}
@@ -1790,6 +1812,10 @@ function AddWhatsAppModal() {
 	}
 
 	function onClose() {
+		if (qrPollRef.current) {
+			clearInterval(qrPollRef.current);
+			qrPollRef.current = null;
+		}
 		showAddWhatsApp.value = false;
 		pairingStarted.value = false;
 		waQrData.value = null;

--- a/crates/web/src/assets/js/page-channels.js
+++ b/crates/web/src/assets/js/page-channels.js
@@ -3,7 +3,7 @@
 import { signal, useSignal } from "@preact/signals";
 import { html } from "htm/preact";
 import { render } from "preact";
-import { useEffect, useState } from "preact/hooks";
+import { useEffect, useRef, useState } from "preact/hooks";
 import {
 	addChannel,
 	buildTeamsEndpoint,

--- a/crates/web/src/assets/js/page-channels.js
+++ b/crates/web/src/assets/js/page-channels.js
@@ -1752,11 +1752,7 @@ function AddWhatsAppModal() {
 
 	function onStartPairing(e) {
 		e.preventDefault();
-		var accountId = accountDraft.value.trim();
-		if (!accountId) {
-			error.value = "Account ID is required.";
-			return;
-		}
+		var accountId = accountDraft.value.trim() || "main";
 		var form = e.target.closest(".channel-form");
 		var advancedPatch = parseChannelConfigPatch(advancedConfigPatch.value);
 		if (!advancedPatch.ok) {
@@ -1867,7 +1863,7 @@ function AddWhatsAppModal() {
         </div>
         <${ConnectionModeHint} type="whatsapp" />
         <label class="text-xs text-[var(--muted)]">Account ID</label>
-        <input data-field="accountId" type="text" placeholder="e.g. my-whatsapp" class="channel-input"
+        <input data-field="accountId" type="text" placeholder="main" class="channel-input"
           value=${accountDraft.value}
           onInput=${(e) => {
 						accountDraft.value = e.target.value;

--- a/crates/web/src/assets/js/page-channels.js
+++ b/crates/web/src/assets/js/page-channels.js
@@ -1795,7 +1795,7 @@ function AddWhatsAppModal() {
 					try {
 						var st = await sendRpc("channels.status");
 						if (!st?.ok) return;
-						var ch = (st.result?.channels || []).find(
+						var ch = (st.payload?.channels || []).find(
 							(c) => c.type === "whatsapp" && c.account_id === accountId,
 						);
 						if (ch?.extra?.qr_data && !waQrData.value) {

--- a/crates/web/src/assets/js/page-channels.js
+++ b/crates/web/src/assets/js/page-channels.js
@@ -1786,9 +1786,7 @@ function AddWhatsAppModal() {
 					try {
 						var st = await sendRpc("channels.status");
 						if (!st?.ok) return;
-						var ch = (st.payload?.channels || []).find(
-							(c) => c.type === "whatsapp" && c.account_id === accountId,
-						);
+						var ch = (st.payload?.channels || []).find((c) => c.type === "whatsapp" && c.account_id === accountId);
 						if (!ch) return;
 						if (ch.status === "connected" || (waQrData.value && !ch.extra?.qr_data)) {
 							clearInterval(qrPollRef.current);

--- a/crates/web/src/assets/js/page-channels.js
+++ b/crates/web/src/assets/js/page-channels.js
@@ -1784,21 +1784,28 @@ function AddWhatsAppModal() {
 			saving.value = false;
 			if (res?.ok) {
 				pairingStarted.value = true;
-				// Poll channels.status as fallback if WebSocket QR event is missed.
+				// Poll channels.status as fallback for QR display and connection detection.
 				if (qrPollRef.current) clearInterval(qrPollRef.current);
 				qrPollRef.current = setInterval(async () => {
-					if (waQrData.value) {
-						clearInterval(qrPollRef.current);
-						qrPollRef.current = null;
-						return;
-					}
 					try {
 						var st = await sendRpc("channels.status");
 						if (!st?.ok) return;
 						var ch = (st.payload?.channels || []).find(
 							(c) => c.type === "whatsapp" && c.account_id === accountId,
 						);
-						if (ch?.extra?.qr_data && !waQrData.value) {
+						if (!ch) return;
+						if (ch.status === "connected") {
+							clearInterval(qrPollRef.current);
+							qrPollRef.current = null;
+							showToast("WhatsApp connected!");
+							showAddWhatsApp.value = false;
+							waPairingAccountId.value = null;
+							waQrData.value = null;
+							waQrSvg.value = null;
+							loadChannels();
+							return;
+						}
+						if (ch.extra?.qr_data && !waQrData.value) {
 							waQrData.value = ch.extra.qr_data;
 							if (ch.extra.qr_svg) waQrSvg.value = ch.extra.qr_svg;
 						}

--- a/crates/web/src/assets/js/page-channels.js
+++ b/crates/web/src/assets/js/page-channels.js
@@ -1800,6 +1800,7 @@ function AddWhatsAppModal() {
 						);
 						if (ch?.extra?.qr_data && !waQrData.value) {
 							waQrData.value = ch.extra.qr_data;
+							if (ch.extra.qr_svg) waQrSvg.value = ch.extra.qr_svg;
 						}
 					} catch (_e) {
 						/* ignore */

--- a/crates/web/src/assets/js/page-channels.js
+++ b/crates/web/src/assets/js/page-channels.js
@@ -1794,7 +1794,7 @@ function AddWhatsAppModal() {
 							(c) => c.type === "whatsapp" && c.account_id === accountId,
 						);
 						if (!ch) return;
-						if (ch.status === "connected") {
+						if (ch.status === "connected" || (waQrData.value && !ch.extra?.qr_data)) {
 							clearInterval(qrPollRef.current);
 							qrPollRef.current = null;
 							showToast("WhatsApp connected!");

--- a/crates/web/src/assets/js/page-channels.js
+++ b/crates/web/src/assets/js/page-channels.js
@@ -442,7 +442,7 @@ function ChannelCard(props) {
 // ── Connect channel buttons ──────────────────────────────────
 function ConnectButtons() {
 	var offered = new Set(getGon("channels_offered") || ["telegram", "whatsapp", "discord", "slack", "matrix"]);
-	return html`<div class="flex gap-2">
+	return html`<div class="flex gap-2 flex-wrap">
 		${
 			offered.has("telegram") &&
 			html`<button class="provider-btn provider-btn-secondary inline-flex items-center gap-1.5"

--- a/crates/web/src/assets/js/page-channels.js
+++ b/crates/web/src/assets/js/page-channels.js
@@ -441,7 +441,7 @@ function ChannelCard(props) {
 
 // ── Connect channel buttons ──────────────────────────────────
 function ConnectButtons() {
-	var offered = new Set(getGon("channels_offered") || ["telegram", "discord", "slack", "matrix"]);
+	var offered = new Set(getGon("channels_offered") || ["telegram", "whatsapp", "discord", "slack", "matrix"]);
 	return html`<div class="flex gap-2">
 		${
 			offered.has("telegram") &&

--- a/crates/web/src/assets/js/page-channels.js
+++ b/crates/web/src/assets/js/page-channels.js
@@ -1801,7 +1801,7 @@ function AddWhatsAppModal() {
 							loadChannels();
 							return;
 						}
-						if (ch.extra?.qr_data && !waQrData.value) {
+						if (ch.extra?.qr_data) {
 							waQrData.value = ch.extra.qr_data;
 							if (ch.extra.qr_svg) waQrSvg.value = ch.extra.qr_svg;
 						}

--- a/crates/web/ui/e2e/specs/onboarding.spec.js
+++ b/crates/web/ui/e2e/specs/onboarding.spec.js
@@ -609,6 +609,85 @@ test.describe("Onboarding wizard", () => {
 		expect(pageErrors).toEqual([]);
 	});
 
+	test("whatsapp pairing falls back to polling channels.status for QR", async ({ page }) => {
+		const pageErrors = watchPageErrors(page);
+		await page.goto("/onboarding");
+		await page.waitForLoadState("networkidle");
+
+		const reachedChannel = await moveToChannelStep(page);
+		if (!reachedChannel) {
+			test.skip(true, "could not reach channel step in this onboarding flow");
+			return;
+		}
+
+		const whatsappSelectBtn = page.getByRole("button", { name: "WhatsApp", exact: true });
+		if (await isVisible(whatsappSelectBtn)) {
+			await whatsappSelectBtn.click();
+		}
+
+		const accountInput = page.getByPlaceholder("e.g. my-whatsapp");
+		if (!(await isVisible(accountInput))) {
+			test.skip(true, "WhatsApp onboarding option is not available in this run");
+			return;
+		}
+
+		const accountId = "e2e-wa-poll";
+
+		// Mock WebSocket: channels.add succeeds, channels.status returns QR data
+		// (simulating the polling fallback path — no channel event is emitted).
+		await page.evaluate(
+			async ({ accountIdArg }) => {
+				const onboardingScript = document.querySelector('script[type="module"][src*="js/onboarding-app.js"]');
+				if (!onboardingScript) throw new Error("onboarding-app.js script not found");
+				const appUrl = new URL(onboardingScript.src, window.location.origin).href;
+				const marker = "js/onboarding-app.js";
+				const prefix = appUrl.slice(0, appUrl.indexOf(marker));
+				const state = await import(`${prefix}js/state.js`);
+				const wsOpen = typeof WebSocket !== "undefined" ? WebSocket.OPEN : 1;
+				state.setConnected(true);
+				state.setWs({
+					readyState: wsOpen,
+					send(raw) {
+						const req = JSON.parse(raw || "{}");
+						const resolver = state.pending[req.id];
+						if (!resolver) return;
+						if (req.method === "channels.add") {
+							resolver({ ok: true, payload: {} });
+						} else if (req.method === "channels.status") {
+							// Return QR data in the extra field, simulating the polling path.
+							resolver({
+								ok: true,
+								payload: {
+									channels: [
+										{
+											type: "whatsapp",
+											account_id: accountIdArg,
+											status: "disconnected",
+											extra: { qr_data: "2@polled_qr_payload" },
+										},
+									],
+								},
+							});
+						} else {
+							resolver({ ok: false, error: { message: `unexpected rpc: ${req.method}` } });
+						}
+						delete state.pending[req.id];
+					},
+				});
+			},
+			{ accountIdArg: accountId },
+		);
+
+		await accountInput.fill(accountId);
+		await page.getByRole("button", { name: "Start Pairing", exact: true }).click();
+
+		// The polling fallback runs every 2s. Wait for QR data to appear.
+		// It should render as raw text since no SVG was provided via polling.
+		const qrFallback = page.getByText("2@polled_qr_payload");
+		await expect(qrFallback).toBeVisible({ timeout: 10_000 });
+		expect(pageErrors).toEqual([]);
+	});
+
 	test("matrix onboarding renders a real mask icon", async ({ page }) => {
 		const pageErrors = watchPageErrors(page);
 		await page.goto("/onboarding");

--- a/crates/web/ui/e2e/specs/onboarding.spec.js
+++ b/crates/web/ui/e2e/specs/onboarding.spec.js
@@ -688,6 +688,109 @@ test.describe("Onboarding wizard", () => {
 		expect(pageErrors).toEqual([]);
 	});
 
+	test("whatsapp pairing with default account ID polls and renders SVG QR", async ({ page }) => {
+		const pageErrors = watchPageErrors(page);
+		await page.goto("/onboarding");
+		await page.waitForLoadState("networkidle");
+
+		// Navigate to "Connect a Channel" by repeatedly clicking Skip/Continue.
+		const channelHeading = page.getByRole("heading", { name: "Connect a Channel", exact: true });
+		await expect
+			.poll(
+				async () => {
+					if (await isVisible(channelHeading)) return true;
+					// Skip or advance whatever step is on screen.
+					// All skip buttons say "Skip for now" (via i18n).
+					const skipBtn = page.getByRole("button", { name: "Skip for now", exact: true }).first();
+					const continueBtn = page.getByRole("button", { name: "Continue", exact: true }).first();
+					const userNameInput = page.getByPlaceholder("e.g. Alice");
+					if (await isVisible(userNameInput)) {
+						await userNameInput.fill("E2E User");
+						const agentNameInput = page.getByPlaceholder("e.g. Rex");
+						if (await isVisible(agentNameInput)) await agentNameInput.fill("E2E Bot");
+						if (await isVisible(continueBtn)) await continueBtn.click();
+					} else if (await isVisible(skipBtn)) {
+						await skipBtn.click();
+					} else if (await isVisible(continueBtn)) {
+						await continueBtn.click();
+					}
+					return false;
+				},
+				{ timeout: 60_000, intervals: [1000] },
+			)
+			.toBeTruthy();
+		if (!(await isVisible(channelHeading))) {
+			test.skip(true, "could not reach channel step in this onboarding flow");
+			return;
+		}
+
+		// Select WhatsApp from channel type grid (may be auto-selected if only one offered)
+		const whatsappSelectBtn = page.getByRole("button", { name: "WhatsApp", exact: true });
+		if (await isVisible(whatsappSelectBtn)) {
+			await whatsappSelectBtn.click();
+		}
+
+		// The WhatsApp form uses placeholder "main" for the Account ID field.
+		const accountInput = page.getByPlaceholder("main");
+		await expect(accountInput).toBeVisible({ timeout: 5_000 });
+
+		// Leave account ID empty — the form defaults to "main".
+		// The bug was that the polling useEffect used accountId.trim() (empty)
+		// instead of accountId.trim() || "main", so channel matching failed.
+		const svg = '<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100"><rect width="100" height="100"/></svg>';
+
+		await page.evaluate(
+			async ({ svgArg }) => {
+				const onboardingScript = document.querySelector('script[type="module"][src*="js/onboarding-app.js"]');
+				if (!onboardingScript) throw new Error("onboarding-app.js script not found");
+				const appUrl = new URL(onboardingScript.src, window.location.origin).href;
+				const marker = "js/onboarding-app.js";
+				const prefix = appUrl.slice(0, appUrl.indexOf(marker));
+				const state = await import(`${prefix}js/state.js`);
+				const wsOpen = typeof WebSocket !== "undefined" ? WebSocket.OPEN : 1;
+				state.setConnected(true);
+				state.setWs({
+					readyState: wsOpen,
+					send(raw) {
+						const req = JSON.parse(raw || "{}");
+						const resolver = state.pending[req.id];
+						if (!resolver) return;
+						if (req.method === "channels.add") {
+							resolver({ ok: true, payload: {} });
+						} else if (req.method === "channels.status") {
+							// Return QR SVG with account_id "main" — the default
+							resolver({
+								ok: true,
+								payload: {
+									channels: [
+										{
+											type: "whatsapp",
+											account_id: "main",
+											status: "disconnected",
+											extra: { qr_data: "2@default_poll", qr_svg: svgArg },
+										},
+									],
+								},
+							});
+						} else {
+							resolver({ ok: false, error: { message: `unexpected rpc: ${req.method}` } });
+						}
+						delete state.pending[req.id];
+					},
+				});
+			},
+			{ svgArg: svg },
+		);
+
+		// Do NOT fill the account input — leave it empty to test the || "main" fallback.
+		await page.getByRole("button", { name: "Start Pairing", exact: true }).click();
+
+		// The QR SVG should render as an <img> via the blob URL path.
+		const qrImage = page.locator('img[alt="WhatsApp pairing QR code"]');
+		await expect(qrImage).toBeVisible({ timeout: 10_000 });
+		expect(pageErrors).toEqual([]);
+	});
+
 	test("matrix onboarding renders a real mask icon", async ({ page }) => {
 		const pageErrors = watchPageErrors(page);
 		await page.goto("/onboarding");

--- a/crates/whatsapp/Cargo.toml
+++ b/crates/whatsapp/Cargo.toml
@@ -18,6 +18,7 @@ serde           = { workspace = true }
 serde_json      = { workspace = true }
 sled            = { workspace = true }
 thiserror       = { workspace = true }
+time            = { workspace = true }
 tokio           = { workspace = true }
 tokio-util      = { workspace = true }
 tracing         = { workspace = true }

--- a/crates/whatsapp/Cargo.toml
+++ b/crates/whatsapp/Cargo.toml
@@ -13,6 +13,7 @@ moltis-config   = { workspace = true }
 moltis-media    = { workspace = true }
 moltis-metrics  = { optional = true, workspace = true }
 postcard        = { workspace = true }
+qrcode          = { workspace = true }
 rand            = { workspace = true }
 serde           = { workspace = true }
 serde_json      = { workspace = true }

--- a/crates/whatsapp/src/connection.rs
+++ b/crates/whatsapp/src/connection.rs
@@ -66,7 +66,7 @@ pub async fn start_connection(
         .with_runtime(whatsapp_rust::TokioRuntime)
         .skip_history_sync()
         .with_device_props(
-            None,
+            Some("Moltis".to_string()),
             None,
             Some(waproto::whatsapp::device_props::PlatformType::Desktop),
         )

--- a/crates/whatsapp/src/connection.rs
+++ b/crates/whatsapp/src/connection.rs
@@ -64,6 +64,7 @@ pub async fn start_connection(
         )
         .with_http_client(whatsapp_rust_ureq_http_client::UreqHttpClient::new())
         .with_runtime(whatsapp_rust::TokioRuntime)
+        .skip_history_sync()
         .on_event(move |event, client| {
             let state_ref = Arc::clone(&state_ref_handler);
             let accounts = Arc::clone(&accounts_handler);

--- a/crates/whatsapp/src/connection.rs
+++ b/crates/whatsapp/src/connection.rs
@@ -65,6 +65,12 @@ pub async fn start_connection(
         .with_http_client(whatsapp_rust_ureq_http_client::UreqHttpClient::new())
         .with_runtime(whatsapp_rust::TokioRuntime)
         .skip_history_sync()
+        .with_device_props(
+            None,
+            None,
+            Some(waproto::whatsapp::device_props::PlatformType::Desktop),
+        )
+        .with_push_name("Moltis")
         .on_event(move |event, client| {
             let state_ref = Arc::clone(&state_ref_handler);
             let accounts = Arc::clone(&accounts_handler);

--- a/crates/whatsapp/src/connection.rs
+++ b/crates/whatsapp/src/connection.rs
@@ -63,6 +63,7 @@ pub async fn start_connection(
             whatsapp_rust_tokio_transport::TokioWebSocketTransportFactory::new(),
         )
         .with_http_client(whatsapp_rust_ureq_http_client::UreqHttpClient::new())
+        .with_runtime(whatsapp_rust::TokioRuntime)
         .on_event(move |event, client| {
             let state_ref = Arc::clone(&state_ref_handler);
             let accounts = Arc::clone(&accounts_handler);

--- a/crates/whatsapp/src/handlers.rs
+++ b/crates/whatsapp/src/handlers.rs
@@ -192,7 +192,9 @@ async fn handle_message(
 
     let peer_id = sender_jid.to_string();
     let chat_id = chat_jid.to_string();
-    let username = sender_jid.user.clone();
+    // Use the sender's user part as display username.  Resolved later for
+    // self-chat so the phone number appears instead of the opaque LID.
+    let mut username = sender_jid.user.clone();
     let sender_name = if info.push_name.is_empty() {
         None
     } else {
@@ -268,9 +270,11 @@ async fn handle_message(
     }
 
     // For self-chat, the chat JID is the LID which doesn't work as a reply
-    // target. Use the PN JID instead so outbound messages are delivered.
+    // target and shows an opaque ID in the UI. Use the PN JID instead so
+    // outbound messages are delivered and the phone number is displayed.
     let chat_id = if is_owner_self_chat {
         if let Some(ref pn) = own_pn {
+            username = pn.user.clone();
             format!("{}@{}", pn.user, pn.server)
         } else {
             chat_id

--- a/crates/whatsapp/src/handlers.rs
+++ b/crates/whatsapp/src/handlers.rs
@@ -87,16 +87,15 @@ pub async fn handle_event(
             }
             mirror_latest_qr(&accounts, &state.account_id, None);
 
-            // Auto-approve the owner's phone and LID JIDs so they don't
-            // need to manually add themselves to the allowlist.
+            // Auto-approve the owner's phone number so they don't need to
+            // manually add themselves to the allowlist.  Only the PN JID is
+            // needed — incoming messages always use the PN format.
             {
                 let own_pn = state.client.get_pn().await;
-                let own_lid = state.client.get_lid().await;
-                auto_approve_owner_jids(
+                auto_approve_owner_jid(
                     &accounts,
                     &state.account_id,
                     own_pn.as_ref(),
-                    own_lid.as_ref(),
                 );
             }
 
@@ -857,35 +856,33 @@ fn message_mentions_owner(msg: &wa::Message, own_pn: Option<&Jid>, own_lid: Opti
 
 /// Auto-add the owner's phone and LID JIDs to the allowlist so they're
 /// always approved without manual configuration or OTP.
-fn auto_approve_owner_jids(
+fn auto_approve_owner_jid(
     accounts: &AccountStateMap,
     account_id: &str,
     own_pn: Option<&Jid>,
-    own_lid: Option<&Jid>,
 ) {
+    let Some(jid) = own_pn else { return };
     let mut map = accounts.write().unwrap_or_else(|e| e.into_inner());
     let Some(state) = map.get_mut(account_id) else {
         return;
     };
 
-    for jid in own_pn.into_iter().chain(own_lid.into_iter()) {
-        // Use "user@server" without the device suffix — incoming messages
-        // arrive as e.g. "15551234567@s.whatsapp.net" (no ":35" device).
-        let canonical = format!("{}@{}", jid.user, jid.server);
-        let user = &jid.user;
-        let already = state
-            .config
-            .allowlist
-            .iter()
-            .any(|entry| entry == user || entry == &canonical);
-        if !already {
-            info!(
-                account_id,
-                jid = %canonical,
-                "auto-adding owner JID to allowlist"
-            );
-            state.config.allowlist.push(canonical);
-        }
+    // Use "user@server" without the device suffix — incoming messages
+    // arrive as e.g. "15551234567@s.whatsapp.net" (no ":35" device).
+    let canonical = format!("{}@{}", jid.user, jid.server);
+    let user = &jid.user;
+    let already = state
+        .config
+        .allowlist
+        .iter()
+        .any(|entry| entry == user || entry == &canonical);
+    if !already {
+        info!(
+            account_id,
+            jid = %canonical,
+            "auto-adding owner JID to allowlist"
+        );
+        state.config.allowlist.push(canonical);
     }
 }
 

--- a/crates/whatsapp/src/handlers.rs
+++ b/crates/whatsapp/src/handlers.rs
@@ -111,6 +111,26 @@ pub async fn handle_event(
                 .await;
             }
         },
+        Event::PairSuccess(ref pair) => {
+            info!(account_id = %state.account_id, jid = %pair.id, "WhatsApp pairing succeeded");
+
+            // Clear QR immediately so the UI stops showing it.
+            if let Ok(mut qr) = state.latest_qr.write() {
+                *qr = None;
+            }
+            mirror_latest_qr(&accounts, &state.account_id, None);
+
+            // Emit PairingComplete now — don't wait for the reconnect cycle.
+            // The UI will transition from QR → success immediately.
+            if let Some(ref sink) = state.event_sink {
+                sink.emit(ChannelEvent::PairingComplete {
+                    channel_type: ChannelType::Whatsapp,
+                    account_id: state.account_id.clone(),
+                    display_name: None,
+                })
+                .await;
+            }
+        },
         Event::PairError(err) => {
             warn!(account_id = %state.account_id, error = ?err, "WhatsApp pairing failed");
             if let Some(ref sink) = state.event_sink {

--- a/crates/whatsapp/src/handlers.rs
+++ b/crates/whatsapp/src/handlers.rs
@@ -87,6 +87,14 @@ pub async fn handle_event(
             }
             mirror_latest_qr(&accounts, &state.account_id, None);
 
+            // Auto-approve the owner's phone number so they don't need
+            // to manually add themselves to the allowlist.
+            if let Some(own_pn) = state.client.get_pn().await {
+                let pn_user = own_pn.user.clone();
+                let pn_jid = own_pn.to_string();
+                auto_approve_owner(&accounts, &state.account_id, &pn_user, &pn_jid);
+            }
+
             let display_name = state.client.get_push_name().await;
             let display = if display_name.is_empty() {
                 None
@@ -808,6 +816,28 @@ fn message_mentions_owner(msg: &wa::Message, own_pn: Option<&Jid>, own_lid: Opti
         own_pn,
         own_lid,
     )
+}
+
+/// Auto-add the owner's phone number to the allowlist so they're always
+/// approved without needing manual configuration or OTP.
+fn auto_approve_owner(accounts: &AccountStateMap, account_id: &str, pn_user: &str, pn_jid: &str) {
+    let mut map = accounts.write().unwrap_or_else(|e| e.into_inner());
+    let Some(state) = map.get_mut(account_id) else {
+        return;
+    };
+    let already = state
+        .config
+        .allowlist
+        .iter()
+        .any(|entry| entry == pn_user || entry == pn_jid);
+    if !already {
+        info!(
+            account_id,
+            phone = pn_user,
+            "auto-adding owner phone number to allowlist"
+        );
+        state.config.allowlist.push(pn_jid.to_string());
+    }
 }
 
 fn should_ignore_inbound_chat(source: &wacore::types::message::MessageSource) -> bool {

--- a/crates/whatsapp/src/handlers.rs
+++ b/crates/whatsapp/src/handlers.rs
@@ -92,11 +92,7 @@ pub async fn handle_event(
             // needed — incoming messages always use the PN format.
             {
                 let own_pn = state.client.get_pn().await;
-                auto_approve_owner_jid(
-                    &accounts,
-                    &state.account_id,
-                    own_pn.as_ref(),
-                );
+                auto_approve_owner_jid(&accounts, &state.account_id, own_pn.as_ref());
             }
 
             let display_name = state.client.get_push_name().await;
@@ -873,12 +869,10 @@ fn message_mentions_owner(msg: &wa::Message, own_pn: Option<&Jid>, own_lid: Opti
 
 /// Auto-add the owner's phone and LID JIDs to the allowlist so they're
 /// always approved without manual configuration or OTP.
-fn auto_approve_owner_jid(
-    accounts: &AccountStateMap,
-    account_id: &str,
-    own_pn: Option<&Jid>,
-) {
-    let Some(jid) = own_pn else { return };
+fn auto_approve_owner_jid(accounts: &AccountStateMap, account_id: &str, own_pn: Option<&Jid>) {
+    let Some(jid) = own_pn else {
+        return;
+    };
     let mut map = accounts.write().unwrap_or_else(|e| e.into_inner());
     let Some(state) = map.get_mut(account_id) else {
         return;

--- a/crates/whatsapp/src/handlers.rs
+++ b/crates/whatsapp/src/handlers.rs
@@ -267,6 +267,18 @@ async fn handle_message(
         is_owner_self_chat = true;
     }
 
+    // For self-chat, the chat JID is the LID which doesn't work as a reply
+    // target. Use the PN JID instead so outbound messages are delivered.
+    let chat_id = if is_owner_self_chat {
+        if let Some(ref pn) = own_pn {
+            format!("{}@{}", pn.user, pn.server)
+        } else {
+            chat_id
+        }
+    } else {
+        chat_id
+    };
+
     // Extract text from the message.
     let text = msg
         .conversation

--- a/crates/whatsapp/src/handlers.rs
+++ b/crates/whatsapp/src/handlers.rs
@@ -869,20 +869,22 @@ fn auto_approve_owner_jids(
     };
 
     for jid in own_pn.into_iter().chain(own_lid.into_iter()) {
-        let jid_str = jid.to_string();
+        // Use "user@server" without the device suffix — incoming messages
+        // arrive as e.g. "15551234567@s.whatsapp.net" (no ":35" device).
+        let canonical = format!("{}@{}", jid.user, jid.server);
         let user = &jid.user;
         let already = state
             .config
             .allowlist
             .iter()
-            .any(|entry| entry == user || entry == &jid_str);
+            .any(|entry| entry == user || entry == &canonical);
         if !already {
             info!(
                 account_id,
-                jid = %jid_str,
+                jid = %canonical,
                 "auto-adding owner JID to allowlist"
             );
-            state.config.allowlist.push(jid_str);
+            state.config.allowlist.push(canonical);
         }
     }
 }

--- a/crates/whatsapp/src/handlers.rs
+++ b/crates/whatsapp/src/handlers.rs
@@ -270,12 +270,13 @@ async fn handle_message(
     }
 
     // For self-chat, the chat JID is the LID which doesn't work as a reply
-    // target and shows an opaque ID in the UI. Use the PN JID instead so
-    // outbound messages are delivered and the phone number is displayed.
+    // target and shows an opaque ID in the UI.  Use just the phone number
+    // as the chat_id — it's human-readable, URL-safe (no dots), and the
+    // outbound layer resolves it to a full PN JID before sending.
     let chat_id = if is_owner_self_chat {
         if let Some(ref pn) = own_pn {
             username = pn.user.clone();
-            format!("{}@{}", pn.user, pn.server)
+            pn.user.clone()
         } else {
             chat_id
         }

--- a/crates/whatsapp/src/handlers.rs
+++ b/crates/whatsapp/src/handlers.rs
@@ -87,12 +87,17 @@ pub async fn handle_event(
             }
             mirror_latest_qr(&accounts, &state.account_id, None);
 
-            // Auto-approve the owner's phone number so they don't need
-            // to manually add themselves to the allowlist.
-            if let Some(own_pn) = state.client.get_pn().await {
-                let pn_user = own_pn.user.clone();
-                let pn_jid = own_pn.to_string();
-                auto_approve_owner(&accounts, &state.account_id, &pn_user, &pn_jid);
+            // Auto-approve the owner's phone and LID JIDs so they don't
+            // need to manually add themselves to the allowlist.
+            {
+                let own_pn = state.client.get_pn().await;
+                let own_lid = state.client.get_lid().await;
+                auto_approve_owner_jids(
+                    &accounts,
+                    &state.account_id,
+                    own_pn.as_ref(),
+                    own_lid.as_ref(),
+                );
             }
 
             let display_name = state.client.get_push_name().await;
@@ -219,6 +224,18 @@ async fn handle_message(
     let own_lid = state.client.get_lid().await;
     let is_self_chat = is_owner_user(chat_jid, own_pn.as_ref(), own_lid.as_ref());
     let sender_is_owner = is_owner_user(sender_jid, own_pn.as_ref(), own_lid.as_ref());
+
+    debug!(
+        account_id = %state.account_id,
+        sender = %sender_jid,
+        chat = %chat_jid,
+        own_pn = ?own_pn.as_ref().map(|j| j.to_string()),
+        own_lid = ?own_lid.as_ref().map(|j| j.to_string()),
+        is_from_me = info.source.is_from_me,
+        is_self_chat,
+        sender_is_owner,
+        "inbound message owner detection"
+    );
 
     if info.source.is_from_me || (is_self_chat && sender_is_owner) {
         // Check text for bot watermark as secondary loop detection.
@@ -838,25 +855,35 @@ fn message_mentions_owner(msg: &wa::Message, own_pn: Option<&Jid>, own_lid: Opti
     )
 }
 
-/// Auto-add the owner's phone number to the allowlist so they're always
-/// approved without needing manual configuration or OTP.
-fn auto_approve_owner(accounts: &AccountStateMap, account_id: &str, pn_user: &str, pn_jid: &str) {
+/// Auto-add the owner's phone and LID JIDs to the allowlist so they're
+/// always approved without manual configuration or OTP.
+fn auto_approve_owner_jids(
+    accounts: &AccountStateMap,
+    account_id: &str,
+    own_pn: Option<&Jid>,
+    own_lid: Option<&Jid>,
+) {
     let mut map = accounts.write().unwrap_or_else(|e| e.into_inner());
     let Some(state) = map.get_mut(account_id) else {
         return;
     };
-    let already = state
-        .config
-        .allowlist
-        .iter()
-        .any(|entry| entry == pn_user || entry == pn_jid);
-    if !already {
-        info!(
-            account_id,
-            phone = pn_user,
-            "auto-adding owner phone number to allowlist"
-        );
-        state.config.allowlist.push(pn_jid.to_string());
+
+    for jid in own_pn.into_iter().chain(own_lid.into_iter()) {
+        let jid_str = jid.to_string();
+        let user = &jid.user;
+        let already = state
+            .config
+            .allowlist
+            .iter()
+            .any(|entry| entry == user || entry == &jid_str);
+        if !already {
+            info!(
+                account_id,
+                jid = %jid_str,
+                "auto-adding owner JID to allowlist"
+            );
+            state.config.allowlist.push(jid_str);
+        }
     }
 }
 

--- a/crates/whatsapp/src/memory_store.rs
+++ b/crates/whatsapp/src/memory_store.rs
@@ -37,6 +37,8 @@ pub struct MemoryStore {
     signed_prekeys: Arc<DashMap<u32, Vec<u8>>>,
     sender_keys: Arc<DashMap<String, Vec<u8>>>,
     sync_keys: Arc<DashMap<Vec<u8>, AppStateSyncKey>>,
+    /// Most recently stored sync key ID (DashMap iteration order is non-deterministic).
+    latest_sync_key_id: Arc<std::sync::Mutex<Option<Vec<u8>>>>,
     app_state_versions: Arc<DashMap<String, HashState>>,
     /// Keyed by `"{name}:{version}:{hex(index_mac)}"`.
     mutation_macs: Arc<DashMap<String, Vec<u8>>>,
@@ -167,6 +169,10 @@ impl AppSyncStore for MemoryStore {
 
     async fn set_sync_key(&self, key_id: &[u8], key: AppStateSyncKey) -> Result<()> {
         self.sync_keys.insert(key_id.to_vec(), key);
+        *self
+            .latest_sync_key_id
+            .lock()
+            .unwrap_or_else(|e| e.into_inner()) = Some(key_id.to_vec());
         Ok(())
     }
 
@@ -232,7 +238,11 @@ impl AppSyncStore for MemoryStore {
     }
 
     async fn get_latest_sync_key_id(&self) -> Result<Option<Vec<u8>>> {
-        Ok(self.sync_keys.iter().map(|e| e.key().clone()).last())
+        Ok(self
+            .latest_sync_key_id
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .clone())
     }
 }
 
@@ -396,10 +406,7 @@ impl ProtocolStore for MemoryStore {
         message_id: &str,
         payload: &[u8],
     ) -> Result<()> {
-        let now = std::time::SystemTime::now()
-            .duration_since(std::time::SystemTime::UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_secs() as i64;
+        let now = time::OffsetDateTime::now_utc().unix_timestamp();
         let key = format!("{chat_jid}:{message_id}");
         self.sent_messages.insert(key, (payload.to_vec(), now));
         Ok(())

--- a/crates/whatsapp/src/memory_store.rs
+++ b/crates/whatsapp/src/memory_store.rs
@@ -16,6 +16,7 @@ use {
         appstate::{hash::HashState, processor::AppStateMutationMAC},
         store::{error::Result, traits::*},
     },
+    wacore_binary::jid::Jid,
 };
 
 /// Hex-encode bytes without pulling in the `hex` crate.
@@ -52,6 +53,10 @@ pub struct MemoryStore {
     sender_key_forget_marks: Arc<DashMap<String, bool>>,
     /// Base keys keyed by `"{address}:{message_id}"`.
     base_keys: Arc<DashMap<String, Vec<u8>>>,
+    /// TC tokens keyed by JID string.
+    tc_tokens: Arc<DashMap<String, TcTokenEntry>>,
+    /// Sent messages keyed by `"{chat_jid}:{message_id}"` → (payload, timestamp).
+    sent_messages: Arc<DashMap<String, (Vec<u8>, i64)>>,
 }
 
 impl MemoryStore {
@@ -106,6 +111,10 @@ impl SignalStore for MemoryStore {
     async fn remove_prekey(&self, id: u32) -> Result<()> {
         self.prekeys.remove(&id);
         Ok(())
+    }
+
+    async fn get_max_prekey_id(&self) -> Result<u32> {
+        Ok(self.prekeys.iter().map(|e| *e.key()).max().unwrap_or(0))
     }
 
     async fn store_signed_prekey(&self, id: u32, record: &[u8]) -> Result<()> {
@@ -221,6 +230,10 @@ impl AppSyncStore for MemoryStore {
         }
         Ok(())
     }
+
+    async fn get_latest_sync_key_id(&self) -> Result<Option<Vec<u8>>> {
+        Ok(self.sync_keys.iter().map(|e| e.key().clone()).last())
+    }
 }
 
 // ============================================================================
@@ -229,19 +242,19 @@ impl AppSyncStore for MemoryStore {
 
 #[async_trait]
 impl ProtocolStore for MemoryStore {
-    async fn get_skdm_recipients(&self, group_jid: &str) -> Result<Vec<String>> {
+    async fn get_skdm_recipients(&self, group_jid: &str) -> Result<Vec<Jid>> {
         Ok(self
             .skdm_recipients
             .get(group_jid)
-            .map(|v| v.value().clone())
+            .map(|v| v.value().iter().filter_map(|s| s.parse().ok()).collect())
             .unwrap_or_default())
     }
 
-    async fn add_skdm_recipients(&self, group_jid: &str, device_jids: &[String]) -> Result<()> {
+    async fn add_skdm_recipients(&self, group_jid: &str, device_jids: &[Jid]) -> Result<()> {
         self.skdm_recipients
             .entry(group_jid.to_string())
             .or_default()
-            .extend(device_jids.iter().cloned());
+            .extend(device_jids.iter().map(|j| j.to_string()));
         Ok(())
     }
 
@@ -339,6 +352,79 @@ impl ProtocolStore for MemoryStore {
             }
         }
         Ok(participants)
+    }
+
+    // --- TcToken Storage ---
+
+    async fn get_tc_token(&self, jid: &str) -> Result<Option<TcTokenEntry>> {
+        Ok(self.tc_tokens.get(jid).map(|v| v.value().clone()))
+    }
+
+    async fn put_tc_token(&self, jid: &str, entry: &TcTokenEntry) -> Result<()> {
+        self.tc_tokens.insert(jid.to_string(), entry.clone());
+        Ok(())
+    }
+
+    async fn delete_tc_token(&self, jid: &str) -> Result<()> {
+        self.tc_tokens.remove(jid);
+        Ok(())
+    }
+
+    async fn get_all_tc_token_jids(&self) -> Result<Vec<String>> {
+        Ok(self.tc_tokens.iter().map(|e| e.key().clone()).collect())
+    }
+
+    async fn delete_expired_tc_tokens(&self, cutoff_timestamp: i64) -> Result<u32> {
+        let keys_to_remove: Vec<String> = self
+            .tc_tokens
+            .iter()
+            .filter(|e| e.value().token_timestamp < cutoff_timestamp)
+            .map(|e| e.key().clone())
+            .collect();
+        let count = keys_to_remove.len() as u32;
+        for key in keys_to_remove {
+            self.tc_tokens.remove(&key);
+        }
+        Ok(count)
+    }
+
+    // --- Sent Message Store ---
+
+    async fn store_sent_message(
+        &self,
+        chat_jid: &str,
+        message_id: &str,
+        payload: &[u8],
+    ) -> Result<()> {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::SystemTime::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs() as i64;
+        let key = format!("{chat_jid}:{message_id}");
+        self.sent_messages.insert(key, (payload.to_vec(), now));
+        Ok(())
+    }
+
+    async fn take_sent_message(&self, chat_jid: &str, message_id: &str) -> Result<Option<Vec<u8>>> {
+        let key = format!("{chat_jid}:{message_id}");
+        Ok(self
+            .sent_messages
+            .remove(&key)
+            .map(|(_, (payload, _))| payload))
+    }
+
+    async fn delete_expired_sent_messages(&self, cutoff_timestamp: i64) -> Result<u32> {
+        let keys_to_remove: Vec<String> = self
+            .sent_messages
+            .iter()
+            .filter(|e| e.value().1 < cutoff_timestamp)
+            .map(|e| e.key().clone())
+            .collect();
+        let count = keys_to_remove.len() as u32;
+        for key in keys_to_remove {
+            self.sent_messages.remove(&key);
+        }
+        Ok(count)
     }
 }
 
@@ -478,7 +564,10 @@ mod tests {
         assert!(recips.is_empty());
 
         store
-            .add_skdm_recipients("group1", &["dev1".into(), "dev2".into()])
+            .add_skdm_recipients("group1", &[
+                "dev1@s.whatsapp.net".parse().unwrap(),
+                "dev2@s.whatsapp.net".parse().unwrap(),
+            ])
             .await
             .unwrap();
         let recips = store.get_skdm_recipients("group1").await.unwrap();
@@ -567,5 +656,119 @@ mod tests {
         // Consumed — should be empty now.
         let marks = store.consume_forget_marks("group1").await.unwrap();
         assert!(marks.is_empty());
+    }
+
+    #[tokio::test]
+    async fn max_prekey_id() {
+        let store = MemoryStore::new();
+        assert_eq!(store.get_max_prekey_id().await.unwrap(), 0);
+        store.store_prekey(5, b"pk5", false).await.unwrap();
+        store.store_prekey(10, b"pk10", true).await.unwrap();
+        store.store_prekey(3, b"pk3", false).await.unwrap();
+        assert_eq!(store.get_max_prekey_id().await.unwrap(), 10);
+    }
+
+    #[tokio::test]
+    async fn latest_sync_key_id() {
+        let store = MemoryStore::new();
+        assert!(store.get_latest_sync_key_id().await.unwrap().is_none());
+        let key = AppStateSyncKey {
+            key_data: vec![1],
+            fingerprint: vec![],
+            timestamp: 1,
+        };
+        store.set_sync_key(b"key-1", key.clone()).await.unwrap();
+        store.set_sync_key(b"key-2", key).await.unwrap();
+        let latest = store.get_latest_sync_key_id().await.unwrap();
+        assert!(latest.is_some());
+    }
+
+    #[tokio::test]
+    async fn tc_token_roundtrip() {
+        let store = MemoryStore::new();
+        assert!(store.get_tc_token("user@lid").await.unwrap().is_none());
+
+        let entry = TcTokenEntry {
+            token: vec![1, 2, 3],
+            token_timestamp: 1000,
+            sender_timestamp: Some(900),
+        };
+        store.put_tc_token("user@lid", &entry).await.unwrap();
+        let loaded = store.get_tc_token("user@lid").await.unwrap().unwrap();
+        assert_eq!(loaded.token, vec![1, 2, 3]);
+        assert_eq!(loaded.token_timestamp, 1000);
+
+        let jids = store.get_all_tc_token_jids().await.unwrap();
+        assert_eq!(jids.len(), 1);
+
+        store.delete_tc_token("user@lid").await.unwrap();
+        assert!(store.get_tc_token("user@lid").await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn tc_token_expiry() {
+        let store = MemoryStore::new();
+        store
+            .put_tc_token("old@lid", &TcTokenEntry {
+                token: vec![1],
+                token_timestamp: 100,
+                sender_timestamp: None,
+            })
+            .await
+            .unwrap();
+        store
+            .put_tc_token("new@lid", &TcTokenEntry {
+                token: vec![2],
+                token_timestamp: 2000,
+                sender_timestamp: None,
+            })
+            .await
+            .unwrap();
+
+        let deleted = store.delete_expired_tc_tokens(500).await.unwrap();
+        assert_eq!(deleted, 1);
+        assert!(store.get_tc_token("old@lid").await.unwrap().is_none());
+        assert!(store.get_tc_token("new@lid").await.unwrap().is_some());
+    }
+
+    #[tokio::test]
+    async fn sent_message_store_and_take() {
+        let store = MemoryStore::new();
+        store
+            .store_sent_message("chat@jid", "msg1", b"payload1")
+            .await
+            .unwrap();
+
+        let taken = store.take_sent_message("chat@jid", "msg1").await.unwrap();
+        assert_eq!(taken, Some(b"payload1".to_vec()));
+
+        // Take again returns None (consumed).
+        assert!(
+            store
+                .take_sent_message("chat@jid", "msg1")
+                .await
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn sent_message_expiry() {
+        let store = MemoryStore::new();
+        store
+            .store_sent_message("chat@jid", "old", b"old-payload")
+            .await
+            .unwrap();
+
+        // Expire anything before far-future timestamp.
+        let deleted = store.delete_expired_sent_messages(i64::MAX).await.unwrap();
+        assert_eq!(deleted, 1);
+        assert!(
+            store
+                .take_sent_message("chat@jid", "old")
+                .await
+                .unwrap()
+                .is_none()
+        );
     }
 }

--- a/crates/whatsapp/src/outbound.rs
+++ b/crates/whatsapp/src/outbound.rs
@@ -21,6 +21,16 @@ use {
 
 use crate::state::{AccountStateMap, BOT_WATERMARK};
 
+/// Parse a JID from a string, treating bare phone numbers (no `@`) as PN JIDs.
+fn resolve_jid(to: &str) -> ChannelResult<Jid> {
+    if to.contains('@') {
+        to.parse()
+            .map_err(|e| moltis_channels::Error::invalid_input(format!("invalid JID: {e:?}")))
+    } else {
+        Ok(Jid::pn(to))
+    }
+}
+
 // ── Media helpers ────────────────────────────────────────────────────
 
 /// Decode a `data:<mime>;base64,<payload>` URI into raw bytes.
@@ -151,9 +161,7 @@ impl ChannelOutbound for WhatsAppOutbound {
         _reply_to: Option<&str>,
     ) -> ChannelResult<()> {
         let client = self.get_client(account_id)?;
-        let jid: Jid = to
-            .parse()
-            .map_err(|e| moltis_channels::Error::invalid_input(format!("invalid JID: {e:?}")))?;
+        let jid = resolve_jid(to)?;
 
         debug!(
             account_id,
@@ -226,9 +234,7 @@ impl ChannelOutbound for WhatsAppOutbound {
         );
 
         let client = self.get_client(account_id)?;
-        let jid: Jid = to
-            .parse()
-            .map_err(|e| moltis_channels::Error::invalid_input(format!("invalid JID: {e:?}")))?;
+        let jid = resolve_jid(to)?;
 
         let upload = client.upload(bytes, media_type).await.map_err(|e| {
             moltis_channels::Error::unavailable(format!("whatsapp media upload: {e}"))
@@ -254,9 +260,7 @@ impl ChannelOutbound for WhatsAppOutbound {
 
     async fn send_typing(&self, account_id: &str, to: &str) -> ChannelResult<()> {
         let client = self.get_client(account_id)?;
-        let jid: Jid = to
-            .parse()
-            .map_err(|e| moltis_channels::Error::invalid_input(format!("invalid JID: {e:?}")))?;
+        let jid = resolve_jid(to)?;
         client
             .chatstate()
             .send(&jid, ChatStateType::Composing)

--- a/crates/whatsapp/src/plugin.rs
+++ b/crates/whatsapp/src/plugin.rs
@@ -316,11 +316,17 @@ impl ChannelStatus for WhatsAppPlugin {
                     } else {
                         Some("disconnected".into())
                     };
+                    let extra = state
+                        .latest_qr
+                        .read()
+                        .ok()
+                        .and_then(|q| q.clone())
+                        .map(|qr| serde_json::json!({ "qr_data": qr }));
                     ChannelHealthSnapshot {
                         connected,
                         account_id: account_id.to_string(),
                         details,
-                        extra: None,
+                        extra,
                     }
                 },
                 None => ChannelHealthSnapshot {

--- a/crates/whatsapp/src/plugin.rs
+++ b/crates/whatsapp/src/plugin.rs
@@ -308,6 +308,12 @@ impl ChannelStatus for WhatsAppPlugin {
             match accounts.get(account_id) {
                 Some(state) => {
                     let connected = state.connected.load(Ordering::Relaxed);
+                    let has_qr = state
+                        .latest_qr
+                        .read()
+                        .ok()
+                        .and_then(|q| q.clone())
+                        .is_some();
                     let details = if connected {
                         state
                             .config
@@ -315,16 +321,10 @@ impl ChannelStatus for WhatsAppPlugin {
                             .as_ref()
                             .map(|n| format!("WhatsApp: {n}"))
                             .or_else(|| Some("WhatsApp: connected".into()))
-                    } else if state
-                        .latest_qr
-                        .read()
-                        .ok()
-                        .and_then(|q| q.clone())
-                        .is_some()
-                    {
+                    } else if has_qr {
                         Some("waiting for QR scan".into())
                     } else {
-                        Some("disconnected".into())
+                        Some("connecting...".into())
                     };
                     let extra = state
                         .latest_qr

--- a/crates/whatsapp/src/plugin.rs
+++ b/crates/whatsapp/src/plugin.rs
@@ -331,7 +331,18 @@ impl ChannelStatus for WhatsAppPlugin {
                         .read()
                         .ok()
                         .and_then(|q| q.clone())
-                        .map(|qr| serde_json::json!({ "qr_data": qr }));
+                        .map(|qr| {
+                            let mut obj = serde_json::json!({ "qr_data": &qr });
+                            if let Ok(code) = qrcode::QrCode::new(&qr) {
+                                let svg = code
+                                    .render::<qrcode::render::svg::Color>()
+                                    .min_dimensions(200, 200)
+                                    .quiet_zone(true)
+                                    .build();
+                                obj["qr_svg"] = serde_json::Value::String(svg);
+                            }
+                            obj
+                        });
                     ChannelHealthSnapshot {
                         connected,
                         account_id: account_id.to_string(),

--- a/crates/whatsapp/src/plugin.rs
+++ b/crates/whatsapp/src/plugin.rs
@@ -155,6 +155,16 @@ impl ChannelPlugin for WhatsAppPlugin {
         account_id: &str,
         config: serde_json::Value,
     ) -> ChannelResult<()> {
+        // If the account is already running (e.g. started from stored channels
+        // on boot), skip re-starting to avoid sled lock conflicts.
+        if self.has_account(account_id) {
+            info!(
+                account_id,
+                "WhatsApp account already running, skipping start"
+            );
+            return Ok(());
+        }
+
         let wa_config: WhatsAppAccountConfig = serde_json::from_value(config)?;
 
         info!(account_id, "starting WhatsApp account");
@@ -396,5 +406,11 @@ mod tests {
         // Threads: WhatsApp does NOT implement ChannelThreadContext
         assert!(!desc.capabilities.supports_threads);
         assert!(plugin.thread_context().is_none());
+    }
+
+    #[test]
+    fn has_account_returns_false_when_empty() {
+        let plugin = WhatsAppPlugin::new(PathBuf::from("/tmp/test"));
+        assert!(!plugin.has_account("main"));
     }
 }

--- a/crates/whatsapp/src/sled_store.rs
+++ b/crates/whatsapp/src/sled_store.rs
@@ -5,7 +5,7 @@
 //!
 //! Each account gets its own sled database at `<data_dir>/whatsapp/<account_id>/`.
 
-use std::{fmt::Write, path::Path, sync::atomic::AtomicI32, time::SystemTime};
+use std::{fmt::Write, path::Path, sync::atomic::AtomicI32};
 
 use {
     async_trait::async_trait,
@@ -580,10 +580,7 @@ impl ProtocolStore for SledStore {
         message_id: &str,
         payload: &[u8],
     ) -> Result<()> {
-        let now = SystemTime::now()
-            .duration_since(SystemTime::UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_secs();
+        let now = time::OffsetDateTime::now_utc().unix_timestamp();
         let key = format!("{chat_jid}:{message_id}");
         let val = encode_persistent(&(payload.to_vec(), now))?;
         self.sent_messages
@@ -596,7 +593,7 @@ impl ProtocolStore for SledStore {
         let key = format!("{chat_jid}:{message_id}");
         match self.sent_messages.remove(key.as_bytes()).map_err(db_err)? {
             Some(v) => {
-                let (payload, _ts): (Vec<u8>, u64) = decode_persistent(&v)?;
+                let (payload, _ts): (Vec<u8>, i64) = decode_persistent(&v)?;
                 Ok(Some(payload))
             },
             None => Ok(None),
@@ -608,8 +605,8 @@ impl ProtocolStore for SledStore {
         let mut keys_to_remove = Vec::new();
         for entry in self.sent_messages.iter() {
             let (k, v) = entry.map_err(db_err)?;
-            let (_payload, ts): (Vec<u8>, u64) = decode_persistent(&v)?;
-            if (ts as i64) < cutoff_timestamp {
+            let (_payload, ts): (Vec<u8>, i64) = decode_persistent(&v)?;
+            if ts < cutoff_timestamp {
                 keys_to_remove.push(k);
             }
         }

--- a/crates/whatsapp/src/sled_store.rs
+++ b/crates/whatsapp/src/sled_store.rs
@@ -5,7 +5,7 @@
 //!
 //! Each account gets its own sled database at `<data_dir>/whatsapp/<account_id>/`.
 
-use std::{fmt::Write, path::Path, sync::atomic::AtomicI32};
+use std::{fmt::Write, path::Path, sync::atomic::AtomicI32, time::SystemTime};
 
 use {
     async_trait::async_trait,
@@ -17,6 +17,7 @@ use {
             traits::*,
         },
     },
+    wacore_binary::jid::Jid,
 };
 
 /// Hex-encode bytes without pulling in the `hex` crate.
@@ -49,6 +50,8 @@ pub struct SledStore {
     device_list_records: sled::Tree,
     sender_key_forget_marks: sled::Tree,
     base_keys: sled::Tree,
+    tc_tokens: sled::Tree,
+    sent_messages: sled::Tree,
 }
 
 fn json_err(e: serde_json::Error) -> StoreError {
@@ -109,6 +112,8 @@ impl SledStore {
             device_list_records: db.open_tree("device_list_records")?,
             sender_key_forget_marks: db.open_tree("sender_key_forget_marks")?,
             base_keys: db.open_tree("base_keys")?,
+            tc_tokens: db.open_tree("tc_tokens")?,
+            sent_messages: db.open_tree("sent_messages")?,
             db,
         })
     }
@@ -217,6 +222,20 @@ impl SignalStore for SledStore {
             .remove(id.to_le_bytes())
             .map_err(db_err)?;
         Ok(())
+    }
+
+    async fn get_max_prekey_id(&self) -> Result<u32> {
+        let mut max_id = 0u32;
+        for entry in self.prekeys.iter() {
+            let (k, _) = entry.map_err(db_err)?;
+            if let Ok(bytes) = k.as_ref().try_into() {
+                let id = u32::from_le_bytes(bytes);
+                if id > max_id {
+                    max_id = id;
+                }
+            }
+        }
+        Ok(max_id)
     }
 
     async fn put_sender_key(&self, address: &str, record: &[u8]) -> Result<()> {
@@ -340,6 +359,14 @@ impl AppSyncStore for SledStore {
         }
         Ok(())
     }
+
+    async fn get_latest_sync_key_id(&self) -> Result<Option<Vec<u8>>> {
+        Ok(self
+            .sync_keys
+            .last()
+            .map_err(db_err)?
+            .map(|(k, _)| k.to_vec()))
+    }
 }
 
 // ============================================================================
@@ -348,20 +375,31 @@ impl AppSyncStore for SledStore {
 
 #[async_trait]
 impl ProtocolStore for SledStore {
-    async fn get_skdm_recipients(&self, group_jid: &str) -> Result<Vec<String>> {
+    async fn get_skdm_recipients(&self, group_jid: &str) -> Result<Vec<Jid>> {
         match self
             .skdm_recipients
             .get(group_jid.as_bytes())
             .map_err(db_err)?
         {
-            Some(v) => decode_persistent(&v),
+            // Stored as Vec<String> for serialization, parse back to Jid.
+            Some(v) => {
+                let strings: Vec<String> = decode_persistent(&v)?;
+                Ok(strings.into_iter().filter_map(|s| s.parse().ok()).collect())
+            },
             None => Ok(Vec::new()),
         }
     }
 
-    async fn add_skdm_recipients(&self, group_jid: &str, device_jids: &[String]) -> Result<()> {
-        let mut current = self.get_skdm_recipients(group_jid).await?;
-        current.extend(device_jids.iter().cloned());
+    async fn add_skdm_recipients(&self, group_jid: &str, device_jids: &[Jid]) -> Result<()> {
+        let mut current: Vec<String> = match self
+            .skdm_recipients
+            .get(group_jid.as_bytes())
+            .map_err(db_err)?
+        {
+            Some(v) => decode_persistent(&v)?,
+            None => Vec::new(),
+        };
+        current.extend(device_jids.iter().map(|j| j.to_string()));
         let val = encode_persistent(&current)?;
         self.skdm_recipients
             .insert(group_jid.as_bytes(), val.as_slice())
@@ -484,6 +522,102 @@ impl ProtocolStore for SledStore {
             self.sender_key_forget_marks.remove(key).map_err(db_err)?;
         }
         Ok(participants)
+    }
+
+    // --- TcToken Storage ---
+
+    async fn get_tc_token(&self, jid: &str) -> Result<Option<TcTokenEntry>> {
+        match self.tc_tokens.get(jid.as_bytes()).map_err(db_err)? {
+            Some(v) => Ok(Some(decode_persistent(&v)?)),
+            None => Ok(None),
+        }
+    }
+
+    async fn put_tc_token(&self, jid: &str, entry: &TcTokenEntry) -> Result<()> {
+        let val = encode_persistent(entry)?;
+        self.tc_tokens
+            .insert(jid.as_bytes(), val.as_slice())
+            .map_err(db_err)?;
+        Ok(())
+    }
+
+    async fn delete_tc_token(&self, jid: &str) -> Result<()> {
+        self.tc_tokens.remove(jid.as_bytes()).map_err(db_err)?;
+        Ok(())
+    }
+
+    async fn get_all_tc_token_jids(&self) -> Result<Vec<String>> {
+        let mut jids = Vec::new();
+        for entry in self.tc_tokens.iter() {
+            let (k, _) = entry.map_err(db_err)?;
+            jids.push(String::from_utf8_lossy(&k).into_owned());
+        }
+        Ok(jids)
+    }
+
+    async fn delete_expired_tc_tokens(&self, cutoff_timestamp: i64) -> Result<u32> {
+        let mut count = 0u32;
+        let mut keys_to_remove = Vec::new();
+        for entry in self.tc_tokens.iter() {
+            let (k, v) = entry.map_err(db_err)?;
+            let token: TcTokenEntry = decode_persistent(&v)?;
+            if token.token_timestamp < cutoff_timestamp {
+                keys_to_remove.push(k);
+            }
+        }
+        for key in keys_to_remove {
+            self.tc_tokens.remove(key).map_err(db_err)?;
+            count += 1;
+        }
+        Ok(count)
+    }
+
+    // --- Sent Message Store ---
+
+    async fn store_sent_message(
+        &self,
+        chat_jid: &str,
+        message_id: &str,
+        payload: &[u8],
+    ) -> Result<()> {
+        let now = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+        let key = format!("{chat_jid}:{message_id}");
+        let val = encode_persistent(&(payload.to_vec(), now))?;
+        self.sent_messages
+            .insert(key.as_bytes(), val.as_slice())
+            .map_err(db_err)?;
+        Ok(())
+    }
+
+    async fn take_sent_message(&self, chat_jid: &str, message_id: &str) -> Result<Option<Vec<u8>>> {
+        let key = format!("{chat_jid}:{message_id}");
+        match self.sent_messages.remove(key.as_bytes()).map_err(db_err)? {
+            Some(v) => {
+                let (payload, _ts): (Vec<u8>, u64) = decode_persistent(&v)?;
+                Ok(Some(payload))
+            },
+            None => Ok(None),
+        }
+    }
+
+    async fn delete_expired_sent_messages(&self, cutoff_timestamp: i64) -> Result<u32> {
+        let mut count = 0u32;
+        let mut keys_to_remove = Vec::new();
+        for entry in self.sent_messages.iter() {
+            let (k, v) = entry.map_err(db_err)?;
+            let (_payload, ts): (Vec<u8>, u64) = decode_persistent(&v)?;
+            if (ts as i64) < cutoff_timestamp {
+                keys_to_remove.push(k);
+            }
+        }
+        for key in keys_to_remove {
+            self.sent_messages.remove(key).map_err(db_err)?;
+            count += 1;
+        }
+        Ok(count)
     }
 }
 
@@ -678,7 +812,10 @@ mod tests {
         assert!(recips.is_empty());
 
         store
-            .add_skdm_recipients("group1", &["dev1".into(), "dev2".into()])
+            .add_skdm_recipients("group1", &[
+                "dev1@s.whatsapp.net".parse().unwrap(),
+                "dev2@s.whatsapp.net".parse().unwrap(),
+            ])
             .await
             .unwrap();
         let recips = store.get_skdm_recipients("group1").await.unwrap();
@@ -825,5 +962,119 @@ mod tests {
             let id = store.create().await.unwrap();
             assert_eq!(id, 1); // counter persisted
         }
+    }
+
+    #[tokio::test]
+    async fn max_prekey_id() {
+        let store = temp_store();
+        assert_eq!(store.get_max_prekey_id().await.unwrap(), 0);
+        store.store_prekey(5, b"pk5", false).await.unwrap();
+        store.store_prekey(10, b"pk10", true).await.unwrap();
+        store.store_prekey(3, b"pk3", false).await.unwrap();
+        assert_eq!(store.get_max_prekey_id().await.unwrap(), 10);
+    }
+
+    #[tokio::test]
+    async fn latest_sync_key_id() {
+        let store = temp_store();
+        assert!(store.get_latest_sync_key_id().await.unwrap().is_none());
+        let key = AppStateSyncKey {
+            key_data: vec![1],
+            fingerprint: vec![],
+            timestamp: 1,
+        };
+        store.set_sync_key(b"key-1", key.clone()).await.unwrap();
+        store.set_sync_key(b"key-2", key).await.unwrap();
+        let latest = store.get_latest_sync_key_id().await.unwrap();
+        assert!(latest.is_some());
+    }
+
+    #[tokio::test]
+    async fn tc_token_roundtrip() {
+        let store = temp_store();
+        assert!(store.get_tc_token("user@lid").await.unwrap().is_none());
+
+        let entry = TcTokenEntry {
+            token: vec![1, 2, 3],
+            token_timestamp: 1000,
+            sender_timestamp: Some(900),
+        };
+        store.put_tc_token("user@lid", &entry).await.unwrap();
+        let loaded = store.get_tc_token("user@lid").await.unwrap().unwrap();
+        assert_eq!(loaded.token, vec![1, 2, 3]);
+        assert_eq!(loaded.token_timestamp, 1000);
+
+        let jids = store.get_all_tc_token_jids().await.unwrap();
+        assert_eq!(jids.len(), 1);
+
+        store.delete_tc_token("user@lid").await.unwrap();
+        assert!(store.get_tc_token("user@lid").await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn tc_token_expiry() {
+        let store = temp_store();
+        store
+            .put_tc_token("old@lid", &TcTokenEntry {
+                token: vec![1],
+                token_timestamp: 100,
+                sender_timestamp: None,
+            })
+            .await
+            .unwrap();
+        store
+            .put_tc_token("new@lid", &TcTokenEntry {
+                token: vec![2],
+                token_timestamp: 2000,
+                sender_timestamp: None,
+            })
+            .await
+            .unwrap();
+
+        let deleted = store.delete_expired_tc_tokens(500).await.unwrap();
+        assert_eq!(deleted, 1);
+        assert!(store.get_tc_token("old@lid").await.unwrap().is_none());
+        assert!(store.get_tc_token("new@lid").await.unwrap().is_some());
+    }
+
+    #[tokio::test]
+    async fn sent_message_store_and_take() {
+        let store = temp_store();
+        store
+            .store_sent_message("chat@jid", "msg1", b"payload1")
+            .await
+            .unwrap();
+
+        let taken = store.take_sent_message("chat@jid", "msg1").await.unwrap();
+        assert_eq!(taken, Some(b"payload1".to_vec()));
+
+        // Take again returns None (consumed).
+        assert!(
+            store
+                .take_sent_message("chat@jid", "msg1")
+                .await
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn sent_message_expiry() {
+        let store = temp_store();
+        store
+            .store_sent_message("chat@jid", "old", b"old-payload")
+            .await
+            .unwrap();
+
+        // Expire anything before far-future timestamp.
+        let deleted = store.delete_expired_sent_messages(i64::MAX).await.unwrap();
+        assert_eq!(deleted, 1);
+        assert!(
+            store
+                .take_sent_message("chat@jid", "old")
+                .await
+                .unwrap()
+                .is_none()
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Upgrade all 6 whatsapp-rust ecosystem crates from 0.2 to 0.5 to fix inbound messages parsing as empty after WhatsApp's protobuf schema update (#534)
- Implement new store trait methods required by wacore 0.5 (TC tokens, sent message cache, `get_max_prekey_id`, `get_latest_sync_key_id`, SKDM `String→Jid` signature changes)
- Add `.with_runtime(TokioRuntime)` to bot builder (new 4th type parameter in 0.5)
- Add WhatsApp to the default offered channels list so it appears in onboarding and settings without manual config

## Validation

### Completed
- [x] `cargo +nightly-2025-11-30 fmt --all -- --check` — clean
- [x] `just lint` — clean (clippy, no warnings)
- [x] `biome check --write` on JS files — clean
- [x] `cargo test -p moltis-whatsapp` — 90 tests pass (78 existing + 12 new)
- [x] `cargo test -p moltis-config --lib` — 227 tests pass
- [x] `cargo nextest run --workspace --exclude moltis-providers --exclude moltis-gateway` — 4053 tests pass

### Remaining
- [ ] `./scripts/local-validate.sh <PR_NUMBER>` — full validation
- [x] Manual QA: pair a WhatsApp device, send a text DM → should route to LLM

## Manual QA

1. Start moltis with a WhatsApp account configured
2. Verify WhatsApp appears in onboarding channel selector and channels settings page by default
3. Scan QR code to pair (existing pairings may need re-scan due to wacore struct changes)
4. Send a plain text message from WhatsApp → should route to LLM and produce a reply
5. Send an image with caption → should download and dispatch with attachment
6. Verify no "unhandled message type" errors for normal text/media messages

## Breaking changes

- Users with existing WhatsApp pairings may need to **re-scan their QR code** if wacore 0.2→0.5 changed any serialized struct layouts in the sled store
- WhatsApp now appears by default in the channel UI. Users who explicitly set `[channels].offered` in their `moltis.toml` are unaffected (their explicit list takes precedence)

Closes #534