### PR TITLE
fix(matrix): retry sync loop on transient connection failures

### DIFF
--- a/crates/matrix/Cargo.toml
+++ b/crates/matrix/Cargo.toml
@@ -27,7 +27,7 @@ default = []
 metrics = ["dep:moltis-metrics"]
 
 [dev-dependencies]
-tokio = { workspace = true }
+tokio = { workspace = true, features = ["test-util"] }
 
 [lints]
 workspace = true

--- a/crates/matrix/src/client.rs
+++ b/crates/matrix/src/client.rs
@@ -1,4 +1,4 @@
-use std::{fs, path::PathBuf, sync::Arc};
+use std::{fs, future::Future, path::PathBuf, sync::Arc};
 
 use {
     matrix_sdk::{
@@ -608,6 +608,45 @@ pub(crate) fn register_event_handlers(
     );
 }
 
+const INITIAL_BACKOFF: std::time::Duration = std::time::Duration::from_secs(5);
+const MAX_BACKOFF: std::time::Duration = std::time::Duration::from_secs(300);
+const HEALTHY_THRESHOLD: std::time::Duration = std::time::Duration::from_secs(60);
+
+async fn retry_loop<F, Fut, T>(mut sync_fn: F, account_id: &str, cancel: CancellationToken)
+where
+    F: FnMut() -> Fut,
+    Fut: Future<Output = T>,
+{
+    let mut backoff = INITIAL_BACKOFF;
+    loop {
+        let start = tokio::time::Instant::now();
+        tokio::select! {
+            _ = sync_fn() => {
+                if start.elapsed() >= HEALTHY_THRESHOLD {
+                    backoff = INITIAL_BACKOFF;
+                }
+                warn!(
+                    account_id = %account_id,
+                    "matrix sync loop ended unexpectedly, retrying in {:?}",
+                    backoff,
+                );
+                tokio::select! {
+                    () = tokio::time::sleep(backoff) => {}
+                    () = cancel.cancelled() => {
+                        info!(account_id = %account_id, "matrix sync loop cancelled during backoff");
+                        break;
+                    }
+                }
+                backoff = (backoff * 2).min(MAX_BACKOFF);
+            }
+            () = cancel.cancelled() => {
+                info!(account_id = %account_id, "matrix sync loop cancelled");
+                break;
+            }
+        }
+    }
+}
+
 #[instrument(skip(client, accounts, cancel), fields(account_id))]
 pub(crate) async fn sync_once_and_spawn_loop(
     client: &Client,
@@ -657,37 +696,12 @@ pub(crate) async fn sync_once_and_spawn_loop(
     let account_id_for_sync = account_id.to_string();
     let client_for_sync = client.clone();
     tokio::spawn(async move {
-        let mut backoff = std::time::Duration::from_secs(5);
-        const MAX_BACKOFF: std::time::Duration = std::time::Duration::from_secs(300);
-        const HEALTHY_THRESHOLD: std::time::Duration = std::time::Duration::from_secs(60);
-
-        loop {
-            let start = tokio::time::Instant::now();
-            tokio::select! {
-                _ = client_for_sync.sync(SyncSettings::default()) => {
-                    if start.elapsed() >= HEALTHY_THRESHOLD {
-                        backoff = std::time::Duration::from_secs(5);
-                    }
-                    warn!(
-                        account_id = %account_id_for_sync,
-                        "matrix sync loop ended unexpectedly, retrying in {:?}",
-                        backoff,
-                    );
-                    tokio::select! {
-                        () = tokio::time::sleep(backoff) => {}
-                        () = cancel.cancelled() => {
-                            info!(account_id = %account_id_for_sync, "matrix sync loop cancelled during backoff");
-                            break;
-                        }
-                    }
-                    backoff = (backoff * 2).min(MAX_BACKOFF);
-                }
-                () = cancel.cancelled() => {
-                    info!(account_id = %account_id_for_sync, "matrix sync loop cancelled");
-                    break;
-                }
-            }
-        }
+        retry_loop(
+            || client_for_sync.sync(SyncSettings::default()),
+            &account_id_for_sync,
+            cancel,
+        )
+        .await;
     });
 
     Ok(())
@@ -1144,5 +1158,234 @@ mod tests {
             false,
             RecoveryState::Unknown
         ));
+    }
+
+    mod retry_loop_tests {
+        use std::sync::atomic::{AtomicU32, Ordering};
+
+        use tokio_util::sync::CancellationToken;
+
+        use super::super::{HEALTHY_THRESHOLD, INITIAL_BACKOFF, MAX_BACKOFF, retry_loop};
+
+        #[tokio::test(start_paused = true)]
+        async fn cancellation_during_sync_exits_immediately() {
+            let cancel = CancellationToken::new();
+            let cancel_inner = cancel.clone();
+
+            let call_count = std::sync::Arc::new(AtomicU32::new(0));
+            let count = call_count.clone();
+
+            cancel_inner.cancel();
+
+            retry_loop(
+                || {
+                    count.fetch_add(1, Ordering::SeqCst);
+                    std::future::pending::<()>()
+                },
+                "test-account",
+                cancel,
+            )
+            .await;
+
+            assert_eq!(call_count.load(Ordering::SeqCst), 1);
+        }
+
+        #[tokio::test(start_paused = true)]
+        async fn cancellation_during_backoff_exits_without_waiting() {
+            let cancel = CancellationToken::new();
+            let cancel_inner = cancel.clone();
+
+            let call_count = std::sync::Arc::new(AtomicU32::new(0));
+            let count = call_count.clone();
+
+            tokio::spawn(async move {
+                // Let the first sync fail and enter backoff, then cancel.
+                tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+                cancel_inner.cancel();
+            });
+
+            retry_loop(
+                || {
+                    let n = count.fetch_add(1, Ordering::SeqCst);
+                    async move {
+                        if n == 0 {
+                            // First call: fail immediately.
+                            return;
+                        }
+                        // Should not be called — cancel fires during backoff.
+                        std::future::pending::<()>().await;
+                    }
+                },
+                "test-account",
+                cancel,
+            )
+            .await;
+
+            // Only 1 sync call — loop exited during backoff before retrying.
+            assert_eq!(call_count.load(Ordering::SeqCst), 1);
+        }
+
+        #[tokio::test(start_paused = true)]
+        async fn backoff_doubles_on_consecutive_failures() {
+            let cancel = CancellationToken::new();
+            let cancel_inner = cancel.clone();
+
+            let call_count = std::sync::Arc::new(AtomicU32::new(0));
+            let count = call_count.clone();
+
+            let timestamps = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+            let ts = timestamps.clone();
+
+            tokio::spawn(async move {
+                // Let 3 sync failures + backoffs complete, then cancel.
+                // Backoff sequence: 5s, 10s, 20s = 35s total + tiny sync time.
+                tokio::time::sleep(std::time::Duration::from_secs(36)).await;
+                cancel_inner.cancel();
+            });
+
+            retry_loop(
+                || {
+                    count.fetch_add(1, Ordering::SeqCst);
+                    let ts = ts.clone();
+                    async move {
+                        ts.lock()
+                            .unwrap_or_else(|e| e.into_inner())
+                            .push(tokio::time::Instant::now());
+                    }
+                },
+                "test-account",
+                cancel,
+            )
+            .await;
+
+            let times = timestamps.lock().unwrap_or_else(|e| e.into_inner());
+            assert!(
+                times.len() >= 3,
+                "expected at least 3 sync calls, got {}",
+                times.len()
+            );
+            // Between call 1 and 2: ~5s backoff
+            let gap1 = times[1] - times[0];
+            assert!(
+                gap1 >= INITIAL_BACKOFF,
+                "first gap {gap1:?} < {INITIAL_BACKOFF:?}"
+            );
+            // Between call 2 and 3: ~10s backoff
+            let gap2 = times[2] - times[1];
+            assert!(
+                gap2 >= INITIAL_BACKOFF * 2,
+                "second gap {gap2:?} < {:?}",
+                INITIAL_BACKOFF * 2
+            );
+        }
+
+        #[tokio::test(start_paused = true)]
+        async fn backoff_resets_after_healthy_connection() {
+            let cancel = CancellationToken::new();
+            let cancel_inner = cancel.clone();
+
+            let call_count = std::sync::Arc::new(AtomicU32::new(0));
+            let count = call_count.clone();
+
+            let timestamps = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+            let ts = timestamps.clone();
+
+            tokio::spawn(async move {
+                // Call 1: fails immediately → 5s backoff
+                // Call 2: runs for HEALTHY_THRESHOLD (60s), then fails → backoff resets to 5s
+                // Call 3: recorded, then we cancel during backoff
+                // Total: ~0 + 5 + 60 + 5 + ~0 = ~70s, cancel at 71s.
+                tokio::time::sleep(std::time::Duration::from_secs(71)).await;
+                cancel_inner.cancel();
+            });
+
+            retry_loop(
+                || {
+                    let n = count.fetch_add(1, Ordering::SeqCst);
+                    let ts = ts.clone();
+                    async move {
+                        ts.lock()
+                            .unwrap_or_else(|e| e.into_inner())
+                            .push(tokio::time::Instant::now());
+                        if n == 1 {
+                            // Simulate healthy connection that eventually dies.
+                            tokio::time::sleep(HEALTHY_THRESHOLD).await;
+                        }
+                        // All others fail immediately.
+                    }
+                },
+                "test-account",
+                cancel,
+            )
+            .await;
+
+            let times = timestamps.lock().unwrap_or_else(|e| e.into_inner());
+            assert!(
+                times.len() >= 3,
+                "expected at least 3 sync calls, got {}",
+                times.len()
+            );
+            // Gap between call 2 (after healthy run) and call 3 should be
+            // INITIAL_BACKOFF (reset), not doubled.
+            let gap = times[2] - times[1];
+            let expected = HEALTHY_THRESHOLD + INITIAL_BACKOFF;
+            let tolerance = std::time::Duration::from_secs(1);
+            assert!(
+                gap <= expected + tolerance,
+                "gap after healthy connection {gap:?} should be ~{expected:?} (reset backoff), not doubled"
+            );
+        }
+
+        #[tokio::test(start_paused = true)]
+        async fn backoff_caps_at_max() {
+            let cancel = CancellationToken::new();
+            let cancel_inner = cancel.clone();
+
+            let call_count = std::sync::Arc::new(AtomicU32::new(0));
+            let count = call_count.clone();
+
+            let timestamps = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+            let ts = timestamps.clone();
+
+            // Backoff sequence: 5, 10, 20, 40, 80, 160, 300, 300, ...
+            // After 7 calls: 5+10+20+40+80+160+300 = 615s total.
+            // Cancel at 620s to let 7th call happen.
+            tokio::spawn(async move {
+                tokio::time::sleep(std::time::Duration::from_secs(620)).await;
+                cancel_inner.cancel();
+            });
+
+            retry_loop(
+                || {
+                    count.fetch_add(1, Ordering::SeqCst);
+                    let ts = ts.clone();
+                    async move {
+                        ts.lock()
+                            .unwrap_or_else(|e| e.into_inner())
+                            .push(tokio::time::Instant::now());
+                    }
+                },
+                "test-account",
+                cancel,
+            )
+            .await;
+
+            let times = timestamps.lock().unwrap_or_else(|e| e.into_inner());
+            assert!(
+                times.len() >= 8,
+                "expected at least 8 sync calls, got {}",
+                times.len()
+            );
+            // Gap between call 7 and 8 should be capped at MAX_BACKOFF.
+            let gap = times[7] - times[6];
+            assert!(
+                gap >= MAX_BACKOFF,
+                "gap {gap:?} should be at least {MAX_BACKOFF:?}"
+            );
+            assert!(
+                gap <= MAX_BACKOFF + std::time::Duration::from_secs(1),
+                "gap {gap:?} should be at most {MAX_BACKOFF:?} + 1s"
+            );
+        }
     }
 }

--- a/crates/matrix/src/client.rs
+++ b/crates/matrix/src/client.rs
@@ -18,7 +18,7 @@ use {
     secrecy::ExposeSecret,
     serde::Deserialize,
     tokio_util::sync::CancellationToken,
-    tracing::{error, info, instrument, warn},
+    tracing::{info, instrument, warn},
 };
 
 use moltis_channels::{Error as ChannelError, Result as ChannelResult};
@@ -668,12 +668,18 @@ pub(crate) async fn sync_once_and_spawn_loop(
                     if start.elapsed() >= HEALTHY_THRESHOLD {
                         backoff = std::time::Duration::from_secs(5);
                     }
-                    error!(
+                    warn!(
                         account_id = %account_id_for_sync,
                         "matrix sync loop ended unexpectedly, retrying in {:?}",
                         backoff,
                     );
-                    tokio::time::sleep(backoff).await;
+                    tokio::select! {
+                        () = tokio::time::sleep(backoff) => {}
+                        () = cancel.cancelled() => {
+                            info!(account_id = %account_id_for_sync, "matrix sync loop cancelled during backoff");
+                            break;
+                        }
+                    }
                     backoff = (backoff * 2).min(MAX_BACKOFF);
                 }
                 () = cancel.cancelled() => {

--- a/crates/matrix/src/client.rs
+++ b/crates/matrix/src/client.rs
@@ -18,7 +18,7 @@ use {
     secrecy::ExposeSecret,
     serde::Deserialize,
     tokio_util::sync::CancellationToken,
-    tracing::{info, instrument, warn},
+    tracing::{error, info, instrument, warn},
 };
 
 use moltis_channels::{Error as ChannelError, Result as ChannelResult};
@@ -657,12 +657,29 @@ pub(crate) async fn sync_once_and_spawn_loop(
     let account_id_for_sync = account_id.to_string();
     let client_for_sync = client.clone();
     tokio::spawn(async move {
-        tokio::select! {
-            _ = client_for_sync.sync(SyncSettings::default()) => {
-                warn!(account_id = %account_id_for_sync, "matrix sync loop ended unexpectedly");
-            }
-            () = cancel.cancelled() => {
-                info!(account_id = %account_id_for_sync, "matrix sync loop cancelled");
+        let mut backoff = std::time::Duration::from_secs(5);
+        const MAX_BACKOFF: std::time::Duration = std::time::Duration::from_secs(300);
+        const HEALTHY_THRESHOLD: std::time::Duration = std::time::Duration::from_secs(60);
+
+        loop {
+            let start = tokio::time::Instant::now();
+            tokio::select! {
+                _ = client_for_sync.sync(SyncSettings::default()) => {
+                    if start.elapsed() >= HEALTHY_THRESHOLD {
+                        backoff = std::time::Duration::from_secs(5);
+                    }
+                    error!(
+                        account_id = %account_id_for_sync,
+                        "matrix sync loop ended unexpectedly, retrying in {:?}",
+                        backoff,
+                    );
+                    tokio::time::sleep(backoff).await;
+                    backoff = (backoff * 2).min(MAX_BACKOFF);
+                }
+                () = cancel.cancelled() => {
+                    info!(account_id = %account_id_for_sync, "matrix sync loop cancelled");
+                    break;
+                }
             }
         }
     });


### PR DESCRIPTION
## Summary

- Wrap the Matrix sync loop in a retry loop with exponential backoff (5s → 300s cap) so transient network errors no longer kill the connection permanently
- Backoff resets to 5s when the connection was healthy for 60+ seconds before failing

Fixes #758

## Validation

### Completed
- [x] `cargo check -p moltis-matrix` passes
- [x] `cargo +nightly-2025-11-30 fmt --all -- --check` passes

### Remaining
- [ ] `just lint`
- [ ] `just test`
- [ ] `./scripts/local-validate.sh`

## Manual QA

1. Start Moltis with a Matrix account configured
2. Kill network connectivity or stop the Matrix homeserver
3. Observe retry logs with increasing backoff in the console
4. Restore connectivity — sync should resume automatically
5. Verify backoff resets after a sustained healthy connection (60s+) followed by another failure