### PR TITLE
fix(sandbox): skip sysfs tmpfs overlays on Podman

### DIFF
--- a/crates/tools/src/sandbox/docker.rs
+++ b/crates/tools/src/sandbox/docker.rs
@@ -179,7 +179,7 @@ impl DockerSandbox {
     /// `is_prebuilt` controls whether `--read-only` is applied: prebuilt images
     /// already have packages baked in so the root FS can be read-only, while
     /// non-prebuilt images need a writable root for `apt-get` provisioning.
-    pub(crate) fn hardening_args(is_prebuilt: bool) -> Vec<String> {
+    pub(crate) fn hardening_args(is_prebuilt: bool, cli: &str) -> Vec<String> {
         let mut args = vec![
             // --- Capability / privilege ---
             "--cap-drop".to_string(),
@@ -196,19 +196,28 @@ impl DockerSandbox {
             // and the `hostname` command do not reveal the host identity.
             "--hostname".to_string(),
             "sandbox".to_string(),
-            // Mask /sys subtrees that expose host hardware identifiers
-            // (serial numbers, BIOS/UEFI data, disk models, LUKS UUIDs).
-            // Empty read-only tmpfs overlays hide the underlying sysfs entries
-            // and work identically on Docker and Podman.
-            "--tmpfs".to_string(),
-            "/sys/firmware:ro,nosuid".to_string(),
-            "--tmpfs".to_string(),
-            "/sys/class/dmi:ro,nosuid".to_string(),
-            "--tmpfs".to_string(),
-            "/sys/devices/virtual/dmi:ro,nosuid".to_string(),
-            "--tmpfs".to_string(),
-            "/sys/class/block:ro,nosuid".to_string(),
         ];
+        // Mask /sys subtrees that expose host hardware identifiers
+        // (serial numbers, BIOS/UEFI data, disk models, LUKS UUIDs).
+        // Empty read-only tmpfs overlays hide the underlying sysfs entries.
+        //
+        // Podman is excluded: its OCI runtime performs "tmpcopyup" on sysfs
+        // tmpfs mounts, copying directory contents into the tmpfs first.
+        // With --cap-drop ALL some sysfs files are permission-denied even for
+        // root, causing the mount (and container startup) to fail.  Podman
+        // already masks /sys/firmware via its built-in OCI MaskedPaths.
+        if cli != "podman" {
+            args.extend([
+                "--tmpfs".to_string(),
+                "/sys/firmware:ro,nosuid".to_string(),
+                "--tmpfs".to_string(),
+                "/sys/class/dmi:ro,nosuid".to_string(),
+                "--tmpfs".to_string(),
+                "/sys/devices/virtual/dmi:ro,nosuid".to_string(),
+                "--tmpfs".to_string(),
+                "/sys/class/block:ro,nosuid".to_string(),
+            ]);
+        }
         if is_prebuilt {
             args.push("--read-only".to_string());
         }
@@ -321,7 +330,7 @@ impl Sandbox for DockerSandbox {
         }
 
         args.extend(self.resource_args());
-        args.extend(Self::hardening_args(is_prebuilt));
+        args.extend(Self::hardening_args(is_prebuilt, self.cli));
         args.extend(self.workspace_args());
         args.extend(self.home_persistence_args(id)?);
 

--- a/crates/tools/src/sandbox/docker.rs
+++ b/crates/tools/src/sandbox/docker.rs
@@ -33,13 +33,23 @@ use {
     },
 };
 
+/// Distinguishes Docker from Podman for behaviour that differs between the two
+/// OCI runtimes (hardening flags, host-gateway resolution, etc.).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum BackendKind {
+    Docker,
+    Podman,
+}
+
 /// Docker/Podman-based sandbox implementation.
 ///
 /// The `cli` field selects the container CLI binary (`"docker"` or `"podman"`).
 /// Podman's CLI is a drop-in replacement for Docker, so both backends share
-/// this single implementation.
+/// this single implementation.  `kind` carries the typed backend identity for
+/// behaviour branching without string comparisons.
 pub struct DockerSandbox {
     pub config: SandboxConfig,
+    kind: BackendKind,
     cli: &'static str,
     backend_label: &'static str,
 }
@@ -48,6 +58,7 @@ impl DockerSandbox {
     pub fn new(config: SandboxConfig) -> Self {
         Self {
             config,
+            kind: BackendKind::Docker,
             cli: "docker",
             backend_label: "docker",
         }
@@ -56,6 +67,7 @@ impl DockerSandbox {
     pub fn podman(config: SandboxConfig) -> Self {
         Self {
             config,
+            kind: BackendKind::Podman,
             cli: "podman",
             backend_label: "podman",
         }
@@ -138,7 +150,7 @@ impl DockerSandbox {
     /// Podman uses a bridge whose gateway we can query via
     /// `podman network inspect`.
     pub(crate) fn resolve_host_gateway(&self) -> String {
-        if self.cli != "podman" {
+        if self.kind != BackendKind::Podman {
             return "host-gateway".to_string();
         }
 
@@ -179,7 +191,7 @@ impl DockerSandbox {
     /// `is_prebuilt` controls whether `--read-only` is applied: prebuilt images
     /// already have packages baked in so the root FS can be read-only, while
     /// non-prebuilt images need a writable root for `apt-get` provisioning.
-    pub(crate) fn hardening_args(is_prebuilt: bool, cli: &str) -> Vec<String> {
+    pub(crate) fn hardening_args(is_prebuilt: bool, kind: BackendKind) -> Vec<String> {
         let mut args = vec![
             // --- Capability / privilege ---
             "--cap-drop".to_string(),
@@ -206,7 +218,7 @@ impl DockerSandbox {
         // With --cap-drop ALL some sysfs files are permission-denied even for
         // root, causing the mount (and container startup) to fail.  Podman
         // already masks /sys/firmware via its built-in OCI MaskedPaths.
-        if cli != "podman" {
+        if kind != BackendKind::Podman {
             args.extend([
                 "--tmpfs".to_string(),
                 "/sys/firmware:ro,nosuid".to_string(),
@@ -330,7 +342,7 @@ impl Sandbox for DockerSandbox {
         }
 
         args.extend(self.resource_args());
-        args.extend(Self::hardening_args(is_prebuilt, self.cli));
+        args.extend(Self::hardening_args(is_prebuilt, self.kind));
         args.extend(self.workspace_args());
         args.extend(self.home_persistence_args(id)?);
 

--- a/crates/tools/src/sandbox/tests/core.rs
+++ b/crates/tools/src/sandbox/tests/core.rs
@@ -17,7 +17,7 @@ fn test_sandbox_scope_display() {
 
 #[test]
 fn test_docker_hardening_args_prebuilt() {
-    let args = DockerSandbox::hardening_args(true, "docker");
+    let args = DockerSandbox::hardening_args(true, BackendKind::Docker);
     assert!(args.contains(&"--cap-drop".to_string()));
     assert!(args.contains(&"ALL".to_string()));
     assert!(args.contains(&"--security-opt".to_string()));
@@ -44,7 +44,7 @@ fn test_docker_hardening_args_prebuilt() {
 
 #[test]
 fn test_docker_hardening_args_not_prebuilt() {
-    let args = DockerSandbox::hardening_args(false, "docker");
+    let args = DockerSandbox::hardening_args(false, BackendKind::Docker);
     assert!(args.contains(&"--cap-drop".to_string()));
     assert!(args.contains(&"ALL".to_string()));
     assert!(args.contains(&"--security-opt".to_string()));
@@ -71,7 +71,7 @@ fn test_docker_hardening_args_not_prebuilt() {
 
 #[test]
 fn test_docker_hardening_args_podman() {
-    let args = DockerSandbox::hardening_args(true, "podman");
+    let args = DockerSandbox::hardening_args(true, BackendKind::Podman);
     // Core hardening flags must still be present
     assert!(args.contains(&"--cap-drop".to_string()));
     assert!(args.contains(&"ALL".to_string()));

--- a/crates/tools/src/sandbox/tests/core.rs
+++ b/crates/tools/src/sandbox/tests/core.rs
@@ -17,7 +17,7 @@ fn test_sandbox_scope_display() {
 
 #[test]
 fn test_docker_hardening_args_prebuilt() {
-    let args = DockerSandbox::hardening_args(true);
+    let args = DockerSandbox::hardening_args(true, "docker");
     assert!(args.contains(&"--cap-drop".to_string()));
     assert!(args.contains(&"ALL".to_string()));
     assert!(args.contains(&"--security-opt".to_string()));
@@ -44,7 +44,7 @@ fn test_docker_hardening_args_prebuilt() {
 
 #[test]
 fn test_docker_hardening_args_not_prebuilt() {
-    let args = DockerSandbox::hardening_args(false);
+    let args = DockerSandbox::hardening_args(false, "docker");
     assert!(args.contains(&"--cap-drop".to_string()));
     assert!(args.contains(&"ALL".to_string()));
     assert!(args.contains(&"--security-opt".to_string()));
@@ -67,6 +67,34 @@ fn test_docker_hardening_args_not_prebuilt() {
     assert!(args.contains(&"/sys/class/dmi:ro,nosuid".to_string()));
     assert!(args.contains(&"/sys/devices/virtual/dmi:ro,nosuid".to_string()));
     assert!(args.contains(&"/sys/class/block:ro,nosuid".to_string()));
+}
+
+#[test]
+fn test_docker_hardening_args_podman() {
+    let args = DockerSandbox::hardening_args(true, "podman");
+    // Core hardening flags must still be present
+    assert!(args.contains(&"--cap-drop".to_string()));
+    assert!(args.contains(&"ALL".to_string()));
+    assert!(args.contains(&"--security-opt".to_string()));
+    assert!(args.contains(&"no-new-privileges".to_string()));
+    assert!(args.contains(&"--read-only".to_string()));
+    assert!(args.contains(&"/tmp:rw,nosuid,size=256m".to_string()));
+    assert!(args.contains(&"/run:rw,nosuid,size=64m".to_string()));
+    let hostname_pos = args
+        .iter()
+        .position(|a| a == "--hostname")
+        .expect("--hostname flag missing");
+    assert_eq!(
+        args[hostname_pos + 1],
+        "sandbox",
+        "--hostname value should be 'sandbox'"
+    );
+    // Sysfs tmpfs overlays must NOT be present — Podman's tmpcopyup breaks
+    // these under --cap-drop ALL.
+    assert!(!args.contains(&"/sys/firmware:ro,nosuid".to_string()));
+    assert!(!args.contains(&"/sys/class/dmi:ro,nosuid".to_string()));
+    assert!(!args.contains(&"/sys/devices/virtual/dmi:ro,nosuid".to_string()));
+    assert!(!args.contains(&"/sys/class/block:ro,nosuid".to_string()));
 }
 
 #[test]

--- a/docs/src/sandbox.md
+++ b/docs/src/sandbox.md
@@ -137,8 +137,9 @@ filesystem masks prevent leakage via shell commands as well.
 > **Podman note:** The sysfs tmpfs overlays are applied on Docker only. Podman's
 > OCI runtime performs "tmpcopyup" when mounting tmpfs over sysfs paths, which
 > fails under `--cap-drop ALL` because some sysfs files are permission-denied
-> even for root. Podman already masks `/sys/firmware` via its built-in OCI
-> `MaskedPaths`, so the remaining exposure is minimal.
+> even for root. Podman masks `/sys/firmware` via its built-in OCI
+> `MaskedPaths`; `/sys/class/dmi`, `/sys/devices/virtual/dmi`, and
+> `/sys/class/block` remain readable inside the container on Podman.
 
 ## WASM Sandbox (Wasmtime + WASI)
 

--- a/docs/src/sandbox.md
+++ b/docs/src/sandbox.md
@@ -120,10 +120,10 @@ hardening flags by default:
 | `--tmpfs /run:rw,nosuid,size=64m` | Writable tmpfs for runtime files |
 | `--read-only` | Read-only root filesystem (prebuilt images only) |
 | `--hostname sandbox` | Prevents host hostname leakage |
-| `--tmpfs /sys/firmware:ro,nosuid` | Masks BIOS/UEFI firmware data |
-| `--tmpfs /sys/class/dmi:ro,nosuid` | Masks system serial numbers and identifiers |
-| `--tmpfs /sys/devices/virtual/dmi:ro,nosuid` | Masks DMI attributes |
-| `--tmpfs /sys/class/block:ro,nosuid` | Masks block device info (disk models, LUKS UUIDs) |
+| `--tmpfs /sys/firmware:ro,nosuid` | Masks BIOS/UEFI firmware data (Docker only) |
+| `--tmpfs /sys/class/dmi:ro,nosuid` | Masks system serial numbers and identifiers (Docker only) |
+| `--tmpfs /sys/devices/virtual/dmi:ro,nosuid` | Masks DMI attributes (Docker only) |
+| `--tmpfs /sys/class/block:ro,nosuid` | Masks block device info (Docker only) |
 
 The `--read-only` flag is applied only to prebuilt sandbox images (where
 packages are already baked in). Non-prebuilt images need a writable root
@@ -133,6 +133,12 @@ The `/sys` tmpfs overlays prevent host hardware metadata (serial numbers, disk
 models, LUKS UUIDs) from being visible inside the container. Note that
 `tools.fs.deny_paths` only restricts Moltis file-access tools — these kernel
 filesystem masks prevent leakage via shell commands as well.
+
+> **Podman note:** The sysfs tmpfs overlays are applied on Docker only. Podman's
+> OCI runtime performs "tmpcopyup" when mounting tmpfs over sysfs paths, which
+> fails under `--cap-drop ALL` because some sysfs files are permission-denied
+> even for root. Podman already masks `/sys/firmware` via its built-in OCI
+> `MaskedPaths`, so the remaining exposure is minimal.
 
 ## WASM Sandbox (Wasmtime + WASI)
 


### PR DESCRIPTION
## Summary

- Skip sysfs tmpfs overlays (`/sys/firmware`, `/sys/class/dmi`, `/sys/devices/virtual/dmi`, `/sys/class/block`) when the sandbox backend is Podman
- Podman's OCI runtime performs "tmpcopyup" on sysfs tmpfs mounts, which fails under `--cap-drop ALL` because some sysfs files are permission-denied even for root — breaking container startup entirely
- Podman already masks `/sys/firmware` via its built-in OCI `MaskedPaths`; all other hardening flags remain for both backends

Fixes #757

## Validation

### Completed

- [x] `cargo test -p moltis-tools --lib sandbox::tests::core` — all 29 tests pass
- [x] `cargo +nightly-2025-11-30 fmt --all -- --check` — clean
- [x] `just lint` — clean

### Remaining

- [ ] `./scripts/local-validate.sh` — full CI validation
- [ ] Manual: verify `podman run` with hardening args succeeds on Ubuntu 24.04/26.04

## Manual QA

1. On a Podman host (Ubuntu 24.04+), start a sandbox-backed session — container should start without mount errors
2. On a Docker host, verify sysfs paths are still masked inside the container:
   ```bash
   docker exec <container> ls /sys/firmware  # should be empty (tmpfs overlay)
   ```