### PR TITLE
fix(providers): prune orphaned required entries from tool schemas

### DIFF
--- a/crates/providers/src/openai_compat/schema_normalization.rs
+++ b/crates/providers/src/openai_compat/schema_normalization.rs
@@ -64,6 +64,14 @@ impl Transform for PruneOrphanedRequiredTransform {
                     .is_some_and(|name| defined_props.contains(name))
             });
         }
+        // Remove `required` entirely when retain emptied it.
+        if obj
+            .get("required")
+            .and_then(|v| v.as_array())
+            .is_some_and(|a| a.is_empty())
+        {
+            obj.remove("required");
+        }
     }
 }
 

--- a/crates/providers/src/openai_compat/schema_normalization.rs
+++ b/crates/providers/src/openai_compat/schema_normalization.rs
@@ -11,6 +11,62 @@ use {
     tracing::warn,
 };
 
+/// Prune `required` entries that reference properties not defined in `properties`.
+///
+/// MCP tools (e.g. Home Assistant with 80+ tools) may declare `required`
+/// entries for properties defined via unsupported keywords (`dependentSchemas`,
+/// `if`/`then`/`else`, `patternProperties`) that get stripped by
+/// `OpenAiSchemaSubsetTransform`. Gemini strictly validates that every
+/// `required` entry has a matching property and rejects the request with
+/// "property is not defined" when they don't match (issue #747).
+#[derive(Debug, Clone, Default)]
+struct PruneOrphanedRequiredTransform;
+
+impl Transform for PruneOrphanedRequiredTransform {
+    fn transform(&mut self, schema: &mut Schema) {
+        let Some(obj) = schema.as_object_mut() else {
+            return;
+        };
+
+        // Collect property names that have a meaningful schema.  Properties
+        // with bare boolean schemas (`true`) or empty objects (`{}`) are
+        // treated as undefined because:
+        //  - canonicalization adds `true` (the "accept anything" schema) for
+        //    orphaned `required` entries
+        //  - keyword stripping can reduce a property to `{}` when all its
+        //    keywords were unsupported
+        // In both cases the property has no usable type information and Gemini
+        // rejects it with "property is not defined" (issue #747).
+        let defined_props: BTreeSet<String> = obj
+            .get("properties")
+            .and_then(|v| v.as_object())
+            .map(|props| {
+                props
+                    .iter()
+                    .filter(|(_, v)| {
+                        v.as_bool().is_none() && !v.as_object().is_some_and(|o| o.is_empty())
+                    })
+                    .map(|(k, _)| k.clone())
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        if defined_props.is_empty() {
+            // No usable properties — `required` is entirely orphaned.
+            obj.remove("required");
+            return;
+        }
+
+        if let Some(required) = obj.get_mut("required").and_then(|v| v.as_array_mut()) {
+            required.retain(|entry| {
+                entry
+                    .as_str()
+                    .is_some_and(|name| defined_props.contains(name))
+            });
+        }
+    }
+}
+
 /// Re-infer `"type"` from `"enum"` values when canonicalization stripped it.
 ///
 /// `json_schema_ast` canonicalization removes redundant `"type"` annotations
@@ -247,6 +303,13 @@ pub(crate) fn sanitize_schema_for_openai_compat(schema: &mut serde_json::Value) 
     // single-variant composites inline (issue #743).
     let mut simplify_composite = RecursiveTransform(SimplifyCompositeTransform);
     simplify_composite.transform(&mut transformed);
+
+    // Prune `required` entries that reference properties not defined in
+    // `properties`. Keyword stripping above can remove property definitions
+    // (e.g. `dependentSchemas`, `if/then/else`) while leaving their names
+    // in `required`. Gemini rejects such schemas (issue #747).
+    let mut prune_orphaned_required = RecursiveTransform(PruneOrphanedRequiredTransform);
+    prune_orphaned_required.transform(&mut transformed);
 
     // Re-infer `"type"` from enum values after canonicalization stripped it.
     // Providers like Fireworks AI reject schemas without explicit type

--- a/crates/providers/src/openai_compat/tests.rs
+++ b/crates/providers/src/openai_compat/tests.rs
@@ -667,6 +667,148 @@ fn sanitize_does_not_infer_type_for_mixed_enums() {
     );
 }
 
+/// Issue #747: MCP tools (e.g. Home Assistant) may have `required` entries
+/// referencing properties not defined in `properties`. Canonicalization adds
+/// implicit `{}` schemas for these, but the prune transform removes them from
+/// `required` since Gemini rejects properties without usable type info.
+#[test]
+fn sanitize_prunes_orphaned_required_entries() {
+    let mut schema = serde_json::json!({
+        "type": "object",
+        "properties": {
+            "entity_id": { "type": "string" },
+            "brightness": { "type": "integer" }
+        },
+        "required": ["entity_id", "brightness", "color_temp", "transition"]
+    });
+
+    sanitize_schema_for_openai_compat(&mut schema);
+
+    let required = schema["required"]
+        .as_array()
+        .unwrap_or_else(|| panic!("required should be an array"));
+    let names: Vec<&str> = required.iter().filter_map(|v| v.as_str()).collect();
+    assert!(
+        names.contains(&"entity_id"),
+        "defined property must stay in required"
+    );
+    assert!(
+        names.contains(&"brightness"),
+        "defined property must stay in required"
+    );
+    assert!(
+        !names.contains(&"color_temp"),
+        "orphaned property must be pruned from required"
+    );
+    assert!(
+        !names.contains(&"transition"),
+        "orphaned property must be pruned from required"
+    );
+    assert_eq!(names.len(), 2);
+}
+
+/// Issue #747: orphaned `required` entries in nested object schemas must
+/// also be pruned (e.g. MCP tools with deeply nested parameters).
+#[test]
+fn sanitize_prunes_orphaned_required_in_nested_objects() {
+    let mut schema = serde_json::json!({
+        "type": "object",
+        "properties": {
+            "target": {
+                "type": "object",
+                "properties": {
+                    "entity_id": { "type": "string" }
+                },
+                "required": ["entity_id", "area_id", "device_id"]
+            }
+        },
+        "required": ["target"]
+    });
+
+    sanitize_schema_for_openai_compat(&mut schema);
+
+    let nested_required = schema["properties"]["target"]["required"]
+        .as_array()
+        .unwrap_or_else(|| panic!("nested required should be an array"));
+    let names: Vec<&str> = nested_required.iter().filter_map(|v| v.as_str()).collect();
+    assert_eq!(
+        names,
+        vec!["entity_id"],
+        "only entity_id should remain — area_id and device_id had no real schema"
+    );
+}
+
+/// Issue #747: end-to-end through `to_openai_tools` with strict=false
+/// (OpenRouter → Gemini path). Orphaned required entries must be pruned
+/// so Gemini doesn't reject with "property is not defined".
+#[test]
+fn to_openai_tools_non_strict_prunes_orphaned_required() {
+    let tools = vec![serde_json::json!({
+        "name": "mcp__ha__light_turn_on",
+        "description": "Turn on a light",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "entity_id": { "type": "string" },
+                "brightness": { "type": "integer" }
+            },
+            "required": ["entity_id", "color_temp", "transition"]
+        }
+    })];
+
+    let converted = to_openai_tools(&tools, false);
+    let params = &converted[0]["function"]["parameters"];
+
+    let required = params["required"]
+        .as_array()
+        .unwrap_or_else(|| panic!("required should be an array"));
+    let names: Vec<&str> = required.iter().filter_map(|v| v.as_str()).collect();
+    assert_eq!(
+        names,
+        vec!["entity_id"],
+        "only defined properties should remain in required"
+    );
+}
+
+/// Issue #747: schemas where `required` references properties only defined
+/// through `dependentSchemas` — after canonicalization and keyword stripping,
+/// those properties lack usable schemas and are pruned from `required`.
+/// The `dependentSchemas` keyword itself must also be stripped.
+#[test]
+fn sanitize_prunes_required_from_stripped_dependent_schemas() {
+    let mut schema = serde_json::json!({
+        "type": "object",
+        "properties": {
+            "mode": { "type": "string" }
+        },
+        "dependentSchemas": {
+            "mode": {
+                "properties": {
+                    "extra_param": { "type": "string" }
+                }
+            }
+        },
+        "required": ["mode", "extra_param"]
+    });
+
+    sanitize_schema_for_openai_compat(&mut schema);
+
+    let required = schema["required"]
+        .as_array()
+        .unwrap_or_else(|| panic!("required should be an array"));
+    let names: Vec<&str> = required.iter().filter_map(|v| v.as_str()).collect();
+    assert!(names.contains(&"mode"), "mode should stay in required");
+    assert!(
+        !names.contains(&"extra_param"),
+        "extra_param should be pruned — only defined via dependentSchemas"
+    );
+    // `dependentSchemas` itself must be stripped
+    assert!(
+        schema.get("dependentSchemas").is_none(),
+        "dependentSchemas should be stripped"
+    );
+}
+
 /// Issue #743: MCP tools declaring `$schema: "http://json-schema.org/draft-07/schema#"`
 /// (e.g. Attio) bypass canonicalization entirely because `SchemaDocument::from_json()`
 /// only accepts Draft 2020-12. Without canonicalization, stripping `not` leaves
@@ -766,8 +908,14 @@ fn responses_tools_draft07_attio_schema_normalized() {
     let params = &converted[0]["parameters"];
     let encoded = params.to_string();
 
-    assert!(!encoded.contains("$schema"), "$schema must be removed: {encoded}");
-    assert!(!encoded.contains("\"not\""), "\"not\" must be removed: {encoded}");
+    assert!(
+        !encoded.contains("$schema"),
+        "$schema must be removed: {encoded}"
+    );
+    assert!(
+        !encoded.contains("\"not\""),
+        "\"not\" must be removed: {encoded}"
+    );
     assert!(
         !encoded.contains("{}"),
         "empty schemas should not remain after sanitization: {encoded}"


### PR DESCRIPTION
## Summary

- Add `PruneOrphanedRequiredTransform` to the schema sanitization pipeline that filters `required` entries where the corresponding property is missing, is a bare boolean schema (`true`/`false`), or is an empty object (`{}`)
- Gemini (via OpenRouter) strictly validates that every `required` entry has a matching property in `properties` and rejects requests with "property is not defined" when they don't match
- MCP tools (e.g. Home Assistant) can declare `required` entries for properties defined via unsupported keywords (`dependentSchemas`, `if/then/else`, `patternProperties`) that get stripped during sanitization; canonicalization also adds bare `true` schemas for orphaned entries

Closes #747

## Validation

### Completed
- [x] `cargo +nightly-2025-11-30 fmt --all -- --check` passes
- [x] `just lint` passes (clippy clean)
- [x] `cargo test -p moltis-providers` passes (25 tests, all green)
- [x] 4 new tests covering orphaned required pruning:
  - `sanitize_prunes_orphaned_required_entries` — top-level orphaned entries
  - `sanitize_prunes_orphaned_required_in_nested_objects` — nested object schemas
  - `to_openai_tools_non_strict_prunes_orphaned_required` — end-to-end through OpenRouter/Gemini path (strict=false)
  - `sanitize_prunes_required_from_stripped_dependent_schemas` — properties from stripped `dependentSchemas`

### Remaining
- [ ] `./scripts/local-validate.sh` (requires CUDA on Linux)
- [ ] Manual QA with Gemini via OpenRouter + MCP tools

## Manual QA

1. Configure an MCP server with tools that have complex schemas (e.g. Home Assistant)
2. Select Gemini 3.1 Pro via OpenRouter as the provider
3. Send a message that triggers tool use
4. Verify no "property is not defined" errors from Gemini