### PR TITLE
fix(tests): remove hardcoded secret fixtures

### DIFF
--- a/crates/httpd/tests/auth_middleware.rs
+++ b/crates/httpd/tests/auth_middleware.rs
@@ -5,7 +5,7 @@ use std::{
     net::SocketAddr,
     sync::{
         Arc,
-        atomic::{AtomicBool, Ordering},
+        atomic::{AtomicBool, AtomicU64, Ordering},
     },
 };
 
@@ -26,6 +26,59 @@ use {
     },
     moltis_httpd::server::{build_gateway_base, finalize_gateway_app},
 };
+
+fn next_test_secret_id() -> u64 {
+    static NEXT_TEST_SECRET_ID: AtomicU64 = AtomicU64::new(1);
+    NEXT_TEST_SECRET_ID.fetch_add(1, Ordering::Relaxed)
+}
+
+fn generated_password() -> String {
+    format!("pw-{:016x}", next_test_secret_id())
+}
+
+fn different_password(forbidden: &str) -> String {
+    loop {
+        let candidate = generated_password();
+        if candidate != forbidden {
+            return candidate;
+        }
+    }
+}
+
+fn generated_setup_code() -> String {
+    format!("{:06}", (next_test_secret_id() % 900_000) + 100_000)
+}
+
+fn different_setup_code(forbidden: &str) -> String {
+    loop {
+        let candidate = generated_setup_code();
+        if candidate != forbidden {
+            return candidate;
+        }
+    }
+}
+
+fn json_password(password: &str) -> String {
+    serde_json::json!({ "password": password }).to_string()
+}
+
+fn json_password_with_setup_code(password: &str, setup_code: &str) -> String {
+    serde_json::json!({
+        "password": password,
+        "setup_code": setup_code,
+    })
+    .to_string()
+}
+
+fn json_new_password(new_password: &str) -> String {
+    serde_json::json!({ "new_password": new_password }).to_string()
+}
+
+async fn set_initial_test_password(store: &CredentialStore) -> String {
+    let password = generated_password();
+    store.set_initial_password(&password).await.unwrap();
+    password
+}
 
 /// Start a test server with a credential store (auth enabled).
 async fn start_auth_server() -> (SocketAddr, Arc<CredentialStore>) {
@@ -324,7 +377,7 @@ async fn setup_not_complete_passes_through() {
 #[tokio::test]
 async fn unauthenticated_returns_401() {
     let (addr, store) = start_auth_server().await;
-    store.set_initial_password("testpass12345").await.unwrap();
+    set_initial_test_password(&store).await;
 
     let resp = reqwest::get(format!("http://{addr}/api/bootstrap"))
         .await
@@ -339,7 +392,7 @@ async fn unauthenticated_returns_401() {
 #[tokio::test]
 async fn session_cookie_auth_succeeds() {
     let (addr, store) = start_auth_server().await;
-    store.set_initial_password("testpass12345").await.unwrap();
+    set_initial_test_password(&store).await;
     let token = store.create_session().await.unwrap();
 
     let client = reqwest::Client::new();
@@ -357,7 +410,7 @@ async fn session_cookie_auth_succeeds() {
 #[tokio::test]
 async fn api_key_auth_succeeds() {
     let (addr, store) = start_auth_server().await;
-    store.set_initial_password("testpass12345").await.unwrap();
+    set_initial_test_password(&store).await;
     let (_id, raw_key) = store.create_api_key("test", None).await.unwrap();
 
     let client = reqwest::Client::new();
@@ -375,7 +428,7 @@ async fn api_key_auth_succeeds() {
 #[tokio::test]
 async fn images_endpoint_returns_401() {
     let (addr, store) = start_auth_server().await;
-    store.set_initial_password("testpass12345").await.unwrap();
+    set_initial_test_password(&store).await;
 
     let resp = reqwest::get(format!("http://{addr}/api/images/cached"))
         .await
@@ -388,7 +441,7 @@ async fn images_endpoint_returns_401() {
 #[tokio::test]
 async fn public_routes_accessible_without_auth() {
     let (addr, store) = start_auth_server().await;
-    store.set_initial_password("testpass12345").await.unwrap();
+    set_initial_test_password(&store).await;
 
     // /health is always public.
     let resp = reqwest::get(format!("http://{addr}/health")).await.unwrap();
@@ -434,7 +487,7 @@ async fn public_routes_accessible_without_auth() {
 #[tokio::test]
 async fn graphql_requires_auth_when_enabled() {
     let (addr, store) = start_auth_server().await;
-    store.set_initial_password("testpass12345").await.unwrap();
+    set_initial_test_password(&store).await;
 
     let client = reqwest::Client::builder()
         .redirect(reqwest::redirect::Policy::none())
@@ -460,7 +513,7 @@ async fn graphql_requires_auth_when_enabled() {
 #[tokio::test]
 async fn graphql_runtime_toggle_applies_immediately() {
     let (addr, store, state) = start_auth_server_with_state().await;
-    store.set_initial_password("testpass12345").await.unwrap();
+    set_initial_test_password(&store).await;
     let token = store.create_session().await.unwrap();
 
     let client = reqwest::Client::new();
@@ -502,7 +555,7 @@ async fn graphql_runtime_toggle_applies_immediately() {
 #[tokio::test]
 async fn graphql_status_includes_uptime_ms() {
     let (addr, store) = start_auth_server().await;
-    store.set_initial_password("testpass12345").await.unwrap();
+    set_initial_test_password(&store).await;
     let token = store.create_session().await.unwrap();
 
     let client = reqwest::Client::new();
@@ -571,7 +624,7 @@ async fn graphql_websocket_upgrade_not_supported_on_legacy_path() {
 #[tokio::test]
 async fn invalid_session_cookie_returns_401() {
     let (addr, store) = start_auth_server().await;
-    store.set_initial_password("testpass12345").await.unwrap();
+    set_initial_test_password(&store).await;
 
     let client = reqwest::Client::new();
     let resp = client
@@ -588,7 +641,7 @@ async fn invalid_session_cookie_returns_401() {
 #[tokio::test]
 async fn reset_auth_removes_all_authentication() {
     let (addr, store) = start_auth_server().await;
-    store.set_initial_password("testpass12345").await.unwrap();
+    set_initial_test_password(&store).await;
     let token = store.create_session().await.unwrap();
 
     // Protected endpoint requires auth.
@@ -642,8 +695,9 @@ async fn reset_auth_removes_all_authentication() {
 #[tokio::test]
 async fn reenable_auth_after_reset() {
     let (addr, store, state) = start_auth_server_with_state().await;
-    store.set_initial_password("testpass12345").await.unwrap();
+    set_initial_test_password(&store).await;
     let token = store.create_session().await.unwrap();
+    let new_password = generated_password();
 
     // Reset auth.
     let client = reqwest::Client::new();
@@ -670,7 +724,7 @@ async fn reenable_auth_after_reset() {
     let resp = client
         .post(format!("http://{addr}/api/auth/setup"))
         .header("Content-Type", "application/json")
-        .body(r#"{"password":"newpass12345678"}"#)
+        .body(json_password(&new_password))
         .send()
         .await
         .unwrap();
@@ -680,9 +734,7 @@ async fn reenable_auth_after_reset() {
     let resp = client
         .post(format!("http://{addr}/api/auth/setup"))
         .header("Content-Type", "application/json")
-        .body(format!(
-            r#"{{"password":"newpass12345678","setup_code":"{code}"}}"#
-        ))
+        .body(json_password_with_setup_code(&new_password, &code))
         .send()
         .await
         .unwrap();
@@ -708,7 +760,7 @@ async fn reenable_auth_after_reset() {
 #[tokio::test]
 async fn reset_auth_requires_session() {
     let (addr, store) = start_auth_server().await;
-    store.set_initial_password("testpass12345").await.unwrap();
+    set_initial_test_password(&store).await;
 
     let client = reqwest::Client::new();
     let resp = client
@@ -724,7 +776,7 @@ async fn reset_auth_requires_session() {
 #[tokio::test]
 async fn revoked_api_key_returns_401() {
     let (addr, store) = start_auth_server().await;
-    store.set_initial_password("testpass12345").await.unwrap();
+    set_initial_test_password(&store).await;
     let (id, raw_key) = store.create_api_key("test", None).await.unwrap();
     store.revoke_api_key(id).await.unwrap();
 
@@ -745,13 +797,15 @@ async fn revoked_api_key_returns_401() {
 #[tokio::test]
 async fn setup_without_code_when_required_returns_403() {
     let (addr, _store, state) = start_auth_server_with_state().await;
-    state.inner.write().await.setup_code = Some(secrecy::Secret::new("123456".to_string()));
+    let setup_code = generated_setup_code();
+    let password = generated_password();
+    state.inner.write().await.setup_code = Some(secrecy::Secret::new(setup_code));
 
     let client = reqwest::Client::new();
     let resp = client
         .post(format!("http://{addr}/api/auth/setup"))
         .header("Content-Type", "application/json")
-        .body(r#"{"password":"testpass12345"}"#)
+        .body(json_password(&password))
         .send()
         .await
         .unwrap();
@@ -763,13 +817,16 @@ async fn setup_without_code_when_required_returns_403() {
 #[tokio::test]
 async fn setup_with_wrong_code_returns_403() {
     let (addr, _store, state) = start_auth_server_with_state().await;
-    state.inner.write().await.setup_code = Some(secrecy::Secret::new("123456".to_string()));
+    let setup_code = generated_setup_code();
+    let wrong_code = different_setup_code(&setup_code);
+    let password = generated_password();
+    state.inner.write().await.setup_code = Some(secrecy::Secret::new(setup_code));
 
     let client = reqwest::Client::new();
     let resp = client
         .post(format!("http://{addr}/api/auth/setup"))
         .header("Content-Type", "application/json")
-        .body(r#"{"password":"testpass12345","setup_code":"999999"}"#)
+        .body(json_password_with_setup_code(&password, &wrong_code))
         .send()
         .await
         .unwrap();
@@ -781,13 +838,15 @@ async fn setup_with_wrong_code_returns_403() {
 #[tokio::test]
 async fn setup_with_correct_code_succeeds() {
     let (addr, _store, state) = start_auth_server_with_state().await;
-    state.inner.write().await.setup_code = Some(secrecy::Secret::new("123456".to_string()));
+    let setup_code = generated_setup_code();
+    let password = generated_password();
+    state.inner.write().await.setup_code = Some(secrecy::Secret::new(setup_code.clone()));
 
     let client = reqwest::Client::new();
     let resp = client
         .post(format!("http://{addr}/api/auth/setup"))
         .header("Content-Type", "application/json")
-        .body(r#"{"password":"testpass12345","setup_code":"123456"}"#)
+        .body(json_password_with_setup_code(&password, &setup_code))
         .send()
         .await
         .unwrap();
@@ -802,7 +861,7 @@ async fn setup_with_correct_code_succeeds() {
 #[tokio::test]
 async fn setup_code_not_required_when_already_setup() {
     let (addr, store, _state) = start_auth_server_with_state().await;
-    store.set_initial_password("testpass12345").await.unwrap();
+    set_initial_test_password(&store).await;
 
     let resp = reqwest::get(format!("http://{addr}/api/auth/status"))
         .await
@@ -819,7 +878,8 @@ async fn setup_code_not_required_when_already_setup() {
 #[tokio::test]
 async fn status_reports_setup_code_required() {
     let (addr, _store, state) = start_proxied_server().await;
-    state.inner.write().await.setup_code = Some(secrecy::Secret::new("654321".to_string()));
+    let setup_code = generated_setup_code();
+    state.inner.write().await.setup_code = Some(secrecy::Secret::new(setup_code));
 
     let resp = reqwest::get(format!("http://{addr}/api/auth/status"))
         .await
@@ -834,7 +894,7 @@ async fn status_reports_setup_code_required() {
 #[tokio::test]
 async fn setup_code_not_required_when_auth_disabled() {
     let (addr, store, _state) = start_auth_server_with_state().await;
-    store.set_initial_password("testpass12345").await.unwrap();
+    set_initial_test_password(&store).await;
     let token = store.create_session().await.unwrap();
 
     // Reset auth to disable it.
@@ -893,12 +953,13 @@ async fn localhost_no_password_session_endpoints_accessible() {
 #[tokio::test]
 async fn localhost_set_password_without_current() {
     let (addr, store, _state) = start_localhost_server().await;
+    let new_password = generated_password();
 
     let client = reqwest::Client::new();
     let resp = client
         .post(format!("http://{addr}/api/auth/password/change"))
         .header("Content-Type", "application/json")
-        .body(r#"{"new_password":"newpass12345678"}"#)
+        .body(json_new_password(&new_password))
         .send()
         .await
         .unwrap();
@@ -906,7 +967,7 @@ async fn localhost_set_password_without_current() {
 
     // Password should now be set.
     assert!(store.has_password().await.unwrap());
-    assert!(store.verify_password("newpass12345678").await.unwrap());
+    assert!(store.verify_password(&new_password).await.unwrap());
 
     // After adding a password, localhost bypass should stop applying.
     let status = reqwest::get(format!("http://{addr}/api/auth/status"))
@@ -928,7 +989,7 @@ async fn localhost_set_password_without_current() {
 #[tokio::test]
 async fn upload_endpoint_requires_auth() {
     let (addr, store) = start_auth_server().await;
-    store.set_initial_password("testpass12345").await.unwrap();
+    set_initial_test_password(&store).await;
 
     // Unauthenticated POST should get 401.
     let client = reqwest::Client::new();
@@ -960,7 +1021,7 @@ async fn upload_endpoint_requires_auth() {
 #[tokio::test]
 async fn media_endpoint_requires_auth() {
     let (addr, store) = start_auth_server().await;
-    store.set_initial_password("testpass12345").await.unwrap();
+    set_initial_test_password(&store).await;
 
     // Unauthenticated GET should get 401.
     let resp = reqwest::get(format!("http://{addr}/api/sessions/main/media/test.png"))
@@ -985,7 +1046,7 @@ async fn media_endpoint_requires_auth() {
 #[tokio::test]
 async fn localhost_with_password_requires_login() {
     let (addr, store, _state) = start_localhost_server().await;
-    store.set_initial_password("testpass12345").await.unwrap();
+    set_initial_test_password(&store).await;
 
     let resp = reqwest::get(format!("http://{addr}/api/auth/status"))
         .await
@@ -1087,7 +1148,7 @@ async fn proxied_no_password_auth_status_accessible() {
 #[tokio::test]
 async fn proxied_with_password_requires_auth() {
     let (addr, store, _state) = start_proxied_server().await;
-    store.set_initial_password("testpass12345").await.unwrap();
+    set_initial_test_password(&store).await;
 
     let resp = reqwest::get(format!("http://{addr}/api/bootstrap"))
         .await
@@ -1115,7 +1176,7 @@ async fn proxied_with_password_requires_auth() {
 #[tokio::test]
 async fn login_cookie_includes_domain_for_localhost_subdomain() {
     let (addr, store, _state) = start_localhost_server().await;
-    store.set_initial_password("testpass12345").await.unwrap();
+    let password = set_initial_test_password(&store).await;
 
     let client = reqwest::Client::builder()
         .redirect(reqwest::redirect::Policy::none())
@@ -1126,7 +1187,7 @@ async fn login_cookie_includes_domain_for_localhost_subdomain() {
         .post(format!("http://{addr}/api/auth/login"))
         .header("Host", "moltis.localhost:18080")
         .header("Content-Type", "application/json")
-        .body(r#"{"password":"testpass12345"}"#)
+        .body(json_password(&password))
         .send()
         .await
         .unwrap();
@@ -1152,7 +1213,7 @@ async fn login_cookie_includes_domain_for_localhost_subdomain() {
 #[tokio::test]
 async fn login_cookie_includes_domain_for_plain_localhost() {
     let (addr, store, _state) = start_localhost_server().await;
-    store.set_initial_password("testpass12345").await.unwrap();
+    let password = set_initial_test_password(&store).await;
 
     let client = reqwest::Client::builder()
         .redirect(reqwest::redirect::Policy::none())
@@ -1163,7 +1224,7 @@ async fn login_cookie_includes_domain_for_plain_localhost() {
         .post(format!("http://{addr}/api/auth/login"))
         .header("Host", "localhost:18080")
         .header("Content-Type", "application/json")
-        .body(r#"{"password":"testpass12345"}"#)
+        .body(json_password(&password))
         .send()
         .await
         .unwrap();
@@ -1188,7 +1249,7 @@ async fn login_cookie_includes_domain_for_plain_localhost() {
 #[tokio::test]
 async fn login_cookie_omits_domain_for_external_host() {
     let (addr, store, _state) = start_localhost_server().await;
-    store.set_initial_password("testpass12345").await.unwrap();
+    let password = set_initial_test_password(&store).await;
 
     let client = reqwest::Client::builder()
         .redirect(reqwest::redirect::Policy::none())
@@ -1199,7 +1260,7 @@ async fn login_cookie_omits_domain_for_external_host() {
         .post(format!("http://{addr}/api/auth/login"))
         .header("Host", "mybox.example.com:443")
         .header("Content-Type", "application/json")
-        .body(r#"{"password":"testpass12345"}"#)
+        .body(json_password(&password))
         .send()
         .await
         .unwrap();
@@ -1223,7 +1284,8 @@ async fn login_cookie_omits_domain_for_external_host() {
 #[tokio::test]
 async fn login_endpoint_rate_limited_after_repeated_failures() {
     let (addr, store) = start_auth_server().await;
-    store.set_initial_password("testpass12345").await.unwrap();
+    let password = set_initial_test_password(&store).await;
+    let wrong_password = different_password(&password);
 
     let client = reqwest::Client::new();
 
@@ -1231,7 +1293,7 @@ async fn login_endpoint_rate_limited_after_repeated_failures() {
         let resp = client
             .post(format!("http://{addr}/api/auth/login"))
             .header("Content-Type", "application/json")
-            .body(r#"{"password":"wrong-password"}"#)
+            .body(json_password(&wrong_password))
             .send()
             .await
             .unwrap();
@@ -1245,7 +1307,7 @@ async fn login_endpoint_rate_limited_after_repeated_failures() {
     let throttled = client
         .post(format!("http://{addr}/api/auth/login"))
         .header("Content-Type", "application/json")
-        .body(r#"{"password":"wrong-password"}"#)
+        .body(json_password(&wrong_password))
         .send()
         .await
         .unwrap();
@@ -1269,7 +1331,7 @@ async fn login_endpoint_rate_limited_after_repeated_failures() {
 #[tokio::test]
 async fn api_endpoint_rate_limited_after_high_request_volume() {
     let (addr, store) = start_auth_server().await;
-    store.set_initial_password("testpass12345").await.unwrap();
+    set_initial_test_password(&store).await;
 
     let client = reqwest::Client::new();
 

--- a/crates/httpd/tests/auth_middleware/more.rs
+++ b/crates/httpd/tests/auth_middleware/more.rs
@@ -137,7 +137,7 @@ pub(super) async fn setup_required_page_accessible_for_remote() {
 #[tokio::test]
 pub(super) async fn setup_required_redirects_to_login_after_setup() {
     let (addr, store, _state) = start_proxied_server().await;
-    store.set_initial_password("testpass12345").await.unwrap();
+    set_initial_test_password(&store).await;
 
     let client = reqwest::Client::builder()
         .redirect(reqwest::redirect::Policy::none())
@@ -172,7 +172,7 @@ pub(super) async fn setup_required_redirects_to_login_after_setup() {
 #[tokio::test]
 pub(super) async fn onboarding_requires_auth_after_setup() {
     let (addr, store, _state) = start_proxied_server().await;
-    store.set_initial_password("testpass12345").await.unwrap();
+    set_initial_test_password(&store).await;
 
     let client = reqwest::Client::builder()
         .redirect(reqwest::redirect::Policy::none())
@@ -208,7 +208,7 @@ pub(super) async fn onboarding_requires_auth_after_setup() {
 #[tokio::test]
 pub(super) async fn onboarding_accessible_with_session_after_setup() {
     let (addr, store, _state) = start_proxied_server().await;
-    store.set_initial_password("testpass12345").await.unwrap();
+    set_initial_test_password(&store).await;
     let token = store.create_session().await.unwrap();
 
     let client = reqwest::Client::builder()
@@ -242,7 +242,7 @@ pub(super) async fn onboarding_accessible_with_session_after_setup() {
 #[tokio::test]
 pub(super) async fn onboarding_remains_accessible_after_auth_reset_when_onboarded() {
     let (addr, store, _state) = start_server_with_onboarding(true, true).await;
-    store.set_initial_password("testpass12345").await.unwrap();
+    set_initial_test_password(&store).await;
     store.reset_all().await.unwrap();
 
     let client = reqwest::Client::builder()
@@ -275,8 +275,9 @@ pub(super) async fn onboarding_remains_accessible_after_auth_reset_when_onboarde
 #[tokio::test]
 pub(super) async fn setup_endpoint_rejected_after_setup_complete() {
     let (addr, store, _state) = start_proxied_server().await;
-    store.set_initial_password("testpass12345").await.unwrap();
+    set_initial_test_password(&store).await;
     let token = store.create_session().await.unwrap();
+    let new_password = generated_password();
 
     let client = reqwest::Client::new();
 
@@ -285,7 +286,7 @@ pub(super) async fn setup_endpoint_rejected_after_setup_complete() {
         .post(format!("http://{addr}/api/auth/setup"))
         .header("Cookie", format!("moltis_session={token}"))
         .header("Content-Type", "application/json")
-        .body(r#"{"password":"evil-new-password"}"#)
+        .body(json_password(&new_password))
         .send()
         .await
         .unwrap();
@@ -301,7 +302,7 @@ pub(super) async fn setup_endpoint_rejected_after_setup_complete() {
 #[tokio::test]
 pub(super) async fn authenticated_api_endpoint_not_rate_limited() {
     let (addr, store) = start_auth_server().await;
-    store.set_initial_password("testpass12345").await.unwrap();
+    set_initial_test_password(&store).await;
     let token = store.create_session().await.unwrap();
 
     let client = reqwest::Client::new();
@@ -327,6 +328,7 @@ pub(super) async fn authenticated_api_endpoint_not_rate_limited() {
 #[tokio::test]
 pub(super) async fn password_change_initializes_vault() {
     let (addr, store, _state, vault) = start_localhost_server_with_vault().await;
+    let new_password = generated_password();
 
     // Vault starts uninitialized.
     assert_eq!(
@@ -339,7 +341,7 @@ pub(super) async fn password_change_initializes_vault() {
     let resp = client
         .post(format!("http://{addr}/api/auth/password/change"))
         .header("Content-Type", "application/json")
-        .body(r#"{"new_password":"newpass12345678"}"#)
+        .body(json_new_password(&new_password))
         .send()
         .await
         .unwrap();
@@ -364,7 +366,7 @@ pub(super) async fn password_change_initializes_vault() {
 
     // Password should be set.
     assert!(store.has_password().await.unwrap());
-    assert!(store.verify_password("newpass12345678").await.unwrap());
+    assert!(store.verify_password(&new_password).await.unwrap());
 }
 
 /// Setting a password via /api/auth/password/change when the vault is already
@@ -373,9 +375,11 @@ pub(super) async fn password_change_initializes_vault() {
 #[tokio::test]
 pub(super) async fn password_change_on_initialized_vault_no_recovery_key() {
     let (addr, store, _state, vault) = start_localhost_server_with_vault().await;
+    let existing_password = generated_password();
+    let new_password = generated_password();
 
     // Pre-initialize the vault to simulate a previous setup.
-    let _rk = vault.initialize("oldpass123").await.unwrap();
+    let _rk = vault.initialize(&existing_password).await.unwrap();
     assert_eq!(
         vault.status().await.unwrap(),
         moltis_vault::VaultStatus::Unsealed
@@ -386,7 +390,7 @@ pub(super) async fn password_change_on_initialized_vault_no_recovery_key() {
     let resp = client
         .post(format!("http://{addr}/api/auth/password/change"))
         .header("Content-Type", "application/json")
-        .body(r#"{"new_password":"newpass12345678"}"#)
+        .body(json_new_password(&new_password))
         .send()
         .await
         .unwrap();
@@ -410,7 +414,8 @@ pub(super) async fn password_change_on_initialized_vault_no_recovery_key() {
 #[tokio::test]
 pub(super) async fn sealed_vault_allows_bootstrap() {
     let (addr, _store, _state, vault) = start_localhost_server_with_vault().await;
-    let _rk = vault.initialize("testpass12345").await.unwrap();
+    let password = generated_password();
+    let _rk = vault.initialize(&password).await.unwrap();
     vault.seal().await;
 
     let blocked_resp = reqwest::get(format!("http://{addr}/api/skills"))
@@ -440,7 +445,8 @@ pub(super) async fn sealed_vault_allows_session_history() {
         )
         .await
         .unwrap();
-    let _rk = vault.initialize("testpass12345").await.unwrap();
+    let password = generated_password();
+    let _rk = vault.initialize(&password).await.unwrap();
     vault.seal().await;
 
     let blocked_resp = reqwest::get(format!("http://{addr}/api/skills"))
@@ -586,7 +592,7 @@ pub(super) async fn start_server_with_onboarding(
 #[tokio::test]
 pub(super) async fn local_api_during_onboarding_bypasses_auth() {
     let (addr, store, _state) = start_server_with_onboarding(false, false).await;
-    store.set_initial_password("testpass12345").await.unwrap();
+    set_initial_test_password(&store).await;
 
     let resp = reqwest::get(format!("http://{addr}/api/bootstrap"))
         .await
@@ -604,7 +610,7 @@ pub(super) async fn local_api_during_onboarding_bypasses_auth() {
 #[tokio::test]
 pub(super) async fn local_api_after_onboarding_requires_auth() {
     let (addr, store, _state) = start_server_with_onboarding(true, false).await;
-    store.set_initial_password("testpass12345").await.unwrap();
+    set_initial_test_password(&store).await;
 
     let resp = reqwest::get(format!("http://{addr}/api/bootstrap"))
         .await
@@ -622,7 +628,7 @@ pub(super) async fn local_api_after_onboarding_requires_auth() {
 #[tokio::test]
 pub(super) async fn remote_api_during_onboarding_requires_auth() {
     let (addr, store, _state) = start_server_with_onboarding(false, true).await;
-    store.set_initial_password("testpass12345").await.unwrap();
+    set_initial_test_password(&store).await;
 
     let resp = reqwest::get(format!("http://{addr}/api/bootstrap"))
         .await
@@ -641,7 +647,7 @@ pub(super) async fn remote_api_during_onboarding_requires_auth() {
 #[tokio::test]
 pub(super) async fn local_privileged_api_during_onboarding_requires_auth() {
     let (addr, store, _state) = start_server_with_onboarding(false, false).await;
-    store.set_initial_password("testpass12345").await.unwrap();
+    set_initial_test_password(&store).await;
 
     // /api/config is not in the onboarding bypass allowlist.
     let resp = reqwest::get(format!("http://{addr}/api/config"))

--- a/crates/providers/src/openai/provider/request.rs
+++ b/crates/providers/src/openai/provider/request.rs
@@ -416,13 +416,24 @@ fn assign_openai_tool_call_id(
 
 #[cfg(test)]
 mod tests {
+    use std::sync::atomic::{AtomicU64, Ordering};
+
     use secrecy::Secret;
 
     use super::*;
 
+    fn next_test_secret_id() -> u64 {
+        static NEXT_TEST_SECRET_ID: AtomicU64 = AtomicU64::new(1);
+        NEXT_TEST_SECRET_ID.fetch_add(1, Ordering::Relaxed)
+    }
+
+    fn generated_api_key() -> Secret<String> {
+        Secret::new(format!("k{:016x}", next_test_secret_id()))
+    }
+
     fn provider(model: &str, provider_name: &str, base_url: &str) -> OpenAiProvider {
         OpenAiProvider::new_with_name(
-            Secret::new("test-key".to_string()),
+            generated_api_key(),
             model.to_string(),
             base_url.to_string(),
             provider_name.to_string(),

--- a/crates/secret-store/src/store.rs
+++ b/crates/secret-store/src/store.rs
@@ -184,7 +184,18 @@ pub async fn decrypt_secret_fields<C: moltis_vault::Cipher>(
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
+    use std::sync::atomic::{AtomicU64, Ordering};
+
     use super::*;
+
+    fn next_test_secret_id() -> u64 {
+        static NEXT_TEST_SECRET_ID: AtomicU64 = AtomicU64::new(1);
+        NEXT_TEST_SECRET_ID.fetch_add(1, Ordering::Relaxed)
+    }
+
+    fn generated_secret_value() -> String {
+        format!("s{:016x}", next_test_secret_id())
+    }
 
     #[cfg(feature = "vault")]
     async fn test_vault() -> moltis_vault::Vault<moltis_vault::XChaCha20Poly1305Cipher> {
@@ -209,14 +220,16 @@ mod tests {
         let vault = moltis_vault::Vault::with_cipher(pool, moltis_vault::XChaCha20Poly1305Cipher)
             .await
             .unwrap();
-        vault.initialize("test-password").await.unwrap();
+        let password = generated_secret_value();
+        vault.initialize(&password).await.unwrap();
         vault
     }
 
     #[test]
     fn plaintext_detection_accepts_legacy_strings() {
+        let token = generated_secret_value();
         let config = serde_json::json!({
-            "token": "secret-token",
+            "token": token,
             "room_policy": "allowlist"
         });
 
@@ -228,9 +241,11 @@ mod tests {
     #[tokio::test]
     async fn encrypt_and_decrypt_round_trip_secret_fields() {
         let vault = test_vault().await;
+        let token = generated_secret_value();
+        let password = generated_secret_value();
         let mut config = serde_json::json!({
-            "token": "secret-token",
-            "password": "hunter2",
+            "token": token.clone(),
+            "password": password.clone(),
             "room_policy": "allowlist"
         });
 
@@ -255,16 +270,17 @@ mod tests {
         .await
         .unwrap();
         assert!(decrypted);
-        assert_eq!(config["token"], "secret-token");
-        assert_eq!(config["password"], "hunter2");
+        assert_eq!(config["token"], token);
+        assert_eq!(config["password"], password);
     }
 
     #[cfg(feature = "vault")]
     #[tokio::test]
     async fn encrypt_skips_already_tagged_fields() {
         let vault = test_vault().await;
+        let token = generated_secret_value();
         let ciphertext = vault
-            .encrypt_string("secret-token", "channel:telegram:bot1:token")
+            .encrypt_string(&token, "channel:telegram:bot1:token")
             .await
             .unwrap();
         let mut config = serde_json::json!({


### PR DESCRIPTION
## Summary

Remove hardcoded secret-looking test fixtures from the auth middleware, secret-store, and OpenAI provider tests.

CodeQL was flagging these literals as `rust/hard-coded-cryptographic-value` findings even though they were only test data. This change generates per-test passwords, setup codes, and fake API keys at runtime so the tests keep the same behavior without leaving embedded credential-shaped literals in the codebase.

## Validation

### Completed

- [x] `cargo +nightly-2025-11-30 fmt --all -- --check`
- [x] `cargo test -p moltis-httpd --test auth_middleware`
- [x] `cargo test -p moltis-secret-store --features vault`
- [x] `cargo test -p moltis-providers --lib openai::provider::request::tests`
- [x] `cargo clippy -p moltis-secret-store --features vault --all-targets --no-deps -- -D warnings`
- [x] `cargo clippy -p moltis-providers --all-targets --no-deps -- -D warnings`
- [x] `cargo clippy -p moltis-httpd --test auth_middleware --no-deps -- -D warnings`

### Remaining

- [ ] `./scripts/local-validate.sh 768` (stopped after the repo's 5-minute cutoff while still progressing through full-workspace validation)

## Manual QA

Not run, this is a test-only change with no user-facing UI behavior.