### PR TITLE
fix(chat): broadcast user_message event so API-sent messages appear in web UI

### DIFF
--- a/apps/ios/Sources/Networking/ChatEventTypes.swift
+++ b/apps/ios/Sources/Networking/ChatEventTypes.swift
@@ -19,6 +19,7 @@ enum ChatEventState: String, Decodable {
     case aborted
     case voicePending = "voice_pending"
     case channelUser = "channel_user"
+    case userMessage = "user_message"
 }
 
 // MARK: - Chat event payload

--- a/crates/chat/src/service/chat_impl/send.rs
+++ b/crates/chat/src/service/chat_impl/send.rs
@@ -1003,6 +1003,26 @@ impl LiveChatService {
             warn!("failed to persist user message: {e}");
         }
 
+        // Broadcast a user_message event so that other connected clients
+        // (e.g. the web UI when the message was sent via the GraphQL API)
+        // can display the message in real-time without a page reload.
+        // We intentionally omit messageIndex (same rationale as
+        // channel_user in dispatch.rs) and include `seq` so that the
+        // originating web client can suppress the echo it already
+        // rendered optimistically.
+        broadcast(
+            &self.state,
+            "chat",
+            serde_json::json!({
+                "state": "user_message",
+                "text": text,
+                "sessionKey": session_key,
+                "seq": client_seq,
+            }),
+            BroadcastOpts::default(),
+        )
+        .await;
+
         // Set preview from the first user message if not already set.
         if let Some(entry) = self.session_metadata.get(&session_key).await
             && entry.preview.is_none()

--- a/crates/web/src/assets/js/websocket.js
+++ b/crates/web/src/assets/js/websocket.js
@@ -455,6 +455,34 @@ function handleChatChannelUser(p, isActive, isChatPage, eventSession) {
 	}
 }
 
+// Handle user messages broadcast by the backend after persisting a message
+// sent via the GraphQL API, mobile app, or any non-web-UI client.
+// The originating web client already rendered the message optimistically,
+// so we skip rendering when the broadcast's seq matches a seq this client
+// has already sent (seq <= S.chatSeq).
+function handleChatUserMessage(p, isActive, isChatPage, eventSession) {
+	// Suppress the echo for the originating client.
+	if (p.seq !== undefined && p.seq !== null && p.seq <= S.chatSeq) return;
+
+	bumpSessionCount(eventSession, 1);
+	cacheSessionHistoryMessage(
+		eventSession,
+		{
+			role: "user",
+			content: p.text || "",
+			created_at: Date.now(),
+		},
+		p.messageIndex,
+	);
+	if (!isActive) {
+		setSessionUnread(eventSession, true);
+	}
+	if (!(isChatPage && isActive)) return;
+	// Safe: renderMarkdown calls esc() first — all user input is
+	// HTML-escaped before formatting tags are applied.
+	chatAddMsg("user", renderMarkdown(p.text || ""), true);
+}
+
 // Safe: renderMarkdown calls esc() first — all user input is HTML-escaped before
 // being passed to innerHTML. This is the standard rendering path for chat messages.
 function setSafeMarkdownHtml(el, text) {
@@ -1055,6 +1083,7 @@ var chatHandlers = {
 	tool_call_start: handleChatToolCallStart,
 	tool_call_end: handleChatToolCallEnd,
 	channel_user: handleChatChannelUser,
+	user_message: handleChatUserMessage,
 	delta: handleChatDelta,
 	final: handleChatFinal,
 	auto_compact: handleChatAutoCompact,

--- a/crates/web/ui/e2e/specs/chat-api-message.spec.js
+++ b/crates/web/ui/e2e/specs/chat-api-message.spec.js
@@ -1,18 +1,11 @@
 // Tests for GH #729: User messages sent via the GraphQL/RPC API (not the web UI)
 // should appear in the web interface in real-time.
 //
-// Currently, when a message is sent via `chat.send` from an external client
-// (GraphQL mutation, mobile app, etc.), the backend persists it and runs the
-// LLM, but no WebSocket event is broadcast for the user message itself.  The
-// web UI only shows it after a full page reload or session switch.
-//
-// The fix will:
-//  1. Backend: broadcast a `user_message` event after persisting the user
-//     message in send_impl().
-//  2. Frontend: add a `user_message` handler in websocket.js that renders the
-//     message and caches it, similar to the existing `channel_user` handler.
-//  3. Frontend: skip rendering when the current connection originated the
-//     message (the web UI already renders it optimistically).
+// The backend now broadcasts a `user_message` event after persisting the user
+// message in send_impl().  The frontend handler in websocket.js renders the
+// message and caches it (similar to the existing `channel_user` handler),
+// skipping rendering when the current connection originated the message
+// (the web UI already renders it optimistically via seq-based dedup).
 
 const { expect, test } = require("../base-test");
 const { navigateAndWait, waitForWsConnected, watchPageErrors } = require("../helpers");
@@ -83,21 +76,18 @@ test.describe("API-sent user messages (GH #729)", () => {
 		);
 	});
 
-	// This test verifies the fix for GH #729: once the backend broadcasts a
-	// `user_message` event and the frontend handles it, an API-sent message
-	// should appear in the chat without a page reload.
-	test.fixme("user_message broadcast renders in active session", async ({ page }) => {
+	test("user_message broadcast renders in active session", async ({ page }) => {
 		await expectRpcOk(page, "chat.clear", {});
 
 		// Simulate the backend broadcasting a user_message event, as it
 		// would after persisting a message sent via the GraphQL API.
+		// The backend omits messageIndex (same as channel_user).
 		await expectRpcOk(page, "system-event", {
 			event: "chat",
 			payload: {
 				sessionKey: "main",
 				state: "user_message",
 				text: "Bonjour Moltis !",
-				messageIndex: 0,
 			},
 		});
 
@@ -130,7 +120,7 @@ test.describe("API-sent user messages (GH #729)", () => {
 	// Verify the sender's own web UI does not duplicate a message it already
 	// rendered optimistically.  The broadcast includes the client seq so the
 	// handler can detect "I already rendered this" and suppress the echo.
-	test.fixme("user_message broadcast is deduplicated for the originating client", async ({ page }) => {
+	test("user_message broadcast is deduplicated for the originating client", async ({ page }) => {
 		await expectRpcOk(page, "chat.clear", {});
 
 		// Simulate the web UI having optimistically rendered a message at
@@ -158,7 +148,6 @@ test.describe("API-sent user messages (GH #729)", () => {
 				state: "user_message",
 				text: "Hello from UI",
 				seq: 1,
-				messageIndex: 0,
 			},
 		});
 
@@ -169,7 +158,7 @@ test.describe("API-sent user messages (GH #729)", () => {
 
 	// Verify that a user_message for a non-active session does not render
 	// in the current chat view but does bump the session badge.
-	test.fixme("user_message for inactive session does not render in active chat", async ({ page }) => {
+	test("user_message for inactive session does not render in active chat", async ({ page }) => {
 		await expectRpcOk(page, "chat.clear", {});
 
 		// Broadcast a user_message for a different session.
@@ -179,7 +168,6 @@ test.describe("API-sent user messages (GH #729)", () => {
 				sessionKey: "other-session",
 				state: "user_message",
 				text: "Message for other session",
-				messageIndex: 0,
 			},
 		});
 

--- a/crates/web/ui/e2e/specs/chat-api-message.spec.js
+++ b/crates/web/ui/e2e/specs/chat-api-message.spec.js
@@ -1,0 +1,184 @@
+// Tests for GH #729: User messages sent via the GraphQL/RPC API (not the web UI)
+// should appear in the web interface in real-time.
+//
+// Currently, when a message is sent via `chat.send` from an external client
+// (GraphQL mutation, mobile app, etc.), the backend persists it and runs the
+// LLM, but no WebSocket event is broadcast for the user message itself.  The
+// web UI only shows it after a full page reload or session switch.
+//
+// The fix will:
+//  1. Backend: broadcast a `user_message` event after persisting the user
+//     message in send_impl().
+//  2. Frontend: add a `user_message` handler in websocket.js that renders the
+//     message and caches it, similar to the existing `channel_user` handler.
+//  3. Frontend: skip rendering when the current connection originated the
+//     message (the web UI already renders it optimistically).
+
+const { expect, test } = require("../base-test");
+const { navigateAndWait, waitForWsConnected, watchPageErrors } = require("../helpers");
+
+function isRetryableRpcError(message) {
+	if (typeof message !== "string") return false;
+	return message.includes("WebSocket not connected") || message.includes("WebSocket disconnected");
+}
+
+async function sendRpcFromPage(page, method, params) {
+	let lastResponse = null;
+	for (let attempt = 0; attempt < 40; attempt++) {
+		if (attempt > 0) {
+			await waitForWsConnected(page);
+		}
+		lastResponse = await page
+			.evaluate(
+				async ({ methodName, methodParams }) => {
+					var appScript = document.querySelector('script[type="module"][src*="js/app.js"]');
+					if (!appScript) throw new Error("app module script not found");
+					var appUrl = new URL(appScript.src, window.location.origin);
+					var prefix = appUrl.href.slice(0, appUrl.href.length - "js/app.js".length);
+					var helpers = await import(`${prefix}js/helpers.js`);
+					return helpers.sendRpc(methodName, methodParams);
+				},
+				{
+					methodName: method,
+					methodParams: params,
+				},
+			)
+			.catch((error) => ({ ok: false, error: { message: error?.message || String(error) } }));
+
+		if (lastResponse?.ok) return lastResponse;
+		if (!isRetryableRpcError(lastResponse?.error?.message)) return lastResponse;
+	}
+	return lastResponse;
+}
+
+async function expectRpcOk(page, method, params) {
+	const response = await sendRpcFromPage(page, method, params);
+	expect(response?.ok, `RPC ${method} failed: ${response?.error?.message || "unknown error"}`).toBeTruthy();
+	return response;
+}
+
+test.describe("API-sent user messages (GH #729)", () => {
+	test.beforeEach(async ({ page }) => {
+		await navigateAndWait(page, "/chats/main");
+		await waitForWsConnected(page);
+
+		// Wait for session switch to finish so renderHistory() doesn't
+		// clear injected DOM elements.
+		await page.waitForFunction(
+			async () => {
+				var appScript = document.querySelector('script[type="module"][src*="js/app.js"]');
+				if (!appScript) return false;
+				var appUrl = new URL(appScript.src, window.location.origin);
+				var prefix = appUrl.href.slice(0, appUrl.href.length - "js/app.js".length);
+				var state = await import(`${prefix}js/state.js`);
+				return !(state.sessionSwitchInProgress || state.chatBatchLoading);
+			},
+			{ timeout: 10_000 },
+		);
+	});
+
+	// This test verifies the fix for GH #729: once the backend broadcasts a
+	// `user_message` event and the frontend handles it, an API-sent message
+	// should appear in the chat without a page reload.
+	test.fixme("user_message broadcast renders in active session", async ({ page }) => {
+		const pageErrors = watchPageErrors(page);
+		await expectRpcOk(page, "chat.clear", {});
+
+		// Simulate the backend broadcasting a user_message event, as it
+		// would after persisting a message sent via the GraphQL API.
+		await expectRpcOk(page, "system-event", {
+			event: "chat",
+			payload: {
+				sessionKey: "main",
+				state: "user_message",
+				text: "Bonjour Moltis !",
+				messageIndex: 0,
+			},
+		});
+
+		// The user message should appear in the DOM.
+		var userMsg = page.locator(".msg.user");
+		await expect(userMsg).toBeVisible({ timeout: 5_000 });
+		await expect(userMsg).toContainText("Bonjour Moltis !");
+
+		// It should also be cached in session history.
+		const cachedHistory = await page.evaluate(async () => {
+			var appScript = document.querySelector('script[type="module"][src*="js/app.js"]');
+			if (!appScript) throw new Error("app module script not found");
+			var appUrl = new URL(appScript.src, window.location.origin);
+			var prefix = appUrl.href.slice(0, appUrl.href.length - "js/app.js".length);
+			var cache = await import(`${prefix}js/stores/session-history-cache.js`);
+			return cache.getSessionHistory("main");
+		});
+
+		expect(cachedHistory).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					role: "user",
+					content: "Bonjour Moltis !",
+				}),
+			]),
+		);
+		expect(pageErrors).toEqual([]);
+	});
+
+	// Verify the sender's own web UI does not duplicate a message it already
+	// rendered optimistically.  The broadcast should include the client seq
+	// so the frontend can detect "I already rendered this".
+	test.fixme("user_message broadcast is deduplicated for the originating client", async ({ page }) => {
+		const pageErrors = watchPageErrors(page);
+		await expectRpcOk(page, "chat.clear", {});
+
+		// Simulate the web UI having already rendered this message
+		// optimistically (seq 1).
+		await page.evaluate(async () => {
+			var appScript = document.querySelector('script[type="module"][src*="js/app.js"]');
+			if (!appScript) throw new Error("app module script not found");
+			var appUrl = new URL(appScript.src, window.location.origin);
+			var prefix = appUrl.href.slice(0, appUrl.href.length - "js/app.js".length);
+			var chatUi = await import(`${prefix}js/chat-ui.js`);
+			var { renderMarkdown } = await import(`${prefix}js/helpers.js`);
+			chatUi.chatAddMsg("user", renderMarkdown("Already rendered"), true);
+		});
+
+		await expect(page.locator(".msg.user")).toHaveCount(1);
+
+		// Now the broadcast arrives — same content but different origin.
+		// The frontend should add it because it came from another client.
+		await expectRpcOk(page, "system-event", {
+			event: "chat",
+			payload: {
+				sessionKey: "main",
+				state: "user_message",
+				text: "From API client",
+				messageIndex: 1,
+			},
+		});
+
+		// Should now have two user messages (the local one + the API one).
+		await expect(page.locator(".msg.user")).toHaveCount(2, { timeout: 5_000 });
+		expect(pageErrors).toEqual([]);
+	});
+
+	// Verify that a user_message for a non-active session does not render
+	// in the current chat view but does bump the session badge.
+	test.fixme("user_message for inactive session does not render in active chat", async ({ page }) => {
+		const pageErrors = watchPageErrors(page);
+		await expectRpcOk(page, "chat.clear", {});
+
+		// Broadcast a user_message for a different session.
+		await expectRpcOk(page, "system-event", {
+			event: "chat",
+			payload: {
+				sessionKey: "other-session",
+				state: "user_message",
+				text: "Message for other session",
+				messageIndex: 0,
+			},
+		});
+
+		// No user message should appear in the active chat.
+		await expect(page.locator(".msg.user")).toHaveCount(0, { timeout: 2_000 });
+		expect(pageErrors).toEqual([]);
+	});
+});

--- a/crates/web/ui/e2e/specs/chat-api-message.spec.js
+++ b/crates/web/ui/e2e/specs/chat-api-message.spec.js
@@ -58,12 +58,18 @@ async function expectRpcOk(page, method, params) {
 }
 
 test.describe("API-sent user messages (GH #729)", () => {
+	// Single pageErrors array shared across beforeEach + test body so errors
+	// during navigation are not silently dropped.
+	let pageErrors;
+
 	test.beforeEach(async ({ page }) => {
+		pageErrors = watchPageErrors(page);
 		await navigateAndWait(page, "/chats/main");
 		await waitForWsConnected(page);
 
-		// Wait for session switch to finish so renderHistory() doesn't
-		// clear injected DOM elements.
+		// Wait for session switch and subscription to finish so
+		// renderHistory() doesn't clear injected DOM elements and
+		// system-event broadcasts are not dropped.
 		await page.waitForFunction(
 			async () => {
 				var appScript = document.querySelector('script[type="module"][src*="js/app.js"]');
@@ -71,7 +77,7 @@ test.describe("API-sent user messages (GH #729)", () => {
 				var appUrl = new URL(appScript.src, window.location.origin);
 				var prefix = appUrl.href.slice(0, appUrl.href.length - "js/app.js".length);
 				var state = await import(`${prefix}js/state.js`);
-				return !(state.sessionSwitchInProgress || state.chatBatchLoading);
+				return state.subscribed && !(state.sessionSwitchInProgress || state.chatBatchLoading);
 			},
 			{ timeout: 10_000 },
 		);
@@ -81,7 +87,6 @@ test.describe("API-sent user messages (GH #729)", () => {
 	// `user_message` event and the frontend handles it, an API-sent message
 	// should appear in the chat without a page reload.
 	test.fixme("user_message broadcast renders in active session", async ({ page }) => {
-		const pageErrors = watchPageErrors(page);
 		await expectRpcOk(page, "chat.clear", {});
 
 		// Simulate the backend broadcasting a user_message event, as it
@@ -123,47 +128,48 @@ test.describe("API-sent user messages (GH #729)", () => {
 	});
 
 	// Verify the sender's own web UI does not duplicate a message it already
-	// rendered optimistically.  The broadcast should include the client seq
-	// so the frontend can detect "I already rendered this".
+	// rendered optimistically.  The broadcast includes the client seq so the
+	// handler can detect "I already rendered this" and suppress the echo.
 	test.fixme("user_message broadcast is deduplicated for the originating client", async ({ page }) => {
-		const pageErrors = watchPageErrors(page);
 		await expectRpcOk(page, "chat.clear", {});
 
-		// Simulate the web UI having already rendered this message
-		// optimistically (seq 1).
+		// Simulate the web UI having optimistically rendered a message at
+		// seq 1: add the DOM element and advance the client chatSeq.
 		await page.evaluate(async () => {
 			var appScript = document.querySelector('script[type="module"][src*="js/app.js"]');
 			if (!appScript) throw new Error("app module script not found");
 			var appUrl = new URL(appScript.src, window.location.origin);
 			var prefix = appUrl.href.slice(0, appUrl.href.length - "js/app.js".length);
 			var chatUi = await import(`${prefix}js/chat-ui.js`);
+			var state = await import(`${prefix}js/state.js`);
 			var { renderMarkdown } = await import(`${prefix}js/helpers.js`);
-			chatUi.chatAddMsg("user", renderMarkdown("Already rendered"), true);
+			chatUi.chatAddMsg("user", renderMarkdown("Hello from UI"), true);
+			state.setChatSeq(1);
 		});
 
 		await expect(page.locator(".msg.user")).toHaveCount(1);
 
-		// Now the broadcast arrives — same content but different origin.
-		// The frontend should add it because it came from another client.
+		// The backend echoes the same message back with the same seq.
+		// The handler should recognise that seq <= chatSeq and skip it.
 		await expectRpcOk(page, "system-event", {
 			event: "chat",
 			payload: {
 				sessionKey: "main",
 				state: "user_message",
-				text: "From API client",
-				messageIndex: 1,
+				text: "Hello from UI",
+				seq: 1,
+				messageIndex: 0,
 			},
 		});
 
-		// Should now have two user messages (the local one + the API one).
-		await expect(page.locator(".msg.user")).toHaveCount(2, { timeout: 5_000 });
+		// Count must stay at 1 — the echo was suppressed.
+		await expect(page.locator(".msg.user")).toHaveCount(1, { timeout: 2_000 });
 		expect(pageErrors).toEqual([]);
 	});
 
 	// Verify that a user_message for a non-active session does not render
 	// in the current chat view but does bump the session badge.
 	test.fixme("user_message for inactive session does not render in active chat", async ({ page }) => {
-		const pageErrors = watchPageErrors(page);
 		await expectRpcOk(page, "chat.clear", {});
 
 		// Broadcast a user_message for a different session.


### PR DESCRIPTION
## Summary

Fixes #729 — user messages sent via the GraphQL `chat.send` mutation were persisted but never appeared in the web UI until a page reload.

**Root cause:** `send_impl()` persists the user message but broadcasts no WebSocket event for it. The web UI relies on optimistic local rendering, which only works when the sender is the web UI itself.

**Changes:**
- **Backend** (`send.rs`): broadcast a `user_message` event after persisting, with `seq` for client-side dedup
- **Frontend** (`websocket.js`): add `user_message` handler — renders the message, caches it in session history, suppresses echoes for the originating client via `seq <= chatSeq`
- **iOS** (`ChatEventTypes.swift`): add `userMessage` enum case
- **E2E tests**: 3 tests covering render, dedup, and inactive-session isolation

## Validation

### Completed
- [x] `cargo check` passes
- [x] `just lint` (clippy) passes
- [x] `cargo test --package moltis-chat` — 96 tests pass
- [x] `npx biome check` passes on JS files
- [x] Greptile review feedback addressed (4/4 comments resolved)

### Remaining
- [ ] `npx playwright test e2e/specs/chat-api-message.spec.js` — run e2e tests with a live server
- [ ] `./scripts/local-validate.sh 734`

## Manual QA

1. Open the web UI to a chat session
2. Send a message via GraphQL: `mutation { chat { send(message: "hello", sessionKey: "main") { ok } } }`
3. Verify: the user message now appears in the web UI immediately (no page reload needed)
4. Verify: messages sent from the web UI itself are NOT duplicated

🤖 Generated with [Claude Code](https://claude.com/claude-code)