### PR TITLE
[codex] fix(providers): normalize qwen system messages

### DIFF
--- a/.github/workflows/provider-integration.yml
+++ b/.github/workflows/provider-integration.yml
@@ -324,6 +324,75 @@ jobs:
           if-no-files-found: ignore
           retention-days: 14
 
+  ollama-qwen-live-e2e:
+    name: Ollama Qwen Live E2E
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    continue-on-error: true
+    env:
+      MOLTIS_E2E_OLLAMA_QWEN_LIVE: "1"
+      MOLTIS_E2E_OLLAMA_QWEN_MODEL: qwen2.5:0.5b
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - uses: dtolnay/rust-toolchain@f7ccc83f9ed1e5b9c81d8a67d7ad1a747e22a561 # master
+        with:
+          toolchain: stable
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: "22"
+          package-manager-cache: false
+
+      - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2
+        with:
+          shared-key: ollama-qwen-live-e2e-v1
+          cache-all-crates: true
+
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cmake build-essential clang libclang-dev pkg-config curl
+
+      - name: Install Ollama
+        run: curl -fsSL https://ollama.com/install.sh | sh
+
+      - name: Install npm dependencies
+        working-directory: crates/web/ui
+        run: npm ci
+
+      - name: Build Tailwind CSS
+        run: |
+          ./scripts/download-tailwindcss-cli.sh tailwindcss-linux-x64
+          cd crates/web/ui && TAILWINDCSS=../../../tailwindcss-linux-x64 ./build.sh
+
+      - name: Build moltis binary
+        run: cargo build --bin moltis
+
+      - name: Install Playwright browsers
+        working-directory: crates/web/ui
+        run: npx playwright install --with-deps chromium
+
+      - name: Run Ollama Qwen live E2E
+        working-directory: crates/web/ui
+        env:
+          CI: "true"
+        run: npx playwright test --project=ollama-qwen-live e2e/specs/ollama-qwen-live.spec.js
+
+      - name: Upload Ollama Qwen live E2E results
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: ollama-qwen-live-e2e-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            crates/web/ui/playwright-report/
+            crates/web/ui/test-results/
+          if-no-files-found: ignore
+          retention-days: 14
+
   summary:
     name: Integration Summary
     runs-on: ubuntu-latest
@@ -333,6 +402,7 @@ jobs:
       - provider-tests
       - provider-e2e-scenarios
       - openai-live-e2e
+      - ollama-qwen-live-e2e
     if: always()
     steps:
       - name: Report

--- a/.github/workflows/provider-integration.yml
+++ b/.github/workflows/provider-integration.yml
@@ -355,10 +355,18 @@ jobs:
       - name: Install build dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y cmake build-essential clang libclang-dev pkg-config curl
+          sudo apt-get install -y cmake build-essential clang libclang-dev pkg-config curl zstd
 
       - name: Install Ollama
-        run: curl -fsSL https://ollama.com/install.sh | sh
+        env:
+          OLLAMA_VERSION: v0.20.7
+          OLLAMA_TARBALL: ollama-linux-amd64.tar.zst
+          OLLAMA_TARBALL_SHA256: 193c41ffee30411a76af4484dae9cdd4c2d6f8f877b7096925c36f2489af131f
+        run: |
+          curl -fsSL -o ollama.tar.zst "https://github.com/ollama/ollama/releases/download/${OLLAMA_VERSION}/${OLLAMA_TARBALL}"
+          echo "${OLLAMA_TARBALL_SHA256}  ollama.tar.zst" | sha256sum -c -
+          sudo tar --use-compress-program=unzstd -C /usr -xf ollama.tar.zst
+          ollama --version
 
       - name: Install npm dependencies
         working-directory: crates/web/ui

--- a/crates/providers/src/openai/provider/request.rs
+++ b/crates/providers/src/openai/provider/request.rs
@@ -2,9 +2,16 @@ use std::collections::{HashMap, HashSet};
 
 use tracing::warn;
 
-use moltis_agents::model::ChatMessage;
+use {crate::raw_model_id, moltis_agents::model::ChatMessage};
 
 use super::OpenAiProvider;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SystemMessageRewriteStrategy {
+    None,
+    MergeLeadingSystem,
+    InlineIntoFirstUser,
+}
 
 impl OpenAiProvider {
     /// Returns `true` when this provider targets an Anthropic model via
@@ -117,18 +124,40 @@ impl OpenAiProvider {
             || self.base_url.to_ascii_lowercase().contains("minimax")
     }
 
-    /// For providers that reject `role: "system"` in the messages array,
-    /// extract all system messages from `body["messages"]`, join their
-    /// content, and prepend it to the first user message.
+    /// Some backends ship chat templates that only accept a single system
+    /// message at the front of the conversation. Qwen-based OpenAI-compatible
+    /// backends commonly behave this way (e.g. llama.cpp chat templates).
+    fn requires_single_leading_system_message(&self) -> bool {
+        raw_model_id(&self.model)
+            .to_ascii_lowercase()
+            .contains("qwen")
+    }
+
+    fn system_message_rewrite_strategy(&self) -> SystemMessageRewriteStrategy {
+        if self.rejects_system_role() {
+            return SystemMessageRewriteStrategy::InlineIntoFirstUser;
+        }
+        if self.requires_single_leading_system_message() {
+            return SystemMessageRewriteStrategy::MergeLeadingSystem;
+        }
+        SystemMessageRewriteStrategy::None
+    }
+
+    /// Rewrite system messages for providers with stricter chat template rules.
     ///
     /// MiniMax's `/v1/chat/completions` endpoint returns error 2013 for
     /// `role: "system"` entries and silently ignores a top-level `"system"`
     /// field. The only reliable way to deliver the system prompt is to
     /// inline it into the first user message.
     ///
+    /// Qwen-based OpenAI-compatible backends often only accept a single system
+    /// message at the very front. For those, join all system messages with
+    /// blank lines and emit exactly one leading `role: "system"` message.
+    ///
     /// Must be called on the request body **after** it is fully assembled.
     pub(super) fn apply_system_prompt_rewrite(&self, body: &mut serde_json::Value) {
-        if !self.rejects_system_role() {
+        let rewrite_strategy = self.system_message_rewrite_strategy();
+        if matches!(rewrite_strategy, SystemMessageRewriteStrategy::None) {
             return;
         }
         let Some(messages) = body
@@ -145,7 +174,10 @@ impl OpenAiProvider {
                 {
                     system_parts.push(content.to_string());
                 } else if msg.get("content").is_some() {
-                    warn!("MiniMax system message has non-string content; it will be dropped");
+                    warn!(
+                        ?rewrite_strategy,
+                        "system message has non-string content; it will be dropped"
+                    );
                 }
                 return false;
             }
@@ -155,6 +187,20 @@ impl OpenAiProvider {
             return;
         }
         let system_text = system_parts.join("\n\n");
+
+        if matches!(
+            rewrite_strategy,
+            SystemMessageRewriteStrategy::MergeLeadingSystem
+        ) {
+            messages.insert(
+                0,
+                serde_json::json!({
+                    "role": "system",
+                    "content": system_text,
+                }),
+            );
+            return;
+        }
 
         // Find the first user message and prepend system content to it.
         let system_block =
@@ -346,4 +392,100 @@ fn assign_openai_tool_call_id(
     used_tool_call_ids.insert(candidate.clone());
     remapped_tool_call_ids.insert(raw.to_string(), candidate.clone());
     candidate
+}
+
+#[cfg(test)]
+mod tests {
+    use secrecy::Secret;
+
+    use super::*;
+
+    fn provider(model: &str, provider_name: &str, base_url: &str) -> OpenAiProvider {
+        OpenAiProvider::new_with_name(
+            Secret::new("test-key".to_string()),
+            model.to_string(),
+            base_url.to_string(),
+            provider_name.to_string(),
+        )
+    }
+
+    fn body_messages(body: &serde_json::Value) -> &[serde_json::Value] {
+        let Some(messages) = body.get("messages").and_then(serde_json::Value::as_array) else {
+            panic!("messages should be an array");
+        };
+        messages
+    }
+
+    #[test]
+    fn system_message_rewrite_qwen_merges_multiple_messages_into_one_leading_message() {
+        let provider = provider(
+            "qwen3:0.6b",
+            "custom-ollama-qwen",
+            "http://127.0.0.1:11435/v1",
+        );
+        let mut body = serde_json::json!({
+            "messages": [
+                {"role": "system", "content": "You are a helpful assistant."},
+                {"role": "user", "content": "hello"},
+                {"role": "assistant", "content": "hi"},
+                {"role": "system", "content": "The current user datetime is 2026-04-15 18:22:00 UTC."},
+                {"role": "user", "content": "what time is it?"}
+            ]
+        });
+
+        provider.apply_system_prompt_rewrite(&mut body);
+
+        let messages = body_messages(&body);
+        assert_eq!(messages.len(), 4);
+        assert_eq!(messages[0]["role"], "system");
+        assert_eq!(
+            messages[0]["content"],
+            "You are a helpful assistant.\n\nThe current user datetime is 2026-04-15 18:22:00 UTC."
+        );
+        assert_eq!(messages[1]["role"], "user");
+        assert_eq!(messages[2]["role"], "assistant");
+        assert_eq!(messages[3]["role"], "user");
+    }
+
+    #[test]
+    fn system_message_rewrite_minimax_inlines_messages_into_first_user_message() {
+        let provider = provider("MiniMax-M2.7", "minimax", "https://api.minimax.io/v1");
+        let mut body = serde_json::json!({
+            "messages": [
+                {"role": "system", "content": "You are a helpful assistant."},
+                {"role": "user", "content": "hello"},
+                {"role": "system", "content": "The current user datetime is 2026-04-15 18:22:00 UTC."}
+            ]
+        });
+
+        provider.apply_system_prompt_rewrite(&mut body);
+
+        let messages = body_messages(&body);
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0]["role"], "user");
+        assert_eq!(
+            messages[0]["content"],
+            "[System Instructions]\nYou are a helpful assistant.\n\nThe current user datetime is 2026-04-15 18:22:00 UTC.\n[End System Instructions]\n\nhello"
+        );
+    }
+
+    #[test]
+    fn system_message_rewrite_default_openai_request_is_unchanged() {
+        let provider = provider("gpt-4o-mini", "openai", "https://api.openai.com/v1");
+        let mut body = serde_json::json!({
+            "messages": [
+                {"role": "system", "content": "sys1"},
+                {"role": "user", "content": "hello"},
+                {"role": "system", "content": "sys2"}
+            ]
+        });
+
+        provider.apply_system_prompt_rewrite(&mut body);
+
+        let messages = body_messages(&body);
+        assert_eq!(messages.len(), 3);
+        assert_eq!(messages[0]["role"], "system");
+        assert_eq!(messages[1]["role"], "user");
+        assert_eq!(messages[2]["role"], "system");
+    }
 }

--- a/crates/providers/src/openai/provider/request.rs
+++ b/crates/providers/src/openai/provider/request.rs
@@ -124,6 +124,25 @@ impl OpenAiProvider {
             || self.base_url.to_ascii_lowercase().contains("minimax")
     }
 
+    fn is_custom_openai_compatible_provider(&self) -> bool {
+        self.provider_name.starts_with("custom-")
+    }
+
+    fn is_alibaba_qwen_backend(&self) -> bool {
+        self.provider_name.eq_ignore_ascii_case("alibaba-coding")
+            || self.provider_name.eq_ignore_ascii_case("alibaba")
+            || self.provider_name.eq_ignore_ascii_case("dashscope-coding")
+            || self.base_url.contains("dashscope.aliyuncs.com")
+            || self.base_url.contains("alibabacloud.com")
+    }
+
+    fn is_qwen_single_system_backend(&self) -> bool {
+        self.provider_name.eq_ignore_ascii_case("ollama")
+            || self.provider_name.to_ascii_lowercase().contains("ollama")
+            || self.is_custom_openai_compatible_provider()
+            || self.is_alibaba_qwen_backend()
+    }
+
     /// Some backends ship chat templates that only accept a single system
     /// message at the front of the conversation. Qwen-based OpenAI-compatible
     /// backends commonly behave this way (e.g. llama.cpp chat templates).
@@ -131,6 +150,7 @@ impl OpenAiProvider {
         raw_model_id(&self.model)
             .to_ascii_lowercase()
             .contains("qwen")
+            && self.is_qwen_single_system_backend()
     }
 
     fn system_message_rewrite_strategy(&self) -> SystemMessageRewriteStrategy {
@@ -487,5 +507,51 @@ mod tests {
         assert_eq!(messages[0]["role"], "system");
         assert_eq!(messages[1]["role"], "user");
         assert_eq!(messages[2]["role"], "system");
+    }
+
+    #[test]
+    fn system_message_rewrite_qwen_model_on_openai_provider_is_unchanged() {
+        let provider = provider("qwen3-coder-plus", "openai", "https://api.openai.com/v1");
+        let mut body = serde_json::json!({
+            "messages": [
+                {"role": "system", "content": "sys1"},
+                {"role": "user", "content": "hello"},
+                {"role": "system", "content": "sys2"}
+            ]
+        });
+
+        provider.apply_system_prompt_rewrite(&mut body);
+
+        let messages = body_messages(&body);
+        assert_eq!(messages.len(), 3);
+        assert_eq!(messages[0]["role"], "system");
+        assert_eq!(messages[0]["content"], "sys1");
+        assert_eq!(messages[1]["role"], "user");
+        assert_eq!(messages[2]["role"], "system");
+        assert_eq!(messages[2]["content"], "sys2");
+    }
+
+    #[test]
+    fn system_message_rewrite_alibaba_qwen_merges_multiple_messages_into_one_leading_message() {
+        let provider = provider(
+            "qwen3.5-plus",
+            "alibaba-coding",
+            "https://coding-intl.dashscope.aliyuncs.com/v1",
+        );
+        let mut body = serde_json::json!({
+            "messages": [
+                {"role": "system", "content": "sys1"},
+                {"role": "user", "content": "hello"},
+                {"role": "system", "content": "sys2"}
+            ]
+        });
+
+        provider.apply_system_prompt_rewrite(&mut body);
+
+        let messages = body_messages(&body);
+        assert_eq!(messages.len(), 2);
+        assert_eq!(messages[0]["role"], "system");
+        assert_eq!(messages[0]["content"], "sys1\n\nsys2");
+        assert_eq!(messages[1]["role"], "user");
     }
 }

--- a/crates/web/ui/e2e/README.md
+++ b/crates/web/ui/e2e/README.md
@@ -42,7 +42,8 @@ app enters onboarding mode. Uses a random free port by default.
 
 ## Playwright Projects
 
-The test suite is split into six Playwright projects:
+The test suite is split into seven Playwright projects, plus one opt-in live
+project for local Ollama/Qwen validation:
 
 | Project | Port | Spec files | Notes |
 |---------|------|------------|-------|
@@ -52,6 +53,7 @@ The test suite is split into six Playwright projects:
 | `onboarding-auth` | Random free port (`MOLTIS_E2E_ONBOARDING_AUTH_PORT`) | `onboarding-auth.spec.js` | Separate server with remote-auth simulation |
 | `onboarding-anthropic` | Random free port (`MOLTIS_E2E_ONBOARDING_ANTHROPIC_PORT`) | `onboarding-anthropic.spec.js` | Separate server proving first-run Anthropic onboarding with zero providers at startup |
 | `openai-live` | Random free port (`MOLTIS_E2E_OPENAI_LIVE_PORT`) | `openai-live.spec.js` | Separate server that preserves only the existing OpenAI env and proves a real OpenAI chat turn works |
+| `ollama-qwen-live` | Random free port (`MOLTIS_E2E_OLLAMA_QWEN_LIVE_PORT`) + Ollama API port (`MOLTIS_E2E_OLLAMA_QWEN_API_PORT`, default `11435`) | `ollama-qwen-live.spec.js` | Opt-in server that starts a local Ollama instance, seeds a custom OpenAI-compatible Qwen provider, and proves the multiple-system-message regression is fixed |
 
 ## Spec Files
 
@@ -74,6 +76,7 @@ The test suite is split into six Playwright projects:
 | `onboarding-auth.spec.js` | 1 | Remote onboarding auth flow with setup code and identity save |
 | `onboarding-anthropic.spec.js` | 1 | Anthropic onboarding from empty startup, model discovery, model selection |
 | `openai-live.spec.js` | 1 | Live OpenAI provider smoke test using the existing env and a real chat turn |
+| `ollama-qwen-live.spec.js` | 1 | Opt-in live Ollama smoke test for the custom OpenAI-compatible Qwen regression path |
 
 ## Shared Helpers
 
@@ -93,6 +96,9 @@ cd crates/web/ui && npx playwright test e2e/specs/sessions.spec.js
 
 # Run a specific project
 npx playwright test --project=auth
+
+# Run the opt-in Ollama/Qwen live project
+MOLTIS_E2E_OLLAMA_QWEN_LIVE=1 npx playwright test --project=ollama-qwen-live e2e/specs/ollama-qwen-live.spec.js
 
 # Run with visible browser
 just ui-e2e-headed

--- a/crates/web/ui/e2e/specs/ollama-qwen-live.spec.js
+++ b/crates/web/ui/e2e/specs/ollama-qwen-live.spec.js
@@ -1,0 +1,113 @@
+const { expect, test } = require("../base-test");
+const { navigateAndWait, waitForWsConnected, watchPageErrors } = require("../helpers");
+
+const PROVIDER_PREFIX = "custom-ollama-qwen::";
+const SYSTEM_MESSAGE_ERROR = "System message must be at the beginning";
+
+function isRetryableRpcError(message) {
+	if (typeof message !== "string") return false;
+	return message.includes("WebSocket not connected") || message.includes("WebSocket disconnected");
+}
+
+async function sendRpcFromPage(page, method, params) {
+	let lastResponse = null;
+	for (let attempt = 0; attempt < 30; attempt++) {
+		if (attempt > 0) {
+			await waitForWsConnected(page, 5_000).catch(() => "ignored");
+		}
+		lastResponse = await page
+			.evaluate(
+				async ({ methodName, methodParams }) => {
+					var appScript = document.querySelector('script[type="module"][src*="js/app.js"]');
+					if (!appScript) throw new Error("app module script not found");
+					var appUrl = new URL(appScript.src, window.location.origin);
+					var prefix = appUrl.href.slice(0, appUrl.href.length - "js/app.js".length);
+					var helpers = await import(`${prefix}js/helpers.js`);
+					return helpers.sendRpc(methodName, methodParams);
+				},
+				{
+					methodName: method,
+					methodParams: params,
+				},
+			)
+			.catch((error) => ({ ok: false, error: { message: error?.message || String(error) } }));
+
+		if (lastResponse?.ok) return lastResponse;
+		if (!isRetryableRpcError(lastResponse?.error?.message)) return lastResponse;
+	}
+	return lastResponse;
+}
+
+async function expectRpcOk(page, method, params) {
+	const response = await sendRpcFromPage(page, method, params);
+	expect(response?.ok, `RPC ${method} failed: ${response?.error?.message || "unknown error"}`).toBeTruthy();
+	return response;
+}
+
+test.describe("Ollama Qwen Live", () => {
+	test.describe.configure({ mode: "serial" });
+
+	test("custom OpenAI-compatible Qwen chat completes a real turn", async ({ page }) => {
+		test.setTimeout(240_000);
+		const pageErrors = watchPageErrors(page);
+
+		await navigateAndWait(page, "/");
+		await waitForWsConnected(page);
+
+		const modelsResponse = await expectRpcOk(page, "models.list", {});
+		const qwenModel = (modelsResponse.payload || []).find(
+			(model) => typeof model?.id === "string" && model.id.startsWith(PROVIDER_PREFIX),
+		);
+
+		expect(qwenModel, "expected a custom-ollama-qwen model from the seeded runtime config").toBeTruthy();
+
+		await expectRpcOk(page, "chat.clear", { sessionKey: "main" });
+
+		const sendResponse = await expectRpcOk(page, "chat.send", {
+			sessionKey: "main",
+			model: qwenModel.id,
+			text: "Reply with a short JSON object containing a token key.",
+		});
+
+		expect(String(sendResponse.payload?.runId || "")).not.toBe("");
+
+		await expect
+			.poll(
+				async () => {
+					const historyResponse = await sendRpcFromPage(page, "chat.history", { sessionKey: "main" });
+					if (!historyResponse?.ok) {
+						return `history-rpc-error:${historyResponse?.error?.message || "unknown error"}`;
+					}
+
+					const pageErrorMessages = page.locator(".error-card, .msg.error");
+					const pageErrorCount = await pageErrorMessages.count();
+					if (pageErrorCount > 0) {
+						const pageErrorText = await pageErrorMessages
+							.nth(pageErrorCount - 1)
+							.textContent()
+							.catch(() => "");
+						if (pageErrorText) {
+							return `page-error:${pageErrorText.trim()}`;
+						}
+					}
+
+					const assistantMessages = (historyResponse.payload || []).filter((message) => message.role === "assistant");
+					return String(assistantMessages.at(-1)?.content || "").trim();
+				},
+				{ timeout: 240_000 },
+			)
+			.not.toBe("");
+
+		const historyResponse = await expectRpcOk(page, "chat.history", { sessionKey: "main" });
+		const assistantMessages = (historyResponse.payload || []).filter((message) => message.role === "assistant");
+		const finalAssistantContent = String(assistantMessages.at(-1)?.content || "").trim();
+		expect(assistantMessages.length).toBeGreaterThan(0);
+		expect(finalAssistantContent).not.toBe("");
+		expect(finalAssistantContent).not.toContain(SYSTEM_MESSAGE_ERROR);
+		expect(assistantMessages.at(-1)?.provider).toBe("custom-ollama-qwen");
+		expect(String(assistantMessages.at(-1)?.model || "")).toContain(qwenModel.id.replace(PROVIDER_PREFIX, ""));
+		await expect(page.locator(".error-card, .msg.error")).toHaveCount(0);
+
+		expect(pageErrors).toEqual([]);
+	});
+});

--- a/crates/web/ui/e2e/start-gateway-ollama-qwen-live.sh
+++ b/crates/web/ui/e2e/start-gateway-ollama-qwen-live.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "${SCRIPT_DIR}/../../../.." && pwd)"
+
+PORT="${MOLTIS_E2E_OLLAMA_QWEN_LIVE_PORT:-0}"
+OLLAMA_API_PORT="${MOLTIS_E2E_OLLAMA_QWEN_API_PORT:-11435}"
+MODEL="${MOLTIS_E2E_OLLAMA_QWEN_MODEL:-qwen2.5:0.5b}"
+RUNTIME_ROOT="${MOLTIS_E2E_OLLAMA_QWEN_LIVE_RUNTIME_DIR:-${REPO_ROOT}/target/e2e-runtime-ollama-qwen-live}"
+CONFIG_DIR="${RUNTIME_ROOT}/config"
+DATA_DIR="${RUNTIME_ROOT}/data"
+HOME_DIR="${RUNTIME_ROOT}/home"
+OLLAMA_ROOT="${MOLTIS_E2E_OLLAMA_QWEN_OLLAMA_ROOT:-${REPO_ROOT}/target/e2e-ollama-qwen-live}"
+OLLAMA_MODELS_DIR="${MOLTIS_E2E_OLLAMA_QWEN_MODELS_DIR:-${OLLAMA_ROOT}/models}"
+OLLAMA_LOG="${OLLAMA_ROOT}/ollama.log"
+ORIGINAL_HOME="${HOME:-}"
+OLLAMA_BIND="127.0.0.1:${OLLAMA_API_PORT}"
+OLLAMA_PID=""
+GATEWAY_PID=""
+
+if ! command -v ollama >/dev/null 2>&1; then
+	echo "Missing ollama CLI. Install it or set MOLTIS_E2E_OLLAMA_QWEN_LIVE=0." >&2
+	exit 1
+fi
+
+cleanup() {
+	local pid=""
+	for pid in "${GATEWAY_PID}" "${OLLAMA_PID}"; do
+		if [[ -n "${pid}" ]] && kill -0 "${pid}" 2>/dev/null; then
+			kill -TERM "${pid}" 2>/dev/null || true
+		fi
+	done
+
+	sleep 1
+
+	for pid in "${GATEWAY_PID}" "${OLLAMA_PID}"; do
+		if [[ -n "${pid}" ]] && kill -0 "${pid}" 2>/dev/null; then
+			kill -KILL "${pid}" 2>/dev/null || true
+		fi
+	done
+}
+
+trap cleanup EXIT INT TERM
+
+rm -rf "${RUNTIME_ROOT}"
+mkdir -p "${CONFIG_DIR}" "${DATA_DIR}" "${HOME_DIR}" "${OLLAMA_MODELS_DIR}"
+
+cat > "${DATA_DIR}/IDENTITY.md" <<'EOF'
+---
+name: e2e-bot
+---
+
+# IDENTITY.md
+
+This file is managed by Moltis settings.
+EOF
+
+cat > "${DATA_DIR}/USER.md" <<'EOF'
+---
+name: e2e-user
+---
+
+# USER.md
+
+This file is managed by Moltis settings.
+EOF
+
+touch "${DATA_DIR}/.onboarded"
+
+cat > "${CONFIG_DIR}/moltis.toml" <<EOF
+[providers]
+offered = ["custom-ollama-qwen"]
+
+[providers.custom-ollama-qwen]
+enabled = true
+api_key = "ollama"
+base_url = "http://127.0.0.1:${OLLAMA_API_PORT}/v1"
+models = ["${MODEL}"]
+fetch_models = false
+EOF
+
+cd "${REPO_ROOT}"
+
+export MOLTIS_CONFIG_DIR="${CONFIG_DIR}"
+export MOLTIS_DATA_DIR="${DATA_DIR}"
+export MOLTIS_SERVER__PORT="${PORT}"
+if [[ -z "${RUSTUP_HOME:-}" ]] && [[ -n "${ORIGINAL_HOME}" ]]; then
+	export RUSTUP_HOME="${ORIGINAL_HOME}/.rustup"
+fi
+if [[ -z "${CARGO_HOME:-}" ]] && [[ -n "${ORIGINAL_HOME}" ]]; then
+	export CARGO_HOME="${ORIGINAL_HOME}/.cargo"
+fi
+export HOME="${HOME_DIR}"
+
+unset OPENAI_API_KEY
+unset ANTHROPIC_API_KEY
+unset GEMINI_API_KEY
+unset GROQ_API_KEY
+unset XAI_API_KEY
+unset DEEPSEEK_API_KEY
+unset FIREWORKS_API_KEY
+unset MISTRAL_API_KEY
+unset OPENROUTER_API_KEY
+unset CEREBRAS_API_KEY
+unset MINIMAX_API_KEY
+unset MOONSHOT_API_KEY
+unset Z_API_KEY
+unset Z_CODE_API_KEY
+unset VENICE_API_KEY
+unset OLLAMA_API_KEY
+unset LMSTUDIO_API_KEY
+unset KIMI_API_KEY
+
+binary_is_stale() {
+	local binary="$1"
+	if [[ ! -f "${binary}" ]]; then
+		return 0
+	fi
+	if [[ "${REPO_ROOT}/Cargo.toml" -nt "${binary}" ]]; then
+		return 0
+	fi
+	if [[ -f "${REPO_ROOT}/Cargo.lock" ]] && [[ "${REPO_ROOT}/Cargo.lock" -nt "${binary}" ]]; then
+		return 0
+	fi
+	find "${REPO_ROOT}/crates" \
+		-type f \
+		\( -name "*.rs" -o -name "*.toml" \) \
+		-newer "${binary}" \
+		-print -quit | grep -q .
+}
+
+BINARY="${MOLTIS_BINARY:-}"
+if [[ -z "${BINARY}" ]]; then
+	for candidate in target/debug/moltis target/release/moltis; do
+		if [[ -x "${candidate}" ]] && { [[ -z "${BINARY}" ]] || [[ "${candidate}" -nt "${BINARY}" ]]; }; then
+			BINARY="${candidate}"
+		fi
+	done
+fi
+
+if [[ -n "${BINARY}" ]] && binary_is_stale "${BINARY}"; then
+	echo "Detected source changes newer than ${BINARY}; using cargo run for a fresh build." >&2
+	BINARY=""
+fi
+
+OLLAMA_HOST="${OLLAMA_BIND}" OLLAMA_MODELS="${OLLAMA_MODELS_DIR}" ollama serve >"${OLLAMA_LOG}" 2>&1 &
+OLLAMA_PID="$!"
+
+for attempt in $(seq 1 60); do
+	if curl -fsS "http://${OLLAMA_BIND}/api/tags" >/dev/null 2>&1; then
+		break
+	fi
+	if ! kill -0 "${OLLAMA_PID}" 2>/dev/null; then
+		echo "ollama serve exited unexpectedly. Recent log output:" >&2
+		tail -n 50 "${OLLAMA_LOG}" >&2 || true
+		exit 1
+	fi
+	sleep 1
+	if [[ "${attempt}" == "60" ]]; then
+		echo "Timed out waiting for Ollama to become ready on ${OLLAMA_BIND}." >&2
+		tail -n 50 "${OLLAMA_LOG}" >&2 || true
+		exit 1
+	fi
+done
+
+OLLAMA_HOST="${OLLAMA_BIND}" OLLAMA_MODELS="${OLLAMA_MODELS_DIR}" ollama pull "${MODEL}"
+
+if [[ -n "${BINARY}" ]]; then
+	"${BINARY}" --no-tls --bind 127.0.0.1 --port "${PORT}" &
+else
+	cargo +nightly-2025-11-30 run --bin moltis -- --no-tls --bind 127.0.0.1 --port "${PORT}" &
+fi
+GATEWAY_PID="$!"
+wait "${GATEWAY_PID}"

--- a/crates/web/ui/playwright.config.js
+++ b/crates/web/ui/playwright.config.js
@@ -46,6 +46,10 @@ const openaiLivePort = resolvePort("MOLTIS_E2E_OPENAI_LIVE_PORT", usedPorts);
 const openaiLiveBaseURL = process.env.MOLTIS_E2E_OPENAI_LIVE_BASE_URL || `http://127.0.0.1:${openaiLivePort}`;
 const openAiLiveKey = process.env.MOLTIS_E2E_OPENAI_API_KEY || process.env.OPENAI_API_KEY || "";
 const enableOpenAiLiveProject = openAiLiveKey !== "";
+const ollamaQwenLiveEnabled = process.env.MOLTIS_E2E_OLLAMA_QWEN_LIVE === "1";
+const ollamaQwenLivePort = resolvePort("MOLTIS_E2E_OLLAMA_QWEN_LIVE_PORT", usedPorts);
+const ollamaQwenLiveBaseURL =
+	process.env.MOLTIS_E2E_OLLAMA_QWEN_LIVE_BASE_URL || `http://127.0.0.1:${ollamaQwenLivePort}`;
 // Reliability first: fresh local gateway instances by default avoid
 // hidden cross-run state leaks. Set MOLTIS_E2E_REUSE_SERVER=1 to trade
 // determinism for faster startup in ad-hoc local runs.
@@ -60,6 +64,7 @@ const projects = [
 			/onboarding-auth\.spec/,
 			/onboarding-anthropic\.spec/,
 			/openai-live\.spec/,
+			/ollama-qwen-live\.spec/,
 			/oauth\.spec/,
 		],
 	},
@@ -104,6 +109,16 @@ if (enableOpenAiLiveProject) {
 		testMatch: /openai-live\.spec/,
 		use: {
 			baseURL: openaiLiveBaseURL,
+		},
+	});
+}
+
+if (ollamaQwenLiveEnabled) {
+	projects.push({
+		name: "ollama-qwen-live",
+		testMatch: /ollama-qwen-live\.spec/,
+		use: {
+			baseURL: ollamaQwenLiveBaseURL,
 		},
 	});
 }
@@ -176,6 +191,20 @@ if (enableOpenAiLiveProject) {
 		env: {
 			...process.env,
 			MOLTIS_E2E_OPENAI_LIVE_PORT: openaiLivePort,
+		},
+	});
+}
+
+if (ollamaQwenLiveEnabled) {
+	webServer.push({
+		command: "./e2e/start-gateway-ollama-qwen-live.sh",
+		cwd: __dirname,
+		url: `${ollamaQwenLiveBaseURL}/health`,
+		reuseExistingServer: reuseExistingServer,
+		timeout: 300_000,
+		env: {
+			...process.env,
+			MOLTIS_E2E_OLLAMA_QWEN_LIVE_PORT: ollamaQwenLivePort,
 		},
 	});
 }

--- a/docs/src/e2e-testing.md
+++ b/docs/src/e2e-testing.md
@@ -16,6 +16,8 @@ The e2e harness lives in `crates/web/ui`:
 
 - `playwright.config.js` configures Playwright and web server startup.
 - `e2e/start-gateway.sh` boots the gateway in deterministic test mode.
+- `e2e/start-gateway-ollama-qwen-live.sh` is the opt-in live-provider harness
+  for the custom OpenAI-compatible Qwen regression path.
 - `e2e/specs/smoke.spec.js` contains smoke coverage for critical routes.
 
 ## How Startup Works
@@ -85,3 +87,11 @@ Pull requests use the local-validation flow: the E2E workflow waits for a
 `local/e2e` commit status, published by `./scripts/local-validate.sh`.
 
 Pushes to `main`, tags, and manual dispatch still run the hosted E2E job.
+
+For the Qwen multiple-system-message regression path, there is also an opt-in
+Playwright project:
+
+```bash
+cd crates/web/ui
+MOLTIS_E2E_OLLAMA_QWEN_LIVE=1 npx playwright test --project=ollama-qwen-live e2e/specs/ollama-qwen-live.spec.js
+```

--- a/docs/src/local-validation.md
+++ b/docs/src/local-validation.md
@@ -34,6 +34,7 @@ The script runs these checks:
 - `local/test`
 - `local/macos-app` — validates the native Swift macOS app build (`Darwin` only)
 - `local/e2e` — runs gateway UI Playwright coverage
+- `local/e2e-ollama` — opt-in live Ollama/Qwen Playwright regression check
 
 In PR mode, the PR workflow verifies these contexts and surfaces them as
 checks in the PR.
@@ -60,6 +61,11 @@ checks in the PR.
 - `local/e2e` auto-runs `npm ci` only when `crates/web/ui/node_modules`
   is missing, then runs `npm run e2e:install` and `npm run e2e`. Override with
   `LOCAL_VALIDATE_E2E_CMD`.
+- Enable the live Ollama/Qwen regression check with
+  `LOCAL_VALIDATE_OLLAMA_QWEN_E2E=1`. It starts a local Ollama server on
+  `MOLTIS_E2E_OLLAMA_QWEN_API_PORT` (default `11435`), pulls the configured
+  Qwen model if missing, and runs the dedicated Playwright project. Override
+  the command with `LOCAL_VALIDATE_OLLAMA_QWEN_E2E_CMD`.
 
 ## Merge and release safety
 

--- a/scripts/local-validate.sh
+++ b/scripts/local-validate.sh
@@ -178,6 +178,7 @@ zizmor_cmd="${LOCAL_VALIDATE_ZIZMOR_CMD:-./scripts/run-zizmor-resilient.sh . --m
 lint_cmd="${LOCAL_VALIDATE_LINT_CMD:-cargo +${nightly_toolchain} clippy -Z unstable-options --workspace --all-features --all-targets --timings -- -D warnings}"
 test_cmd="${LOCAL_VALIDATE_TEST_CMD:-cargo +${nightly_toolchain} nextest run --all-features --profile ci}"
 e2e_cmd="${LOCAL_VALIDATE_E2E_CMD:-cd crates/web/ui && if [ ! -d node_modules ]; then npm ci; fi && npm run e2e:install && npm run e2e}"
+ollama_qwen_e2e_cmd="${LOCAL_VALIDATE_OLLAMA_QWEN_E2E_CMD:-cd crates/web/ui && if [ ! -d node_modules ]; then npm ci; fi && npm run e2e:install && MOLTIS_E2E_OLLAMA_QWEN_LIVE=1 npx playwright test --project=ollama-qwen-live e2e/specs/ollama-qwen-live.spec.js}"
 coverage_cmd="${LOCAL_VALIDATE_COVERAGE_CMD:-cargo +${nightly_toolchain} llvm-cov --workspace --all-features --html}"
 macos_app_cmd="${LOCAL_VALIDATE_MACOS_APP_CMD:-./scripts/build-swift-bridge.sh && ./scripts/generate-swift-project.sh && ./scripts/lint-swift.sh && xcodebuild -project apps/macos/Moltis.xcodeproj -scheme Moltis -configuration Release -destination \"platform=macOS\" -derivedDataPath apps/macos/.derivedData-local-validate build}"
 ios_app_cmd="${LOCAL_VALIDATE_IOS_APP_CMD:-cargo run -p moltis-schema-export -- apps/ios/GraphQL/Schema/schema.graphqls && ./scripts/generate-ios-graphql.sh && ./scripts/generate-ios-project.sh && xcodebuild -project apps/ios/Moltis.xcodeproj -scheme Moltis -configuration Debug -destination \"generic/platform=iOS\" CODE_SIGNING_ALLOWED=NO build}"
@@ -260,8 +261,19 @@ cleanup_e2e_ports() {
     return 0
   fi
 
+  local ports=(
+    "${MOLTIS_E2E_PORT:-18789}"
+    "${MOLTIS_E2E_ONBOARDING_PORT:-18790}"
+    "${MOLTIS_E2E_ONBOARDING_AUTH_PORT:-18791}"
+    "${MOLTIS_E2E_OAUTH_PORT:-18792}"
+    "${MOLTIS_E2E_ONBOARDING_ANTHROPIC_PORT:-18793}"
+    "${MOLTIS_E2E_OPENAI_LIVE_PORT:-18794}"
+    "${MOLTIS_E2E_OLLAMA_QWEN_LIVE_PORT:-18795}"
+    "${MOLTIS_E2E_OLLAMA_QWEN_API_PORT:-11435}"
+  )
+
   local port
-  for port in "${MOLTIS_E2E_PORT:-18789}" "${MOLTIS_E2E_ONBOARDING_PORT:-18790}"; do
+  for port in "${ports[@]}"; do
     local pids
     pids="$(lsof -ti "tcp:${port}" -sTCP:LISTEN 2>/dev/null || true)"
     if [[ -z "$pids" ]]; then
@@ -572,6 +584,13 @@ if [[ "${LOCAL_VALIDATE_SKIP_E2E:-0}" != "1" ]]; then
   run_check "local/e2e" "$e2e_cmd"
 else
   echo "Skipping E2E checks (LOCAL_VALIDATE_SKIP_E2E=1)."
+fi
+
+if [[ "${LOCAL_VALIDATE_OLLAMA_QWEN_E2E:-0}" == "1" ]]; then
+  cleanup_e2e_ports
+  run_check "local/e2e-ollama" "$ollama_qwen_e2e_cmd"
+else
+  echo "Skipping Ollama Qwen live E2E (LOCAL_VALIDATE_OLLAMA_QWEN_E2E=0)."
 fi
 
 # Coverage (optional — requires cargo-llvm-cov).


### PR DESCRIPTION
## Summary

- normalize OpenAI-compatible Qwen requests so multiple `system` messages become one leading `system` message instead of tripping stricter chat templates
- keep the existing MiniMax inline-into-first-user rewrite intact and add provider-level regression coverage for both paths
- add an opt-in Ollama + Qwen live Playwright project, local-validation hook, and provider-integration workflow coverage for the regression

This fixes the Qwen multiple-system-message failure reported in issue #317 without scattering provider quirks through the chat call sites.

## Validation

### Completed

- [x] `just format`
- [x] `cd crates/web/ui && if [ ! -d node_modules ]; then npm ci; fi && npx biome check --write playwright.config.js e2e/specs/ollama-qwen-live.spec.js`
- [x] `cargo +nightly-2025-11-30 test -p moltis-providers system_message_rewrite`
- [x] `cargo +nightly-2025-11-30 clippy -Z unstable-options -p moltis-providers --all-targets -- -D warnings`
- [x] `cd crates/web/ui && MOLTIS_E2E_OLLAMA_QWEN_LIVE=1 npx playwright test --project=ollama-qwen-live e2e/specs/ollama-qwen-live.spec.js`

### Remaining

- [ ] `./scripts/local-validate.sh <PR_NUMBER>`

## Manual QA

- Ran the opt-in local Ollama/Qwen live Playwright scenario against `qwen2.5:0.5b` and verified the chat turn completes without the `System message must be at the beginning` failure.
