### PR TITLE
fix(providers): restore type annotations stripped by schema canonicalization

### DIFF
--- a/crates/providers/src/openai_compat/schema_normalization.rs
+++ b/crates/providers/src/openai_compat/schema_normalization.rs
@@ -69,6 +69,12 @@ impl Transform for RestoreEnumTypeTransform {
             }
         }
 
+        // In JSON Schema, "number" subsumes "integer". When both appear
+        // (e.g. enum mixes 1 and 1.5), collapse to "number".
+        if types.contains("integer") && types.contains("number") {
+            types.remove("integer");
+        }
+
         // Only restore when all non-null values share a single type.
         if types.len() == 1 {
             let inferred_type = types.into_iter().next().unwrap_or_default();

--- a/crates/providers/src/openai_compat/schema_normalization.rs
+++ b/crates/providers/src/openai_compat/schema_normalization.rs
@@ -7,8 +7,78 @@ use {
             ReplaceUnevaluatedProperties, Transform,
         },
     },
+    std::collections::BTreeSet,
     tracing::warn,
 };
+
+/// Re-infer `"type"` from `"enum"` values when canonicalization stripped it.
+///
+/// `json_schema_ast` canonicalization removes redundant `"type"` annotations
+/// when all enum values match the declared type (`lower_enum_with_type`), and
+/// converts `"type": "boolean"` → `"enum": [false, true]`
+/// (`lower_boolean_and_null_types`). This is correct per JSON Schema semantics
+/// but providers like Fireworks AI reject schemas without explicit `"type"`.
+///
+/// This transform walks every schema node and restores `"type"` when:
+/// - `"enum"` is present but `"type"` is absent
+/// - All non-null enum values share a single JSON type
+#[derive(Debug, Clone, Default)]
+struct RestoreEnumTypeTransform;
+
+impl Transform for RestoreEnumTypeTransform {
+    fn transform(&mut self, schema: &mut Schema) {
+        let Some(obj) = schema.as_object_mut() else {
+            return;
+        };
+
+        // Only act when `enum` is present and `type` is absent.
+        if obj.contains_key("type") {
+            return;
+        }
+        let Some(values) = obj.get("enum").and_then(|v| v.as_array()) else {
+            return;
+        };
+        if values.is_empty() {
+            return;
+        }
+
+        // Collect the distinct JSON types of non-null enum values.
+        let mut types = BTreeSet::new();
+        for value in values {
+            match value {
+                serde_json::Value::Null => {}, // ignore null for type inference
+                serde_json::Value::Bool(_) => {
+                    types.insert("boolean");
+                },
+                serde_json::Value::Number(n) => {
+                    if n.is_f64() && !n.is_i64() && !n.is_u64() {
+                        types.insert("number");
+                    } else {
+                        types.insert("integer");
+                    }
+                },
+                serde_json::Value::String(_) => {
+                    types.insert("string");
+                },
+                serde_json::Value::Array(_) => {
+                    types.insert("array");
+                },
+                serde_json::Value::Object(_) => {
+                    types.insert("object");
+                },
+            }
+        }
+
+        // Only restore when all non-null values share a single type.
+        if types.len() == 1 {
+            let inferred_type = types.into_iter().next().unwrap_or_default();
+            obj.insert(
+                "type".to_string(),
+                serde_json::Value::String(inferred_type.to_string()),
+            );
+        }
+    }
+}
 
 const OPENAI_ALLOWED_SCHEMA_KEYWORDS: &[&str] = &[
     "$ref",
@@ -109,6 +179,12 @@ pub(crate) fn sanitize_schema_for_openai_compat(schema: &mut serde_json::Value) 
     remove_ref_siblings.transform(&mut transformed);
     let mut subset_transform = RecursiveTransform(OpenAiSchemaSubsetTransform);
     subset_transform.transform(&mut transformed);
+
+    // Re-infer `"type"` from enum values after canonicalization stripped it.
+    // Providers like Fireworks AI reject schemas without explicit type
+    // annotations even when enum values unambiguously imply the type.
+    let mut restore_enum_type = RecursiveTransform(RestoreEnumTypeTransform);
+    restore_enum_type.transform(&mut transformed);
 
     *schema = transformed.to_value();
 }

--- a/crates/providers/src/openai_compat/tests.rs
+++ b/crates/providers/src/openai_compat/tests.rs
@@ -514,6 +514,119 @@ fn to_openai_tools_strict_nullable_enum_has_null() {
     );
 }
 
+/// Fireworks regression: canonicalization strips `"type": "string"` from
+/// enum properties when all enum values are strings. The post-canonicalization
+/// `RestoreEnumTypeTransform` must re-infer and restore the type annotation
+/// so providers like Fireworks AI don't reject the schema with 400.
+#[test]
+fn sanitize_restores_type_on_string_enum() {
+    let mut schema = serde_json::json!({
+        "type": "object",
+        "properties": {
+            "action": {
+                "type": "string",
+                "enum": ["navigate", "click", "scroll"]
+            }
+        },
+        "required": ["action"]
+    });
+
+    sanitize_schema_for_openai_compat(&mut schema);
+
+    assert_eq!(
+        schema["properties"]["action"]["type"], "string",
+        "type must be restored after canonicalization strips it"
+    );
+    let Some(enum_values) = schema["properties"]["action"]["enum"].as_array() else {
+        panic!("enum should be preserved");
+    };
+    assert_eq!(enum_values.len(), 3);
+}
+
+/// Fireworks regression: `"type": "boolean"` gets canonicalized to
+/// `"enum": [false, true]` (lower_boolean_and_null_types). The restore
+/// transform must re-add `"type": "boolean"`.
+#[test]
+fn sanitize_restores_type_on_boolean_enum() {
+    let mut schema = serde_json::json!({
+        "type": "object",
+        "properties": {
+            "verbose": { "type": "boolean" }
+        }
+    });
+
+    sanitize_schema_for_openai_compat(&mut schema);
+
+    assert_eq!(
+        schema["properties"]["verbose"]["type"], "boolean",
+        "type must be restored for boolean enums"
+    );
+}
+
+/// End-to-end: `to_openai_tools` with strict=true must preserve type
+/// annotations on enum properties after the full pipeline.
+#[test]
+fn to_openai_tools_strict_preserves_enum_type_annotation() {
+    let tools = vec![serde_json::json!({
+        "name": "browser_action",
+        "description": "Perform a browser action",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "action": {
+                    "type": "string",
+                    "enum": ["navigate", "click", "scroll"]
+                },
+                "enabled": { "type": "boolean" }
+            },
+            "required": ["action"]
+        }
+    })];
+
+    let converted = to_openai_tools(&tools, true);
+    let params = &converted[0]["function"]["parameters"];
+
+    assert_eq!(
+        params["properties"]["action"]["type"], "string",
+        "string enum must retain type through strict pipeline"
+    );
+    // `enabled` is optional → strict mode makes it nullable → type becomes
+    // ["boolean", "null"]. The important thing is that "type" is present
+    // (not stripped), and includes "boolean".
+    let enabled_type = &params["properties"]["enabled"]["type"];
+    let has_boolean = if let Some(arr) = enabled_type.as_array() {
+        arr.iter().any(|v| v.as_str() == Some("boolean"))
+    } else {
+        enabled_type.as_str() == Some("boolean")
+    };
+    assert!(
+        has_boolean,
+        "boolean must retain type through strict pipeline, got: {enabled_type}"
+    );
+}
+
+/// Mixed enum values (e.g. string + integer) should NOT get a type
+/// inferred, since there's no single type that covers all values.
+#[test]
+fn sanitize_does_not_infer_type_for_mixed_enums() {
+    let mut schema = serde_json::json!({
+        "type": "object",
+        "properties": {
+            "value": {
+                "enum": ["auto", 42]
+            }
+        }
+    });
+
+    sanitize_schema_for_openai_compat(&mut schema);
+
+    // Mixed types → no single type can be inferred
+    assert!(
+        schema["properties"]["value"]["type"].is_null(),
+        "mixed enum should not get a type annotation"
+    );
+}
+
 /// Issue #712: enum-only schemas (no `type` key) must also get null
 /// appended. Canonicalization can strip the redundant `"type": "string"`
 /// leaving just `{"enum": [...]}` — the final fallback in make_nullable

--- a/crates/providers/src/openai_compat/tests.rs
+++ b/crates/providers/src/openai_compat/tests.rs
@@ -563,6 +563,46 @@ fn sanitize_restores_type_on_boolean_enum() {
     );
 }
 
+/// Fireworks regression: integer enum values (e.g. priority levels) must
+/// also get their type restored after canonicalization.
+#[test]
+fn sanitize_restores_type_on_integer_enum() {
+    let mut schema = serde_json::json!({
+        "type": "object",
+        "properties": {
+            "priority": { "type": "integer", "enum": [1, 2, 3] }
+        }
+    });
+
+    sanitize_schema_for_openai_compat(&mut schema);
+
+    assert_eq!(
+        schema["properties"]["priority"]["type"], "integer",
+        "type must be restored for integer enums"
+    );
+}
+
+/// Mixed integer+float enum values should infer "number" since JSON Schema
+/// "number" subsumes "integer".
+#[test]
+fn sanitize_infers_number_for_mixed_int_float_enum() {
+    let mut schema = serde_json::json!({
+        "type": "object",
+        "properties": {
+            "threshold": {
+                "enum": [1, 1.5, 2]
+            }
+        }
+    });
+
+    sanitize_schema_for_openai_compat(&mut schema);
+
+    assert_eq!(
+        schema["properties"]["threshold"]["type"], "number",
+        "mixed integer+float enum should infer number"
+    );
+}
+
 /// End-to-end: `to_openai_tools` with strict=true must preserve type
 /// annotations on enum properties after the full pipeline.
 #[test]


### PR DESCRIPTION
## Summary

- Fireworks AI (and potentially other providers) reject tool schemas without explicit `"type"` annotations, returning 400 Bad Request
- `json_schema_ast` canonicalization strips `"type": "string"` from enum properties when all values are strings, and converts `"type": "boolean"` to `"enum": [false, true]` — semantically correct but provider-incompatible
- Adds `RestoreEnumTypeTransform` post-canonicalization pass that re-infers `"type"` from enum values when the key is missing and all non-null values share a single JSON type

## Validation

### Completed
- [x] `cargo +nightly-2025-11-30 fmt --all -- --check`
- [x] `cargo clippy -p moltis-providers --all-targets -- -D warnings`
- [x] `cargo test -p moltis-providers --lib openai_compat::tests` (17 passed)
- [x] `cargo test -p moltis-providers --test openai_compat_type_arrays` (12 passed)

### Remaining
- [ ] `./scripts/local-validate.sh`
- [ ] Live test with Fireworks API key: `cargo test --test fireworks_integration -- --ignored`

## Manual QA

1. Configure Fireworks provider with `kimi-k2p5-turbo` model
2. Send a message that triggers tool use (e.g. "what's the weather in Tokyo?")
3. Verify the request succeeds (previously returned 400 Bad Request)
4. Check that enum properties in tool schemas include `"type"` in the sent payload