### PR TITLE
fix(providers): sanitize MCP tool schemas regardless of JSON Schema draft

### DIFF
--- a/crates/providers/src/openai_compat/schema_normalization.rs
+++ b/crates/providers/src/openai_compat/schema_normalization.rs
@@ -102,7 +102,7 @@ impl Transform for SimplifyCompositeTransform {
             return;
         };
 
-        for keyword in ["anyOf", "oneOf"] {
+        for keyword in ["anyOf", "oneOf", "allOf"] {
             let Some(variants) = obj.get_mut(keyword).and_then(|v| v.as_array_mut()) else {
                 continue;
             };
@@ -116,6 +116,10 @@ impl Transform for SimplifyCompositeTransform {
                 obj.remove(keyword);
                 if let serde_json::Value::Object(inner) = single {
                     for (k, v) in inner {
+                        // Parent-key wins: if a key is already present (e.g. `type`
+                        // from a surrounding object schema), we keep the parent value
+                        // and discard the variant's. This is safe for the `not`→`{}`
+                        // canonicalization pattern this transform targets.
                         obj.entry(k).or_insert(v);
                     }
                 }

--- a/crates/providers/src/openai_compat/schema_normalization.rs
+++ b/crates/providers/src/openai_compat/schema_normalization.rs
@@ -86,6 +86,46 @@ impl Transform for RestoreEnumTypeTransform {
     }
 }
 
+/// Remove empty `{}` (the JSON Schema "true" schema) from `anyOf`/`oneOf`
+/// composite arrays and collapse single-variant composites inline.
+///
+/// Canonicalization of `not` and other negation keywords produces `{}` (the
+/// "accepts anything" schema). After keyword stripping, these survive as
+/// empty objects inside `anyOf`/`oneOf`, which OpenAI rejects with
+/// "schema must have a 'type' key" (issue #743).
+#[derive(Debug, Clone, Default)]
+struct SimplifyCompositeTransform;
+
+impl Transform for SimplifyCompositeTransform {
+    fn transform(&mut self, schema: &mut Schema) {
+        let Some(obj) = schema.as_object_mut() else {
+            return;
+        };
+
+        for keyword in ["anyOf", "oneOf"] {
+            let Some(variants) = obj.get_mut(keyword).and_then(|v| v.as_array_mut()) else {
+                continue;
+            };
+
+            // Drop empty-object variants (`{}`).
+            variants.retain(|v| !v.as_object().is_some_and(|o| o.is_empty()));
+
+            if variants.len() == 1 {
+                // Single variant left — inline it, replacing the composite.
+                let single = variants.remove(0);
+                obj.remove(keyword);
+                if let serde_json::Value::Object(inner) = single {
+                    for (k, v) in inner {
+                        obj.entry(k).or_insert(v);
+                    }
+                }
+            } else if variants.is_empty() {
+                obj.remove(keyword);
+            }
+        }
+    }
+}
+
 const OPENAI_ALLOWED_SCHEMA_KEYWORDS: &[&str] = &[
     "$ref",
     "$defs",
@@ -132,14 +172,26 @@ impl Transform for OpenAiSchemaSubsetTransform {
 }
 
 fn canonicalize_schema_for_openai_compat(schema: &serde_json::Value) -> serde_json::Value {
-    let document = match SchemaDocument::from_json(schema) {
+    // Strip `$schema` so `SchemaDocument::from_json()` doesn't reject
+    // non-2020-12 drafts (e.g. draft-07 from Attio MCP tools, issue #743).
+    // Draft-07 and 2020-12 share enough structural keywords that
+    // canonicalization works; remaining differences (`definitions` vs
+    // `$defs`, tuple `items` vs `prefixItems`) are handled by schemars
+    // transforms downstream. `$schema` itself is later stripped by
+    // `OpenAiSchemaSubsetTransform` anyway.
+    let mut input = schema.clone();
+    if let Some(obj) = input.as_object_mut() {
+        obj.remove("$schema");
+    }
+
+    let document = match SchemaDocument::from_json(&input) {
         Ok(document) => document,
         Err(error) => {
             warn!(
                 error = %error,
                 "openai tool schema failed Draft 2020-12 preflight; using raw schema for best-effort normalization"
             );
-            return schema.clone();
+            return input;
         },
     };
 
@@ -148,7 +200,7 @@ fn canonicalize_schema_for_openai_compat(schema: &serde_json::Value) -> serde_js
             error = %error,
             "openai tool schema failed canonical AST resolution; using raw schema for best-effort normalization"
         );
-        return schema.clone();
+        return input;
     }
 
     document
@@ -159,7 +211,7 @@ fn canonicalize_schema_for_openai_compat(schema: &serde_json::Value) -> serde_js
                     error = %error,
                     "openai tool schema canonicalization was unavailable; using raw schema for best-effort normalization"
                 );
-                schema.clone()
+                input
             },
             serde_json::Value::clone,
         )
@@ -185,6 +237,12 @@ pub(crate) fn sanitize_schema_for_openai_compat(schema: &mut serde_json::Value) 
     remove_ref_siblings.transform(&mut transformed);
     let mut subset_transform = RecursiveTransform(OpenAiSchemaSubsetTransform);
     subset_transform.transform(&mut transformed);
+
+    // Strip empty `{}` schemas from anyOf/oneOf (left behind by
+    // canonicalization of `not` and other negation keywords) and collapse
+    // single-variant composites inline (issue #743).
+    let mut simplify_composite = RecursiveTransform(SimplifyCompositeTransform);
+    simplify_composite.transform(&mut transformed);
 
     // Re-infer `"type"` from enum values after canonicalization stripped it.
     // Providers like Fireworks AI reject schemas without explicit type

--- a/crates/providers/src/openai_compat/tests.rs
+++ b/crates/providers/src/openai_compat/tests.rs
@@ -667,6 +667,114 @@ fn sanitize_does_not_infer_type_for_mixed_enums() {
     );
 }
 
+/// Issue #743: MCP tools declaring `$schema: "http://json-schema.org/draft-07/schema#"`
+/// (e.g. Attio) bypass canonicalization entirely because `SchemaDocument::from_json()`
+/// only accepts Draft 2020-12. Without canonicalization, stripping `not` leaves
+/// empty `{}` schemas inside `anyOf` which OpenAI rejects ("schema must have a
+/// 'type' key"). The sanitizer must strip `$schema` before canonicalization so
+/// that draft-07 schemas get the same AST resolution as draft 2020-12.
+#[test]
+fn sanitize_draft07_schema_strips_unsupported_keywords() {
+    // Reproduces the Attio MCP schema pattern from issue #743:
+    // nested anyOf with `not` and no `type` key, declared as draft-07.
+    let mut schema = serde_json::json!({
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+            "query": {
+                "anyOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "not": {
+                                    "const": ""
+                                }
+                            },
+                            {
+                                "type": "string"
+                            }
+                        ]
+                    },
+                    {
+                        "type": "null"
+                    }
+                ]
+            }
+        }
+    });
+
+    sanitize_schema_for_openai_compat(&mut schema);
+    let encoded = schema.to_string();
+
+    // `$schema` must be stripped.
+    assert!(
+        !encoded.contains("$schema"),
+        "$schema should be removed, got: {encoded}"
+    );
+    // `not` must be stripped.
+    assert!(
+        !encoded.contains("\"not\""),
+        "\"not\" should be removed from draft-07 schema, got: {encoded}"
+    );
+
+    // Critical assertion: no empty `{}` schemas left inside anyOf variants.
+    // Without canonicalization, stripping `not` leaves `{}` which OpenAI
+    // rejects with "schema must have a 'type' key".
+    assert!(
+        !encoded.contains("{}"),
+        "empty schemas should not remain after sanitization, got: {encoded}"
+    );
+    // The root `type: object` must survive.
+    assert_eq!(schema["type"], "object");
+}
+
+/// Issue #743: end-to-end through `to_responses_api_tools` with a draft-07
+/// schema containing the exact Attio pattern that OpenAI rejects.
+#[test]
+fn responses_tools_draft07_attio_schema_normalized() {
+    let tools = vec![serde_json::json!({
+        "name": "mcp__attio__list-attribute-definitions",
+        "description": "Attio test tool (draft-07)",
+        "parameters": {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "type": "object",
+            "properties": {
+                "query": {
+                    "anyOf": [
+                        {
+                            "anyOf": [
+                                {
+                                    "not": {
+                                        "const": ""
+                                    }
+                                },
+                                {
+                                    "type": "string"
+                                }
+                            ]
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                }
+            }
+        }
+    })];
+
+    let converted = to_responses_api_tools(&tools);
+    let params = &converted[0]["parameters"];
+    let encoded = params.to_string();
+
+    assert!(!encoded.contains("$schema"), "$schema must be removed: {encoded}");
+    assert!(!encoded.contains("\"not\""), "\"not\" must be removed: {encoded}");
+    assert!(
+        !encoded.contains("{}"),
+        "empty schemas should not remain after sanitization: {encoded}"
+    );
+    assert_eq!(params["type"], "object");
+}
+
 /// Issue #712: enum-only schemas (no `type` key) must also get null
 /// appended. Canonicalization can strip the redundant `"type": "string"`
 /// leaving just `{"enum": [...]}` — the final fallback in make_nullable


### PR DESCRIPTION
## Summary

- Strip `$schema` before passing to `SchemaDocument::from_json()` so MCP tools declaring draft-07 (e.g. Attio) get the same AST canonicalization as draft 2020-12
- Add `SimplifyCompositeTransform` to remove empty `{}` (true schema) variants from `anyOf`/`oneOf` and collapse single-variant composites inline
- Fixes the OpenAI rejection: "schema must have a 'type' key" for Attio MCP tools

Closes #743

## Validation

### Completed
- [x] `cargo test -p moltis-providers --lib` — 128/128 pass (0 regressions)
- [x] New test `sanitize_draft07_schema_strips_unsupported_keywords` — reproduces exact Attio schema pattern
- [x] New test `responses_tools_draft07_attio_schema_normalized` — end-to-end through `to_responses_api_tools`

### Remaining
- [ ] `just lint` — full clippy pass
- [ ] `just test` — full workspace test suite
- [ ] `./scripts/local-validate.sh` — full CI simulation

## Manual QA
1. Connect the Attio MCP server (`https://mcp.attio.com/mcp`) via OAuth
2. Use OpenAI Codex as the LLM provider
3. Ask the agent to use any Attio tool (e.g. "give me 3 Attio deals")
4. Confirm no "schema must have a 'type' key" error
5. Confirm no `openai tool schema failed Draft 2020-12 preflight` warnings in logs