### PR TITLE
fix(mcp): treat any HTTP response as alive in health check (#732)

### DIFF
--- a/crates/mcp/src/sse_transport.rs
+++ b/crates/mcp/src/sse_transport.rs
@@ -902,6 +902,99 @@ mod tests {
         assert!(resp.result.is_some());
     }
 
+    // ── is_alive health-check tests (issue #732) ──────────────────────
+
+    #[tokio::test]
+    async fn test_is_alive_200_returns_true() {
+        let mut server = mockito::Server::new_async().await;
+        let _mock = server
+            .mock("GET", "/")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"ok":true}"#)
+            .create_async()
+            .await;
+
+        let transport = SseTransport::new(&server.url()).unwrap();
+        assert!(transport.is_alive().await);
+    }
+
+    #[tokio::test]
+    async fn test_is_alive_401_returns_true() {
+        let mut server = mockito::Server::new_async().await;
+        let _mock = server
+            .mock("GET", "/")
+            .with_status(401)
+            .with_header("www-authenticate", r#"Bearer realm="test""#)
+            .create_async()
+            .await;
+
+        let transport = SseTransport::new(&server.url()).unwrap();
+        assert!(transport.is_alive().await);
+    }
+
+    /// Streamable HTTP servers may not support GET (it's optional in the MCP
+    /// spec). A 405 response proves the server is reachable and alive.
+    #[tokio::test]
+    async fn test_is_alive_405_method_not_allowed_returns_true() {
+        let mut server = mockito::Server::new_async().await;
+        let _mock = server
+            .mock("GET", "/")
+            .with_status(405)
+            .with_header("allow", "POST, DELETE")
+            .create_async()
+            .await;
+
+        let transport = SseTransport::new(&server.url()).unwrap();
+        // BUG (issue #732): currently returns false because is_alive()
+        // only treats 2xx and 401 as alive. This causes "dead" status
+        // in the UI for working Streamable HTTP servers.
+        //
+        // After fix: this assertion should be `assert!(transport.is_alive().await);`
+        assert!(
+            !transport.is_alive().await,
+            "expected false (unfixed bug #732); flip to assert!(true) when fixed"
+        );
+    }
+
+    /// A 403 Forbidden from the health check still proves the server is
+    /// reachable — it just refused the request. The server is alive.
+    #[tokio::test]
+    async fn test_is_alive_403_forbidden_returns_true() {
+        let mut server = mockito::Server::new_async().await;
+        let _mock = server
+            .mock("GET", "/")
+            .with_status(403)
+            .create_async()
+            .await;
+
+        let transport = SseTransport::new(&server.url()).unwrap();
+        // BUG (issue #732): currently returns false.
+        assert!(
+            !transport.is_alive().await,
+            "expected false (unfixed bug #732); flip to assert!(true) when fixed"
+        );
+    }
+
+    /// A 400 Bad Request still proves the server endpoint is alive.
+    #[tokio::test]
+    async fn test_is_alive_400_bad_request_returns_true() {
+        let mut server = mockito::Server::new_async().await;
+        let _mock = server
+            .mock("GET", "/")
+            .with_status(400)
+            .with_body(r#"{"error":"bad request"}"#)
+            .create_async()
+            .await;
+
+        let transport = SseTransport::new(&server.url()).unwrap();
+        // BUG (issue #732): currently returns false.
+        assert!(
+            !transport.is_alive().await,
+            "expected false (unfixed bug #732); flip to assert!(true) when fixed"
+        );
+    }
+
     #[tokio::test]
     async fn test_sse_transport_kill_sends_delete_with_session_id() {
         let mut server = mockito::Server::new_async().await;

--- a/crates/mcp/src/sse_transport.rs
+++ b/crates/mcp/src/sse_transport.rs
@@ -482,13 +482,12 @@ impl McpTransport for SseTransport {
         match req.send().await {
             Ok(resp) => {
                 self.store_session_id_from_response(&resp).await;
-                if resp.status() == reqwest::StatusCode::UNAUTHORIZED {
-                    return true;
-                }
-                // Any successful response means the server is reachable —
-                // Streamable HTTP servers may reply with application/json
-                // rather than text/event-stream, which is equally valid.
-                resp.status().is_success()
+                // Any HTTP response proves the server is reachable.
+                // Non-success statuses (401, 403, 405) are common for
+                // Streamable HTTP servers where GET is optional (MCP spec)
+                // or auth headers differ between GET and POST. Only true
+                // network errors (connection refused, timeout, DNS) mean dead.
+                true
             },
             Err(_) => false,
         }
@@ -946,15 +945,7 @@ mod tests {
             .await;
 
         let transport = SseTransport::new(&server.url()).unwrap();
-        // BUG (issue #732): currently returns false because is_alive()
-        // only treats 2xx and 401 as alive. This causes "dead" status
-        // in the UI for working Streamable HTTP servers.
-        //
-        // After fix: this assertion should be `assert!(transport.is_alive().await);`
-        assert!(
-            !transport.is_alive().await,
-            "expected false (unfixed bug #732); flip to assert!(true) when fixed"
-        );
+        assert!(transport.is_alive().await);
     }
 
     /// A 403 Forbidden from the health check still proves the server is
@@ -969,11 +960,7 @@ mod tests {
             .await;
 
         let transport = SseTransport::new(&server.url()).unwrap();
-        // BUG (issue #732): currently returns false.
-        assert!(
-            !transport.is_alive().await,
-            "expected false (unfixed bug #732); flip to assert!(true) when fixed"
-        );
+        assert!(transport.is_alive().await);
     }
 
     /// A 400 Bad Request still proves the server endpoint is alive.
@@ -988,11 +975,7 @@ mod tests {
             .await;
 
         let transport = SseTransport::new(&server.url()).unwrap();
-        // BUG (issue #732): currently returns false.
-        assert!(
-            !transport.is_alive().await,
-            "expected false (unfixed bug #732); flip to assert!(true) when fixed"
-        );
+        assert!(transport.is_alive().await);
     }
 
     #[tokio::test]

--- a/crates/web/ui/e2e/mock-mcp-server.js
+++ b/crates/web/ui/e2e/mock-mcp-server.js
@@ -1,0 +1,154 @@
+// Mock MCP Streamable HTTP server for E2E testing.
+// Implements the MCP protocol over HTTP POST (JSON-RPC 2.0).
+// Validates Bearer token auth when configured.
+// Returns 405 for GET by default (many real Streamable HTTP servers do this).
+//
+// Usage: node mock-mcp-server.js [--bearer-token TOKEN] [--get-status CODE]
+// Prints JSON to stdout: { "port": <number> }
+
+const http = require("node:http");
+
+var bearerToken = null;
+var getStatusCode = 405;
+var tools = [
+	{
+		name: "mock_echo",
+		description: "Echoes the input back",
+		inputSchema: { type: "object", properties: { message: { type: "string" } } },
+	},
+];
+
+// Parse CLI args
+for (var i = 2; i < process.argv.length; i++) {
+	if (process.argv[i] === "--bearer-token" && process.argv[i + 1]) {
+		bearerToken = process.argv[++i];
+	}
+	if (process.argv[i] === "--get-status" && process.argv[i + 1]) {
+		getStatusCode = parseInt(process.argv[++i], 10);
+	}
+}
+
+function respond(res, status, body, extraHeaders) {
+	var json = JSON.stringify(body);
+	var headers = { "Content-Type": "application/json", ...extraHeaders };
+	res.writeHead(status, headers);
+	res.end(json);
+}
+
+function parseBody(req) {
+	return new Promise((resolve) => {
+		var chunks = [];
+		req.on("data", (c) => chunks.push(c));
+		req.on("end", () => {
+			var body = Buffer.concat(chunks).toString();
+			try {
+				resolve(JSON.parse(body));
+			} catch {
+				resolve(null);
+			}
+		});
+	});
+}
+
+function checkAuth(req, res) {
+	if (!bearerToken) return true;
+	var auth = req.headers["authorization"] || "";
+	if (auth === `Bearer ${bearerToken}`) return true;
+	respond(res, 401, { error: "unauthorized" }, { "WWW-Authenticate": 'Bearer realm="mock-mcp"' });
+	return false;
+}
+
+function handleJsonRpc(rpcBody) {
+	var method = rpcBody.method;
+	var id = rpcBody.id;
+
+	if (method === "initialize") {
+		return {
+			jsonrpc: "2.0",
+			id,
+			result: {
+				protocolVersion: "2025-03-26",
+				capabilities: { tools: {} },
+				serverInfo: { name: "mock-mcp-server", version: "1.0.0" },
+			},
+		};
+	}
+
+	if (method === "notifications/initialized") {
+		// Notification — no response needed, but we send 202 from caller
+		return null;
+	}
+
+	if (method === "tools/list") {
+		return {
+			jsonrpc: "2.0",
+			id,
+			result: { tools },
+		};
+	}
+
+	if (method === "tools/call") {
+		var args = rpcBody.params?.arguments || {};
+		return {
+			jsonrpc: "2.0",
+			id,
+			result: {
+				content: [{ type: "text", text: `echo: ${args.message || "(empty)"}` }],
+			},
+		};
+	}
+
+	return {
+		jsonrpc: "2.0",
+		id,
+		error: { code: -32601, message: `Method not found: ${method}` },
+	};
+}
+
+var server = http.createServer(async (req, res) => {
+	// GET: health check probe from Moltis. Many real Streamable HTTP servers
+	// return 405 here because GET is optional in the MCP spec.
+	if (req.method === "GET") {
+		if (req.url === "/health") {
+			return respond(res, 200, { ok: true });
+		}
+		res.writeHead(getStatusCode, { Allow: "POST, DELETE" });
+		res.end();
+		return;
+	}
+
+	// DELETE: session termination
+	if (req.method === "DELETE") {
+		res.writeHead(204);
+		res.end();
+		return;
+	}
+
+	// POST: JSON-RPC requests
+	if (req.method === "POST") {
+		if (!checkAuth(req, res)) return;
+
+		var body = await parseBody(req);
+		if (!body || !body.jsonrpc) {
+			return respond(res, 400, { error: "invalid JSON-RPC request" });
+		}
+
+		var rpcResponse = handleJsonRpc(body);
+		if (rpcResponse === null) {
+			// Notification — no response body
+			res.writeHead(202);
+			res.end();
+			return;
+		}
+
+		return respond(res, 200, rpcResponse);
+	}
+
+	res.writeHead(405, { Allow: "GET, POST, DELETE" });
+	res.end();
+});
+
+server.listen(0, "127.0.0.1", () => {
+	var port = server.address().port;
+	process.stdout.write(`${JSON.stringify({ port })}\n`);
+});

--- a/crates/web/ui/e2e/specs/mcp.spec.js
+++ b/crates/web/ui/e2e/specs/mcp.spec.js
@@ -203,10 +203,10 @@ test.describe("MCP page", () => {
 			});
 			await expect(serverEntry).toBeVisible({ timeout: 10_000 });
 
-			// Check the state badge text — should be "running" now that #732 is fixed
+			// Check the state badge text — should be "running" now that #732 is fixed.
+			// Use toHaveText with retry to avoid flakes during status transitions.
 			var stateBadge = serverEntry.locator("span").filter({ hasText: /^(running|dead|stopped|connecting)$/ }).first();
-			await expect(stateBadge).toBeVisible();
-			expect(await stateBadge.textContent()).toBe("running");
+			await expect(stateBadge).toHaveText("running", { timeout: 15_000 });
 
 			// Verify the server has 1 tool (mock_echo) — proves POST connection worked
 			await expect(serverEntry.getByText("1 tool", { exact: false })).toBeVisible();

--- a/crates/web/ui/e2e/specs/mcp.spec.js
+++ b/crates/web/ui/e2e/specs/mcp.spec.js
@@ -187,23 +187,16 @@ test.describe("MCP page", () => {
 
 			// Find the server entry and check its status badge.
 			// The mock server responds to POST (tools work) but returns 405 for GET.
-			//
-			// BUG #732: Currently shows "dead" because is_alive() GET check fails
-			//           with 405 even though the server is fully functional.
-			// EXPECTED: Should show "running" after the fix.
+			// After the fix for #732, is_alive() treats any HTTP response as alive.
 			var serverEntry = page.locator(".skills-repo-card").filter({
 				has: page.locator(`text=127-0-0-1`),
 			});
 			await expect(serverEntry).toBeVisible({ timeout: 10_000 });
 
-			// Check the state badge text
+			// Check the state badge text — should be "running" now that #732 is fixed
 			var stateBadge = serverEntry.locator("span").filter({ hasText: /^(running|dead|stopped|connecting)$/ }).first();
 			await expect(stateBadge).toBeVisible();
-			var statusText = await stateBadge.textContent();
-
-			// Assert the current buggy behavior. When fix is applied, change to:
-			// expect(statusText).toBe("running");
-			expect(["running", "dead"]).toContain(statusText);
+			expect(await stateBadge.textContent()).toBe("running");
 
 			// Verify the server has 1 tool (mock_echo) — proves POST connection worked
 			await expect(serverEntry.getByText("1 tool", { exact: false })).toBeVisible();

--- a/crates/web/ui/e2e/specs/mcp.spec.js
+++ b/crates/web/ui/e2e/specs/mcp.spec.js
@@ -1,5 +1,38 @@
 const { expect, test } = require("../base-test");
-const { navigateAndWait, watchPageErrors } = require("../helpers");
+const { navigateAndWait, watchPageErrors, waitForWsConnected } = require("../helpers");
+const { fork } = require("node:child_process");
+const path = require("node:path");
+
+/**
+ * Start the mock MCP Streamable HTTP server as a child process.
+ * Returns { port, process } — caller must kill the process on teardown.
+ */
+function startMockMcpServer(args = []) {
+	return new Promise((resolve, reject) => {
+		var serverPath = path.resolve(__dirname, "../mock-mcp-server.js");
+		var child = fork(serverPath, args, { silent: true });
+		var output = "";
+
+		child.stdout.on("data", (chunk) => {
+			output += chunk.toString();
+			try {
+				var parsed = JSON.parse(output.trim());
+				if (parsed.port) {
+					resolve({ port: parsed.port, process: child });
+				}
+			} catch {
+				// Not complete JSON yet, keep accumulating
+			}
+		});
+
+		child.on("error", reject);
+		child.on("exit", (code) => {
+			if (!output) reject(new Error(`Mock MCP server exited with code ${code}`));
+		});
+
+		setTimeout(() => reject(new Error("Mock MCP server startup timeout")), 5000);
+	});
+}
 
 test.describe("MCP page", () => {
 	test("MCP page loads", async ({ page }) => {
@@ -111,5 +144,71 @@ test.describe("MCP page", () => {
 		const pageErrors = watchPageErrors(page);
 		await navigateAndWait(page, "/settings/mcp");
 		expect(pageErrors).toEqual([]);
+	});
+
+	// Issue #732: MCP status shows "dead" for working Streamable HTTP servers
+	// with Bearer token auth because is_alive() health check sends GET and
+	// only accepts 2xx/401 as alive. Many real servers return 405 for GET.
+	//
+	// This test adds a real mock MCP server via the UI form, then verifies
+	// the status indicator. The mock returns 405 for GET (reproducing #732).
+	test.describe("Streamable HTTP status (#732)", () => {
+		var mockMcp;
+
+		test.beforeAll(async () => {
+			mockMcp = await startMockMcpServer(["--bearer-token", "e2e-test-token"]);
+		});
+
+		test.afterAll(() => {
+			if (mockMcp?.process) mockMcp.process.kill();
+		});
+
+		test("server added via Streamable HTTP with Bearer token shows running status", async ({ page }) => {
+			var pageErrors = watchPageErrors(page);
+			await navigateAndWait(page, "/settings/mcp");
+			await waitForWsConnected(page);
+
+			// Fill out the Streamable HTTP custom server form
+			await page.getByRole("button", { name: "Streamable HTTP", exact: true }).click();
+			await page.getByPlaceholder("https://mcp.linear.app/mcp").fill(`http://127.0.0.1:${mockMcp.port}`);
+			await page.getByPlaceholder("Authorization=Bearer ...").fill(`Authorization=Bearer e2e-test-token`);
+
+			// Submit the form (press Enter or click Add)
+			var addBtn = page.getByRole("button", { name: "Add", exact: true });
+			await addBtn.click();
+
+			// Wait for success toast
+			await expect(page.getByText("Added MCP tool", { exact: false })).toBeVisible({ timeout: 15_000 });
+
+			// The server should now appear in the list. Wait for it.
+			// The name is derived from the URL, typically "127-0-0-1" or similar.
+			// Navigate to refresh the MCP list (status_all is called on page load).
+			await navigateAndWait(page, "/settings/mcp");
+
+			// Find the server entry and check its status badge.
+			// The mock server responds to POST (tools work) but returns 405 for GET.
+			//
+			// BUG #732: Currently shows "dead" because is_alive() GET check fails
+			//           with 405 even though the server is fully functional.
+			// EXPECTED: Should show "running" after the fix.
+			var serverEntry = page.locator(".skills-repo-card").filter({
+				has: page.locator(`text=127-0-0-1`),
+			});
+			await expect(serverEntry).toBeVisible({ timeout: 10_000 });
+
+			// Check the state badge text
+			var stateBadge = serverEntry.locator("span").filter({ hasText: /^(running|dead|stopped|connecting)$/ }).first();
+			await expect(stateBadge).toBeVisible();
+			var statusText = await stateBadge.textContent();
+
+			// Assert the current buggy behavior. When fix is applied, change to:
+			// expect(statusText).toBe("running");
+			expect(["running", "dead"]).toContain(statusText);
+
+			// Verify the server has 1 tool (mock_echo) — proves POST connection worked
+			await expect(serverEntry.getByText("1 tool", { exact: false })).toBeVisible();
+
+			expect(pageErrors).toEqual([]);
+		});
 	});
 });

--- a/crates/web/ui/e2e/specs/mcp.spec.js
+++ b/crates/web/ui/e2e/specs/mcp.spec.js
@@ -12,12 +12,18 @@ function startMockMcpServer(args = []) {
 		var serverPath = path.resolve(__dirname, "../mock-mcp-server.js");
 		var child = fork(serverPath, args, { silent: true });
 		var output = "";
+		var timeoutHandle = setTimeout(() => reject(new Error("Mock MCP server startup timeout")), 5000);
+
+		child.stderr.on("data", (chunk) => {
+			process.stderr.write(`[mock-mcp-server] ${chunk}`);
+		});
 
 		child.stdout.on("data", (chunk) => {
 			output += chunk.toString();
 			try {
 				var parsed = JSON.parse(output.trim());
 				if (parsed.port) {
+					clearTimeout(timeoutHandle);
 					resolve({ port: parsed.port, process: child });
 				}
 			} catch {
@@ -25,12 +31,16 @@ function startMockMcpServer(args = []) {
 			}
 		});
 
-		child.on("error", reject);
-		child.on("exit", (code) => {
-			if (!output) reject(new Error(`Mock MCP server exited with code ${code}`));
+		child.on("error", (err) => {
+			clearTimeout(timeoutHandle);
+			reject(err);
 		});
-
-		setTimeout(() => reject(new Error("Mock MCP server startup timeout")), 5000);
+		child.on("exit", (code) => {
+			if (!output) {
+				clearTimeout(timeoutHandle);
+				reject(new Error(`Mock MCP server exited with code ${code}`));
+			}
+		});
 	});
 }
 


### PR DESCRIPTION
## Summary

- Fix MCP status showing "dead" for working Streamable HTTP servers with Bearer token / OAuth auth (#732)
- Root cause: `SseTransport::is_alive()` sent a GET health probe and only treated 2xx/401 as "alive", but GET is optional in the MCP Streamable HTTP spec — servers commonly return 405, 403, or 400
- Fix: any HTTP response = alive; only network errors (connection refused, timeout, DNS) = dead
- Add mock MCP Streamable HTTP server (`mock-mcp-server.js`) for testing
- Add 5 Rust unit tests for `is_alive()` covering 200, 401, 405, 403, 400
- Add E2E test that starts mock server, adds via UI with Bearer token, verifies "running" status

## Validation

### Completed
- [x] `cargo test -p moltis-mcp` — all 93 tests pass
- [x] `biome check --write` — JS lint clean
- [x] `cargo +nightly-2025-11-30 fmt` — no formatting issues in changed files

### Remaining
- [ ] `npx playwright test e2e/specs/mcp.spec.js` — E2E tests
- [ ] `./scripts/local-validate.sh 733`

## Manual QA

1. Start mock server: `node crates/web/ui/e2e/mock-mcp-server.js --bearer-token test123`
2. Add in Settings > MCP > Streamable HTTP with URL `http://127.0.0.1:<port>` and header `Authorization=Bearer test123`
3. Verify status badge shows **"running"** (was "dead" before fix)
4. Verify tool count shows "1 tool"

Fixes #732