### PR TITLE
[codex] fix(chat): preserve sender names in user messages

### DIFF
--- a/crates/agents/src/model.rs
+++ b/crates/agents/src/model.rs
@@ -50,6 +50,8 @@ pub enum ChatMessage {
     },
     User {
         content: UserContent,
+        /// Optional sender name for channel messages (Telegram, Discord, etc.).
+        name: Option<String>,
     },
     Assistant {
         content: Option<String>,
@@ -94,6 +96,15 @@ impl ChatMessage {
     pub fn user(content: impl Into<String>) -> Self {
         Self::User {
             content: UserContent::Text(content.into()),
+            name: None,
+        }
+    }
+
+    /// Create a user message with plain text and a sender name.
+    pub fn user_named(content: impl Into<String>, name: impl Into<String>) -> Self {
+        Self::User {
+            content: UserContent::Text(content.into()),
+            name: Some(name.into()),
         }
     }
 
@@ -101,6 +112,15 @@ impl ChatMessage {
     pub fn user_multimodal(parts: Vec<ContentPart>) -> Self {
         Self::User {
             content: UserContent::Multimodal(parts),
+            name: None,
+        }
+    }
+
+    /// Create a user message with multimodal content and a sender name.
+    pub fn user_multimodal_named(parts: Vec<ContentPart>, name: impl Into<String>) -> Self {
+        Self::User {
+            content: UserContent::Multimodal(parts),
+            name: Some(name.into()),
         }
     }
 
@@ -138,28 +158,34 @@ impl ChatMessage {
             ChatMessage::System { content } => {
                 serde_json::json!({ "role": "system", "content": content })
             },
-            ChatMessage::User { content } => match content {
-                UserContent::Text(text) => {
-                    serde_json::json!({ "role": "user", "content": text })
-                },
-                UserContent::Multimodal(parts) => {
-                    let blocks: Vec<serde_json::Value> = parts
-                        .iter()
-                        .map(|part| match part {
-                            ContentPart::Text(text) => {
-                                serde_json::json!({ "type": "text", "text": text })
-                            },
-                            ContentPart::Image { media_type, data } => {
-                                let data_uri = format!("data:{media_type};base64,{data}");
-                                serde_json::json!({
-                                    "type": "image_url",
-                                    "image_url": { "url": data_uri }
-                                })
-                            },
-                        })
-                        .collect();
-                    serde_json::json!({ "role": "user", "content": blocks })
-                },
+            ChatMessage::User { content, name } => {
+                let mut msg = match content {
+                    UserContent::Text(text) => {
+                        serde_json::json!({ "role": "user", "content": text })
+                    },
+                    UserContent::Multimodal(parts) => {
+                        let blocks: Vec<serde_json::Value> = parts
+                            .iter()
+                            .map(|part| match part {
+                                ContentPart::Text(text) => {
+                                    serde_json::json!({ "type": "text", "text": text })
+                                },
+                                ContentPart::Image { media_type, data } => {
+                                    let data_uri = format!("data:{media_type};base64,{data}");
+                                    serde_json::json!({
+                                        "type": "image_url",
+                                        "image_url": { "url": data_uri }
+                                    })
+                                },
+                            })
+                            .collect();
+                        serde_json::json!({ "role": "user", "content": blocks })
+                    },
+                };
+                if let Some(n) = name {
+                    msg["name"] = serde_json::Value::String(n.clone());
+                }
+                msg
             },
             ChatMessage::Assistant {
                 content,
@@ -233,6 +259,16 @@ pub fn values_to_chat_messages(values: &[serde_json::Value]) -> Vec<ChatMessage>
                 messages.push(ChatMessage::system(content));
             },
             "user" => {
+                // Extract sender name from persisted channel metadata.
+                let sender_name = val
+                    .get("channel")
+                    .and_then(|ch| {
+                        ch["sender_name"]
+                            .as_str()
+                            .or_else(|| ch["username"].as_str())
+                    })
+                    .map(|s| s.to_string());
+
                 let document_context = val["documents"].as_array().and_then(|documents| {
                     let mut sections = Vec::new();
                     for document in documents {
@@ -270,7 +306,10 @@ pub fn values_to_chat_messages(values: &[serde_json::Value]) -> Vec<ChatMessage>
                     } else {
                         text.to_string()
                     };
-                    messages.push(ChatMessage::user(content));
+                    messages.push(ChatMessage::User {
+                        content: UserContent::Text(content),
+                        name: sender_name,
+                    });
                 } else if let Some(arr) = val["content"].as_array() {
                     let mut parts: Vec<ContentPart> = arr
                         .iter()
@@ -306,9 +345,15 @@ pub fn values_to_chat_messages(values: &[serde_json::Value]) -> Vec<ChatMessage>
                             parts.insert(0, ContentPart::Text(document_context));
                         }
                     }
-                    messages.push(ChatMessage::user_multimodal(parts));
+                    messages.push(ChatMessage::User {
+                        content: UserContent::Multimodal(parts),
+                        name: sender_name,
+                    });
                 } else {
-                    messages.push(ChatMessage::user(document_context.unwrap_or_default()));
+                    messages.push(ChatMessage::User {
+                        content: UserContent::Text(document_context.unwrap_or_default()),
+                        name: sender_name,
+                    });
                 }
             },
             "assistant" => {
@@ -628,7 +673,9 @@ mod tests {
     #[test]
     fn user_message_text() {
         let msg = ChatMessage::user("Hello");
-        assert!(matches!(msg, ChatMessage::User { content: UserContent::Text(t) } if t == "Hello"));
+        assert!(
+            matches!(msg, ChatMessage::User { content: UserContent::Text(t), .. } if t == "Hello")
+        );
     }
 
     #[test]
@@ -771,7 +818,7 @@ mod tests {
         assert_eq!(msgs.len(), 3);
         assert!(matches!(&msgs[0], ChatMessage::System { content } if content == "sys"));
         assert!(
-            matches!(&msgs[1], ChatMessage::User { content: UserContent::Text(t) } if t == "hi")
+            matches!(&msgs[1], ChatMessage::User { content: UserContent::Text(t), .. } if t == "hi")
         );
         assert!(
             matches!(&msgs[2], ChatMessage::Assistant { content: Some(t), .. } if t == "hello")
@@ -820,6 +867,7 @@ mod tests {
         match &msgs[0] {
             ChatMessage::User {
                 content: UserContent::Text(text),
+                ..
             } => {
                 assert!(text.contains("review this"));
                 assert!(text.contains("[Inbound documents available]"));
@@ -855,6 +903,7 @@ mod tests {
         match &msgs[0] {
             ChatMessage::User {
                 content: UserContent::Text(text),
+                ..
             } => {
                 assert!(text.contains("filename: valid-report.pdf"));
                 assert!(text.contains(&format!("local_path: {expected_path}")));
@@ -1024,6 +1073,7 @@ mod tests {
         match &msgs[0] {
             ChatMessage::User {
                 content: UserContent::Text(t),
+                ..
             } => {
                 assert_eq!(t, injected_content);
             },
@@ -1204,5 +1254,111 @@ mod tests {
         let meta = provider.model_metadata().await.unwrap();
         assert_eq!(meta.id, "stub-model");
         assert_eq!(meta.context_length, 42_000);
+    }
+
+    // ── Sender name tests ─────────────────────────────────────────────
+
+    #[test]
+    fn user_named_constructor() {
+        let msg = ChatMessage::user_named("hello", "Alice");
+        match msg {
+            ChatMessage::User {
+                content: UserContent::Text(t),
+                name,
+            } => {
+                assert_eq!(t, "hello");
+                assert_eq!(name.as_deref(), Some("Alice"));
+            },
+            _ => panic!("expected User message"),
+        }
+    }
+
+    #[test]
+    fn user_multimodal_named_constructor() {
+        let msg = ChatMessage::user_multimodal_named(vec![ContentPart::Text("hi".into())], "Bob");
+        match msg {
+            ChatMessage::User {
+                content: UserContent::Multimodal(_),
+                name,
+            } => {
+                assert_eq!(name.as_deref(), Some("Bob"));
+            },
+            _ => panic!("expected multimodal User message"),
+        }
+    }
+
+    #[test]
+    fn to_openai_value_includes_name_when_present() {
+        let msg = ChatMessage::user_named("hi", "Alice");
+        let val = msg.to_openai_value();
+        assert_eq!(val["role"], "user");
+        assert_eq!(val["content"], "hi");
+        assert_eq!(val["name"], "Alice");
+    }
+
+    #[test]
+    fn to_openai_value_omits_name_when_none() {
+        let msg = ChatMessage::user("hi");
+        let val = msg.to_openai_value();
+        assert_eq!(val["role"], "user");
+        assert_eq!(val["content"], "hi");
+        assert!(val.get("name").is_none());
+    }
+
+    #[test]
+    fn values_to_chat_messages_extracts_sender_name_from_channel() {
+        let values = vec![serde_json::json!({
+            "role": "user",
+            "content": "hello from telegram",
+            "channel": {
+                "sender_name": "Alice",
+                "username": "alice42",
+                "channel_type": "telegram"
+            }
+        })];
+        let msgs = values_to_chat_messages(&values);
+        assert_eq!(msgs.len(), 1);
+        match &msgs[0] {
+            ChatMessage::User { name, .. } => {
+                assert_eq!(name.as_deref(), Some("Alice"));
+            },
+            _ => panic!("expected User message"),
+        }
+    }
+
+    #[test]
+    fn values_to_chat_messages_falls_back_to_username() {
+        let values = vec![serde_json::json!({
+            "role": "user",
+            "content": "hello",
+            "channel": {
+                "username": "bob99",
+                "channel_type": "discord"
+            }
+        })];
+        let msgs = values_to_chat_messages(&values);
+        assert_eq!(msgs.len(), 1);
+        match &msgs[0] {
+            ChatMessage::User { name, .. } => {
+                assert_eq!(name.as_deref(), Some("bob99"));
+            },
+            _ => panic!("expected User message"),
+        }
+    }
+
+    #[test]
+    fn values_to_chat_messages_no_channel_means_no_name() {
+        let values = vec![serde_json::json!({
+            "role": "user",
+            "content": "web message"
+        })];
+        let msgs = values_to_chat_messages(&values);
+        assert_eq!(msgs.len(), 1);
+        match &msgs[0] {
+            ChatMessage::User { name, .. } => {
+                assert!(name.is_none());
+            },
+            _ => panic!("expected User message"),
+        }
     }
 }

--- a/crates/agents/src/runner/non_streaming.rs
+++ b/crates/agents/src/runner/non_streaming.rs
@@ -105,6 +105,7 @@ pub async fn run_agent_loop_with_context(
 
     messages.push(ChatMessage::User {
         content: user_content.clone(),
+        name: None,
     });
     let explicit_shell_command = explicit_shell_command_from_user_content(user_content);
 

--- a/crates/agents/src/runner/non_streaming.rs
+++ b/crates/agents/src/runner/non_streaming.rs
@@ -57,6 +57,7 @@ pub async fn run_agent_loop(
         history,
         None,
         None,
+        None,
     )
     .await
 }
@@ -72,6 +73,7 @@ pub async fn run_agent_loop_with_context(
     history: Option<Vec<ChatMessage>>,
     tool_context: Option<serde_json::Value>,
     hook_registry: Option<Arc<HookRegistry>>,
+    sender_name: Option<String>,
 ) -> Result<AgentRunResult, AgentRunError> {
     let native_tools = provider.supports_tools();
     let config = moltis_config::discover_and_load();
@@ -105,7 +107,7 @@ pub async fn run_agent_loop_with_context(
 
     messages.push(ChatMessage::User {
         content: user_content.clone(),
-        name: None,
+        name: sender_name,
     });
     let explicit_shell_command = explicit_shell_command_from_user_content(user_content);
 

--- a/crates/agents/src/runner/streaming.rs
+++ b/crates/agents/src/runner/streaming.rs
@@ -60,6 +60,7 @@ pub async fn run_agent_loop_streaming(
     history: Option<Vec<ChatMessage>>,
     tool_context: Option<serde_json::Value>,
     hook_registry: Option<Arc<HookRegistry>>,
+    sender_name: Option<String>,
 ) -> Result<AgentRunResult, AgentRunError> {
     let native_tools = provider.supports_tools();
     let config = moltis_config::discover_and_load();
@@ -93,6 +94,7 @@ pub async fn run_agent_loop_streaming(
 
     messages.push(ChatMessage::User {
         content: user_content.clone(),
+        name: sender_name,
     });
     let explicit_shell_command = explicit_shell_command_from_user_content(user_content);
 

--- a/crates/agents/src/runner/tests/basic.rs
+++ b/crates/agents/src/runner/tests/basic.rs
@@ -197,6 +197,7 @@ async fn test_streaming_runner_preserves_cache_usage() {
         None,
         None,
         None,
+        None,
     )
     .await
     .unwrap();

--- a/crates/agents/src/runner/tests/helpers.rs
+++ b/crates/agents/src/runner/tests/helpers.rs
@@ -630,6 +630,7 @@ pub(super) fn last_user_text(messages: &[ChatMessage]) -> &str {
         .find_map(|message| match message {
             ChatMessage::User {
                 content: UserContent::Text(text),
+                ..
             } => Some(text.as_str()),
             _ => None,
         })
@@ -665,6 +666,7 @@ pub(super) fn history_contains_intervention(messages: &[ChatMessage]) -> bool {
     messages.iter().any(|m| match m {
         ChatMessage::User {
             content: UserContent::Text(text),
+            ..
         } => text.contains("LOOP DETECTED") || text.contains("TOOLS DISABLED"),
         _ => false,
     })

--- a/crates/agents/src/runner/tests_legacy/runner.rs
+++ b/crates/agents/src/runner/tests_legacy/runner.rs
@@ -87,6 +87,7 @@ pub async fn run_agent_loop_with_context(
 
     messages.push(ChatMessage::User {
         content: user_content.clone(),
+        name: None,
     });
     let explicit_shell_command = explicit_shell_command_from_user_content(user_content);
 

--- a/crates/agents/src/runner/tests_legacy/streaming.rs
+++ b/crates/agents/src/runner/tests_legacy/streaming.rs
@@ -54,6 +54,7 @@ pub async fn run_agent_loop_streaming(
 
     messages.push(ChatMessage::User {
         content: user_content.clone(),
+        name: None,
     });
     let explicit_shell_command = explicit_shell_command_from_user_content(user_content);
 

--- a/crates/agents/src/silent_turn.rs
+++ b/crates/agents/src/silent_turn.rs
@@ -165,9 +165,11 @@ pub async fn run_silent_memory_turn(
             ChatMessage::System { content } => ("system", content.as_str()),
             ChatMessage::User {
                 content: crate::model::UserContent::Text(t),
+                ..
             } => ("user", t.as_str()),
             ChatMessage::User {
                 content: crate::model::UserContent::Multimodal(_),
+                ..
             } => ("user", "[multimodal content]"),
             ChatMessage::Assistant { content, .. } => {
                 ("assistant", content.as_deref().unwrap_or(""))

--- a/crates/chat/src/compaction_run/test_support.rs
+++ b/crates/chat/src/compaction_run/test_support.rs
@@ -94,9 +94,11 @@ fn message_contains(msg: &ChatMessage, needle: &str) -> bool {
         ChatMessage::System { content } => content.contains(needle),
         ChatMessage::User {
             content: UserContent::Text(t),
+            ..
         } => t.contains(needle),
         ChatMessage::User {
             content: UserContent::Multimodal(parts),
+            ..
         } => parts
             .iter()
             .any(|p| matches!(p, ContentPart::Text(t) if t.contains(needle))),

--- a/crates/chat/src/run_with_tools.rs
+++ b/crates/chat/src/run_with_tools.rs
@@ -84,6 +84,7 @@ pub(crate) async fn run_with_tools(
     active_partial_assistant: Option<Arc<RwLock<HashMap<String, ActiveAssistantDraft>>>>,
     active_event_forwarders: &Arc<RwLock<HashMap<String, tokio::task::JoinHandle<String>>>>,
     terminal_runs: &Arc<RwLock<HashSet<String>>>,
+    sender_name: Option<String>,
 ) -> Option<AssistantTurnOutput> {
     let run_started = Instant::now();
 
@@ -787,6 +788,7 @@ pub(crate) async fn run_with_tools(
         hist,
         Some(tool_context.clone()),
         hook_registry.clone(),
+        sender_name.clone(),
     )
     .await;
 
@@ -889,6 +891,7 @@ pub(crate) async fn run_with_tools(
                         retry_hist,
                         Some(tool_context),
                         hook_registry,
+                        sender_name,
                     )
                     .await
                 },

--- a/crates/chat/src/service/chat_impl.rs
+++ b/crates/chat/src/service/chat_impl.rs
@@ -232,6 +232,7 @@ impl ChatService for LiveChatService {
                 user_message_index,
                 &[],
                 Some(&runtime_context),
+                None, // send_sync: no sender name
                 Some(&self.session_store),
                 None, // send_sync: no client seq
                 None, // send_sync: no partial assistant tracking
@@ -268,6 +269,7 @@ impl ChatService for LiveChatService {
                 None,  // send_sync: no partial assistant tracking
                 &active_event_forwarders,
                 &terminal_runs,
+                None, // send_sync: no sender name
             )
             .await
         };

--- a/crates/chat/src/service/chat_impl/send.rs
+++ b/crates/chat/src/service/chat_impl/send.rs
@@ -747,6 +747,15 @@ impl LiveChatService {
         // know the message won't be queued — avoids double-persist when a
         // queued message is replayed via send()).
         let channel_meta = params.get("channel").cloned();
+        // Extract sender name from channel metadata for LLM identity.
+        let sender_name = channel_meta
+            .as_ref()
+            .and_then(|ch| {
+                ch["sender_name"]
+                    .as_str()
+                    .or_else(|| ch["username"].as_str())
+            })
+            .map(|s| s.to_string());
         let user_audio = user_audio_path_from_params(&params, &session_key);
         let user_msg = PersistedMessage::User {
             content: message_content,
@@ -1062,6 +1071,7 @@ impl LiveChatService {
                         user_message_index,
                         &discovered_skills,
                         Some(&runtime_context),
+                        sender_name,
                         Some(&session_store),
                         client_seq,
                         Some(Arc::clone(&active_partial_assistant)),
@@ -1098,6 +1108,7 @@ impl LiveChatService {
                         Some(Arc::clone(&active_partial_assistant)),
                         &active_event_forwarders,
                         &terminal_runs,
+                        sender_name,
                     )
                     .await
                 }

--- a/crates/chat/src/streaming.rs
+++ b/crates/chat/src/streaming.rs
@@ -127,6 +127,7 @@ pub(crate) async fn run_streaming(
     user_message_index: usize,
     _skills: &[moltis_skills::types::SkillMetadata],
     runtime_context: Option<&PromptRuntimeContext>,
+    sender_name: Option<String>,
     session_store: Option<&Arc<SessionStore>>,
     client_seq: Option<u64>,
     active_partial_assistant: Option<Arc<RwLock<HashMap<String, ActiveAssistantDraft>>>>,
@@ -162,6 +163,7 @@ pub(crate) async fn run_streaming(
     }
     messages.push(ChatMessage::User {
         content: user_content.clone(),
+        name: sender_name,
     });
 
     let mut server_retries_remaining: u8 = STREAM_SERVER_MAX_RETRIES;

--- a/crates/providers/src/anthropic.rs
+++ b/crates/providers/src/anthropic.rs
@@ -405,12 +405,18 @@ fn to_anthropic_messages(
                         out.push(serde_json::json!({"role": "user", "content": content_str}));
                     },
                     UserContent::Multimodal(parts) => {
+                        let mut prefixed_first_text = false;
                         let mut blocks: Vec<serde_json::Value> = parts
                             .iter()
                             .map(|part| match part {
                                 ContentPart::Text(text) => {
-                                    let prefixed = format!("{prefix}{text}");
-                                    serde_json::json!({"type": "text", "text": prefixed})
+                                    let content = if !prefix.is_empty() && !prefixed_first_text {
+                                        prefixed_first_text = true;
+                                        format!("{prefix}{text}")
+                                    } else {
+                                        text.clone()
+                                    };
+                                    serde_json::json!({"type": "text", "text": content})
                                 },
                                 ContentPart::Image { media_type, data } => {
                                     serde_json::json!({
@@ -1327,6 +1333,43 @@ mod tests {
 
         // Last block (image) should have cache_control.
         assert_eq!(content[1]["cache_control"]["type"], "ephemeral");
+    }
+
+    #[test]
+    fn named_multimodal_prefixes_only_first_text_block() {
+        let messages = vec![ChatMessage::User {
+            content: UserContent::Multimodal(vec![
+                ContentPart::Text("first".into()),
+                ContentPart::Image {
+                    media_type: "image/png".into(),
+                    data: "base64data".into(),
+                },
+                ContentPart::Text("second".into()),
+            ]),
+            name: Some("Alice".into()),
+        }];
+
+        let (_, out) = to_anthropic_messages(&messages, false);
+        let content = out[0]["content"].as_array().expect("should be array");
+        assert_eq!(content[0]["text"], "[Alice]: first");
+        assert_eq!(content[2]["text"], "second");
+    }
+
+    #[test]
+    fn named_multimodal_without_text_inserts_prefix_block() {
+        let messages = vec![ChatMessage::User {
+            content: UserContent::Multimodal(vec![ContentPart::Image {
+                media_type: "image/png".into(),
+                data: "base64data".into(),
+            }]),
+            name: Some("Alice".into()),
+        }];
+
+        let (_, out) = to_anthropic_messages(&messages, false);
+        let content = out[0]["content"].as_array().expect("should be array");
+        assert_eq!(content[0]["type"], "text");
+        assert_eq!(content[0]["text"], "[Alice]:");
+        assert_eq!(content[1]["type"], "image");
     }
 
     #[test]

--- a/crates/providers/src/anthropic.rs
+++ b/crates/providers/src/anthropic.rs
@@ -393,31 +393,49 @@ fn to_anthropic_messages(
                     None => content.clone(),
                 });
             },
-            ChatMessage::User { content } => match content {
-                UserContent::Text(text) => {
-                    out.push(serde_json::json!({"role": "user", "content": text}));
-                },
-                UserContent::Multimodal(parts) => {
-                    let blocks: Vec<serde_json::Value> = parts
-                        .iter()
-                        .map(|part| match part {
-                            ContentPart::Text(text) => {
-                                serde_json::json!({"type": "text", "text": text})
-                            },
-                            ContentPart::Image { media_type, data } => {
-                                serde_json::json!({
-                                    "type": "image",
-                                    "source": {
-                                        "type": "base64",
-                                        "media_type": media_type,
-                                        "data": data,
-                                    }
-                                })
-                            },
-                        })
-                        .collect();
-                    out.push(serde_json::json!({"role": "user", "content": blocks}));
-                },
+            ChatMessage::User { content, name } => {
+                // Anthropic doesn't have a `name` field — prepend `[name]: ` to content.
+                let prefix = name
+                    .as_ref()
+                    .map(|n| format!("[{n}]: "))
+                    .unwrap_or_default();
+                match content {
+                    UserContent::Text(text) => {
+                        let content_str = format!("{prefix}{text}");
+                        out.push(serde_json::json!({"role": "user", "content": content_str}));
+                    },
+                    UserContent::Multimodal(parts) => {
+                        let mut blocks: Vec<serde_json::Value> = parts
+                            .iter()
+                            .map(|part| match part {
+                                ContentPart::Text(text) => {
+                                    let prefixed = format!("{prefix}{text}");
+                                    serde_json::json!({"type": "text", "text": prefixed})
+                                },
+                                ContentPart::Image { media_type, data } => {
+                                    serde_json::json!({
+                                        "type": "image",
+                                        "source": {
+                                            "type": "base64",
+                                            "media_type": media_type,
+                                            "data": data,
+                                        }
+                                    })
+                                },
+                            })
+                            .collect();
+                        // If name prefix is present but no text block exists, prepend one.
+                        if !prefix.is_empty()
+                            && !blocks.iter().any(|b| b["type"].as_str() == Some("text"))
+                        {
+                            blocks.insert(
+                                0,
+                                serde_json::json!({"type": "text", "text": prefix.trim_end()}),
+                            );
+                        }
+                        out.push(serde_json::json!({"role": "user", "content": blocks}));
+                    },
+                }
             },
             ChatMessage::Assistant {
                 content,
@@ -1202,10 +1220,12 @@ mod tests {
             ChatMessage::system("You are a helpful assistant."),
             ChatMessage::User {
                 content: UserContent::Text("hello".into()),
+                name: None,
             },
             ChatMessage::system("The current user datetime is 2026-03-24 01:23:45 CET."),
             ChatMessage::User {
                 content: UserContent::Text("what time is it?".into()),
+                name: None,
             },
         ];
 
@@ -1236,6 +1256,7 @@ mod tests {
             ChatMessage::system("You are a coding assistant."),
             ChatMessage::User {
                 content: UserContent::Text("hi".into()),
+                name: None,
             },
         ];
 
@@ -1257,6 +1278,7 @@ mod tests {
             ChatMessage::system("sys"),
             ChatMessage::User {
                 content: UserContent::Text("first".into()),
+                name: None,
             },
             ChatMessage::Assistant {
                 content: Some("reply".into()),
@@ -1264,6 +1286,7 @@ mod tests {
             },
             ChatMessage::User {
                 content: UserContent::Text("second".into()),
+                name: None,
             },
         ];
 
@@ -1292,6 +1315,7 @@ mod tests {
                     data: "base64data".into(),
                 },
             ]),
+            name: None,
         }];
 
         let (_, out) = to_anthropic_messages(&messages, true);
@@ -1309,6 +1333,7 @@ mod tests {
     fn no_system_returns_none() {
         let messages = vec![ChatMessage::User {
             content: UserContent::Text("hello".into()),
+            name: None,
         }];
         let (system_value, _) = to_anthropic_messages(&messages, true);
         assert!(system_value.is_none());
@@ -1318,6 +1343,7 @@ mod tests {
     fn caching_disabled_returns_plain_string_system() {
         let messages = vec![ChatMessage::system("You are helpful."), ChatMessage::User {
             content: UserContent::Text("hi".into()),
+            name: None,
         }];
 
         let (system_value, out) = to_anthropic_messages(&messages, false);

--- a/crates/providers/src/async_openai_provider.rs
+++ b/crates/providers/src/async_openai_provider.rs
@@ -84,6 +84,7 @@ fn build_messages(messages: &[ChatMessage]) -> anyhow::Result<Vec<ChatCompletion
             },
             ChatMessage::User {
                 content: UserContent::Text(text),
+                ..
             } => {
                 out.push(
                     ChatCompletionRequestUserMessageArgs::default()
@@ -94,6 +95,7 @@ fn build_messages(messages: &[ChatMessage]) -> anyhow::Result<Vec<ChatCompletion
             },
             ChatMessage::User {
                 content: UserContent::Multimodal(parts),
+                ..
             } => {
                 let content_parts: Vec<ChatCompletionRequestUserMessageContentPart> = parts
                     .iter()

--- a/crates/providers/src/async_openai_provider.rs
+++ b/crates/providers/src/async_openai_provider.rs
@@ -84,18 +84,18 @@ fn build_messages(messages: &[ChatMessage]) -> anyhow::Result<Vec<ChatCompletion
             },
             ChatMessage::User {
                 content: UserContent::Text(text),
-                ..
+                name,
             } => {
-                out.push(
-                    ChatCompletionRequestUserMessageArgs::default()
-                        .content(text.as_str())
-                        .build()?
-                        .into(),
-                );
+                let mut builder = ChatCompletionRequestUserMessageArgs::default();
+                builder.content(text.as_str());
+                if let Some(name) = name {
+                    builder.name(name.clone());
+                }
+                out.push(builder.build()?.into());
             },
             ChatMessage::User {
                 content: UserContent::Multimodal(parts),
-                ..
+                name,
             } => {
                 let content_parts: Vec<ChatCompletionRequestUserMessageContentPart> = parts
                     .iter()
@@ -121,7 +121,7 @@ fn build_messages(messages: &[ChatMessage]) -> anyhow::Result<Vec<ChatCompletion
                 out.push(ChatCompletionRequestMessage::User(
                     async_openai::types::chat::ChatCompletionRequestUserMessage {
                         content: ChatCompletionRequestUserMessageContent::Array(content_parts),
-                        name: None,
+                        name: name.clone(),
                     },
                 ));
             },
@@ -248,5 +248,72 @@ impl LlmProvider for AsyncOpenAiProvider {
 
             yield StreamEvent::Done(Usage::default());
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::build_messages,
+        async_openai::types::chat::{
+            ChatCompletionRequestMessage, ChatCompletionRequestUserMessageContent,
+            ChatCompletionRequestUserMessageContentPart,
+        },
+        moltis_agents::model::{ChatMessage, ContentPart, UserContent},
+    };
+
+    #[test]
+    fn build_messages_preserves_name_for_text_user_messages() {
+        let messages = vec![ChatMessage::User {
+            content: UserContent::Text("hello".into()),
+            name: Some("Alice".into()),
+        }];
+
+        let built = build_messages(&messages).expect("messages should build");
+        assert_eq!(built.len(), 1);
+        match &built[0] {
+            ChatCompletionRequestMessage::User(msg) => {
+                assert_eq!(msg.name.as_deref(), Some("Alice"));
+                assert_eq!(
+                    msg.content,
+                    ChatCompletionRequestUserMessageContent::Text("hello".into())
+                );
+            },
+            other => panic!("expected user message, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn build_messages_preserves_name_for_multimodal_user_messages() {
+        let messages = vec![ChatMessage::User {
+            content: UserContent::Multimodal(vec![
+                ContentPart::Text("describe this".into()),
+                ContentPart::Image {
+                    media_type: "image/png".into(),
+                    data: "base64data".into(),
+                },
+            ]),
+            name: Some("Alice".into()),
+        }];
+
+        let built = build_messages(&messages).expect("messages should build");
+        assert_eq!(built.len(), 1);
+        match &built[0] {
+            ChatCompletionRequestMessage::User(msg) => {
+                assert_eq!(msg.name.as_deref(), Some("Alice"));
+                let ChatCompletionRequestUserMessageContent::Array(parts) = &msg.content else {
+                    panic!("expected array content");
+                };
+                assert!(matches!(
+                    parts.first(),
+                    Some(ChatCompletionRequestUserMessageContentPart::Text(_))
+                ));
+                assert!(matches!(
+                    parts.get(1),
+                    Some(ChatCompletionRequestUserMessageContentPart::ImageUrl(_))
+                ));
+            },
+            other => panic!("expected user message, got {other:?}"),
+        }
     }
 }

--- a/crates/providers/src/genai_provider.rs
+++ b/crates/providers/src/genai_provider.rs
@@ -63,9 +63,11 @@ fn build_genai_messages(messages: &[ChatMessage]) -> Vec<genai::chat::ChatMessag
             )),
             ChatMessage::User {
                 content: UserContent::Text(text),
+                ..
             } => Some(genai::chat::ChatMessage::user(text)),
             ChatMessage::User {
                 content: UserContent::Multimodal(_),
+                ..
             } => {
                 // genai doesn't support multimodal content; send empty string.
                 Some(genai::chat::ChatMessage::user(""))

--- a/crates/providers/src/local_gguf/chat_templates.rs
+++ b/crates/providers/src/local_gguf/chat_templates.rs
@@ -39,7 +39,7 @@ impl ChatTemplateHint {
 fn role_content(msg: &ChatMessage) -> (&str, &str) {
     match msg {
         ChatMessage::System { content } => ("system", content.as_str()),
-        ChatMessage::User { content } => match content {
+        ChatMessage::User { content, .. } => match content {
             UserContent::Text(text) => ("user", text.as_str()),
             UserContent::Multimodal(_) => ("user", ""),
         },

--- a/crates/providers/src/local_llm/models/chat_templates.rs
+++ b/crates/providers/src/local_llm/models/chat_templates.rs
@@ -39,7 +39,7 @@ impl ChatTemplateHint {
 fn role_content(msg: &ChatMessage) -> (&str, &str) {
     match msg {
         ChatMessage::System { content } => ("system", content.as_str()),
-        ChatMessage::User { content } => match content {
+        ChatMessage::User { content, .. } => match content {
             UserContent::Text(text) => ("user", text.as_str()),
             UserContent::Multimodal(_) => ("user", ""),
         },

--- a/crates/providers/src/openai_codex.rs
+++ b/crates/providers/src/openai_codex.rs
@@ -194,7 +194,7 @@ impl OpenAiCodexProvider {
                         // System messages are extracted as instructions; skip here
                         vec![]
                     },
-                    ChatMessage::User { content } => {
+                    ChatMessage::User { content, .. } => {
                         let content_blocks = match content {
                             UserContent::Text(t) => {
                                 vec![serde_json::json!({"type": "input_text", "text": t})]
@@ -1314,6 +1314,7 @@ mod tests {
                     data: "ABC123".to_string(),
                 },
             ]),
+            name: None,
         }];
         let converted = OpenAiCodexProvider::convert_messages(&messages);
         assert_eq!(converted.len(), 1);

--- a/crates/providers/src/openai_compat/mod.rs
+++ b/crates/providers/src/openai_compat/mod.rs
@@ -319,7 +319,7 @@ pub fn to_responses_input(messages: &[ChatMessage]) -> Vec<serde_json::Value> {
                 // System messages are extracted into `instructions`.
                 vec![]
             },
-            ChatMessage::User { content } => {
+            ChatMessage::User { content, .. } => {
                 let content_blocks = match content {
                     UserContent::Text(t) => {
                         vec![serde_json::json!({"type": "input_text", "text": t})]

--- a/crates/swift-bridge/src/chat.rs
+++ b/crates/swift-bridge/src/chat.rs
@@ -83,6 +83,7 @@ pub(crate) fn build_chat_response(request: ChatRequest) -> String {
                 let provider_name = provider.name().to_string();
                 let messages = vec![AgentChatMessage::User {
                     content: UserContent::text(&request.message),
+                    name: None,
                 }];
 
                 emit_log(
@@ -276,6 +277,7 @@ pub unsafe extern "C" fn moltis_chat_stream(
     let provider_name = provider.name().to_string();
     let messages = vec![AgentChatMessage::User {
         content: UserContent::text(&request.message),
+        name: None,
     }];
 
     let ctx = StreamCallbackCtx {

--- a/crates/swift-bridge/src/ffi_sessions.rs
+++ b/crates/swift-bridge/src/ffi_sessions.rs
@@ -239,6 +239,7 @@ pub unsafe extern "C" fn moltis_session_chat_stream(
     let provider_name = provider.name().to_string();
     let messages = vec![AgentChatMessage::User {
         content: UserContent::text(&request.message),
+        name: None,
     }];
 
     let ctx = StreamCallbackCtx {

--- a/crates/tools/src/spawn_agent.rs
+++ b/crates/tools/src/spawn_agent.rs
@@ -495,6 +495,7 @@ impl AgentTool for SpawnAgentTool {
             None, // no history
             Some(tool_context),
             None, // no hooks for sub-agents
+            None, // no sender name for spawned agents
         );
 
         let result = if let Some(timeout_secs) = preset.as_ref().and_then(|p| p.timeout_secs) {


### PR DESCRIPTION
## Summary
- preserve optional sender names on `ChatMessage::User` and recover them from persisted channel metadata
- thread `sender_name` through chat and agent streaming paths so provider requests keep the original channel identity
- map providers that support names directly, and prefix Anthropic user content when the API has no native `name` field

## Validation
### Completed
- [x] `just format-check`
- [x] `cargo +nightly-2025-11-30 test -p moltis-agents -p moltis-providers -p moltis-chat -p moltis-swift-bridge --lib`

### Remaining
- [ ] `./scripts/local-validate.sh 715` (stopped after partial progress to honor the repo's 5-minute command limit)

## Manual QA
- Not run, this change is backend-only.
