### PR TITLE
fix(providers): detect Grok 3/4 as reasoning-capable models

### DIFF
--- a/crates/providers/src/model_capabilities.rs
+++ b/crates/providers/src/model_capabilities.rs
@@ -253,6 +253,10 @@ pub fn supports_reasoning_for_model(model_id: &str) -> bool {
     if id.contains("deepseek-r1") || id.contains("deepseek-reasoner") {
         return true;
     }
+    // xAI Grok 3+ reasoning models (Grok 3, Grok 3 Mini, Grok 4 series)
+    if id.starts_with("grok-3") || id.starts_with("grok-4") {
+        return true;
+    }
     false
 }
 
@@ -542,6 +546,23 @@ mod tests {
         assert!(supports_reasoning_for_model("gpt-5"));
         assert!(supports_reasoning_for_model("gpt-5-mini"));
         assert!(supports_reasoning_for_model("gpt-5.2"));
+        // xAI Grok reasoning models
+        assert!(supports_reasoning_for_model("grok-3"));
+        assert!(supports_reasoning_for_model("grok-3-latest"));
+        assert!(supports_reasoning_for_model("grok-3-mini"));
+        assert!(supports_reasoning_for_model("grok-3-mini-latest"));
+        assert!(supports_reasoning_for_model("grok-4-0420"));
+        assert!(supports_reasoning_for_model("grok-4"));
+        // OpenRouter-style namespaced Grok model IDs
+        assert!(supports_reasoning_for_model(
+            "custom-openrouter::xai/grok-4-0420"
+        ));
+        assert!(supports_reasoning_for_model(
+            "custom-openrouter::xai/grok-3-mini"
+        ));
+        // Grok 2 does NOT support reasoning
+        assert!(!supports_reasoning_for_model("grok-2"));
+        assert!(!supports_reasoning_for_model("grok-2-latest"));
 
         // Models that don't support reasoning
         assert!(!supports_reasoning_for_model("gemini-2.0-flash"));


### PR DESCRIPTION
## Summary

- Add `grok-3` and `grok-4` prefix patterns to `supports_reasoning_for_model()` so reasoning effort is correctly applied when using Grok models through OpenRouter or xAI directly
- Add tests covering Grok 3, Grok 3 Mini, Grok 4, OpenRouter-namespaced variants, and negative cases for Grok 2

Closes #738

## Validation

### Completed
- [x] `cargo +nightly-2025-11-30 fmt --all -- --check` passes
- [x] `cargo test -p moltis-providers` — all 115 tests pass
- [x] Test fails without the fix (verified red-green cycle)

### Remaining
- [ ] `just lint`
- [ ] `just test`

## Manual QA

1. Configure OpenRouter provider
2. Select a Grok 4 model (e.g. `xai/grok-4-0420`)
3. Verify reasoning variants (`@reasoning-low/medium/high`) appear in model picker
4. Start a session — confirm reasoning is active