### PR TITLE
fix(slack): register /commands HTTP endpoint for slash commands

### DIFF
--- a/crates/httpd/src/server/gateway.rs
+++ b/crates/httpd/src/server/gateway.rs
@@ -430,6 +430,79 @@ pub async fn prepare_gateway(
                 },
             ),
         );
+
+        // Slack slash command webhook -- receives /command payloads.
+        let slack_cmd_plugin = Arc::clone(&slack_webhook_plugin);
+        let state_for_slack_cmd = Arc::clone(&state);
+        app = app.route(
+            "/api/channels/slack/{account_id}/commands",
+            axum::routing::post(
+                move |axum::extract::Path(account_id): axum::extract::Path<String>,
+                      headers: axum::http::HeaderMap,
+                      body: axum::body::Bytes| {
+                    let plugin = Arc::clone(&slack_cmd_plugin);
+                    let gw_state = Arc::clone(&state_for_slack_cmd);
+                    async move {
+                        // Get the verifier from the plugin.
+                        let verifier = {
+                            let p = plugin.read().await;
+                            p.channel_webhook_verifier(&account_id)
+                        };
+                        let Some(verifier) = verifier else {
+                            return (
+                                StatusCode::NOT_FOUND,
+                                Json(serde_json::json!({ "ok": false, "error": "unknown Slack account" })),
+                            )
+                                .into_response();
+                        };
+
+                        // Run the middleware pipeline.
+                        match moltis_gateway::channel_webhook_middleware::channel_webhook_gate(
+                            verifier.as_ref(),
+                            &gw_state.channel_webhook_dedup,
+                            &gw_state.channel_webhook_rate_limiter,
+                            &account_id,
+                            &headers,
+                            &body,
+                        ) {
+                            Err(rejection) => {
+                                crate::channel_webhook_middleware::rejection_into_response(
+                                    rejection,
+                                )
+                            },
+                            Ok((_, moltis_channels::ChannelWebhookDedupeResult::Duplicate)) => (
+                                StatusCode::OK,
+                                Json(serde_json::json!({ "ok": true, "deduplicated": true })),
+                            )
+                                .into_response(),
+                            Ok((verified, moltis_channels::ChannelWebhookDedupeResult::New)) => {
+                                // Dispatch to Slack plugin with verified body.
+                                let result = {
+                                    let p = plugin.read().await;
+                                    p.ingest_verified_command_webhook(
+                                        &account_id,
+                                        &verified.body,
+                                    )
+                                    .await
+                                };
+                                match result {
+                                    Ok(response_text) => (
+                                        StatusCode::OK,
+                                        response_text,
+                                    )
+                                        .into_response(),
+                                    Err(e) => (
+                                        StatusCode::BAD_REQUEST,
+                                        Json(serde_json::json!({ "ok": false, "error": e.to_string() })),
+                                    )
+                                        .into_response(),
+                                }
+                            },
+                        }
+                    }
+                },
+            ),
+        );
     }
 
     // -- Generic webhook ingress ------------------------------------------------

--- a/crates/httpd/src/server/gateway.rs
+++ b/crates/httpd/src/server/gateway.rs
@@ -470,11 +470,12 @@ pub async fn prepare_gateway(
                                     rejection,
                                 )
                             },
-                            Ok((_, moltis_channels::ChannelWebhookDedupeResult::Duplicate)) => (
-                                StatusCode::OK,
-                                Json(serde_json::json!({ "ok": true, "deduplicated": true })),
-                            )
-                                .into_response(),
+                            Ok((_, moltis_channels::ChannelWebhookDedupeResult::Duplicate)) => {
+                                // Slash commands display the response body in
+                                // Slack, so return an empty 200 for deduped
+                                // requests instead of JSON the user would see.
+                                StatusCode::OK.into_response()
+                            },
                             Ok((verified, moltis_channels::ChannelWebhookDedupeResult::New)) => {
                                 // Dispatch to Slack plugin with verified body.
                                 let result = {

--- a/crates/slack/src/plugin.rs
+++ b/crates/slack/src/plugin.rs
@@ -103,6 +103,17 @@ impl SlackPlugin {
     ) -> ChannelResult<()> {
         crate::webhook::handle_verified_interaction_webhook(account_id, body, &self.accounts).await
     }
+
+    /// Ingest an already-verified slash command webhook.
+    ///
+    /// Returns the response text to send back to the Slack user.
+    pub async fn ingest_verified_command_webhook(
+        &self,
+        account_id: &str,
+        body: &[u8],
+    ) -> ChannelResult<String> {
+        crate::webhook::handle_verified_command_webhook(account_id, body, &self.accounts).await
+    }
 }
 
 impl Default for SlackPlugin {

--- a/crates/slack/src/webhook.rs
+++ b/crates/slack/src/webhook.rs
@@ -277,6 +277,59 @@ pub async fn handle_verified_interaction_webhook(
     Ok(())
 }
 
+/// Handle an already-verified slash command webhook request.
+///
+/// Slack sends slash commands as `application/x-www-form-urlencoded` with
+/// fields: `command`, `text`, `user_id`, `channel_id`, etc.
+/// Returns the response text to send back to the user.
+pub async fn handle_verified_command_webhook(
+    account_id: &str,
+    body: &[u8],
+    accounts: &AccountStateMap,
+) -> moltis_channels::Result<String> {
+    let body_str = std::str::from_utf8(body)
+        .map_err(|e| moltis_channels::Error::invalid_input(format!("invalid utf-8: {e}")))?;
+
+    let command = extract_form_field(body_str, "command").unwrap_or_default();
+    let text = extract_form_field(body_str, "text").unwrap_or_default();
+    let user_id = extract_form_field(body_str, "user_id").unwrap_or_default();
+    let channel_id = extract_form_field(body_str, "channel_id").unwrap_or_default();
+
+    if command.is_empty() {
+        return Err(moltis_channels::Error::invalid_input(
+            "missing command field in slash command payload",
+        ));
+    }
+
+    let full_command = format!("{command} {text}").trim().to_string();
+
+    let event_sink = {
+        let accts = accounts.read().unwrap_or_else(|e| e.into_inner());
+        accts.get(account_id).and_then(|s| s.event_sink.clone())
+    };
+
+    if let Some(sink) = event_sink {
+        let reply_to = ChannelReplyTarget {
+            channel_type: ChannelType::Slack,
+            account_id: account_id.to_string(),
+            chat_id: channel_id,
+            message_id: None,
+            thread_id: None,
+        };
+        let sender = if user_id.is_empty() {
+            None
+        } else {
+            Some(user_id.as_str())
+        };
+        match sink.dispatch_command(&full_command, reply_to, sender).await {
+            Ok(response_text) => Ok(response_text),
+            Err(e) => Ok(format!("Error: {e}")),
+        }
+    } else {
+        Ok("Channel not configured".to_string())
+    }
+}
+
 /// Dispatch an event_callback payload to the appropriate handler.
 async fn dispatch_event_callback(
     account_id: &str,
@@ -452,15 +505,20 @@ pub async fn handle_interaction_webhook(
     Ok(())
 }
 
-/// Extract the `payload` field from a `application/x-www-form-urlencoded` body.
-fn extract_form_payload(body: &str) -> Option<String> {
+/// Extract a named field from a `application/x-www-form-urlencoded` body.
+fn extract_form_field(body: &str, name: &str) -> Option<String> {
+    let prefix = format!("{name}=");
     for pair in body.split('&') {
-        if let Some(value) = pair.strip_prefix("payload=") {
-            // URL-decode the value.
+        if let Some(value) = pair.strip_prefix(prefix.as_str()) {
             return url_decode(value);
         }
     }
     None
+}
+
+/// Extract the `payload` field from a `application/x-www-form-urlencoded` body.
+fn extract_form_payload(body: &str) -> Option<String> {
+    extract_form_field(body, "payload")
 }
 
 /// Simple percent-decoding for URL-encoded strings.
@@ -560,5 +618,70 @@ mod tests {
     fn extract_form_payload_missing() {
         let body = "token=abc&other=val";
         assert!(extract_form_payload(body).is_none());
+    }
+
+    #[test]
+    fn extract_form_field_finds_named_field() {
+        let body = "token=abc&command=%2Fnew&text=hello+world&user_id=U123";
+        assert_eq!(
+            extract_form_field(body, "command"),
+            Some("/new".to_string())
+        );
+        assert_eq!(
+            extract_form_field(body, "text"),
+            Some("hello world".to_string())
+        );
+        assert_eq!(
+            extract_form_field(body, "user_id"),
+            Some("U123".to_string())
+        );
+        assert!(extract_form_field(body, "missing").is_none());
+    }
+
+    #[test]
+    fn extract_form_field_does_not_match_prefix_of_other_field() {
+        let body = "user_id=U123&user_name=roadrunner";
+        assert_eq!(
+            extract_form_field(body, "user_id"),
+            Some("U123".to_string())
+        );
+        assert_eq!(
+            extract_form_field(body, "user_name"),
+            Some("roadrunner".to_string())
+        );
+    }
+
+    #[tokio::test]
+    async fn handle_verified_command_missing_command_field() {
+        let accounts: AccountStateMap =
+            Arc::new(std::sync::RwLock::new(std::collections::HashMap::new()));
+        let body = b"text=hello&user_id=U123&channel_id=C456";
+        let result = handle_verified_command_webhook("acct1", body, &accounts).await;
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("missing command field"), "error: {err}");
+    }
+
+    #[tokio::test]
+    async fn handle_verified_command_no_event_sink() {
+        let accounts: AccountStateMap =
+            Arc::new(std::sync::RwLock::new(std::collections::HashMap::new()));
+        {
+            let mut accts = accounts.write().unwrap();
+            accts.insert("acct1".to_string(), AccountState {
+                account_id: "acct1".to_string(),
+                config: SlackAccountConfig::default(),
+                message_log: None,
+                event_sink: None,
+                cancel: tokio_util::sync::CancellationToken::new(),
+                bot_user_id: Some("B123".to_string()),
+                pending_threads: std::collections::HashMap::new(),
+            });
+        }
+
+        let body = b"command=%2Fnew&text=&user_id=U123&channel_id=C456";
+        let result = handle_verified_command_webhook("acct1", body, &accounts).await;
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), "Channel not configured");
     }
 }

--- a/crates/slack/src/webhook.rs
+++ b/crates/slack/src/webhook.rs
@@ -323,7 +323,10 @@ pub async fn handle_verified_command_webhook(
         };
         match sink.dispatch_command(&full_command, reply_to, sender).await {
             Ok(response_text) => Ok(response_text),
-            Err(e) => Ok(format!("Error: {e}")),
+            Err(e) => {
+                debug!(account_id, %full_command, "command dispatch failed: {e}");
+                Ok(format!("Error: {e}"))
+            },
         }
     } else {
         Ok("Channel not configured".to_string())


### PR DESCRIPTION
## Summary

- Register `POST /api/channels/slack/{account_id}/commands` in the HTTP gateway, fixing 404s for slash commands when using webhook mode (closes #766)
- Add `handle_verified_command_webhook()` that parses Slack's form-encoded slash command payload and dispatches via `ChannelEventSink::dispatch_command()`, mirroring the existing Socket Mode handler
- Extract reusable `extract_form_field()` helper from the existing `extract_form_payload()`

## Validation

### Completed
- [x] `cargo +nightly-2025-11-30 fmt --all -- --check`
- [x] `just lint`
- [x] `just test` — 367 tests pass
- [x] New tests: missing command field rejection, no-event-sink fallback, form field extraction edge cases

### Remaining
- [ ] `./scripts/local-validate.sh <PR_NUMBER>` — full CI validation
- [ ] Manual QA with a Slack app configured in Events API / HTTP webhook mode

## Manual QA

1. Deploy with a Slack channel in Events API (HTTP webhook) mode
2. Configure the Slack app manifest with `/api/channels/slack/{account_id}/commands` as the slash command URL
3. Send `/new` in Slack — should start a new session instead of returning 404
4. Send `/help` — should return the help text
5. Verify Socket Mode still works unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)