### PR TITLE
feat(nostr): add NIP-59 Gift Wrap support for private DMs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -207,7 +207,7 @@ jsonwebtoken       = { features = ["aws_lc_rs"], version = "10" }
 llama-cpp-2        = "0.1"
 matrix-sdk         = { default-features = false, features = ["e2e-encryption", "markdown", "native-tls", "sqlite"], version = "0.16" }
 mockito            = "1.7"
-nostr-sdk          = { features = ["nip04", "nip44"], version = "0.44" }
+nostr-sdk          = { features = ["nip04", "nip44", "nip59"], version = "0.44" }
 open               = "5.3"
 rand               = "0.10"
 regex              = "1"

--- a/crates/nostr/src/bus.rs
+++ b/crates/nostr/src/bus.rs
@@ -1,8 +1,9 @@
 //! Nostr relay subscription loop — inbound DM pipeline.
 //!
-//! Subscribes to kind:4 (NIP-04 encrypted DMs) addressed to the bot's pubkey.
-//! Events flow through dedup, self-message filtering, access control, and
-//! decryption before being dispatched to the gateway via `ChannelEventSink`.
+//! Subscribes to kind:4 (NIP-04 encrypted DMs) and kind:1059 (NIP-59 gift
+//! wraps) addressed to the bot's pubkey. Events flow through dedup,
+//! self-message filtering, access control, and decryption/unwrapping before
+//! being dispatched to the gateway via `ChannelEventSink`.
 
 use std::sync::{Arc, RwLock};
 
@@ -32,9 +33,10 @@ const OTP_CHALLENGE_MSG: &str = "You are not on the allowlist. A PIN challenge h
 
 /// Run the relay subscription loop for a single Nostr account.
 ///
-/// Subscribes to NIP-04 DMs (kind:4) targeted at `bot_pubkey` and dispatches
-/// inbound messages to the gateway. Runs until `cancel` is triggered or the
-/// relay pool shuts down (which triggers an auto-disable request).
+/// Subscribes to NIP-04 DMs (kind:4) and NIP-59 gift wraps (kind:1059)
+/// targeted at `bot_pubkey` and dispatches inbound messages to the gateway.
+/// Runs until `cancel` is triggered or the relay pool shuts down (which
+/// triggers an auto-disable request).
 pub async fn run_subscription_loop(
     client: Client,
     keys: Keys,
@@ -50,10 +52,16 @@ pub async fn run_subscription_loop(
         u64::try_from(::time::OffsetDateTime::now_utc().unix_timestamp()).unwrap_or_default();
     let since = Timestamp::from(now_secs);
 
+    // Gift wraps have randomly tweaked timestamps (0–2 days), so use a wider
+    // window for the relay filter. The staleness check in handle_event uses
+    // the rumor's actual created_at for gift wraps, filtering old kind:4
+    // messages that happen to fall in this window.
+    let gift_wrap_since = Timestamp::from(now_secs.saturating_sub(172_800));
+
     let filter = Filter::new()
-        .kind(Kind::EncryptedDirectMessage)
+        .kinds([Kind::EncryptedDirectMessage, Kind::GiftWrap])
         .pubkey(bot_pubkey)
-        .since(since);
+        .since(gift_wrap_since);
 
     let npub = bot_pubkey
         .to_bech32()
@@ -61,12 +69,11 @@ pub async fn run_subscription_loop(
     tracing::info!(
         account_id,
         pubkey = %npub,
-        "starting Nostr DM subscription"
+        "starting Nostr DM subscription (kind:4 + kind:1059)"
     );
 
     let mut seen = SeenTracker::new();
 
-    // Subscribe (single filter)
     if let Err(e) = client.subscribe(filter, None).await {
         tracing::error!(account_id, "failed to subscribe: {e}");
         return;
@@ -131,8 +138,9 @@ async fn handle_event(
     account_id: &str,
     event_sink: &Arc<dyn moltis_channels::ChannelEventSink>,
 ) {
-    // 1. Skip non-DM events
-    if event.kind != Kind::EncryptedDirectMessage {
+    // 1. Kind gate — accept kind:4 (legacy NIP-04) and kind:1059 (NIP-59 gift wrap)
+    let is_gift_wrap = event.kind == Kind::GiftWrap;
+    if event.kind != Kind::EncryptedDirectMessage && !is_gift_wrap {
         return;
     }
 
@@ -141,30 +149,65 @@ async fn handle_event(
         return;
     }
 
-    // 3. Skip self-messages
-    if event.pubkey == *bot_pubkey {
+    // 3. Extract sender, plaintext, and created_at based on kind.
+    //    Gift wraps hide the real sender inside the sealed rumor; kind:4
+    //    exposes it as event.pubkey.
+    let (sender_pubkey, plaintext, event_time) = if is_gift_wrap {
+        match crate::gift_wrap::unwrap_gift_wrap(keys, event).await {
+            Ok(result) => result,
+            Err(e) => {
+                #[cfg(feature = "metrics")]
+                counter!(nostr_metrics::DECRYPT_ERRORS_TOTAL).increment(1);
+                tracing::warn!(
+                    account_id,
+                    event_id = %event.id,
+                    "gift unwrap failed: {e}"
+                );
+                return;
+            },
+        }
+    } else {
+        // Kind:4 — decrypt NIP-04, fall back to NIP-44
+        let text = match try_decrypt(keys, &event.pubkey, &event.content) {
+            Some(t) => t,
+            None => {
+                #[cfg(feature = "metrics")]
+                counter!(nostr_metrics::DECRYPT_ERRORS_TOTAL).increment(1);
+                tracing::warn!(
+                    account_id,
+                    event_id = %event.id,
+                    "decrypt failed (NIP-04 and NIP-44)"
+                );
+                return;
+            },
+        };
+        (event.pubkey, text, event.created_at)
+    };
+
+    // 4. Skip self-messages
+    if sender_pubkey == *bot_pubkey {
         return;
     }
 
-    // 4. Skip stale events
-    if event.created_at < since {
+    // 5. Skip stale events (gift wraps use rumor's created_at, not the
+    //    randomly tweaked outer timestamp)
+    if event_time < since {
         return;
     }
 
-    let sender_hex = event.pubkey.to_hex();
-    let sender_npub = event
-        .pubkey
+    let sender_hex = sender_pubkey.to_hex();
+    let sender_npub = sender_pubkey
         .to_bech32()
         .unwrap_or_else(|_| sender_hex.clone());
 
-    // 5. Read config fields (drop guard before any .await).
+    // 6. Read config fields (drop guard before any .await).
     let (dm_policy, otp_self_approval) = {
         let cfg = config.read().unwrap_or_else(|e| e.into_inner());
         (cfg.dm_policy.clone(), cfg.otp_self_approval)
     };
 
-    // 5a. OTP verification — if this sender has a pending challenge, decrypt
-    //     first to check if the message is a 6-digit code, and verify it.
+    // 6a. OTP verification — if this sender has a pending challenge, check
+    //     if the plaintext is a 6-digit code and verify it.
     //     This must run BEFORE the access-control gate because the sender is
     //     not yet on the allowlist when they reply with the OTP code.
     let has_pending = {
@@ -172,32 +215,30 @@ async fn handle_event(
         guard.has_pending(&sender_hex)
     };
     if has_pending {
-        if let Some(plaintext) = try_decrypt(keys, &event.pubkey, &event.content) {
-            let trimmed = plaintext.trim();
-            if trimmed.len() == 6 && trimmed.chars().all(|c| c.is_ascii_digit()) {
-                handle_otp_verification(
-                    otp,
-                    client,
-                    keys,
-                    &event.pubkey,
-                    account_id,
-                    &sender_hex,
-                    &sender_npub,
-                    trimmed,
-                    event_sink,
-                )
-                .await;
-                return;
-            }
+        let trimmed = plaintext.trim();
+        if trimmed.len() == 6 && trimmed.chars().all(|c| c.is_ascii_digit()) {
+            handle_otp_verification(
+                otp,
+                client,
+                keys,
+                &sender_pubkey,
+                account_id,
+                &sender_hex,
+                &sender_npub,
+                trimmed,
+                event_sink,
+            )
+            .await;
+            return;
         }
         // Non-code reply while challenge pending — silently ignore.
         return;
     }
 
-    // 5b. Normal access-control gate (scope the guard so it drops before any .await).
+    // 6b. Normal access-control gate (scope the guard so it drops before any .await).
     let access_result = {
         let allowed = cached_allowlist.read().unwrap_or_else(|e| e.into_inner());
-        access::check_dm_access(&event.pubkey, &dm_policy, &allowed)
+        access::check_dm_access(&sender_pubkey, &dm_policy, &allowed)
     };
 
     match &access_result {
@@ -217,7 +258,7 @@ async fn handle_event(
                 handle_otp_challenge(
                     client,
                     keys,
-                    &event.pubkey,
+                    &sender_pubkey,
                     otp,
                     account_id,
                     &sender_hex,
@@ -235,24 +276,6 @@ async fn handle_event(
             return;
         },
     }
-
-    // 6. Decrypt content — try NIP-04 first, fall back to NIP-44
-    let plaintext = match nip04::decrypt(keys.secret_key(), &event.pubkey, &event.content) {
-        Ok(text) => text,
-        Err(_nip04_err) => match nip44::decrypt(keys.secret_key(), &event.pubkey, &event.content) {
-            Ok(text) => text,
-            Err(nip44_err) => {
-                #[cfg(feature = "metrics")]
-                counter!(nostr_metrics::DECRYPT_ERRORS_TOTAL).increment(1);
-                tracing::warn!(
-                    account_id,
-                    event_id = %event.id,
-                    "decrypt failed (NIP-04 and NIP-44): {nip44_err}"
-                );
-                return;
-            },
-        },
-    };
 
     // 7. Size validation — truncate at a safe UTF-8 boundary
     let text = if plaintext.len() > MAX_MESSAGE_BYTES {
@@ -356,15 +379,11 @@ async fn handle_otp_verification(
         ),
     };
 
-    // Send the reply to the sender.
-    if let Ok(encrypted) = nip04::encrypt(keys.secret_key(), sender_pubkey, reply_text) {
-        let tag = nostr_sdk::prelude::Tag::public_key(*sender_pubkey);
-        let builder =
-            nostr_sdk::prelude::EventBuilder::new(Kind::EncryptedDirectMessage, &encrypted)
-                .tag(tag);
-        if let Err(e) = client.send_event_builder(builder).await {
-            tracing::warn!(account_id, "failed to send OTP verification reply: {e}");
-        }
+    // Send the reply to the sender via gift wrap.
+    if let Err(e) =
+        crate::gift_wrap::send_gift_wrapped_dm(client, keys, sender_pubkey, reply_text).await
+    {
+        tracing::warn!(account_id, "failed to send OTP verification reply: {e}");
     }
 
     // Emit resolution event for admin UI.
@@ -404,17 +423,16 @@ async fn handle_otp_challenge(
 
     match init_result {
         OtpInitResult::Created(code) => {
-            // Send challenge prompt to the sender via encrypted DM.
-            if let Ok(encrypted) =
-                nip04::encrypt(keys.secret_key(), sender_pubkey, OTP_CHALLENGE_MSG)
+            // Send challenge prompt to the sender via gift wrap.
+            if let Err(e) = crate::gift_wrap::send_gift_wrapped_dm(
+                client,
+                keys,
+                sender_pubkey,
+                OTP_CHALLENGE_MSG,
+            )
+            .await
             {
-                let tag = nostr_sdk::prelude::Tag::public_key(*sender_pubkey);
-                let builder =
-                    nostr_sdk::prelude::EventBuilder::new(Kind::EncryptedDirectMessage, &encrypted)
-                        .tag(tag);
-                if let Err(e) = client.send_event_builder(builder).await {
-                    tracing::warn!(account_id, "failed to send OTP challenge DM: {e}");
-                }
+                tracing::warn!(account_id, "failed to send OTP challenge DM: {e}");
             }
 
             // Emit OTP challenge event for the admin UI.

--- a/crates/nostr/src/bus.rs
+++ b/crates/nostr/src/bus.rs
@@ -52,14 +52,18 @@ pub async fn run_subscription_loop(
         u64::try_from(::time::OffsetDateTime::now_utc().unix_timestamp()).unwrap_or_default();
     let since = Timestamp::from(now_secs);
 
-    // Gift wraps have randomly tweaked timestamps (0–2 days), so use a wider
-    // window for the relay filter. The staleness check in handle_event uses
-    // the rumor's actual created_at for gift wraps, filtering old kind:4
-    // messages that happen to fall in this window.
-    let gift_wrap_since = Timestamp::from(now_secs.saturating_sub(172_800));
+    // Two separate filters: kind:4 uses `since` (now), kind:1059 uses a wider
+    // window because gift wrap timestamps are randomly tweaked by 0–2 days.
+    let gift_wrap_since =
+        Timestamp::from(now_secs.saturating_sub(crate::gift_wrap::TIMESTAMP_WINDOW_SECS));
 
-    let filter = Filter::new()
-        .kinds([Kind::EncryptedDirectMessage, Kind::GiftWrap])
+    let nip04_filter = Filter::new()
+        .kind(Kind::EncryptedDirectMessage)
+        .pubkey(bot_pubkey)
+        .since(since);
+
+    let gift_wrap_filter = Filter::new()
+        .kind(Kind::GiftWrap)
         .pubkey(bot_pubkey)
         .since(gift_wrap_since);
 
@@ -74,9 +78,11 @@ pub async fn run_subscription_loop(
 
     let mut seen = SeenTracker::new();
 
-    if let Err(e) = client.subscribe(filter, None).await {
-        tracing::error!(account_id, "failed to subscribe: {e}");
-        return;
+    for filter in [nip04_filter, gift_wrap_filter] {
+        if let Err(e) = client.subscribe(filter, None).await {
+            tracing::error!(account_id, "failed to subscribe: {e}");
+            return;
+        }
     }
 
     let mut notifications = client.notifications();

--- a/crates/nostr/src/gift_wrap.rs
+++ b/crates/nostr/src/gift_wrap.rs
@@ -1,0 +1,110 @@
+//! NIP-59 Gift Wrap helpers for sending and receiving private DMs.
+//!
+//! Wraps messages with ephemeral keys (NIP-17/NIP-59), fully hiding
+//! sender and receiver metadata — unlike legacy NIP-04 (kind:4).
+
+use nostr_sdk::prelude::{Event, EventBuilder, Keys, Kind, PublicKey, Timestamp, nip59};
+
+use crate::error::Error;
+
+/// Send a gift-wrapped DM (NIP-17/NIP-59, kind:1059) to the recipient.
+///
+/// Uses `EventBuilder::private_msg` to create a sealed, gift-wrapped event
+/// and publishes it to connected relays.
+pub async fn send_gift_wrapped_dm(
+    client: &nostr_sdk::Client,
+    keys: &Keys,
+    recipient: &PublicKey,
+    text: &str,
+) -> Result<(), Error> {
+    let event = EventBuilder::private_msg(keys, *recipient, text, [])
+        .await
+        .map_err(|e| Error::Encryption(format!("gift wrap failed: {e}")))?;
+
+    client.send_event(&event).await?;
+    Ok(())
+}
+
+/// Unwrap a gift-wrapped event (kind:1059) and return the sender, plaintext,
+/// and the rumor's `created_at` timestamp.
+///
+/// The outer event's timestamp is randomly tweaked (0–2 days), so callers
+/// should use the returned timestamp for staleness checks.
+pub async fn unwrap_gift_wrap(
+    keys: &Keys,
+    event: &Event,
+) -> Result<(PublicKey, String, Timestamp), Error> {
+    let unwrapped = nip59::extract_rumor(keys, event)
+        .await
+        .map_err(|e| Error::Encryption(format!("gift unwrap failed: {e}")))?;
+
+    if unwrapped.rumor.kind != Kind::PrivateDirectMessage {
+        return Err(Error::Encryption(format!(
+            "expected kind:14 (PrivateDirectMessage), got kind:{}",
+            unwrapped.rumor.kind.as_u16()
+        )));
+    }
+
+    Ok((
+        unwrapped.sender,
+        unwrapped.rumor.content,
+        unwrapped.rumor.created_at,
+    ))
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn gift_wrap_round_trip() {
+        let sender_keys = Keys::generate();
+        let receiver_keys = Keys::generate();
+
+        let text = "hello, gift-wrapped world!";
+        let event = EventBuilder::private_msg(&sender_keys, receiver_keys.public_key(), text, [])
+            .await
+            .expect("create gift wrap");
+
+        assert_eq!(event.kind, Kind::GiftWrap);
+
+        let (sender, content, _ts) = unwrap_gift_wrap(&receiver_keys, &event)
+            .await
+            .expect("unwrap gift wrap");
+
+        assert_eq!(sender, sender_keys.public_key());
+        assert_eq!(content, text);
+    }
+
+    #[tokio::test]
+    async fn wrong_recipient_fails() {
+        let sender_keys = Keys::generate();
+        let receiver_keys = Keys::generate();
+        let wrong_keys = Keys::generate();
+
+        let event = EventBuilder::private_msg(
+            &sender_keys,
+            receiver_keys.public_key(),
+            "secret message",
+            [],
+        )
+        .await
+        .expect("create gift wrap");
+
+        let result = unwrap_gift_wrap(&wrong_keys, &event).await;
+        assert!(result.is_err(), "unwrap with wrong keys must fail");
+    }
+
+    #[tokio::test]
+    async fn non_gift_wrap_rejected() {
+        let keys = Keys::generate();
+        let event = EventBuilder::text_note("not a gift wrap")
+            .sign(&keys)
+            .await
+            .expect("sign event");
+
+        let result = unwrap_gift_wrap(&keys, &event).await;
+        assert!(result.is_err(), "non-gift-wrap event must be rejected");
+    }
+}

--- a/crates/nostr/src/gift_wrap.rs
+++ b/crates/nostr/src/gift_wrap.rs
@@ -7,6 +7,10 @@ use nostr_sdk::prelude::{Event, EventBuilder, Keys, Kind, PublicKey, Timestamp, 
 
 use crate::error::Error;
 
+/// Gift wrap timestamps are randomly tweaked by 0–2 days (per NIP-59), so
+/// relay filters need a wider `since` window to avoid missing recent wraps.
+pub const TIMESTAMP_WINDOW_SECS: u64 = ::time::Duration::days(2).whole_seconds() as u64;
+
 /// Send a gift-wrapped DM (NIP-17/NIP-59, kind:1059) to the recipient.
 ///
 /// Uses `EventBuilder::private_msg` to create a sealed, gift-wrapped event

--- a/crates/nostr/src/lib.rs
+++ b/crates/nostr/src/lib.rs
@@ -2,6 +2,7 @@ pub mod access;
 pub mod bus;
 pub mod config;
 pub mod error;
+pub mod gift_wrap;
 pub mod keys;
 pub mod outbound;
 pub mod plugin;

--- a/crates/nostr/src/outbound.rs
+++ b/crates/nostr/src/outbound.rs
@@ -1,7 +1,7 @@
 //! Outbound message sending for Nostr channels.
 //!
-//! Implements `ChannelOutbound` and `ChannelStreamOutbound` — encrypts text
-//! with NIP-04 and publishes to connected relays.
+//! Implements `ChannelOutbound` and `ChannelStreamOutbound` — sends text as
+//! NIP-59 gift-wrapped DMs (kind:1059) to connected relays.
 
 use std::{
     collections::HashMap,
@@ -67,25 +67,15 @@ impl ChannelOutbound for NostrOutbound {
         #[cfg(feature = "metrics")]
         let start = tokio::time::Instant::now();
 
-        // Encrypt with NIP-04
-        let encrypted = nip04::encrypt(keys.secret_key(), &recipient, text).map_err(|e| {
-            #[cfg(feature = "metrics")]
-            counter!(nostr_metrics::MESSAGE_SEND_ERRORS_TOTAL, "reason" => "encrypt").increment(1);
-            moltis_channels::Error::external(
-                "nostr",
-                crate::error::Error::Encryption(format!("NIP-04 encrypt failed: {e}")),
-            )
-        })?;
-
-        // Build and publish kind:4 event
-        let tag = Tag::public_key(recipient);
-        let builder = EventBuilder::new(Kind::EncryptedDirectMessage, &encrypted).tag(tag);
-
-        client.send_event_builder(builder).await.map_err(|e| {
-            #[cfg(feature = "metrics")]
-            counter!(nostr_metrics::MESSAGE_SEND_ERRORS_TOTAL, "reason" => "relay").increment(1);
-            moltis_channels::Error::external("nostr", crate::error::Error::Sdk(e))
-        })?;
+        // Send as NIP-59 gift-wrapped DM (kind:1059)
+        crate::gift_wrap::send_gift_wrapped_dm(&client, &keys, &recipient, text)
+            .await
+            .map_err(|e| {
+                #[cfg(feature = "metrics")]
+                counter!(nostr_metrics::MESSAGE_SEND_ERRORS_TOTAL, "reason" => "gift_wrap")
+                    .increment(1);
+                moltis_channels::Error::external("nostr", e)
+            })?;
 
         #[cfg(feature = "metrics")]
         {
@@ -95,7 +85,7 @@ impl ChannelOutbound for NostrOutbound {
         }
 
         let npub = recipient.to_bech32().unwrap_or_else(|_| recipient.to_hex());
-        tracing::debug!(account_id, to = %npub, len = text.len(), "sent NIP-04 DM");
+        tracing::debug!(account_id, to = %npub, len = text.len(), "sent gift-wrapped DM");
 
         Ok(())
     }

--- a/crates/nostr/tests/nostr_integration.rs
+++ b/crates/nostr/tests/nostr_integration.rs
@@ -230,3 +230,120 @@ fn nip44_encrypt_decrypt_round_trip() {
 
     assert_eq!(decrypted, plaintext);
 }
+
+// ── NIP-59 Gift Wrap round-trip (local, no relay) ──────────
+
+#[tokio::test]
+async fn nip59_gift_wrap_round_trip() {
+    let sender_keys = Keys::generate();
+    let receiver_keys = Keys::generate();
+
+    let text = "NIP-59 gift wrap test";
+    let event = EventBuilder::private_msg(&sender_keys, receiver_keys.public_key(), text, [])
+        .await
+        .expect("create gift wrap");
+
+    assert_eq!(event.kind, Kind::GiftWrap);
+
+    let unwrapped = moltis_nostr::gift_wrap::unwrap_gift_wrap(&receiver_keys, &event)
+        .await
+        .expect("unwrap gift wrap");
+
+    assert_eq!(unwrapped.0, sender_keys.public_key());
+    assert_eq!(unwrapped.1, text);
+}
+
+// ── NIP-59 Gift Wrap DM via relay ──────────────────────────
+
+#[tokio::test]
+#[ignore]
+async fn send_and_receive_gift_wrapped_dm() {
+    let sender_key = match sender_secret() {
+        Some(k) => k,
+        None => {
+            println!("NOSTR_TEST_SENDER_KEY not set — skipping");
+            return;
+        },
+    };
+
+    // Set up bot (receiver)
+    let bot_keys = moltis_nostr::keys::derive_keys(&bot_secret()).unwrap();
+    let bot_pubkey = bot_keys.public_key();
+    let bot_client = Client::new(bot_keys.clone());
+    let mut notifications = bot_client.notifications();
+    for relay in DEFAULT_RELAYS {
+        let _ = bot_client.add_relay(*relay).await;
+    }
+    bot_client.connect().await;
+
+    // Set up sender
+    let sender_keys = moltis_nostr::keys::derive_keys(&sender_key).unwrap();
+    let sender_client = Client::new(sender_keys.clone());
+    for relay in DEFAULT_RELAYS {
+        let _ = sender_client.add_relay(*relay).await;
+    }
+    sender_client.connect().await;
+
+    tokio::time::sleep(Duration::from_secs(5)).await;
+
+    // Subscribe bot to gift wraps
+    let since = Timestamp::from(
+        u64::try_from(::time::OffsetDateTime::now_utc().unix_timestamp())
+            .unwrap_or_default()
+            .saturating_sub(172_800),
+    );
+    let filter = Filter::new()
+        .kind(Kind::GiftWrap)
+        .pubkey(bot_pubkey)
+        .since(since);
+    bot_client.subscribe(filter, None).await.expect("subscribe");
+
+    tokio::time::sleep(Duration::from_secs(3)).await;
+
+    // Send gift-wrapped DM
+    let test_msg = format!("gift wrap test {}", Timestamp::now().as_secs());
+    let gift_event = EventBuilder::private_msg(&sender_keys, bot_pubkey, &test_msg, [])
+        .await
+        .expect("create gift wrap");
+
+    sender_client
+        .send_event(&gift_event)
+        .await
+        .expect("send gift wrap");
+
+    println!("Sent gift-wrapped DM: {test_msg}");
+
+    // Wait for bot to receive
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(30);
+    let mut received = false;
+
+    while tokio::time::Instant::now() < deadline {
+        tokio::select! {
+            Ok(notification) = notifications.recv() => {
+                if let RelayPoolNotification::Event { event, .. } = notification
+                    && event.kind == Kind::GiftWrap
+                {
+                    let (sender, content, _ts) =
+                        moltis_nostr::gift_wrap::unwrap_gift_wrap(&bot_keys, &event)
+                            .await
+                            .expect("unwrap");
+                    if sender == sender_keys.public_key() {
+                        println!("Received gift-wrapped DM: {content}");
+                        assert_eq!(content, test_msg);
+                        received = true;
+                        break;
+                    }
+                }
+            }
+            _ = tokio::time::sleep(Duration::from_millis(100)) => {}
+        }
+    }
+
+    assert!(
+        received,
+        "bot must receive gift-wrapped DM within 30 seconds"
+    );
+
+    bot_client.disconnect().await;
+    sender_client.disconnect().await;
+}

--- a/crates/nostr/tests/nostr_integration.rs
+++ b/crates/nostr/tests/nostr_integration.rs
@@ -290,7 +290,7 @@ async fn send_and_receive_gift_wrapped_dm() {
     let since = Timestamp::from(
         u64::try_from(::time::OffsetDateTime::now_utc().unix_timestamp())
             .unwrap_or_default()
-            .saturating_sub(172_800),
+            .saturating_sub(moltis_nostr::gift_wrap::TIMESTAMP_WINDOW_SECS),
     );
     let filter = Filter::new()
         .kind(Kind::GiftWrap)


### PR DESCRIPTION
## Summary

- Replace NIP-04 (kind:4) outbound DMs with NIP-59 gift wraps (kind:1059), hiding sender/receiver metadata via ephemeral keys
- Accept both kind:4 (legacy) and kind:1059 inbound for backward compatibility
- New `gift_wrap` module with shared `send_gift_wrapped_dm()` and `unwrap_gift_wrap()` helpers
- OTP challenge/verification messages also sent via gift wrap

## Validation

### Completed
- [x] `cargo check` — feature resolution OK
- [x] `cargo test -p moltis-nostr` — 28 unit tests + 1 integration test pass
- [x] `just test` — all 367 workspace tests pass
- [x] `just lint` — clippy clean
- [x] `just format-check` — formatting clean

### Remaining
- [ ] `./scripts/local-validate.sh` with PR number
- [ ] Manual test with real Nostr relay (run ignored integration tests)

## Manual QA

1. Start moltis with a Nostr account configured
2. Send a DM from a Nostr client (e.g. Damus, Amethyst) — verify inbound works for both NIP-04 and NIP-59
3. Verify bot replies arrive as gift wraps (kind:1059) in the client
4. Test OTP flow — non-allowlisted sender should receive gift-wrapped challenge

Closes #759

🤖 Generated with [Claude Code](https://claude.com/claude-code)