### PR TITLE
fix(providers): skip strict tool schemas for Google/Gemini via OpenRouter

### DIFF
--- a/crates/config/src/schema/providers.rs
+++ b/crates/config/src/schema/providers.rs
@@ -184,6 +184,17 @@ pub struct ProviderEntry {
     #[serde(default, skip_serializing_if = "is_default_cache_retention")]
     pub cache_retention: CacheRetention,
 
+    /// Whether to use OpenAI strict mode for tool schemas.
+    ///
+    /// - `true`: force strict mode (`additionalProperties: false`, all properties
+    ///   required, optional properties made nullable via array-form types).
+    /// - `false`: skip strict-mode patching. Use this for providers that reject
+    ///   array-form types like `["boolean", "null"]` (e.g. Google/Gemini).
+    /// - unset (default): auto-detect based on provider. OpenRouter and Gemini
+    ///   default to non-strict; all others default to strict.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub strict_tools: Option<bool>,
+
     /// Tool policy override for this provider. When set, these allow/deny
     /// rules are merged on top of the global `[tools.policy]` for requests
     /// routed through this provider.
@@ -204,6 +215,7 @@ impl std::fmt::Debug for ProviderEntry {
             .field("alias", &self.alias)
             .field("tool_mode", &self.tool_mode)
             .field("cache_retention", &self.cache_retention)
+            .field("strict_tools", &self.strict_tools)
             .field("policy", &self.policy)
             .finish()
     }
@@ -222,6 +234,7 @@ impl Default for ProviderEntry {
             alias: None,
             tool_mode: ToolMode::Auto,
             cache_retention: CacheRetention::Short,
+            strict_tools: None,
             policy: None,
         }
     }

--- a/crates/config/src/template.rs
+++ b/crates/config/src/template.rs
@@ -105,6 +105,7 @@ auto_generate = true              # Auto-generate local CA and server certificat
 #   fetch_models - Discover models from provider API when available (default: true)
 #   stream_transport - Streaming transport: "sse", "websocket", or "auto" (default: "sse")
 #   alias     - Custom name for metrics labels (useful for multiple instances)
+#   strict_tools - Force strict/non-strict tool schemas (default: auto-detect per provider)
 #   policy    - Per-provider tool policy override (allow/deny lists)
 
 [providers]

--- a/crates/config/src/validate/schema_map.rs
+++ b/crates/config/src/validate/schema_map.rs
@@ -43,6 +43,7 @@ pub(super) fn build_schema_map() -> KnownKeys {
             ("alias", Leaf),
             ("tool_mode", Leaf),
             ("cache_retention", Leaf),
+            ("strict_tools", Leaf),
             ("policy", tool_policy_entry()),
         ]))
     };

--- a/crates/providers/src/github_copilot/mod.rs
+++ b/crates/providers/src/github_copilot/mod.rs
@@ -545,7 +545,7 @@ async fn collect_streamed_completion(
     });
 
     if !tools.is_empty() {
-        body["tools"] = serde_json::Value::Array(to_openai_tools(tools));
+        body["tools"] = serde_json::Value::Array(to_openai_tools(tools, true));
     }
 
     debug!(
@@ -888,7 +888,7 @@ impl LlmProvider for GitHubCopilotProvider {
         });
 
         if !tools.is_empty() {
-            body["tools"] = serde_json::Value::Array(to_openai_tools(tools));
+            body["tools"] = serde_json::Value::Array(to_openai_tools(tools, true));
         }
 
         debug!(
@@ -1222,7 +1222,7 @@ impl GitHubCopilotProvider {
             });
 
             if !tools.is_empty() {
-                body["tools"] = serde_json::Value::Array(to_openai_tools(&tools));
+                body["tools"] = serde_json::Value::Array(to_openai_tools(&tools, true));
             }
 
             debug!(

--- a/crates/providers/src/kimi_code.rs
+++ b/crates/providers/src/kimi_code.rs
@@ -214,7 +214,7 @@ impl LlmProvider for KimiCodeProvider {
         });
 
         if !tools.is_empty() {
-            body["tools"] = serde_json::Value::Array(to_openai_tools(tools));
+            body["tools"] = serde_json::Value::Array(to_openai_tools(tools, true));
         }
 
         debug!(
@@ -309,7 +309,7 @@ impl LlmProvider for KimiCodeProvider {
             });
 
             if !tools.is_empty() {
-                body["tools"] = serde_json::Value::Array(to_openai_tools(&tools));
+                body["tools"] = serde_json::Value::Array(to_openai_tools(&tools, true));
             }
 
             debug!(
@@ -529,7 +529,7 @@ mod tests {
             });
 
             if !tools.is_empty() {
-                body["tools"] = serde_json::Value::Array(to_openai_tools(tools));
+                body["tools"] = serde_json::Value::Array(to_openai_tools(tools, true));
             }
 
             let http_resp = self

--- a/crates/providers/src/openai/mod.rs
+++ b/crates/providers/src/openai/mod.rs
@@ -27,6 +27,8 @@ pub struct OpenAiProvider {
     reasoning_effort: Option<moltis_agents::model::ReasoningEffort>,
     /// Prompt cache retention policy (used for OpenRouter Anthropic passthrough).
     cache_retention: moltis_config::CacheRetention,
+    /// Explicit override for strict tool schema mode. `None` = auto-detect.
+    strict_tools_override: Option<bool>,
 }
 
 const OPENAI_MODELS_ENDPOINT_PATH: &str = "/models";

--- a/crates/providers/src/openai/provider/completion.rs
+++ b/crates/providers/src/openai/provider/completion.rs
@@ -225,7 +225,8 @@ impl OpenAiProvider {
         self.apply_system_prompt_rewrite(&mut body);
 
         if !tools.is_empty() {
-            body["tools"] = serde_json::Value::Array(to_openai_tools(tools));
+            body["tools"] =
+                serde_json::Value::Array(to_openai_tools(tools, self.needs_strict_tools()));
         }
 
         self.apply_reasoning_effort_chat(&mut body);

--- a/crates/providers/src/openai/provider/mod.rs
+++ b/crates/providers/src/openai/provider/mod.rs
@@ -36,6 +36,7 @@ impl OpenAiProvider {
             tool_mode_override: None,
             reasoning_effort: None,
             cache_retention: moltis_config::CacheRetention::Short,
+            strict_tools_override: None,
         }
     }
 
@@ -57,6 +58,7 @@ impl OpenAiProvider {
             tool_mode_override: None,
             reasoning_effort: None,
             cache_retention: moltis_config::CacheRetention::Short,
+            strict_tools_override: None,
         }
     }
 
@@ -81,6 +83,12 @@ impl OpenAiProvider {
     #[must_use]
     pub fn with_wire_api(mut self, wire_api: WireApi) -> Self {
         self.wire_api = wire_api;
+        self
+    }
+
+    #[must_use]
+    pub fn with_strict_tools(mut self, strict: bool) -> Self {
+        self.strict_tools_override = Some(strict);
         self
     }
 
@@ -163,6 +171,7 @@ impl LlmProvider for OpenAiProvider {
             reasoning_effort: Some(effort),
             wire_api: self.wire_api,
             cache_retention: self.cache_retention,
+            strict_tools_override: self.strict_tools_override,
         }))
     }
 

--- a/crates/providers/src/openai/provider/request.rs
+++ b/crates/providers/src/openai/provider/request.rs
@@ -75,6 +75,30 @@ impl OpenAiProvider {
         }
     }
 
+    /// Returns `true` when tool schemas should use OpenAI strict mode.
+    ///
+    /// Strict mode is an OpenAI-specific feature that adds `additionalProperties:
+    /// false` and forces all properties into the `required` array (making
+    /// originally-optional ones nullable via array-form types like
+    /// `["boolean", "null"]`).
+    ///
+    /// The `strict_tools` config field overrides auto-detection when set.
+    /// When unset, providers whose backends reject array-form types default to
+    /// non-strict: OpenRouter (proxies to Google, Anthropic, Meta, etc.) and
+    /// Gemini direct.
+    pub(super) fn needs_strict_tools(&self) -> bool {
+        if let Some(explicit) = self.strict_tools_override {
+            return explicit;
+        }
+        if self.base_url.contains("openrouter.ai") {
+            return false;
+        }
+        if self.provider_name.eq_ignore_ascii_case("gemini") {
+            return false;
+        }
+        true
+    }
+
     fn requires_reasoning_content_on_tool_messages(&self) -> bool {
         self.provider_name.eq_ignore_ascii_case("moonshot")
             || self.base_url.contains("moonshot.ai")

--- a/crates/providers/src/openai/provider/request.rs
+++ b/crates/providers/src/openai/provider/request.rs
@@ -84,8 +84,8 @@ impl OpenAiProvider {
     ///
     /// The `strict_tools` config field overrides auto-detection when set.
     /// When unset, providers whose backends reject array-form types default to
-    /// non-strict: OpenRouter (proxies to Google, Anthropic, Meta, etc.) and
-    /// Gemini direct.
+    /// non-strict: OpenRouter (proxies to Google, Anthropic, Meta, etc.),
+    /// Gemini direct, and Vertex AI (`googleapis.com`).
     pub(super) fn needs_strict_tools(&self) -> bool {
         if let Some(explicit) = self.strict_tools_override {
             return explicit;
@@ -93,7 +93,9 @@ impl OpenAiProvider {
         if self.base_url.contains("openrouter.ai") {
             return false;
         }
-        if self.provider_name.eq_ignore_ascii_case("gemini") {
+        if self.provider_name.eq_ignore_ascii_case("gemini")
+            || self.base_url.contains("googleapis.com")
+        {
             return false;
         }
         true

--- a/crates/providers/src/openai/provider/streaming.rs
+++ b/crates/providers/src/openai/provider/streaming.rs
@@ -173,7 +173,8 @@ impl OpenAiProvider {
             self.apply_system_prompt_rewrite(&mut body);
 
             if !tools.is_empty() {
-                body["tools"] = serde_json::Value::Array(to_openai_tools(&tools));
+                body["tools"] =
+                    serde_json::Value::Array(to_openai_tools(&tools, self.needs_strict_tools()));
             }
 
             self.apply_reasoning_effort_chat(&mut body);

--- a/crates/providers/src/openai_compat/mod.rs
+++ b/crates/providers/src/openai_compat/mod.rs
@@ -214,22 +214,25 @@ pub fn patch_schema_for_strict_mode(schema: &mut serde_json::Value) {
 /// { "type": "function", "function": { "name": "...", ... } }
 /// ```
 ///
-/// Adds `strict: true` and patches schemas for strict mode compliance:
+/// When `strict` is `true`, patches schemas for strict mode compliance:
 /// - `additionalProperties: false` on all object schemas
 /// - All properties included in `required` array
+/// - Originally-optional properties made nullable via array-form types
 ///
-/// This is required by some APIs (Claude via Copilot) to ensure the model
-/// provides all required fields.
+/// When `strict` is `false`, schemas are sanitized but not patched for strict
+/// mode. This avoids array-form types like `["boolean", "null"]` that
+/// non-OpenAI backends (e.g. Google via OpenRouter) reject.
 ///
 /// See: <https://platform.openai.com/docs/guides/function-calling>
-pub fn to_openai_tools(tools: &[serde_json::Value]) -> Vec<serde_json::Value> {
+pub fn to_openai_tools(tools: &[serde_json::Value], strict: bool) -> Vec<serde_json::Value> {
     let result: Vec<serde_json::Value> = tools
         .iter()
         .filter_map(|t| {
-            // Clone parameters and patch for strict mode
             let mut params = t["parameters"].clone();
             sanitize_schema_for_openai_compat(&mut params);
-            patch_schema_for_strict_mode(&mut params);
+            if strict {
+                patch_schema_for_strict_mode(&mut params);
+            }
 
             let name = t["name"].as_str()?.to_string();
             let description = t["description"].as_str().unwrap_or("").to_string();
@@ -241,11 +244,11 @@ pub fn to_openai_tools(tools: &[serde_json::Value]) -> Vec<serde_json::Value> {
                     name: name.clone(),
                     description,
                     parameters: params,
-                    strict: true,
+                    strict,
                 },
             };
 
-            trace!(tool_name = %name, "converted tool to Chat Completions format");
+            trace!(tool_name = %name, strict, "converted tool to Chat Completions format");
 
             // Serialize to Value for compatibility with existing API
             serde_json::to_value(tool).ok()
@@ -1117,7 +1120,7 @@ pub fn parse_responses_completion(resp: &serde_json::Value) -> CompletionRespons
 mod tests {
     use super::{
         parse_responses_completion, parse_tool_calls, sanitize_schema_for_openai_compat,
-        to_responses_api_tools,
+        to_openai_tools, to_responses_api_tools,
     };
 
     #[test]
@@ -1379,5 +1382,153 @@ mod tests {
         };
         assert!(tuple_items[0].get("not").is_none());
         assert!(tuple_items[1].get("patternProperties").is_none());
+    }
+
+    #[test]
+    fn to_openai_tools_strict_mode_applied_by_default() {
+        let tools = vec![serde_json::json!({
+            "name": "create_file",
+            "description": "Create a file",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "path": { "type": "string" },
+                    "content": { "type": "string" },
+                    "overwrite": { "type": "boolean" }
+                },
+                "required": ["path"]
+            }
+        })];
+
+        let converted = to_openai_tools(&tools, true);
+        assert_eq!(converted.len(), 1);
+
+        let func = &converted[0]["function"];
+        assert_eq!(func["strict"], true);
+        assert_eq!(func["parameters"]["additionalProperties"], false);
+
+        // All properties must be in the required array.
+        let Some(required) = func["parameters"]["required"].as_array() else {
+            panic!("required should be an array");
+        };
+        let required_names: Vec<&str> = required.iter().filter_map(|v| v.as_str()).collect();
+        assert!(required_names.contains(&"path"));
+        assert!(required_names.contains(&"content"));
+        assert!(required_names.contains(&"overwrite"));
+    }
+
+    #[test]
+    fn to_openai_tools_non_strict_skips_patching() {
+        let tools = vec![serde_json::json!({
+            "name": "create_file",
+            "description": "Create a file",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "path": { "type": "string" },
+                    "content": { "type": "string" },
+                    "overwrite": { "type": "boolean" }
+                },
+                "required": ["path"]
+            }
+        })];
+
+        let converted = to_openai_tools(&tools, false);
+        assert_eq!(converted.len(), 1);
+
+        let func = &converted[0]["function"];
+        assert_eq!(func["strict"], false);
+
+        // strict-mode patching must NOT have run: no additionalProperties
+        // and no array-form nullable types like ["boolean","null"].
+        let serialized = func["parameters"].to_string();
+        assert!(
+            !serialized.contains("additionalProperties"),
+            "strict mode should not inject additionalProperties: {serialized}"
+        );
+        assert!(
+            !serialized.contains("[\"boolean\""),
+            "strict mode should not produce array-form types: {serialized}"
+        );
+        assert!(
+            !serialized.contains("[\"string\""),
+            "strict mode should not produce array-form types: {serialized}"
+        );
+    }
+
+    #[test]
+    fn to_openai_tools_non_strict_complex_cron_like_schema() {
+        // Schema modeled after the cron tool's `job` property: nested objects,
+        // optional booleans, enum fields — the shapes that trigger Google's
+        // INVALID_ARGUMENT when strict-mode array types are present.
+        let tools = vec![serde_json::json!({
+            "name": "schedule_cron",
+            "description": "Schedule a cron job",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "name": { "type": "string" },
+                    "job": {
+                        "type": "object",
+                        "properties": {
+                            "enabled": { "type": "boolean" },
+                            "schedule": { "type": "string" },
+                            "retry": { "type": "boolean" },
+                            "mode": {
+                                "type": "string",
+                                "enum": ["once", "recurring"]
+                            },
+                            "config": {
+                                "type": "object",
+                                "properties": {
+                                    "timeout": { "type": "integer" },
+                                    "verbose": { "type": "boolean" }
+                                },
+                                "required": ["timeout"]
+                            }
+                        },
+                        "required": ["schedule"]
+                    }
+                },
+                "required": ["name", "job"]
+            }
+        })];
+
+        let converted = to_openai_tools(&tools, false);
+        let func = &converted[0]["function"];
+        assert_eq!(func["strict"], false);
+
+        // No array-form types anywhere in the output.
+        let serialized = func["parameters"].to_string();
+        // Array-form types look like `["boolean","null"]` — must not appear.
+        assert!(
+            !serialized.contains("[\"boolean\""),
+            "should not contain array-form types: {serialized}"
+        );
+        assert!(
+            !serialized.contains("[\"string\""),
+            "should not contain array-form types: {serialized}"
+        );
+        assert!(
+            !serialized.contains("[\"integer\""),
+            "should not contain array-form types: {serialized}"
+        );
+
+        // Original required arrays preserved.
+        let Some(job_required) = func["parameters"]["properties"]["job"]["required"].as_array()
+        else {
+            panic!("job required should be an array");
+        };
+        assert_eq!(job_required.len(), 1);
+        assert_eq!(job_required[0], "schedule");
+
+        // Nested object required array also preserved.
+        let Some(config_required) =
+            func["parameters"]["properties"]["job"]["properties"]["config"]["required"].as_array()
+        else {
+            panic!("config required should be an array");
+        };
+        assert_eq!(config_required.len(), 1);
+        assert_eq!(config_required[0], "timeout");
     }
 }

--- a/crates/providers/src/registry/registration.rs
+++ b/crates/providers/src/registry/registration.rs
@@ -202,6 +202,9 @@ impl ProviderRegistry {
                 if !matches!(effective_tool_mode, moltis_config::ToolMode::Auto) {
                     oai = oai.with_tool_mode(effective_tool_mode);
                 }
+                if let Some(strict) = config.get(def.config_name).and_then(|e| e.strict_tools) {
+                    oai = oai.with_strict_tools(strict);
+                }
 
                 self.register(
                     ModelInfo {
@@ -899,6 +902,9 @@ impl ProviderRegistry {
                 if !matches!(effective_tool_mode, moltis_config::ToolMode::Auto) {
                     oai = oai.with_tool_mode(effective_tool_mode);
                 }
+                if let Some(strict) = config.get(def.config_name).and_then(|e| e.strict_tools) {
+                    oai = oai.with_strict_tools(strict);
+                }
 
                 let provider = Arc::new(oai);
                 self.register(
@@ -988,6 +994,9 @@ impl ProviderRegistry {
                 }
                 if !matches!(custom_tool_mode, moltis_config::ToolMode::Auto) {
                     oai = oai.with_tool_mode(custom_tool_mode);
+                }
+                if let Some(strict) = entry.strict_tools {
+                    oai = oai.with_strict_tools(strict);
                 }
                 let provider = Arc::new(oai);
                 self.register(

--- a/crates/providers/tests/e2e_scenarios/tool_arg_serialization.json
+++ b/crates/providers/tests/e2e_scenarios/tool_arg_serialization.json
@@ -32,6 +32,9 @@
         "zai": {
           "mode": "must_pass"
         },
+        "openrouter-google": {
+          "mode": "must_pass"
+        },
         "alibaba-coding": {
           "mode": "allow_known_mismatch",
           "reason": "qwen3.5-plus currently serializes null as an empty string on the Alibaba coding endpoint",
@@ -42,6 +45,61 @@
             "multiline": false,
             "type": ""
           }
+        }
+      }
+    },
+    {
+      "id": "issue-716-nested-optional-booleans",
+      "prompt": "Schedule a cron job named 'db-backup' with schedule '0 0 * * *', enabled true, retry false, mode 'recurring', timeout 300, and verbose false. Use the schedule_cron tool.",
+      "tool": {
+        "name": "schedule_cron",
+        "description": "You MUST call this tool exactly once with the exact values requested by the user. Do not convert, normalize, or omit values.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "name": { "type": "string", "description": "Job name" },
+            "job": {
+              "type": "object",
+              "properties": {
+                "enabled": { "type": "boolean", "description": "Whether the job is enabled" },
+                "schedule": { "type": "string", "description": "Cron expression" },
+                "retry": { "type": "boolean", "description": "Retry on failure" },
+                "mode": {
+                  "type": "string",
+                  "enum": ["once", "recurring"],
+                  "description": "Execution mode"
+                },
+                "config": {
+                  "type": "object",
+                  "properties": {
+                    "timeout": { "type": "integer", "description": "Timeout in seconds" },
+                    "verbose": { "type": "boolean", "description": "Enable verbose logging" }
+                  },
+                  "required": ["timeout"]
+                }
+              },
+              "required": ["schedule"]
+            }
+          },
+          "required": ["name", "job"]
+        }
+      },
+      "expected_arguments": {
+        "name": "db-backup",
+        "job": {
+          "enabled": true,
+          "schedule": "0 0 * * *",
+          "retry": false,
+          "mode": "recurring",
+          "config": {
+            "timeout": 300,
+            "verbose": false
+          }
+        }
+      },
+      "providers": {
+        "openrouter-google": {
+          "mode": "must_pass"
         }
       }
     }

--- a/crates/providers/tests/tool_arg_serialization_integration.rs
+++ b/crates/providers/tests/tool_arg_serialization_integration.rs
@@ -235,3 +235,21 @@ async fn alibaba_coding_serialization_scenarios_non_streaming() {
 
     run_provider_scenarios(config.provider_name, provider).await;
 }
+
+#[tokio::test]
+#[ignore]
+async fn openrouter_google_serialization_scenarios_non_streaming() {
+    let config = ProviderConfig {
+        provider_name: "openrouter-google",
+        api_key_env: "OPENROUTER_API_KEY",
+        base_url_env: None,
+        default_base_url: "https://openrouter.ai/api/v1",
+        model_env: "SERIALIZATION_TEST_OPENROUTER_GOOGLE_MODEL",
+        default_model: "google/gemma-4-31b-it:free",
+    };
+    let Some(provider) = configured_provider(&config) else {
+        return;
+    };
+
+    run_provider_scenarios(config.provider_name, provider).await;
+}


### PR DESCRIPTION
## Summary

Fixes #716.

- Google's native API (reached via OpenRouter) rejects array-form types like `["boolean","null"]` that OpenAI strict mode produces in tool schemas. The cron tool's nested optional booleans triggered `INVALID_ARGUMENT` errors.
- Parameterize `to_openai_tools()` with a `strict: bool` flag — when `false`, skip `patch_schema_for_strict_mode()` and set `strict: false` in the payload.
- Auto-detect: OpenRouter and Gemini direct default to non-strict; all others default to strict.
- Add `strict_tools` config field on `ProviderEntry` so users can override per-provider for any backend.
- Add e2e scenario (`issue-716-nested-optional-booleans`) to the serialization test framework, covering `openrouter-google` on both the new nested-schema scenario and the existing #693 falsy/null scenario.

## Validation

### Completed

- [x] `cargo +nightly-2025-11-30 fmt --all -- --check`
- [x] `just lint`
- [x] `cargo test -p moltis-providers --lib` (97 passed)
- [x] `cargo test -p moltis-config --lib` (227 passed)
- [x] `cargo check --workspace`

### Remaining

- [ ] `OPENROUTER_API_KEY=... cargo test --test tool_arg_serialization_integration -- --ignored openrouter_google`
- [ ] `./scripts/local-validate.sh 716`

## Manual QA

1. Configure OpenRouter with a Google model (e.g. `google/gemma-4-31b-it:free`)
2. Trigger a tool call that uses the cron tool (nested objects, optional booleans)
3. Confirm the request no longer fails with `INVALID_ARGUMENT`
4. Verify OpenAI models via OpenRouter still work with tool calling
5. Optionally set `strict_tools = false` on a custom provider and confirm it skips strict patching

🤖 Generated with [Claude Code](https://claude.com/claude-code)