### PR TITLE
feat(providers): configurable context windows + oldest-first compaction

### DIFF
--- a/crates/agents/src/runner/helpers.rs
+++ b/crates/agents/src/runner/helpers.rs
@@ -17,8 +17,6 @@ use crate::{
 
 // ── Constants ───────────────────────────────────────────────────────────
 
-pub(crate) const TOOL_RESULT_COMPACTION_RATIO_PERCENT: usize = 75;
-pub(crate) const PREEMPTIVE_OVERFLOW_RATIO_PERCENT: usize = 90;
 pub(crate) const TOOL_RESULT_COMPACTION_PLACEHOLDER: &str =
     "[tool result compacted to preserve context budget]";
 pub(crate) const TOOL_RESULT_COMPACTION_MIN_BYTES: usize = 200;
@@ -441,7 +439,7 @@ pub(crate) fn has_tool_result_messages(messages: &[ChatMessage]) -> bool {
         .any(|message| matches!(message, ChatMessage::Tool { .. }))
 }
 
-pub(crate) fn compact_tool_results_newest_first_in_place(
+pub(crate) fn compact_tool_results_oldest_first_in_place(
     messages: &mut [ChatMessage],
     tokens_needed: usize,
 ) -> usize {
@@ -450,7 +448,7 @@ pub(crate) fn compact_tool_results_newest_first_in_place(
     }
 
     let mut reduced = 0;
-    for message in messages.iter_mut().rev() {
+    for message in messages.iter_mut() {
         if reduced >= tokens_needed {
             break;
         }
@@ -492,27 +490,40 @@ pub(crate) fn enforce_tool_result_context_budget(
     messages: &mut [ChatMessage],
     tool_schemas: &[serde_json::Value],
     context_window: u32,
+    compaction_ratio: usize,
+    overflow_ratio: usize,
 ) -> Result<(), AgentRunError> {
     let context_window = context_window as usize;
     if context_window == 0 || !has_tool_result_messages(messages) {
         return Ok(());
     }
 
-    let compaction_budget =
-        context_window.saturating_mul(TOOL_RESULT_COMPACTION_RATIO_PERCENT) / 100;
-    let overflow_budget = context_window.saturating_mul(PREEMPTIVE_OVERFLOW_RATIO_PERCENT) / 100;
+    // Allow disabling per-iteration compaction entirely via config (ratio = 0).
+    if compaction_ratio == 0 {
+        let overflow_budget = context_window.saturating_mul(overflow_ratio) / 100;
+        let current_tokens = estimate_prompt_tokens(messages, tool_schemas);
+        if current_tokens > overflow_budget {
+            return Err(AgentRunError::ContextWindowExceeded(format!(
+                "preemptive context overflow: estimated prompt size {current_tokens} tokens \
+                 exceeds {overflow_budget} token budget (compaction disabled)"
+            )));
+        }
+        return Ok(());
+    }
+    let compaction_budget = context_window.saturating_mul(compaction_ratio) / 100;
+    let overflow_budget = context_window.saturating_mul(overflow_ratio) / 100;
     let current_tokens = estimate_prompt_tokens(messages, tool_schemas);
 
     if current_tokens > compaction_budget {
         let needed = current_tokens.saturating_sub(compaction_budget);
-        let reduced = compact_tool_results_newest_first_in_place(messages, needed);
+        let reduced = compact_tool_results_oldest_first_in_place(messages, needed);
         tracing::debug!(
             current_tokens,
             compaction_budget,
             overflow_budget,
             needed,
             reduced,
-            "compacted newest tool results to preserve prompt budget"
+            "compacted oldest tool results to preserve prompt budget"
         );
     }
 

--- a/crates/agents/src/runner/mod.rs
+++ b/crates/agents/src/runner/mod.rs
@@ -36,6 +36,6 @@ pub(crate) use helpers::{
 // Items only consumed by test submodules (`tests`, `tests_legacy`).
 #[cfg(test)]
 pub(crate) use helpers::{
-    TOOL_RESULT_COMPACTION_PLACEHOLDER, compact_tool_results_newest_first_in_place,
+    TOOL_RESULT_COMPACTION_PLACEHOLDER, compact_tool_results_oldest_first_in_place,
     legacy_public_tool_alias,
 };

--- a/crates/agents/src/runner/non_streaming.rs
+++ b/crates/agents/src/runner/non_streaming.rs
@@ -80,6 +80,9 @@ pub async fn run_agent_loop_with_context(
     let max_tool_result_bytes = config.tools.max_tool_result_bytes;
     let max_auto_continues = config.tools.agent_max_auto_continues;
     let auto_continue_min_tool_calls = config.tools.agent_auto_continue_min_tool_calls;
+    let compaction_ratio = config.tools.tool_result_compaction_ratio as usize;
+    let overflow_ratio = config.tools.preemptive_overflow_ratio as usize;
+    let compaction_min_iterations = config.tools.compaction_min_iterations;
     let base_max_iterations = resolve_agent_max_iterations(config.tools.agent_max_iterations);
     // Lazy mode needs extra iterations for tool_search discovery round-trips.
     let max_iterations = if config.tools.registry_mode == moltis_config::ToolRegistryMode::Lazy {
@@ -160,10 +163,17 @@ pub async fn run_agent_loop_with_context(
             loop_detector.clear_strip_tools();
         }
 
+        let effective_ratio = if iterations > compaction_min_iterations {
+            compaction_ratio
+        } else {
+            0 // skip compaction but still check for overflow
+        };
         super::enforce_tool_result_context_budget(
             &mut messages,
             &schemas_for_api,
             provider.context_window(),
+            effective_ratio,
+            overflow_ratio,
         )?;
 
         if let Some(cb) = on_event {

--- a/crates/agents/src/runner/streaming.rs
+++ b/crates/agents/src/runner/streaming.rs
@@ -67,6 +67,9 @@ pub async fn run_agent_loop_streaming(
     let max_tool_result_bytes = config.tools.max_tool_result_bytes;
     let max_auto_continues = config.tools.agent_max_auto_continues;
     let auto_continue_min_tool_calls = config.tools.agent_auto_continue_min_tool_calls;
+    let compaction_ratio = config.tools.tool_result_compaction_ratio as usize;
+    let overflow_ratio = config.tools.preemptive_overflow_ratio as usize;
+    let compaction_min_iterations = config.tools.compaction_min_iterations;
     let base_max_iterations = resolve_agent_max_iterations(config.tools.agent_max_iterations);
     // Lazy mode needs extra iterations for tool_search discovery round-trips.
     let max_iterations = if config.tools.registry_mode == moltis_config::ToolRegistryMode::Lazy {
@@ -155,10 +158,17 @@ pub async fn run_agent_loop_streaming(
             loop_detector.clear_strip_tools();
         }
 
+        let effective_ratio = if iterations > compaction_min_iterations {
+            compaction_ratio
+        } else {
+            0 // skip compaction but still check for overflow
+        };
         super::enforce_tool_result_context_budget(
             &mut messages,
             &schemas_for_api,
             provider.context_window(),
+            effective_ratio,
+            overflow_ratio,
         )?;
 
         if let Some(cb) = on_event {

--- a/crates/agents/src/runner/tests/basic.rs
+++ b/crates/agents/src/runner/tests/basic.rs
@@ -1488,3 +1488,244 @@ fn resolve_tool_lookup_falls_back_to_legacy_name_when_no_public_tool_exists() {
     assert_eq!(resolved_name, "web_search_wasm");
     assert_eq!(tool.name(), "web_search_wasm");
 }
+
+// ── Compaction tests ───────────────────────────────────────────────────
+
+#[test]
+fn compact_oldest_first_compacts_earliest_tool_result() {
+    let mut messages = vec![
+        ChatMessage::tool("id1", &"a".repeat(300)), // oldest — should be compacted first
+        ChatMessage::tool("id2", &"b".repeat(300)), // newer — should remain intact
+    ];
+    let reduced = compact_tool_results_oldest_first_in_place(&mut messages, 1);
+    assert!(reduced > 0, "should have compacted something");
+
+    // Oldest message compacted.
+    let ChatMessage::Tool { tool_call_id, content } = &messages[0] else {
+        panic!("expected Tool message");
+    };
+    assert_eq!(tool_call_id, "id1");
+    assert_eq!(content, TOOL_RESULT_COMPACTION_PLACEHOLDER);
+    // Newer message untouched.
+    match &messages[1] {
+        ChatMessage::Tool { content, .. } => {
+            assert_ne!(content, TOOL_RESULT_COMPACTION_PLACEHOLDER);
+        }
+        _ => panic!("expected Tool message"),
+    }
+}
+
+#[test]
+fn compact_oldest_first_skips_already_compacted() {
+    let mut messages = vec![
+        ChatMessage::tool("id1", TOOL_RESULT_COMPACTION_PLACEHOLDER), // already compacted
+        ChatMessage::tool("id2", &"b".repeat(300)),                   // should be compacted
+    ];
+    let reduced = compact_tool_results_oldest_first_in_place(&mut messages, 1);
+    assert!(reduced > 0);
+
+    // id1 unchanged (already compacted), id2 now compacted.
+    match &messages[0] {
+        ChatMessage::Tool { content, .. } => {
+            assert_eq!(content, TOOL_RESULT_COMPACTION_PLACEHOLDER);
+        }
+        _ => panic!("expected Tool message"),
+    }
+    match &messages[1] {
+        ChatMessage::Tool { content, .. } => {
+            assert_eq!(content, TOOL_RESULT_COMPACTION_PLACEHOLDER);
+        }
+        _ => panic!("expected Tool message"),
+    }
+}
+
+#[test]
+fn compact_oldest_first_skips_small_results() {
+    // Content below TOOL_RESULT_COMPACTION_MIN_BYTES (200) should be skipped.
+    let mut messages = vec![
+        ChatMessage::tool("id1", &"a".repeat(50)), // too small
+        ChatMessage::tool("id2", &"b".repeat(300)), // should be compacted
+    ];
+    let reduced = compact_tool_results_oldest_first_in_place(&mut messages, 1);
+    assert!(reduced > 0);
+
+    // id1 untouched (too small), id2 compacted.
+    match &messages[0] {
+        ChatMessage::Tool { content, .. } => {
+            assert_ne!(content, TOOL_RESULT_COMPACTION_PLACEHOLDER);
+            assert_eq!(content.len(), 50);
+        }
+        _ => panic!("expected Tool message"),
+    }
+    // id2 compacted.
+    match &messages[1] {
+        ChatMessage::Tool { content, .. } => {
+            assert_eq!(content, TOOL_RESULT_COMPACTION_PLACEHOLDER);
+        }
+        _ => panic!("expected Tool message"),
+    }
+}
+
+#[test]
+fn compact_oldest_first_returns_zero_when_nothing_to_compact() {
+    let mut messages = vec![
+        ChatMessage::tool("id1", "short"), // below min bytes
+    ];
+    let reduced = compact_tool_results_oldest_first_in_place(&mut messages, 100);
+    assert_eq!(reduced, 0);
+}
+
+#[test]
+fn compact_oldest_first_returns_zero_for_zero_tokens_needed() {
+    let mut messages = vec![
+        ChatMessage::tool("id1", &"a".repeat(300)),
+    ];
+    let reduced = compact_tool_results_oldest_first_in_place(&mut messages, 0);
+    assert_eq!(reduced, 0);
+}
+
+#[test]
+fn compact_oldest_first_stops_once_budget_freed() {
+    let mut messages = vec![
+        ChatMessage::tool("id1", &"a".repeat(500)), // will be compacted
+        ChatMessage::tool("id2", &"b".repeat(500)), // may or may not be compacted
+        ChatMessage::tool("id3", &"c".repeat(500)), // should be untouched
+    ];
+    let reduced = compact_tool_results_oldest_first_in_place(&mut messages, 1);
+    assert!(reduced > 0);
+
+    // First result compacted.
+    match &messages[0] {
+        ChatMessage::Tool { content, .. } => {
+            assert_eq!(content, TOOL_RESULT_COMPACTION_PLACEHOLDER);
+        }
+        _ => panic!("expected Tool message"),
+    }
+    // Last message should be untouched since we only needed 1 token.
+    match &messages[2] {
+        ChatMessage::Tool { content, .. } => {
+            assert_ne!(content, TOOL_RESULT_COMPACTION_PLACEHOLDER);
+        }
+        _ => panic!("expected Tool message"),
+    }
+}
+
+#[test]
+fn enforce_budget_ratio_zero_disables_compaction_ok_when_under_overflow() {
+    // compaction_ratio=0 should skip compaction entirely.
+    // With a huge context window, even with tool results, we're under overflow.
+    let mut messages = vec![
+        ChatMessage::tool("id1", &"a".repeat(300)),
+    ];
+    let result = enforce_tool_result_context_budget(
+        &mut messages,
+        &[],
+        100_000, // large context window
+        0,       // compaction disabled
+        90,      // overflow ratio
+    );
+    assert!(result.is_ok());
+    // Message should be untouched (no compaction ran).
+    match &messages[0] {
+        ChatMessage::Tool { content, .. } => {
+            assert_ne!(content, TOOL_RESULT_COMPACTION_PLACEHOLDER);
+        }
+        _ => panic!("expected Tool message"),
+    }
+}
+
+#[test]
+fn enforce_budget_ratio_zero_errors_on_overflow() {
+    // compaction_ratio=0 with a tiny context window → overflow error.
+    let mut messages = vec![
+        ChatMessage::tool("id1", &"a".repeat(500)),
+    ];
+    let result = enforce_tool_result_context_budget(
+        &mut messages,
+        &[],
+        10, // tiny context window
+        0,  // compaction disabled
+        90, // overflow ratio
+    );
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("compaction disabled"),
+        "error should mention compaction disabled: {msg}"
+    );
+}
+
+#[test]
+fn enforce_budget_compacts_when_over_compaction_threshold() {
+    // With compaction_ratio=50 and a small context window, compaction should fire.
+    let mut messages = vec![
+        ChatMessage::tool("id1", &"a".repeat(300)),
+        ChatMessage::tool("id2", &"b".repeat(300)),
+    ];
+    let result = enforce_tool_result_context_budget(
+        &mut messages,
+        &[],
+        100,  // small context window → compaction budget = 50 tokens
+        75,   // compaction ratio
+        90,   // overflow ratio
+    );
+    assert!(result.is_ok());
+    // At least one message should have been compacted.
+    let compacted = messages.iter().filter(|m| {
+        matches!(m, ChatMessage::Tool { content, .. } if content == TOOL_RESULT_COMPACTION_PLACEHOLDER)
+    }).count();
+    assert!(compacted > 0, "at least one message should be compacted");
+}
+
+#[test]
+fn enforce_budget_errors_when_over_overflow_even_after_compaction() {
+    // Even after compacting everything, if still over overflow → error.
+    let mut messages = vec![
+        ChatMessage::tool("id1", TOOL_RESULT_COMPACTION_PLACEHOLDER), // already compacted
+        ChatMessage::tool("id2", "tiny"),                              // too small to compact
+    ];
+    let result = enforce_tool_result_context_budget(
+        &mut messages,
+        &[],
+        5, // tiny context window
+        75,
+        90,
+    );
+    assert!(result.is_err());
+}
+
+#[test]
+fn enforce_budget_noop_when_no_tool_results() {
+    let mut messages = vec![
+        ChatMessage::user("hello"),
+    ];
+    let result = enforce_tool_result_context_budget(
+        &mut messages,
+        &[],
+        100,
+        75,
+        90,
+    );
+    assert!(result.is_ok());
+    // Verify user message is untouched.
+    match &messages[0] {
+        ChatMessage::User { .. } => {}
+        _ => panic!("expected User message"),
+    }
+}
+
+#[test]
+fn enforce_budget_noop_when_context_window_zero() {
+    let mut messages = vec![
+        ChatMessage::tool("id1", &"a".repeat(300)),
+    ];
+    let result = enforce_tool_result_context_budget(
+        &mut messages,
+        &[],
+        0, // zero context window
+        75,
+        90,
+    );
+    assert!(result.is_ok());
+}

--- a/crates/agents/src/runner/tests/helpers.rs
+++ b/crates/agents/src/runner/tests/helpers.rs
@@ -16,7 +16,8 @@ use {
 pub(super) use {
     super::super::{
         AgentRunError, AgentRunResult, OnEvent, RunnerEvent, TOOL_RESULT_COMPACTION_PLACEHOLDER,
-        compact_tool_results_newest_first_in_place, explicit_shell_command_from_user_content,
+        compact_tool_results_oldest_first_in_place, enforce_tool_result_context_budget,
+        explicit_shell_command_from_user_content,
         is_substantive_answer_text, legacy_public_tool_alias, resolve_tool_lookup,
         retry::*,
         run_agent_loop, run_agent_loop_with_context, sanitize_tool_name, sanitize_tool_result,

--- a/crates/config/src/schema/providers.rs
+++ b/crates/config/src/schema/providers.rs
@@ -20,7 +20,7 @@ pub struct OAuthProviderConfig {
 
 /// Override configuration for a specific model.
 ///
-/// Used in both `[models.<id>]` (global) and `[providers.<name>.models.<id>]`
+/// Used in both `[models.<id>]` (global) and `[providers.<name>.model_overrides.<id>]`
 /// (provider-scoped) sections of `moltis.toml`.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(default)]
@@ -30,7 +30,7 @@ pub struct ModelOverride {
     /// When set, this value takes precedence over the built-in heuristic.
     /// Must be between 1 and 10,000,000 (inclusive).
     ///
-    /// Provider-scoped overrides (`[providers.<name>.models.<id>]`)
+    /// Provider-scoped overrides (`[providers.<name>.model_overrides.<id>]`)
     /// take precedence over global overrides (`[models.<id>]`).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub context_window: Option<u32>,

--- a/crates/config/src/schema/tools.rs
+++ b/crates/config/src/schema/tools.rs
@@ -47,6 +47,21 @@ pub struct ToolsConfig {
     /// in text. Default true.
     #[serde(default = "default_agent_loop_detector_strip_tools")]
     pub agent_loop_detector_strip_tools_on_second_fire: bool,
+    /// Percentage of the provider's context window at which per-iteration
+    /// tool-result compaction starts. Oldest results are compacted first.
+    /// Set to 0 to disable per-iteration compaction entirely. Default 75.
+    #[serde(default = "default_tool_result_compaction_ratio")]
+    pub tool_result_compaction_ratio: u32,
+    /// Percentage of the provider's context window at which a hard
+    /// `ContextWindowExceeded` error fires even after compaction.
+    /// Must be greater than `tool_result_compaction_ratio`. Default 90.
+    #[serde(default = "default_preemptive_overflow_ratio")]
+    pub preemptive_overflow_ratio: u32,
+    /// Minimum number of agent loop iterations before per-iteration
+    /// tool-result compaction is allowed to fire. Prevents premature
+    /// context destruction in short loops. Default 3.
+    #[serde(default = "default_compaction_min_iterations")]
+    pub compaction_min_iterations: usize,
 }
 
 impl Default for ToolsConfig {
@@ -67,6 +82,9 @@ impl Default for ToolsConfig {
             agent_loop_detector_window: default_agent_loop_detector_window(),
             agent_loop_detector_strip_tools_on_second_fire: default_agent_loop_detector_strip_tools(
             ),
+            tool_result_compaction_ratio: default_tool_result_compaction_ratio(),
+            preemptive_overflow_ratio: default_preemptive_overflow_ratio(),
+            compaction_min_iterations: default_compaction_min_iterations(),
         }
     }
 }
@@ -211,6 +229,18 @@ fn default_agent_loop_detector_window() -> usize {
 
 fn default_agent_loop_detector_strip_tools() -> bool {
     true
+}
+
+fn default_tool_result_compaction_ratio() -> u32 {
+    75
+}
+
+fn default_preemptive_overflow_ratio() -> u32 {
+    90
+}
+
+fn default_compaction_min_iterations() -> usize {
+    3
 }
 
 /// Map tools configuration.

--- a/crates/config/src/template.rs
+++ b/crates/config/src/template.rs
@@ -332,6 +332,9 @@ max_tool_result_bytes = 50000     # Max bytes per tool result before truncation 
 # registry_mode = "full"          # "full" = all schemas every turn, "lazy" = tool_search discovery
 agent_loop_detector_window = 3    # Fire intervention after N identical failing tool calls in a row (0 = disable)
 agent_loop_detector_strip_tools_on_second_fire = true  # On second consecutive fire, strip tool schemas for one turn to force a text response
+tool_result_compaction_ratio = 75     # % of context_window before oldest tool results are compacted (0 = disable)
+preemptive_overflow_ratio = 90        # % of context_window before hard ContextWindowExceeded error
+compaction_min_iterations = 3         # Min loop iterations before per-iteration compaction can fire
 
 # ── Maps ─────────────────────────────────────────────────────────────────────
 

--- a/crates/config/src/template.rs
+++ b/crates/config/src/template.rs
@@ -867,8 +867,9 @@ reset_on_exit = true              # Reset serve/funnel when gateway shuts down
 
 [channels]
 # Which channel types appear in the web UI's "+ Add Channel" menu.
-# Default: ["telegram", "whatsapp", "msteams", "discord", "slack", "matrix", "nostr"]
-# offered = ["telegram", "whatsapp", "msteams", "discord", "slack", "matrix", "nostr"]
+# Default: ["telegram", "msteams", "discord", "slack", "matrix", "nostr"]
+# Add "whatsapp" to enable it in the UI.
+# offered = ["telegram", "msteams", "discord", "slack", "matrix", "nostr", "whatsapp"]
 
 # WhatsApp linked-device accounts
 # [channels.whatsapp.my-bot]

--- a/crates/config/src/validate/schema_map.rs
+++ b/crates/config/src/validate/schema_map.rs
@@ -221,6 +221,9 @@ pub(super) fn build_schema_map() -> KnownKeys {
             ("registry_mode", Leaf),
             ("agent_loop_detector_window", Leaf),
             ("agent_loop_detector_strip_tools_on_second_fire", Leaf),
+            ("tool_result_compaction_ratio", Leaf),
+            ("preemptive_overflow_ratio", Leaf),
+            ("compaction_min_iterations", Leaf),
         ]))
     };
 

--- a/crates/config/src/validate/semantic.rs
+++ b/crates/config/src/validate/semantic.rs
@@ -764,8 +764,7 @@ pub(super) fn check_semantic_warnings(config: &MoltisConfig, diagnostics: &mut V
             category: "invalid-value",
             path: "tools.preemptive_overflow_ratio".into(),
             message: format!(
-                "preemptive_overflow_ratio ({}) should be greater than 
-                 tool_result_compaction_ratio ({}) to avoid context overflow on every iteration",
+                "preemptive_overflow_ratio ({}) should be greater than tool_result_compaction_ratio ({}) to avoid context overflow on every iteration",
                 config.tools.preemptive_overflow_ratio, config.tools.tool_result_compaction_ratio
             ),
         });

--- a/crates/config/src/validate/semantic.rs
+++ b/crates/config/src/validate/semantic.rs
@@ -754,6 +754,22 @@ pub(super) fn check_semantic_warnings(config: &MoltisConfig, diagnostics: &mut V
             );
         }
     }
+
+    // tools: overflow_ratio must be greater than compaction_ratio
+    if config.tools.tool_result_compaction_ratio > 0
+        && config.tools.preemptive_overflow_ratio <= config.tools.tool_result_compaction_ratio
+    {
+        diagnostics.push(Diagnostic {
+            severity: Severity::Warning,
+            category: "invalid-value",
+            path: "tools.preemptive_overflow_ratio".into(),
+            message: format!(
+                "preemptive_overflow_ratio ({}) should be greater than 
+                 tool_result_compaction_ratio ({}) to avoid context overflow on every iteration",
+                config.tools.preemptive_overflow_ratio, config.tools.tool_result_compaction_ratio
+            ),
+        });
+    }
 }
 
 /// Validate a `context_window` override value (optional field).

--- a/crates/config/src/validate/semantic.rs
+++ b/crates/config/src/validate/semantic.rs
@@ -749,7 +749,7 @@ pub(super) fn check_semantic_warnings(config: &MoltisConfig, diagnostics: &mut V
         for (model_id, override_cfg) in &provider_entry.model_overrides {
             validate_context_window(
                 override_cfg.context_window,
-                &format!("providers.{provider_name}.models.{model_id}.context_window"),
+                &format!("providers.{provider_name}.model_overrides.{model_id}.context_window"),
                 diagnostics,
             );
         }

--- a/crates/config/src/validate/semantic.rs
+++ b/crates/config/src/validate/semantic.rs
@@ -755,6 +755,30 @@ pub(super) fn check_semantic_warnings(config: &MoltisConfig, diagnostics: &mut V
         }
     }
 
+    // tools: ratio fields should not exceed 100 (percentages)
+    if config.tools.tool_result_compaction_ratio > 100 {
+        diagnostics.push(Diagnostic {
+            severity: Severity::Warning,
+            category: "invalid-value",
+            path: "tools.tool_result_compaction_ratio".into(),
+            message: format!(
+                "tool_result_compaction_ratio ({}) exceeds 100 — compaction will trigger on every iteration regardless of context usage",
+                config.tools.tool_result_compaction_ratio
+            ),
+        });
+    }
+    if config.tools.preemptive_overflow_ratio > 100 {
+        diagnostics.push(Diagnostic {
+            severity: Severity::Warning,
+            category: "invalid-value",
+            path: "tools.preemptive_overflow_ratio".into(),
+            message: format!(
+                "preemptive_overflow_ratio ({}) exceeds 100 — overflow protection will always trigger",
+                config.tools.preemptive_overflow_ratio
+            ),
+        });
+    }
+
     // tools: overflow_ratio must be greater than compaction_ratio
     if config.tools.tool_result_compaction_ratio > 0
         && config.tools.preemptive_overflow_ratio <= config.tools.tool_result_compaction_ratio

--- a/crates/config/src/validate/semantic.rs
+++ b/crates/config/src/validate/semantic.rs
@@ -755,6 +755,18 @@ pub(super) fn check_semantic_warnings(config: &MoltisConfig, diagnostics: &mut V
         }
     }
 
+    // tools: overflow_ratio must not be zero (budget becomes 0, every iteration fails)
+    if config.tools.preemptive_overflow_ratio == 0 {
+        diagnostics.push(Diagnostic {
+            severity: Severity::Warning,
+            category: "invalid-value",
+            path: "tools.preemptive_overflow_ratio".into(),
+            message: "preemptive_overflow_ratio = 0 means the overflow budget is always \
+                      0 tokens; the agent loop will fail immediately on every iteration"
+                .into(),
+        });
+    }
+
     // tools: ratio fields should not exceed 100 (percentages)
     if config.tools.tool_result_compaction_ratio > 100 {
         diagnostics.push(Diagnostic {

--- a/crates/gateway/src/server/prepare_core.rs
+++ b/crates/gateway/src/server/prepare_core.rs
@@ -287,6 +287,7 @@ pub async fn prepare_gateway_core(
         deploy_platform.clone(),
     )
     .with_env_overrides(config_env_overrides.clone())
+    .with_global_cw_overrides(moltis_providers::extract_cw_overrides(&config.models))
     .with_error_parser(crate::chat_error::parse_chat_error)
     .with_callback_bind_addr(bind.to_string());
     provider_setup.set_priority_models(live_model_service.priority_models_handle());

--- a/crates/gateway/src/server/prepare_core.rs
+++ b/crates/gateway/src/server/prepare_core.rs
@@ -147,6 +147,7 @@ pub async fn prepare_gateway_core(
         ProviderRegistry::from_config_with_static_catalogs(
             &effective_providers,
             &config_env_overrides,
+            moltis_providers::extract_cw_overrides(&config.models),
         ),
     ));
     {

--- a/crates/gateway/src/server/prepare_core/post_state.rs
+++ b/crates/gateway/src/server/prepare_core/post_state.rs
@@ -489,6 +489,7 @@ pub(super) async fn complete_startup(
         let state_for_startup_discovery = Arc::clone(&state);
         let provider_config_for_startup_discovery = effective_providers.clone();
         let provider_config_for_registry_rebuild = provider_config_for_startup_discovery.clone();
+        let global_cw_overrides = moltis_providers::extract_cw_overrides(&config.models);
         let env_overrides_for_startup_discovery = config_env_overrides.clone();
         tokio::spawn(async move {
             let startup_discovery_started = std::time::Instant::now();
@@ -513,6 +514,7 @@ pub(super) async fn complete_startup(
                     &provider_config_for_registry_rebuild,
                     &env_overrides_for_startup_discovery,
                     &prefetched,
+                    global_cw_overrides.clone(),
                 )
             })
             .await

--- a/crates/provider-setup/src/service/implementation/oauth.rs
+++ b/crates/provider-setup/src/service/implementation/oauth.rs
@@ -59,6 +59,8 @@ impl LiveProviderSetupService {
         let registry = Arc::clone(&self.registry);
         let config = self.effective_config();
         let env_overrides = self.env_overrides.clone();
+        let cw_overrides = self.global_cw_overrides.lock()
+            .unwrap_or_else(|e| e.into_inner()).clone();
         let poll_headers = extra_headers.clone();
         tokio::spawn(async move {
             let poll_extra = poll_headers.as_ref();
@@ -83,6 +85,7 @@ impl LiveProviderSetupService {
                     let new_registry = ProviderRegistry::from_env_with_config_and_overrides(
                         &config,
                         &env_overrides,
+                        cw_overrides,
                     );
                     let provider_summary = new_registry.provider_summary();
                     let model_count = new_registry.list_models().len();
@@ -198,6 +201,8 @@ impl LiveProviderSetupService {
         let registry = Arc::clone(&self.registry);
         let config = self.effective_config();
         let env_overrides = self.env_overrides.clone();
+        let cw_overrides = self.global_cw_overrides.lock()
+            .unwrap_or_else(|e| e.into_inner()).clone();
         let bind_addr = self.callback_bind_addr.clone();
         let pending_oauth = Arc::clone(&self.pending_oauth);
         let callback_state = expected_state.clone();
@@ -231,6 +236,7 @@ impl LiveProviderSetupService {
                             let new_registry = ProviderRegistry::from_env_with_config_and_overrides(
                                 &config,
                                 &env_overrides,
+                                cw_overrides,
                             );
                             let provider_summary = new_registry.provider_summary();
                             let model_count = new_registry.list_models().len();

--- a/crates/provider-setup/src/service/implementation/oauth.rs
+++ b/crates/provider-setup/src/service/implementation/oauth.rs
@@ -59,8 +59,7 @@ impl LiveProviderSetupService {
         let registry = Arc::clone(&self.registry);
         let config = self.effective_config();
         let env_overrides = self.env_overrides.clone();
-        let cw_overrides = self.global_cw_overrides.lock()
-            .unwrap_or_else(|e| e.into_inner()).clone();
+        let cw_overrides = self.global_cw_overrides.clone();
         let poll_headers = extra_headers.clone();
         tokio::spawn(async move {
             let poll_extra = poll_headers.as_ref();
@@ -201,8 +200,7 @@ impl LiveProviderSetupService {
         let registry = Arc::clone(&self.registry);
         let config = self.effective_config();
         let env_overrides = self.env_overrides.clone();
-        let cw_overrides = self.global_cw_overrides.lock()
-            .unwrap_or_else(|e| e.into_inner()).clone();
+        let cw_overrides = self.global_cw_overrides.clone();
         let bind_addr = self.callback_bind_addr.clone();
         let pending_oauth = Arc::clone(&self.pending_oauth);
         let callback_state = expected_state.clone();

--- a/crates/provider-setup/src/service/implementation/service.rs
+++ b/crates/provider-setup/src/service/implementation/service.rs
@@ -62,9 +62,8 @@ pub struct LiveProviderSetupService {
     /// provider credentials without mutating the process environment.
     pub(crate) env_overrides: HashMap<String, String>,
     /// Global context-window overrides extracted from `[models.*].context_window`.
-    /// Threaded through on every registry rebuild so runtime paths don't
-    /// silently drop the overrides.
-    pub(crate) global_cw_overrides: Arc<Mutex<HashMap<String, u32>>>,
+    /// Set once at construction, then cloned into spawned tasks.
+    pub(crate) global_cw_overrides: HashMap<String, u32>,
     /// Injected error parser for interpreting provider API errors.
     pub(crate) error_parser: ErrorParser,
     /// Address the OAuth callback server binds to. Defaults to `127.0.0.1`
@@ -90,7 +89,7 @@ impl LiveProviderSetupService {
             priority_models: None,
             registry_rebuild_seq: Arc::new(AtomicU64::new(0)),
             env_overrides: HashMap::new(),
-            global_cw_overrides: Arc::new(Mutex::new(HashMap::new())),
+            global_cw_overrides: HashMap::new(),
             error_parser: default_error_parser,
             callback_bind_addr: "127.0.0.1".to_string(),
         }
@@ -103,7 +102,7 @@ impl LiveProviderSetupService {
 
     /// Set global context-window overrides (from `[models.*].context_window`).
     pub fn with_global_cw_overrides(mut self, overrides: HashMap<String, u32>) -> Self {
-        self.global_cw_overrides = Arc::new(Mutex::new(overrides));
+        self.global_cw_overrides = overrides;
         self
     }
 
@@ -166,8 +165,7 @@ impl LiveProviderSetupService {
         let config = Arc::clone(&self.config);
         let key_store = self.key_store.clone();
         let env_overrides = self.env_overrides.clone();
-        let cw_overrides = self.global_cw_overrides.lock()
-            .unwrap_or_else(|e| e.into_inner()).clone();
+        let cw_overrides = self.global_cw_overrides.clone();
         let provider_name = provider_name.to_string();
 
         tokio::spawn(async move {
@@ -348,9 +346,7 @@ impl LiveProviderSetupService {
     }
 
     pub(crate) fn build_registry(&self, config: &ProvidersConfig) -> ProviderRegistry {
-        let cw_overrides = self.global_cw_overrides.lock()
-            .unwrap_or_else(|e| e.into_inner()).clone();
-        ProviderRegistry::from_env_with_config_and_overrides(config, &self.env_overrides, cw_overrides)
+        ProviderRegistry::from_env_with_config_and_overrides(config, &self.env_overrides, self.global_cw_overrides.clone())
     }
 }
 

--- a/crates/provider-setup/src/service/implementation/service.rs
+++ b/crates/provider-setup/src/service/implementation/service.rs
@@ -61,6 +61,10 @@ pub struct LiveProviderSetupService {
     /// Static env overrides (for example config `[env]`) used when resolving
     /// provider credentials without mutating the process environment.
     pub(crate) env_overrides: HashMap<String, String>,
+    /// Global context-window overrides extracted from `[models.*].context_window`.
+    /// Threaded through on every registry rebuild so runtime paths don't
+    /// silently drop the overrides.
+    pub(crate) global_cw_overrides: Arc<Mutex<HashMap<String, u32>>>,
     /// Injected error parser for interpreting provider API errors.
     pub(crate) error_parser: ErrorParser,
     /// Address the OAuth callback server binds to. Defaults to `127.0.0.1`
@@ -86,6 +90,7 @@ impl LiveProviderSetupService {
             priority_models: None,
             registry_rebuild_seq: Arc::new(AtomicU64::new(0)),
             env_overrides: HashMap::new(),
+            global_cw_overrides: Arc::new(Mutex::new(HashMap::new())),
             error_parser: default_error_parser,
             callback_bind_addr: "127.0.0.1".to_string(),
         }
@@ -93,6 +98,12 @@ impl LiveProviderSetupService {
 
     pub fn with_env_overrides(mut self, env_overrides: HashMap<String, String>) -> Self {
         self.env_overrides = env_overrides;
+        self
+    }
+
+    /// Set global context-window overrides (from `[models.*].context_window`).
+    pub fn with_global_cw_overrides(mut self, overrides: HashMap<String, u32>) -> Self {
+        self.global_cw_overrides = Arc::new(Mutex::new(overrides));
         self
     }
 
@@ -155,6 +166,8 @@ impl LiveProviderSetupService {
         let config = Arc::clone(&self.config);
         let key_store = self.key_store.clone();
         let env_overrides = self.env_overrides.clone();
+        let cw_overrides = self.global_cw_overrides.lock()
+            .unwrap_or_else(|e| e.into_inner()).clone();
         let provider_name = provider_name.to_string();
 
         tokio::spawn(async move {
@@ -172,7 +185,7 @@ impl LiveProviderSetupService {
             };
 
             let new_registry = match tokio::task::spawn_blocking(move || {
-                ProviderRegistry::from_env_with_config_and_overrides(&effective, &env_overrides)
+                ProviderRegistry::from_env_with_config_and_overrides(&effective, &env_overrides, cw_overrides)
             })
             .await
             {
@@ -335,7 +348,9 @@ impl LiveProviderSetupService {
     }
 
     pub(crate) fn build_registry(&self, config: &ProvidersConfig) -> ProviderRegistry {
-        ProviderRegistry::from_env_with_config_and_overrides(config, &self.env_overrides)
+        let cw_overrides = self.global_cw_overrides.lock()
+            .unwrap_or_else(|e| e.into_inner()).clone();
+        ProviderRegistry::from_env_with_config_and_overrides(config, &self.env_overrides, cw_overrides)
     }
 }
 

--- a/crates/provider-setup/src/service/tests.rs
+++ b/crates/provider-setup/src/service/tests.rs
@@ -22,6 +22,7 @@ async fn noop_service_returns_empty() {
 async fn remove_key_rejects_unknown_provider() {
     let registry = Arc::new(RwLock::new(ProviderRegistry::from_env_with_config(
         &ProvidersConfig::default(),
+        HashMap::new(),
     )));
     let svc = LiveProviderSetupService::new(registry, ProvidersConfig::default(), None);
     let result = svc
@@ -34,6 +35,7 @@ async fn remove_key_rejects_unknown_provider() {
 async fn remove_key_rejects_missing_params() {
     let registry = Arc::new(RwLock::new(ProviderRegistry::from_env_with_config(
         &ProvidersConfig::default(),
+        HashMap::new(),
     )));
     let svc = LiveProviderSetupService::new(registry, ProvidersConfig::default(), None);
     assert!(svc.remove_key(serde_json::json!({})).await.is_err());
@@ -43,6 +45,7 @@ async fn remove_key_rejects_missing_params() {
 async fn disabled_provider_is_not_reported_configured() {
     let registry = Arc::new(RwLock::new(ProviderRegistry::from_env_with_config(
         &ProvidersConfig::default(),
+        HashMap::new(),
     )));
     let svc = LiveProviderSetupService::new(registry, ProvidersConfig::default(), None);
     let provider = known_providers()
@@ -65,6 +68,7 @@ async fn disabled_provider_is_not_reported_configured() {
 async fn live_service_lists_providers() {
     let registry = Arc::new(RwLock::new(ProviderRegistry::from_env_with_config(
         &ProvidersConfig::default(),
+        HashMap::new(),
     )));
     let svc = LiveProviderSetupService::new(registry, ProvidersConfig::default(), None);
     let result = svc.available().await.unwrap();
@@ -86,6 +90,7 @@ async fn live_service_lists_providers() {
 async fn available_marks_provider_configured_from_generic_provider_env() {
     let registry = Arc::new(RwLock::new(ProviderRegistry::from_env_with_config(
         &ProvidersConfig::default(),
+        HashMap::new(),
     )));
     let svc = LiveProviderSetupService::new(registry, ProvidersConfig::default(), None)
         .with_env_overrides(HashMap::from([
@@ -115,6 +120,7 @@ async fn available_marks_provider_configured_from_generic_provider_env() {
 async fn available_hides_unconfigured_providers_not_in_offered_list() {
     let registry = Arc::new(RwLock::new(ProviderRegistry::from_env_with_config(
         &ProvidersConfig::default(),
+        HashMap::new(),
     )));
     let config = ProvidersConfig {
         offered: vec!["openai".into()],
@@ -143,6 +149,7 @@ async fn available_hides_unconfigured_providers_not_in_offered_list() {
 async fn available_respects_offered_order() {
     let registry = Arc::new(RwLock::new(ProviderRegistry::from_env_with_config(
         &ProvidersConfig::default(),
+        HashMap::new(),
     )));
     let config = ProvidersConfig {
         offered: vec!["github-copilot".into(), "openai".into(), "anthropic".into()],
@@ -181,6 +188,7 @@ async fn available_respects_offered_order() {
 async fn available_accepts_offered_provider_aliases() {
     let registry = Arc::new(RwLock::new(ProviderRegistry::from_env_with_config(
         &ProvidersConfig::default(),
+        HashMap::new(),
     )));
     let config = ProvidersConfig {
         offered: vec!["claude".into()],
@@ -206,6 +214,7 @@ async fn available_accepts_offered_provider_aliases() {
 async fn available_hides_configured_provider_outside_offered() {
     let registry = Arc::new(RwLock::new(ProviderRegistry::from_env_with_config(
         &ProvidersConfig::default(),
+        HashMap::new(),
     )));
     let mut config = ProvidersConfig {
         offered: vec!["openai".into()],
@@ -259,6 +268,7 @@ async fn available_includes_subscription_provider_with_oauth_token_outside_offer
 
     let registry = Arc::new(RwLock::new(ProviderRegistry::from_env_with_config(
         &ProvidersConfig::default(),
+        HashMap::new(),
     )));
     let mut svc = LiveProviderSetupService::new(registry, config, None);
     svc.token_store = token_store;
@@ -305,6 +315,7 @@ async fn available_includes_configured_custom_provider_outside_offered() {
 
     let registry = Arc::new(RwLock::new(ProviderRegistry::from_env_with_config(
         &ProvidersConfig::default(),
+        HashMap::new(),
     )));
     let mut svc = LiveProviderSetupService::new(registry, config, None);
     svc.key_store = key_store;
@@ -333,6 +344,7 @@ async fn available_includes_configured_custom_provider_outside_offered() {
 async fn available_includes_default_base_urls() {
     let registry = Arc::new(RwLock::new(ProviderRegistry::from_env_with_config(
         &ProvidersConfig::default(),
+        HashMap::new(),
     )));
     let svc = LiveProviderSetupService::new(registry, ProvidersConfig::default(), None);
     let result = svc.available().await.unwrap();
@@ -375,6 +387,7 @@ async fn available_includes_default_base_urls() {
 async fn save_key_rejects_unknown_provider() {
     let registry = Arc::new(RwLock::new(ProviderRegistry::from_env_with_config(
         &ProvidersConfig::default(),
+        HashMap::new(),
     )));
     let svc = LiveProviderSetupService::new(registry, ProvidersConfig::default(), None);
     let result = svc
@@ -387,6 +400,7 @@ async fn save_key_rejects_unknown_provider() {
 async fn save_key_rejects_missing_params() {
     let registry = Arc::new(RwLock::new(ProviderRegistry::from_env_with_config(
         &ProvidersConfig::default(),
+        HashMap::new(),
     )));
     let svc = LiveProviderSetupService::new(registry, ProvidersConfig::default(), None);
     assert!(svc.save_key(serde_json::json!({})).await.is_err());
@@ -401,6 +415,7 @@ async fn save_key_rejects_missing_params() {
 async fn oauth_start_rejects_unknown_provider() {
     let registry = Arc::new(RwLock::new(ProviderRegistry::from_env_with_config(
         &ProvidersConfig::default(),
+        HashMap::new(),
     )));
     let svc = LiveProviderSetupService::new(registry, ProvidersConfig::default(), None);
     let result = svc
@@ -413,6 +428,7 @@ async fn oauth_start_rejects_unknown_provider() {
 async fn oauth_start_ignores_redirect_uri_override_for_registered_provider() {
     let registry = Arc::new(RwLock::new(ProviderRegistry::from_env_with_config(
         &ProvidersConfig::default(),
+        HashMap::new(),
     )));
     let svc = LiveProviderSetupService::new(registry, ProvidersConfig::default(), None);
 
@@ -452,6 +468,7 @@ async fn oauth_start_ignores_redirect_uri_override_for_registered_provider() {
 async fn oauth_start_stores_pending_state_for_registered_redirect_provider() {
     let registry = Arc::new(RwLock::new(ProviderRegistry::from_env_with_config(
         &ProvidersConfig::default(),
+        HashMap::new(),
     )));
     let svc = LiveProviderSetupService::new(registry, ProvidersConfig::default(), None);
 
@@ -491,6 +508,7 @@ async fn oauth_start_stores_pending_state_for_registered_redirect_provider() {
 async fn oauth_complete_accepts_callback_input_parameter() {
     let registry = Arc::new(RwLock::new(ProviderRegistry::from_env_with_config(
         &ProvidersConfig::default(),
+        HashMap::new(),
     )));
     let svc = LiveProviderSetupService::new(registry, ProvidersConfig::default(), None);
 
@@ -511,6 +529,7 @@ async fn oauth_complete_accepts_callback_input_parameter() {
 async fn oauth_complete_rejects_provider_mismatch_without_consuming_state() {
     let registry = Arc::new(RwLock::new(ProviderRegistry::from_env_with_config(
         &ProvidersConfig::default(),
+        HashMap::new(),
     )));
     let svc = LiveProviderSetupService::new(registry, ProvidersConfig::default(), None);
 
@@ -576,6 +595,7 @@ async fn oauth_complete_rejects_provider_mismatch_without_consuming_state() {
 async fn oauth_status_returns_not_authenticated() {
     let registry = Arc::new(RwLock::new(ProviderRegistry::from_env_with_config(
         &ProvidersConfig::default(),
+        HashMap::new(),
     )));
     let svc = LiveProviderSetupService::new(registry, ProvidersConfig::default(), None);
     let result = svc
@@ -590,6 +610,7 @@ async fn oauth_status_returns_not_authenticated() {
 async fn save_key_accepts_new_providers() {
     let registry = Arc::new(RwLock::new(ProviderRegistry::from_env_with_config(
         &ProvidersConfig::default(),
+        HashMap::new(),
     )));
     let _svc = LiveProviderSetupService::new(registry, ProvidersConfig::default(), None);
 
@@ -621,6 +642,7 @@ async fn save_key_accepts_new_providers() {
 async fn available_includes_new_providers() {
     let registry = Arc::new(RwLock::new(ProviderRegistry::from_env_with_config(
         &ProvidersConfig::default(),
+        HashMap::new(),
     )));
     let svc = LiveProviderSetupService::new(registry, ProvidersConfig::default(), None);
     let result = svc.available().await.unwrap();
@@ -656,6 +678,7 @@ async fn available_includes_new_providers() {
 async fn available_hides_local_providers_on_cloud() {
     let registry = Arc::new(RwLock::new(ProviderRegistry::from_env_with_config(
         &ProvidersConfig::default(),
+        HashMap::new(),
     )));
     let svc = LiveProviderSetupService::new(
         registry,
@@ -696,6 +719,7 @@ async fn available_hides_local_providers_on_cloud() {
 async fn available_shows_all_providers_locally() {
     let registry = Arc::new(RwLock::new(ProviderRegistry::from_env_with_config(
         &ProvidersConfig::default(),
+        HashMap::new(),
     )));
     let svc = LiveProviderSetupService::new(registry, ProvidersConfig::default(), None);
     let result = svc.available().await.unwrap();
@@ -724,6 +748,7 @@ async fn available_shows_all_providers_locally() {
 async fn validate_key_rejects_unknown_provider() {
     let registry = Arc::new(RwLock::new(ProviderRegistry::from_env_with_config(
         &ProvidersConfig::default(),
+        HashMap::new(),
     )));
     let svc = LiveProviderSetupService::new(registry, ProvidersConfig::default(), None);
     let result = svc
@@ -737,6 +762,7 @@ async fn validate_key_rejects_unknown_provider() {
 async fn validate_key_rejects_missing_provider_param() {
     let registry = Arc::new(RwLock::new(ProviderRegistry::from_env_with_config(
         &ProvidersConfig::default(),
+        HashMap::new(),
     )));
     let svc = LiveProviderSetupService::new(registry, ProvidersConfig::default(), None);
     let result = svc.validate_key(serde_json::json!({})).await;
@@ -753,6 +779,7 @@ async fn validate_key_rejects_missing_provider_param() {
 async fn validate_key_rejects_missing_api_key_for_api_key_provider() {
     let registry = Arc::new(RwLock::new(ProviderRegistry::from_env_with_config(
         &ProvidersConfig::default(),
+        HashMap::new(),
     )));
     let svc = LiveProviderSetupService::new(registry, ProvidersConfig::default(), None);
     let result = svc
@@ -766,6 +793,7 @@ async fn validate_key_rejects_missing_api_key_for_api_key_provider() {
 async fn validate_key_allows_missing_api_key_for_ollama() {
     let registry = Arc::new(RwLock::new(ProviderRegistry::from_env_with_config(
         &ProvidersConfig::default(),
+        HashMap::new(),
     )));
     let svc = LiveProviderSetupService::new(registry, ProvidersConfig::default(), None);
     let result = svc
@@ -799,6 +827,7 @@ async fn validate_key_ollama_without_model_returns_discovered_models() {
 
     let registry = Arc::new(RwLock::new(ProviderRegistry::from_env_with_config(
         &ProvidersConfig::default(),
+        HashMap::new(),
     )));
     let svc = LiveProviderSetupService::new(registry, ProvidersConfig::default(), None);
     let result = svc
@@ -851,6 +880,7 @@ async fn validate_key_ollama_reports_uninstalled_model() {
 
     let registry = Arc::new(RwLock::new(ProviderRegistry::from_env_with_config(
         &ProvidersConfig::default(),
+        HashMap::new(),
     )));
     let svc = LiveProviderSetupService::new(registry, ProvidersConfig::default(), None);
     let result = svc
@@ -912,6 +942,7 @@ async fn validate_key_ollama_with_model_returns_model_list() {
 
     let registry = Arc::new(RwLock::new(ProviderRegistry::from_env_with_config(
         &ProvidersConfig::default(),
+        HashMap::new(),
     )));
     let svc = LiveProviderSetupService::new(registry, ProvidersConfig::default(), None);
     let result = svc
@@ -962,6 +993,7 @@ async fn validate_key_custom_provider_without_model_returns_discovered_models() 
 
     let registry = Arc::new(RwLock::new(ProviderRegistry::from_env_with_config(
         &ProvidersConfig::default(),
+        HashMap::new(),
     )));
     let svc = LiveProviderSetupService::new(registry, ProvidersConfig::default(), None);
     let result = svc
@@ -1020,6 +1052,7 @@ async fn validate_key_custom_provider_uses_saved_base_url_when_request_omits_it(
 
     let registry = Arc::new(RwLock::new(ProviderRegistry::from_env_with_config(
         &ProvidersConfig::default(),
+        HashMap::new(),
     )));
     let svc = LiveProviderSetupService::new(registry, ProvidersConfig::default(), None);
     svc.key_store
@@ -1071,6 +1104,7 @@ async fn validate_key_custom_provider_discovery_error_returns_invalid() {
 
     let registry = Arc::new(RwLock::new(ProviderRegistry::from_env_with_config(
         &ProvidersConfig::default(),
+        HashMap::new(),
     )));
     let svc = LiveProviderSetupService::new(registry, ProvidersConfig::default(), None);
     let result = svc
@@ -1142,6 +1176,7 @@ async fn validate_key_custom_provider_returns_discovered_models_without_probing(
 
     let registry = Arc::new(RwLock::new(ProviderRegistry::from_env_with_config(
         &ProvidersConfig::default(),
+        HashMap::new(),
     )));
     let svc = LiveProviderSetupService::new(registry, ProvidersConfig::default(), None);
     let result = svc
@@ -1176,6 +1211,7 @@ async fn validate_key_custom_provider_connection_refused_returns_error() {
 
     let registry = Arc::new(RwLock::new(ProviderRegistry::from_env_with_config(
         &ProvidersConfig::default(),
+        HashMap::new(),
     )));
     let svc = LiveProviderSetupService::new(registry, ProvidersConfig::default(), None);
     let result = svc

--- a/crates/providers/src/anthropic.rs
+++ b/crates/providers/src/anthropic.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashSet, pin::Pin, sync::mpsc, time::Duration};
+use std::{collections::{HashMap, HashSet}, pin::Pin, sync::mpsc, time::Duration};
 
 use {async_trait::async_trait, futures::StreamExt, secrecy::ExposeSecret, tokio_stream::Stream};
 
@@ -20,6 +20,11 @@ pub struct AnthropicProvider {
     reasoning_effort: Option<moltis_agents::model::ReasoningEffort>,
     /// Prompt cache retention policy. When `None`, caching is disabled.
     cache_retention: moltis_config::CacheRetention,
+    /// Global per-model context window overrides from `[models.<id>]` config.
+    context_window_global: HashMap<String, u32>,
+    /// Provider-scoped per-model context window overrides from
+    /// `[providers.<name>.model_overrides.<id>]` config.
+    context_window_provider: HashMap<String, u32>,
 }
 
 const ANTHROPIC_MODELS_ENDPOINT_PATH: &str = "/v1/models";
@@ -34,6 +39,8 @@ impl AnthropicProvider {
             alias: None,
             reasoning_effort: None,
             cache_retention: moltis_config::CacheRetention::Short,
+            context_window_global: HashMap::new(),
+            context_window_provider: HashMap::new(),
         }
     }
 
@@ -52,6 +59,8 @@ impl AnthropicProvider {
             alias,
             reasoning_effort: None,
             cache_retention: moltis_config::CacheRetention::Short,
+            context_window_global: HashMap::new(),
+            context_window_provider: HashMap::new(),
         }
     }
 
@@ -64,6 +73,21 @@ impl AnthropicProvider {
     /// Returns `true` when prompt caching is enabled (short or long retention).
     fn caching_enabled(&self) -> bool {
         !matches!(self.cache_retention, moltis_config::CacheRetention::None)
+    }
+
+    /// Set context window override maps extracted from config.
+    ///
+    /// `global` comes from `[models.<id>].context_window` and
+    /// `provider` comes from `[providers.<name>.model_overrides.<id>].context_window`.
+    #[must_use]
+    pub fn with_context_window_overrides(
+        mut self,
+        global: HashMap<String, u32>,
+        provider: HashMap<String, u32>,
+    ) -> Self {
+        self.context_window_global = global;
+        self.context_window_provider = provider;
+        self
     }
 
     /// Apply `thinking` configuration to an Anthropic request body based on
@@ -563,6 +587,8 @@ impl LlmProvider for AnthropicProvider {
             alias: self.alias.clone(),
             reasoning_effort: Some(effort),
             cache_retention: self.cache_retention,
+            context_window_global: self.context_window_global.clone(),
+            context_window_provider: self.context_window_provider.clone(),
         }))
     }
 
@@ -575,7 +601,11 @@ impl LlmProvider for AnthropicProvider {
     }
 
     fn context_window(&self) -> u32 {
-        super::context_window_for_model(&self.model)
+        crate::context_window_for_model_with_config(
+            &self.model,
+            &self.context_window_global,
+            &self.context_window_provider,
+        )
     }
 
     fn supports_vision(&self) -> bool {
@@ -1011,6 +1041,8 @@ mod tests {
     #[test]
     fn apply_thinking_injects_budget_for_high_effort() {
         let provider = AnthropicProvider {
+            context_window_global: std::collections::HashMap::new(),
+            context_window_provider: std::collections::HashMap::new(),
             api_key: secrecy::Secret::new("test".into()),
             model: "claude-opus-4-5-20251101".into(),
             base_url: "https://api.anthropic.com".into(),
@@ -1044,6 +1076,8 @@ mod tests {
     #[test]
     fn apply_thinking_low_effort_budget() {
         let provider = AnthropicProvider {
+            context_window_global: std::collections::HashMap::new(),
+            context_window_provider: std::collections::HashMap::new(),
             api_key: secrecy::Secret::new("test".into()),
             model: "claude-sonnet-4-5-20250929".into(),
             base_url: "https://api.anthropic.com".into(),
@@ -1403,6 +1437,8 @@ mod tests {
     #[test]
     fn cache_retention_none_skips_cache_control() {
         let provider = AnthropicProvider {
+            context_window_global: std::collections::HashMap::new(),
+            context_window_provider: std::collections::HashMap::new(),
             api_key: secrecy::Secret::new("test".into()),
             model: "claude-sonnet-4-5-20250929".into(),
             base_url: "https://api.anthropic.com".into(),

--- a/crates/providers/src/lib.rs
+++ b/crates/providers/src/lib.rs
@@ -55,7 +55,7 @@ pub use {
     discovered_model::{DiscoveredModel, catalog_to_discovered},
     model_capabilities::{
         ModelCapabilities, ModelInfo, context_window_for_model,
-        context_window_for_model_with_config, is_chat_capable_model, supports_reasoning_for_model,
+        context_window_for_model_with_config, extract_cw_overrides, is_chat_capable_model, supports_reasoning_for_model,
         supports_tools_for_model, supports_vision_for_model,
     },
     registry::{

--- a/crates/providers/src/model_capabilities.rs
+++ b/crates/providers/src/model_capabilities.rs
@@ -1,6 +1,20 @@
 //! Model capability heuristics: context window, tool support, vision, reasoning.
 
 use crate::model_id::capability_model_id;
+use moltis_config::schema::ModelOverride;
+
+/// Extract a `HashMap<String, u32>` of model ID → context window from
+/// a `HashMap<String, ModelOverride>`, filtering out entries without a
+/// `context_window` value.
+#[must_use]
+pub fn extract_cw_overrides(
+    overrides: &std::collections::HashMap<String, ModelOverride>,
+) -> std::collections::HashMap<String, u32> {
+    overrides
+        .iter()
+        .filter_map(|(k, v)| v.context_window.map(|cw| (k.clone(), cw)))
+        .collect()
+}
 
 /// Return the known context window size (in tokens) for a model ID.
 /// Falls back to 200,000 for unknown models.
@@ -774,3 +788,80 @@ mod tests {
         );
     }
 }
+
+#[cfg(test)]
+mod tests_cw_overrides {
+    use super::*;
+    use std::collections::HashMap;
+
+    /// Verify provider-scoped override wins over global and heuristic.
+    #[test]
+    fn provider_override_wins() {
+        let global: HashMap<String, u32> =
+            vec![("claude-sonnet-4-20250514".into(), 300_000)].into_iter().collect();
+        let provider: HashMap<String, u32> =
+            vec![("claude-sonnet-4-20250514".into(), 999_000)].into_iter().collect();
+
+        let cw = context_window_for_model_with_config(
+            "claude-sonnet-4-20250514",
+            &global,
+            &provider,
+        );
+        assert_eq!(cw, 999_000);
+    }
+
+    /// Verify global override wins over heuristic when no provider override.
+    #[test]
+    fn global_override_wins_over_heuristic() {
+        let global: HashMap<String, u32> =
+            vec![("claude-sonnet-4-20250514".into(), 500_000)].into_iter().collect();
+        let provider: HashMap<String, u32> = HashMap::new();
+
+        let cw = context_window_for_model_with_config(
+            "claude-sonnet-4-20250514",
+            &global,
+            &provider,
+        );
+        assert_eq!(cw, 500_000);
+    }
+
+    /// Verify empty maps fall through to heuristic.
+    #[test]
+    fn empty_maps_use_heuristic() {
+        let cw = context_window_for_model_with_config(
+            "claude-sonnet-4-20250514",
+            &HashMap::new(),
+            &HashMap::new(),
+        );
+        // Heuristic for claude-* is 200_000
+        assert_eq!(cw, 200_000);
+    }
+
+    /// Verify extract_cw_overrides filters out None entries.
+    #[test]
+    fn extract_cw_overrides_filters_none() {
+        use moltis_config::schema::ModelOverride;
+
+        let mut overrides = HashMap::new();
+        overrides.insert(
+            "claude-opus-4-20250514".into(),
+            ModelOverride { context_window: Some(1_000_000) },
+        );
+        overrides.insert(
+            "gpt-4o".into(),
+            ModelOverride { context_window: None },
+        );
+
+        let extracted = extract_cw_overrides(&overrides);
+        assert_eq!(extracted.len(), 1);
+        assert_eq!(extracted.get("claude-opus-4-20250514"), Some(&1_000_000));
+    }
+
+    /// Verify extract_cw_overrides returns empty map for empty input.
+    #[test]
+    fn extract_cw_overrides_empty() {
+        let extracted = extract_cw_overrides(&HashMap::new());
+        assert!(extracted.is_empty());
+    }
+}
+

--- a/crates/providers/src/openai/mod.rs
+++ b/crates/providers/src/openai/mod.rs
@@ -27,4 +27,9 @@ pub struct OpenAiProvider {
     cache_retention: moltis_config::CacheRetention,
     /// Explicit override for strict tool schema mode. `None` = auto-detect.
     strict_tools_override: Option<bool>,
+    /// Global per-model context window overrides from `[models.<id>]` config.
+    context_window_global: std::collections::HashMap<String, u32>,
+    /// Provider-scoped per-model context window overrides from
+    /// `[providers.<name>.model_overrides.<id>]` config.
+    context_window_provider: std::collections::HashMap<String, u32>,
 }

--- a/crates/providers/src/openai/provider/core.rs
+++ b/crates/providers/src/openai/provider/core.rs
@@ -9,7 +9,7 @@ use {
 
 use tracing::debug;
 
-use crate::{context_window_for_model, supports_tools_for_model, supports_vision_for_model};
+use crate::{context_window_for_model_with_config, supports_tools_for_model, supports_vision_for_model};
 
 use moltis_agents::model::{
     ChatMessage, CompletionResponse, LlmProvider, ModelMetadata, StreamEvent,
@@ -32,6 +32,8 @@ impl OpenAiProvider {
             reasoning_effort: None,
             cache_retention: moltis_config::CacheRetention::Short,
             strict_tools_override: None,
+            context_window_global: std::collections::HashMap::new(),
+            context_window_provider: std::collections::HashMap::new(),
         }
     }
 
@@ -54,6 +56,8 @@ impl OpenAiProvider {
             reasoning_effort: None,
             cache_retention: moltis_config::CacheRetention::Short,
             strict_tools_override: None,
+            context_window_global: std::collections::HashMap::new(),
+            context_window_provider: std::collections::HashMap::new(),
         }
     }
 
@@ -84,6 +88,21 @@ impl OpenAiProvider {
     #[must_use]
     pub fn with_strict_tools(mut self, strict: bool) -> Self {
         self.strict_tools_override = Some(strict);
+        self
+    }
+
+    /// Set context window override maps extracted from config.
+    ///
+    /// `global` comes from `[models.<id>].context_window` and
+    /// `provider` comes from `[providers.<name>.model_overrides.<id>].context_window`.
+    #[must_use]
+    pub fn with_context_window_overrides(
+        mut self,
+        global: std::collections::HashMap<String, u32>,
+        provider: std::collections::HashMap<String, u32>,
+    ) -> Self {
+        self.context_window_global = global;
+        self.context_window_provider = provider;
         self
     }
 
@@ -166,6 +185,8 @@ impl LlmProvider for OpenAiProvider {
             reasoning_effort: Some(effort),
             wire_api: self.wire_api,
             cache_retention: self.cache_retention,
+            context_window_global: self.context_window_global.clone(),
+            context_window_provider: self.context_window_provider.clone(),
             strict_tools_override: self.strict_tools_override,
         }))
     }
@@ -187,7 +208,11 @@ impl LlmProvider for OpenAiProvider {
     }
 
     fn context_window(&self) -> u32 {
-        context_window_for_model(&self.model)
+        context_window_for_model_with_config(
+            &self.model,
+            &self.context_window_global,
+            &self.context_window_provider,
+        )
     }
 
     fn supports_vision(&self) -> bool {

--- a/crates/providers/src/registry/core.rs
+++ b/crates/providers/src/registry/core.rs
@@ -29,7 +29,7 @@ use crate::{
         DiscoveredModel, catalog_to_discovered, merge_discovered_with_fallback_catalog,
         merge_preferred_and_discovered_models,
     },
-    model_capabilities::{ModelCapabilities, ModelInfo},
+    model_capabilities::{extract_cw_overrides, ModelCapabilities, ModelInfo},
     model_catalogs::{ANTHROPIC_MODELS, OPENAI_COMPAT_PROVIDERS},
     model_id::{
         REASONING_SUFFIX_SEP, REASONING_SUFFIXES, namespaced_model_id, raw_model_id,
@@ -424,6 +424,8 @@ impl DynamicModelDiscovery for GitHubCopilotDiscovery {
 pub struct ProviderRegistry {
     pub(crate) providers: HashMap<String, Arc<dyn LlmProvider>>,
     pub(crate) models: Vec<ModelInfo>,
+    /// Global per-model context window overrides from `[models.<id>]` config.
+    pub(crate) global_cw_overrides: HashMap<String, u32>,
 }
 
 /// Pending model discovery handles returned by [`ProviderRegistry::fire_discoveries`].
@@ -438,6 +440,7 @@ impl ProviderRegistry {
         Self {
             providers: HashMap::new(),
             models: Vec::new(),
+            global_cw_overrides: HashMap::new(),
         }
     }
 
@@ -621,8 +624,10 @@ impl ProviderRegistry {
         provider_label: &str,
         alias: Option<String>,
         cache_retention: moltis_config::CacheRetention,
+        provider_cw_overrides: HashMap<String, u32>,
     ) -> usize {
         let mut added = 0usize;
+        let global = self.global_cw_overrides.clone();
 
         for model in models {
             let caps = model
@@ -644,7 +649,8 @@ impl ProviderRegistry {
                     base_url.to_string(),
                     alias.clone(),
                 )
-                .with_cache_retention(cache_retention),
+                .with_cache_retention(cache_retention)
+                .with_context_window_overrides(global.clone(), provider_cw_overrides.clone()),
             );
             self.register(
                 ModelInfo {
@@ -671,7 +677,9 @@ impl ProviderRegistry {
         provider_label: &str,
         alias: Option<String>,
         cache_retention: moltis_config::CacheRetention,
+        provider_cw_overrides: HashMap<String, u32>,
     ) -> usize {
+        let global = self.global_cw_overrides.clone();
         let new_entries: Vec<(ModelInfo, Arc<dyn LlmProvider>)> = models
             .into_iter()
             .map(|model| {
@@ -685,7 +693,8 @@ impl ProviderRegistry {
                         base_url.to_string(),
                         alias.clone(),
                     )
-                    .with_cache_retention(cache_retention),
+                    .with_cache_retention(cache_retention)
+                .with_context_window_overrides(global.clone(), provider_cw_overrides.clone()),
                 );
                 (
                     ModelInfo {
@@ -787,7 +796,7 @@ impl ProviderRegistry {
     ) -> Self {
         let pending = Self::fire_discoveries(config, env_overrides);
         let prefetched = Self::collect_discoveries(pending);
-        Self::from_config_with_prefetched(config, env_overrides, &prefetched)
+        Self::from_config_with_prefetched(config, env_overrides, &prefetched, HashMap::new())
     }
 
     /// Register providers without making any discovery HTTP requests.
@@ -797,9 +806,10 @@ impl ProviderRegistry {
     pub fn from_config_with_static_catalogs(
         config: &ProvidersConfig,
         env_overrides: &HashMap<String, String>,
+        global_cw_overrides: HashMap<String, u32>,
     ) -> Self {
         let prefetched = HashMap::new();
-        Self::from_config_with_prefetched(config, env_overrides, &prefetched)
+        Self::from_config_with_prefetched(config, env_overrides, &prefetched, global_cw_overrides)
     }
 
     /// Register providers using already-collected discovery results.
@@ -810,8 +820,10 @@ impl ProviderRegistry {
         config: &ProvidersConfig,
         env_overrides: &HashMap<String, String>,
         prefetched: &HashMap<String, Vec<DiscoveredModel>>,
+        global_cw_overrides: HashMap<String, u32>,
     ) -> Self {
         let mut reg = Self::empty();
+        reg.global_cw_overrides = global_cw_overrides;
 
         // Built-in providers first: they support tool calling.
         reg.register_builtin_providers(config, env_overrides, prefetched);

--- a/crates/providers/src/registry/core.rs
+++ b/crates/providers/src/registry/core.rs
@@ -761,7 +761,7 @@ impl ProviderRegistry {
     /// Auto-discover providers from environment variables.
     /// Uses default config (all providers enabled).
     pub fn from_env() -> Self {
-        Self::from_env_with_config(&ProvidersConfig::default())
+        Self::from_env_with_config(&ProvidersConfig::default(), HashMap::new())
     }
 
     /// Auto-discover providers from environment variables,
@@ -778,9 +778,12 @@ impl ProviderRegistry {
     /// 2. Everything else
     ///
     /// Within the same preference tier, registration order wins.
-    pub fn from_env_with_config(config: &ProvidersConfig) -> Self {
+    pub fn from_env_with_config(
+        config: &ProvidersConfig,
+        global_cw_overrides: HashMap<String, u32>,
+    ) -> Self {
         let env_overrides = HashMap::new();
-        Self::from_env_with_config_and_overrides(config, &env_overrides)
+        Self::from_env_with_config_and_overrides(config, &env_overrides, global_cw_overrides)
     }
 
     /// Auto-discover providers from config, process env, and optional env
@@ -793,10 +796,11 @@ impl ProviderRegistry {
     pub fn from_env_with_config_and_overrides(
         config: &ProvidersConfig,
         env_overrides: &HashMap<String, String>,
+        global_cw_overrides: HashMap<String, u32>,
     ) -> Self {
         let pending = Self::fire_discoveries(config, env_overrides);
         let prefetched = Self::collect_discoveries(pending);
-        Self::from_config_with_prefetched(config, env_overrides, &prefetched, HashMap::new())
+        Self::from_config_with_prefetched(config, env_overrides, &prefetched, global_cw_overrides)
     }
 
     /// Register providers without making any discovery HTTP requests.

--- a/crates/providers/src/registry/registration.rs
+++ b/crates/providers/src/registry/registration.rs
@@ -65,6 +65,10 @@ impl ProviderRegistry {
                 .map(|e| e.cache_retention)
                 .unwrap_or(moltis_config::CacheRetention::Short);
             let models = Self::desired_anthropic_models(config, fetched);
+            let provider_cw = config
+                .get("anthropic")
+                .map(|e| extract_cw_overrides(&e.model_overrides))
+                .unwrap_or_default();
 
             added += self.replace_anthropic_catalog(
                 models,
@@ -73,6 +77,7 @@ impl ProviderRegistry {
                 &provider_label,
                 alias,
                 cache_retention,
+                provider_cw,
             );
         }
 
@@ -104,7 +109,13 @@ impl ProviderRegistry {
                         base_url.clone(),
                         provider_label.clone(),
                     )
-                    .with_stream_transport(stream_transport),
+                    .with_stream_transport(stream_transport)
+                    .with_context_window_overrides(
+                        self.global_cw_overrides.clone(),
+                        config.get("openai")
+                            .map(|e| extract_cw_overrides(&e.model_overrides))
+                            .unwrap_or_default(),
+                    ),
                 );
                 self.register(
                     ModelInfo {
@@ -197,7 +208,14 @@ impl ProviderRegistry {
                     provider_label.clone(),
                 )
                 .with_stream_transport(stream_transport)
-                .with_cache_retention(cache_retention);
+                .with_cache_retention(cache_retention)
+                .with_context_window_overrides(
+                    self.global_cw_overrides.clone(),
+                    config
+                        .get(def.config_name)
+                        .map(|e| extract_cw_overrides(&e.model_overrides))
+                        .unwrap_or_default(),
+                );
 
                 if !matches!(effective_tool_mode, moltis_config::ToolMode::Auto) {
                     oai = oai.with_tool_mode(effective_tool_mode);
@@ -253,7 +271,11 @@ impl ProviderRegistry {
                     base_url.clone(),
                     name.clone(),
                 )
-                .with_stream_transport(entry.stream_transport);
+                .with_stream_transport(entry.stream_transport)
+                .with_context_window_overrides(
+                    self.global_cw_overrides.clone(),
+                    extract_cw_overrides(&entry.model_overrides),
+                );
                 if !matches!(entry.wire_api, moltis_config::WireApi::ChatCompletions) {
                     oai = oai.with_wire_api(entry.wire_api);
                 }
@@ -681,6 +703,10 @@ impl ProviderRegistry {
                 .map(|e| e.cache_retention)
                 .unwrap_or(moltis_config::CacheRetention::Short);
             let models = Self::desired_anthropic_models(config, prefetched);
+            let provider_cw = config
+                .get("anthropic")
+                .map(|e| extract_cw_overrides(&e.model_overrides))
+                .unwrap_or_default();
             self.register_anthropic_catalog(
                 models,
                 &key,
@@ -688,6 +714,7 @@ impl ProviderRegistry {
                 &provider_label,
                 alias,
                 cache_retention,
+                provider_cw,
             );
         }
 
@@ -745,7 +772,14 @@ impl ProviderRegistry {
                         base_url.clone(),
                         provider_label.clone(),
                     )
-                    .with_stream_transport(stream_transport),
+                    .with_stream_transport(stream_transport)
+                    .with_context_window_overrides(
+                        self.global_cw_overrides.clone(),
+                        config
+                            .get("openai")
+                            .map(|e| extract_cw_overrides(&e.model_overrides))
+                            .unwrap_or_default(),
+                    ),
                 );
                 self.register(
                     ModelInfo {
@@ -897,7 +931,14 @@ impl ProviderRegistry {
                     provider_label.clone(),
                 )
                 .with_stream_transport(stream_transport)
-                .with_cache_retention(cache_retention);
+                .with_cache_retention(cache_retention)
+                .with_context_window_overrides(
+                    self.global_cw_overrides.clone(),
+                    config
+                        .get(def.config_name)
+                        .map(|e| extract_cw_overrides(&e.model_overrides))
+                        .unwrap_or_default(),
+                );
 
                 if !matches!(effective_tool_mode, moltis_config::ToolMode::Auto) {
                     oai = oai.with_tool_mode(effective_tool_mode);
@@ -988,7 +1029,11 @@ impl ProviderRegistry {
                     name.clone(),
                 )
                 .with_stream_transport(entry.stream_transport)
-                .with_cache_retention(entry.cache_retention);
+                .with_cache_retention(entry.cache_retention)
+                .with_context_window_overrides(
+                    self.global_cw_overrides.clone(),
+                    extract_cw_overrides(&entry.model_overrides),
+                );
                 if !matches!(entry.wire_api, moltis_config::WireApi::ChatCompletions) {
                     oai = oai.with_wire_api(entry.wire_api);
                 }

--- a/crates/swift-bridge/src/state.rs
+++ b/crates/swift-bridge/src/state.rs
@@ -163,7 +163,11 @@ pub(crate) fn build_registry() -> ProviderRegistry {
     }
     #[cfg(not(test))]
     {
-        ProviderRegistry::from_env_with_config_and_overrides(&effective, &env_overrides)
+        ProviderRegistry::from_env_with_config_and_overrides(
+            &effective,
+            &env_overrides,
+            moltis_providers::extract_cw_overrides(&config.models),
+        )
     }
 }
 

--- a/crates/swift-bridge/src/state.rs
+++ b/crates/swift-bridge/src/state.rs
@@ -159,7 +159,7 @@ pub(crate) fn build_registry() -> ProviderRegistry {
         moltis_provider_setup::config_with_saved_keys(&config.providers, &key_store, &[]);
     #[cfg(test)]
     {
-        ProviderRegistry::from_config_with_static_catalogs(&effective, &env_overrides)
+        ProviderRegistry::from_config_with_static_catalogs(&effective, &env_overrides, std::collections::HashMap::new())
     }
     #[cfg(not(test))]
     {

--- a/crates/tools/src/spawn_agent.rs
+++ b/crates/tools/src/spawn_agent.rs
@@ -627,7 +627,7 @@ mod tests {
     fn make_empty_provider_registry() -> Arc<tokio::sync::RwLock<ProviderRegistry>> {
         let env_overrides = std::collections::HashMap::new();
         Arc::new(tokio::sync::RwLock::new(
-            ProviderRegistry::from_config_with_static_catalogs(&Default::default(), &env_overrides),
+            ProviderRegistry::from_config_with_static_catalogs(&Default::default(), &env_overrides, std::collections::HashMap::new()),
         ))
     }
 


### PR DESCRIPTION
## Summary

Combined replacement for #723, #726, #727 — merges all three PRs into a single clean branch to eliminate cross-PR merge-order conflicts.

### Commit 1 — `fix(config): correct model_overrides doc references`
Fixes stale comments referencing `[providers.<name>.models.<id>]` — the actual TOML key is `model_overrides`. Also updates WhatsApp channel template defaults.
**Replaces:** #723

### Commit 2 — `fix(agents): oldest-first tool result compaction with configurable ratios`
Three changes to per-iteration tool-result compaction:
- **A)** Reverse compaction direction: compact **oldest** results first instead of newest. The model needs its most recent tool outputs for coherent operation in long agent loops.
- **B)** Make compaction/overflow ratios configurable via `ToolsConfig`:
  - `tool_result_compaction_ratio` (default 75, set to 0 to disable)
  - `preemptive_overflow_ratio` (default 90)
- **C)** Add `compaction_min_iterations` (default 3): skip compaction for the first N iterations.
All defaults match previous hardcoded values — backward compatible.
**Replaces:** #726

### Commit 3 — `feat(providers): wire config overrides into provider context_window()`
Wire per-model context window overrides from `MoltisConfig.models` into `AnthropicProvider` and `OpenAiProvider` so `context_window()` returns config-aware values at runtime. Provider-scope overrides win over global overrides, which win over the hardcoded heuristic.
- Override map fields added to both providers with builder methods
- Global overrides threaded through `ProviderRegistry` and all registration paths
- `extract_cw_overrides()` helper converts `ModelOverride` maps → `HashMap<String, u32>`
- 5 new unit tests for override precedence
**Replaces:** #727

## Validation
- `cargo check --workspace --all-targets` ✅
- Leaked test commit from #727 dropped — only provider wiring changes included
- No overlapping file conflicts between the three domains

## Config Shape
```toml
# Global context window override
[models.claude-opus-4-6]
context_window = 1_000_000

# Provider-scoped (takes precedence)
[providers.zai-code.model_overrides.glm-5-turbo]
context_window = 200_000

# Compaction tuning
[tools]
tool_result_compaction_ratio = 75
preemptive_overflow_ratio = 90
compaction_min_iterations = 3
```

Closes #723, closes #726, closes #727