### PR TITLE
fix(node-host): install rustls CryptoProvider before wss:// connections

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7799,6 +7799,7 @@ dependencies = [
  "moltis-metrics",
  "moltis-protocol",
  "reqwest 0.13.2",
+ "rustls 0.23.36",
  "serde",
  "serde_json",
  "sysinfo",

--- a/crates/node-host/Cargo.toml
+++ b/crates/node-host/Cargo.toml
@@ -14,11 +14,12 @@ moltis-config     = { workspace = true }
 moltis-metrics    = { optional = true, workspace = true }
 moltis-protocol   = { workspace = true }
 reqwest           = { workspace = true }
+rustls            = { workspace = true }
 serde             = { workspace = true }
 serde_json        = { workspace = true }
 sysinfo           = { workspace = true }
 tokio             = { workspace = true }
-tokio-tungstenite = { workspace = true }
+tokio-tungstenite = { features = ["rustls-tls-webpki-roots"], workspace = true }
 tracing           = { workspace = true }
 url               = { workspace = true }
 uuid              = { workspace = true }

--- a/crates/node-host/src/runner.rs
+++ b/crates/node-host/src/runner.rs
@@ -129,6 +129,13 @@ impl NodeHost {
     ///
     /// Returns `Ok(())` on clean shutdown, `Err` on connection/protocol errors.
     pub async fn run(&self) -> anyhow::Result<()> {
+        // Install a rustls CryptoProvider before any TLS connection.
+        // Without this, `connect_async` on a `wss://` URL panics because
+        // tokio-tungstenite uses rustls under the hood and no provider is
+        // registered in the node-host code path (the gateway sets its own
+        // in `gateway.rs`). See #744.
+        let _ = rustls::crypto::ring::default_provider().install_default();
+
         // Validate URL first, then pass string to connect_async.
         let _url = url::Url::parse(&self.config.gateway_url)?;
         info!(url = %self.config.gateway_url, node_id = %self.config.node_id, "connecting to gateway");
@@ -612,6 +619,23 @@ mod tests {
         });
         let result = host.handle_system_run(&args).await.unwrap();
         assert_eq!(result["stderr"].as_str().unwrap().trim(), "err");
+    }
+
+    /// Regression test for #744: `connect_async("wss://...")` panicked on
+    /// Windows because no rustls `CryptoProvider` was installed in the
+    /// node-host code path.  After the fix, `run()` returns a connection
+    /// error instead of panicking.
+    #[tokio::test]
+    async fn wss_url_does_not_panic_without_crypto_provider() {
+        let config = NodeConfig {
+            gateway_url: "wss://127.0.0.1:1/ws".into(),
+            device_token: "test-token".into(),
+            ..Default::default()
+        };
+        let node = NodeHost::new(config);
+        // Should return Err (unreachable host), NOT panic.
+        let result = node.run().await;
+        assert!(result.is_err(), "expected connection error, got Ok");
     }
 
     #[tokio::test]

--- a/crates/node-host/src/runner.rs
+++ b/crates/node-host/src/runner.rs
@@ -634,7 +634,14 @@ mod tests {
         };
         let node = NodeHost::new(config);
         // Should return Err (unreachable host), NOT panic.
-        let result = node.run().await;
+        // Wrap in a timeout so the test doesn't hang if a firewall silently
+        // drops packets to 127.0.0.1:1 instead of refusing immediately.
+        let result = tokio::time::timeout(
+            Duration::from_secs(5),
+            node.run(),
+        )
+        .await
+        .expect("timed out — possible firewall drop on 127.0.0.1:1");
         assert!(result.is_err(), "expected connection error, got Ok");
     }
 

--- a/crates/node-host/src/runner.rs
+++ b/crates/node-host/src/runner.rs
@@ -560,7 +560,7 @@ impl NodeHost {
 
 #[cfg(test)]
 mod tests {
-    #![allow(clippy::unwrap_used)]
+    #![allow(clippy::unwrap_used, clippy::expect_used)]
 
     use super::*;
 


### PR DESCRIPTION
## Summary

- Fixes #744 — `moltis node add --host wss://... --foreground` panicked on Windows because no rustls `CryptoProvider` was registered in the node-host code path
- Adds `rustls::crypto::ring::default_provider().install_default()` at the top of `NodeHost::run()`, matching the pattern used in the gateway (`gateway.rs:54`) and TLS crate (`certs.rs:327`)
- Enables `rustls-tls-webpki-roots` on `tokio-tungstenite` in the node-host crate so it's self-contained for outbound TLS

## Validation

### Completed
- [x] `cargo test -p moltis-node-host` — all 16 tests pass
- [x] Regression test `wss_url_does_not_panic_without_crypto_provider` verifies the fix
- [x] `cargo +nightly-2025-11-30 fmt -p moltis-node-host -- --check` clean
- [x] `cargo clippy -p moltis-node-host --all-targets -- -D warnings` clean
- [x] `taplo fmt` clean
- [x] `cargo fetch --locked` — lockfile in sync

### Remaining
- [ ] `./scripts/local-validate.sh` full run
- [ ] Manual test on Windows with `wss://` gateway URL

## Manual QA

1. Build the binary on Windows
2. Run `moltis node add --host wss://<gateway>:port/ws --token <token> --foreground`
3. Should see a connection error or successful connect — **not** a panic