### PR TITLE
feat(config): per-model context window overrides (PR 1/N)

### DIFF
--- a/crates/config/src/schema/providers.rs
+++ b/crates/config/src/schema/providers.rs
@@ -20,7 +20,7 @@ pub struct OAuthProviderConfig {
 
 /// Override configuration for a specific model.
 ///
-/// Used in both `[models.<id>]` (global) and `[providers.<name>.models.<id>]`
+/// Used in both `[models.<id>]` (global) and `[providers.<name>.model_overrides.<id>]`
 /// (provider-scoped) sections of `moltis.toml`.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(default)]
@@ -30,7 +30,7 @@ pub struct ModelOverride {
     /// When set, this value takes precedence over the built-in heuristic.
     /// Must be between 1 and 10,000,000 (inclusive).
     ///
-    /// Provider-scoped overrides (`[providers.<name>.models.<id>]`)
+    /// Provider-scoped overrides (`[providers.<name>.model_overrides.<id>]`)
     /// take precedence over global overrides (`[models.<id>]`).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub context_window: Option<u32>,
@@ -202,6 +202,17 @@ pub struct ProviderEntry {
     #[serde(default, skip_serializing_if = "is_default_cache_retention")]
     pub cache_retention: CacheRetention,
 
+    /// Whether to use OpenAI strict mode for tool schemas.
+    ///
+    /// - `true`: force strict mode (`additionalProperties: false`, all properties
+    ///   required, optional properties made nullable via array-form types).
+    /// - `false`: skip strict-mode patching. Use this for providers that reject
+    ///   array-form types like `["boolean", "null"]` (e.g. Google/Gemini).
+    /// - unset (default): auto-detect based on provider. OpenRouter and Gemini
+    ///   default to non-strict; all others default to strict.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub strict_tools: Option<bool>,
+
     /// Tool policy override for this provider. When set, these allow/deny
     /// rules are merged on top of the global `[tools.policy]` for requests
     /// routed through this provider.
@@ -234,6 +245,7 @@ impl std::fmt::Debug for ProviderEntry {
             .field("alias", &self.alias)
             .field("tool_mode", &self.tool_mode)
             .field("cache_retention", &self.cache_retention)
+            .field("strict_tools", &self.strict_tools)
             .field("policy", &self.policy)
             .field("model_overrides", &self.model_overrides)
             .finish()
@@ -253,6 +265,7 @@ impl Default for ProviderEntry {
             alias: None,
             tool_mode: ToolMode::Auto,
             cache_retention: CacheRetention::Short,
+            strict_tools: None,
             policy: None,
             model_overrides: HashMap::new(),
         }

--- a/crates/config/src/schema/providers.rs
+++ b/crates/config/src/schema/providers.rs
@@ -202,17 +202,6 @@ pub struct ProviderEntry {
     #[serde(default, skip_serializing_if = "is_default_cache_retention")]
     pub cache_retention: CacheRetention,
 
-    /// Whether to use OpenAI strict mode for tool schemas.
-    ///
-    /// - `true`: force strict mode (`additionalProperties: false`, all properties
-    ///   required, optional properties made nullable via array-form types).
-    /// - `false`: skip strict-mode patching. Use this for providers that reject
-    ///   array-form types like `["boolean", "null"]` (e.g. Google/Gemini).
-    /// - unset (default): auto-detect based on provider. OpenRouter and Gemini
-    ///   default to non-strict; all others default to strict.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub strict_tools: Option<bool>,
-
     /// Tool policy override for this provider. When set, these allow/deny
     /// rules are merged on top of the global `[tools.policy]` for requests
     /// routed through this provider.
@@ -245,7 +234,6 @@ impl std::fmt::Debug for ProviderEntry {
             .field("alias", &self.alias)
             .field("tool_mode", &self.tool_mode)
             .field("cache_retention", &self.cache_retention)
-            .field("strict_tools", &self.strict_tools)
             .field("policy", &self.policy)
             .field("model_overrides", &self.model_overrides)
             .finish()
@@ -265,7 +253,6 @@ impl Default for ProviderEntry {
             alias: None,
             tool_mode: ToolMode::Auto,
             cache_retention: CacheRetention::Short,
-            strict_tools: None,
             policy: None,
             model_overrides: HashMap::new(),
         }

--- a/crates/config/src/template.rs
+++ b/crates/config/src/template.rs
@@ -105,7 +105,6 @@ auto_generate = true              # Auto-generate local CA and server certificat
 #   fetch_models - Discover models from provider API when available (default: true)
 #   stream_transport - Streaming transport: "sse", "websocket", or "auto" (default: "sse")
 #   alias     - Custom name for metrics labels (useful for multiple instances)
-#   strict_tools - Force strict/non-strict tool schemas (default: auto-detect per provider)
 #   policy    - Per-provider tool policy override (allow/deny lists)
 #   model_overrides.<model_id>.context_window - Override context window for a specific model
 
@@ -867,8 +866,9 @@ reset_on_exit = true              # Reset serve/funnel when gateway shuts down
 
 [channels]
 # Which channel types appear in the web UI's "+ Add Channel" menu.
-# Default: ["telegram", "whatsapp", "msteams", "discord", "slack", "matrix", "nostr"]
-# offered = ["telegram", "whatsapp", "msteams", "discord", "slack", "matrix", "nostr"]
+# Default: ["telegram", "msteams", "discord", "slack", "matrix", "nostr"]
+# Add "whatsapp" to enable it in the UI.
+# offered = ["telegram", "msteams", "discord", "slack", "matrix", "nostr", "whatsapp"]
 
 # WhatsApp linked-device accounts
 # [channels.whatsapp.my-bot]

--- a/crates/config/src/template.rs
+++ b/crates/config/src/template.rs
@@ -105,6 +105,7 @@ auto_generate = true              # Auto-generate local CA and server certificat
 #   fetch_models - Discover models from provider API when available (default: true)
 #   stream_transport - Streaming transport: "sse", "websocket", or "auto" (default: "sse")
 #   alias     - Custom name for metrics labels (useful for multiple instances)
+#   strict_tools - Force strict/non-strict tool schemas (default: auto-detect per provider)
 #   policy    - Per-provider tool policy override (allow/deny lists)
 #   model_overrides.<model_id>.context_window - Override context window for a specific model
 

--- a/crates/config/src/validate/schema_map.rs
+++ b/crates/config/src/validate/schema_map.rs
@@ -45,6 +45,7 @@ pub(super) fn build_schema_map() -> KnownKeys {
             ("alias", Leaf),
             ("tool_mode", Leaf),
             ("cache_retention", Leaf),
+            ("strict_tools", Leaf),
             ("policy", tool_policy_entry()),
             ("model_overrides", Map(Box::new(model_override()))),
         ]))

--- a/crates/config/src/validate/schema_map.rs
+++ b/crates/config/src/validate/schema_map.rs
@@ -45,7 +45,6 @@ pub(super) fn build_schema_map() -> KnownKeys {
             ("alias", Leaf),
             ("tool_mode", Leaf),
             ("cache_retention", Leaf),
-            ("strict_tools", Leaf),
             ("policy", tool_policy_entry()),
             ("model_overrides", Map(Box::new(model_override()))),
         ]))

--- a/crates/config/src/validate/semantic.rs
+++ b/crates/config/src/validate/semantic.rs
@@ -749,7 +749,7 @@ pub(super) fn check_semantic_warnings(config: &MoltisConfig, diagnostics: &mut V
         for (model_id, override_cfg) in &provider_entry.model_overrides {
             validate_context_window(
                 override_cfg.context_window,
-                &format!("providers.{provider_name}.models.{model_id}.context_window"),
+                &format!("providers.{provider_name}.model_overrides.{model_id}.context_window"),
                 diagnostics,
             );
         }


### PR DESCRIPTION
## Summary

Allow users to override context window sizes per model via `moltis.toml`, with a 3-level precedence chain: **provider-scoped > global > hardcoded heuristic**.

## Config Shape

```toml
# Global override (all providers)
[models.claude-opus-4-6]
context_window = 1_000_000

# Provider-scoped (takes precedence over global)
[providers.zai-code.model_overrides.glm-5-turbo]
context_window = 200_000
```

## Changes

| Area | File | Change |
|------|------|--------|
| Schema | `crates/config/src/schema/providers.rs` | `ModelOverride` struct, `model_overrides` on `ProviderEntry` |
| Schema | `crates/config/src/schema.rs` | `models: HashMap<String, ModelOverride>` on `MoltisConfig` |
| Validation | `crates/config/src/validate/schema_map.rs` | Schema map entries for new keys |
| Validation | `crates/config/src/validate/semantic.rs` | `validate_context_window()` helper (error on 0, warn on >10M) |
| Resolution | `crates/providers/src/model_capabilities.rs` | `context_window_for_model_with_config()` with precedence chain |
| Export | `crates/providers/src/lib.rs` | Export new function |
| Template | `crates/config/src/template.rs` | Documented new sections with examples |
| Docs | `docs/src/configuration-reference.md` | Documented `ModelOverride`, `models`, `model_overrides` |

## Tests

5 new unit tests covering:
- Empty overrides → heuristic fallback
- Global override > heuristic
- Provider override > global
- Normalized model ID matching
- Override isolation (no cross-model leakage)

## Design Notes

- **Fully backward compatible** — all new fields use `#[serde(default)]` and `skip_serializing_if`
- **Providers crate independent** — `context_window_for_model_with_config()` accepts `HashMap<String, u32>`, not `ModelOverride`, to avoid a config→providers dependency
- Config keys use **normalized** model IDs (after `capability_model_id()` processing)
- `#[must_use]` on both context window functions

## Part of Series

PR 1 of N:
- **PR 1** (this): Config schema + resolution function
- **PR 2**: Wire config into provider trait impls + compaction
- **PR 3**: Provider API metadata integration (full precedence chain)
- **PR 4**: Heuristic accuracy fixes + observability