### PR TITLE
feat(code-index): add code indexing crate with builtin SQLite+FTS5 backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7342,6 +7342,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "moltis-code-index"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "gix",
+ "metrics 0.24.3",
+ "moltis-agents",
+ "moltis-config",
+ "moltis-memory",
+ "moltis-qmd",
+ "moltis-tools",
+ "notify-debouncer-full",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "sqlx",
+ "tempfile",
+ "thiserror 2.0.18",
+ "time",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "moltis-common"
 version = "0.1.0"
 dependencies = [
@@ -7466,6 +7492,7 @@ dependencies = [
  "moltis-canvas",
  "moltis-channels",
  "moltis-chat",
+ "moltis-code-index",
  "moltis-common",
  "moltis-config",
  "moltis-cron",
@@ -7568,6 +7595,7 @@ dependencies = [
  "moltis-auth",
  "moltis-browser",
  "moltis-channels",
+ "moltis-code-index",
  "moltis-common",
  "moltis-config",
  "moltis-cron",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ default-members = [
   "crates/canvas",
   "crates/channels",
   "crates/chat",
+  "crates/code-index",
   "crates/cli",
   "crates/common",
   "crates/config",
@@ -69,6 +70,7 @@ members = [
   "crates/canvas",
   "crates/channels",
   "crates/chat",
+  "crates/code-index",
   "crates/cli",
   "crates/common",
   "crates/config",
@@ -329,6 +331,7 @@ moltis-caldav           = { path = "crates/caldav" }
 moltis-canvas           = { path = "crates/canvas" }
 moltis-channels         = { path = "crates/channels" }
 moltis-chat             = { path = "crates/chat" }
+moltis-code-index      = { path = "crates/code-index" }
 moltis-common           = { path = "crates/common" }
 moltis-config           = { path = "crates/config" }
 moltis-cron             = { path = "crates/cron" }

--- a/crates/code-index/Cargo.toml
+++ b/crates/code-index/Cargo.toml
@@ -1,0 +1,47 @@
+[package]
+description       = "Codebase indexing for moltis — git-tracked file discovery, filtering, chunking, and project-scoped search"
+edition.workspace = true
+name              = "moltis-code-index"
+version.workspace = true
+
+[features]
+default = ["builtin", "tracing"]
+qmd = ["dep:moltis-qmd", "dep:moltis-agents"]
+builtin = ["dep:moltis-memory", "dep:moltis-agents", "dep:sqlx", "dep:tokio"]
+file-watcher = ["dep:notify-debouncer-full", "dep:tokio", "dep:tokio-util"]
+tracing = ["dep:tracing"]
+metrics = ["dep:metrics"]
+
+[dependencies]
+anyhow           = { workspace = true }
+async-trait      = { workspace = true }
+gix              = { workspace = true }
+moltis-agents    = { optional = true, workspace = true }
+moltis-memory    = { optional = true, workspace = true }
+moltis-qmd       = { optional = true, workspace = true }
+moltis-config    = { workspace = true }
+moltis-tools     = { workspace = true }
+notify-debouncer-full = { optional = true, workspace = true }
+serde            = { workspace = true }
+serde_json       = { workspace = true }
+sha2             = { workspace = true }
+sqlx             = { optional = true, workspace = true }
+tempfile         = { workspace = true }
+thiserror        = { workspace = true }
+time             = { workspace = true }
+tokio            = { workspace = true, features = ["sync"], optional = true }
+tokio-util       = { workspace = true, optional = true }
+tracing          = { workspace = true, optional = true }
+metrics          = { workspace = true, optional = true }
+
+# Future dependencies (add when wiring P5+ features):
+# moltis-memory    = { workspace = true }
+# moltis-projects  = { workspace = true }
+# regex            = { workspace = true }
+
+[dev-dependencies]
+serde_json = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt"] }
+
+[lints]
+workspace = true

--- a/crates/code-index/migrations/20260416200000_code_index_init.sql
+++ b/crates/code-index/migrations/20260416200000_code_index_init.sql
@@ -39,12 +39,12 @@ END;
 CREATE TRIGGER IF NOT EXISTS code_chunks_fts_delete
 AFTER DELETE ON code_chunks
 BEGIN
-    DELETE FROM code_chunks_fts WHERE rowid = OLD.id;
+    INSERT INTO code_chunks_fts(code_chunks_fts, rowid, content) VALUES('delete', OLD.id, OLD.content);
 END;
 
 CREATE TRIGGER IF NOT EXISTS code_chunks_fts_update
 AFTER UPDATE ON code_chunks
 BEGIN
-    DELETE FROM code_chunks_fts WHERE rowid = OLD.id;
+    INSERT INTO code_chunks_fts(code_chunks_fts, rowid, content) VALUES('delete', OLD.id, OLD.content);
     INSERT INTO code_chunks_fts(rowid, content) VALUES (NEW.id, NEW.content);
 END;

--- a/crates/code-index/migrations/20260416200000_code_index_init.sql
+++ b/crates/code-index/migrations/20260416200000_code_index_init.sql
@@ -1,0 +1,50 @@
+-- Initial schema for code-index SQLite+FTS5 backend.
+-- Stores code chunks with optional quantized embeddings and
+-- FTS5 full-text index for keyword search.
+
+CREATE TABLE IF NOT EXISTS code_chunks (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    project_id TEXT NOT NULL,
+    file_path TEXT NOT NULL,
+    chunk_index INTEGER NOT NULL,
+    content TEXT NOT NULL,
+    embedding BLOB,  -- Quantized i8 vector
+    start_line INTEGER NOT NULL,
+    end_line INTEGER NOT NULL,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(project_id, file_path, chunk_index)
+);
+
+CREATE INDEX IF NOT EXISTS idx_chunks_project ON code_chunks(project_id);
+CREATE INDEX IF NOT EXISTS idx_chunks_file ON code_chunks(project_id, file_path);
+
+-- FTS5 virtual table for keyword search (porter stemmer).
+-- External content table avoids storing content twice — FTS5 reads from
+-- `code_chunks` using `content_rowid` and the `content` column is looked
+-- up automatically via the `content=` directive.
+CREATE VIRTUAL TABLE IF NOT EXISTS code_chunks_fts USING fts5(
+    content,
+    content=code_chunks,
+    content_rowid=rowid,
+    tokenize='porter'
+);
+
+-- Triggers to keep FTS5 index in sync with code_chunks.
+CREATE TRIGGER IF NOT EXISTS code_chunks_fts_insert
+AFTER INSERT ON code_chunks
+BEGIN
+    INSERT INTO code_chunks_fts(rowid, content) VALUES (NEW.id, NEW.content);
+END;
+
+CREATE TRIGGER IF NOT EXISTS code_chunks_fts_delete
+AFTER DELETE ON code_chunks
+BEGIN
+    DELETE FROM code_chunks_fts WHERE rowid = OLD.id;
+END;
+
+CREATE TRIGGER IF NOT EXISTS code_chunks_fts_update
+AFTER UPDATE ON code_chunks
+BEGIN
+    DELETE FROM code_chunks_fts WHERE rowid = OLD.id;
+    INSERT INTO code_chunks_fts(rowid, content) VALUES (NEW.id, NEW.content);
+END;

--- a/crates/code-index/src/backend_qmd.rs
+++ b/crates/code-index/src/backend_qmd.rs
@@ -1,0 +1,111 @@
+//! QMD backend for code indexing.
+//!
+//! Creates [`QmdCollection`] entries scoped to a single project, using the
+//! code-index extension allowlist as the QMD glob mask.
+//!
+//! QMD's `--mask` flag accepts a single glob pattern per collection, so
+//! we emit one [`QmdCollection`] per extension.
+
+#[cfg(feature = "qmd")]
+use moltis_qmd::{QmdCollection, QmdManagerConfig};
+
+use crate::config::CodeIndexConfig;
+
+// P2 will use Error, Result, and IndexStatus when wiring the full backend.
+#[allow(unused_imports)]
+use crate::error::Result;
+#[allow(unused_imports)]
+use crate::types::IndexStatus;
+
+/// Build QMD collection configurations for a project.
+///
+/// Creates one [`QmdCollection`] per extension in the allowlist, each
+/// targeting the project directory. Multiple collections are needed
+/// because QMD's `--mask` flag accepts a single glob pattern per
+/// collection.
+#[cfg(feature = "qmd")]
+pub fn project_collections(
+    project_dir: &std::path::Path,
+    _project_id: &str,
+    config: &CodeIndexConfig,
+) -> Vec<QmdCollection> {
+    config
+        .extensions
+        .iter()
+        .map(|ext| QmdCollection {
+            path: project_dir.to_path_buf(),
+            glob: format!("**/*.{ext}"),
+        })
+        .collect()
+}
+
+/// Build a [`QmdManagerConfig`] for code indexing.
+///
+/// Registers one collection per extension keyed by
+/// `{project_id}-{extension}` and sets the QMD index name to
+/// `code-{project_id}`.
+#[cfg(feature = "qmd")]
+pub fn qmd_config_for_project(
+    project_dir: &std::path::Path,
+    work_dir: &std::path::Path,
+    project_id: &str,
+    config: &CodeIndexConfig,
+) -> QmdManagerConfig {
+    let mut collections = std::collections::HashMap::new();
+
+    for collection in project_collections(project_dir, project_id, config) {
+        // Derive a stable key from the glob pattern (e.g. "project-rs").
+        let ext_key = collection
+            .glob
+            .strip_prefix("**/*.")
+            .unwrap_or(&collection.glob);
+        let key = format!("{project_id}-{ext_key}");
+        collections.insert(key, collection);
+    }
+
+    QmdManagerConfig {
+        collections,
+        index_name: format!("code-{project_id}"),
+        work_dir: work_dir.to_path_buf(),
+        ..QmdManagerConfig::default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_project_collections_emits_per_extension() {
+        let config = CodeIndexConfig {
+            extensions: vec!["rs".into(), "py".into()],
+            ..CodeIndexConfig::default()
+        };
+        let colls = project_collections(
+            std::path::Path::new("/tmp/test-repo"),
+            "test-project",
+            &config,
+        );
+        assert_eq!(colls.len(), 2);
+        assert_eq!(colls[0].glob, "**/*.rs");
+        assert_eq!(colls[1].glob, "**/*.py");
+        assert_eq!(colls[0].path, std::path::PathBuf::from("/tmp/test-repo"));
+    }
+
+    #[test]
+    fn test_qmd_config_for_project_sets_work_dir() {
+        let config = CodeIndexConfig {
+            extensions: vec!["rs".into()],
+            ..CodeIndexConfig::default()
+        };
+        let qmc = qmd_config_for_project(
+            std::path::Path::new("/tmp/test-repo"),
+            std::path::Path::new("/tmp/work"),
+            "test-project",
+            &config,
+        );
+        assert_eq!(qmc.work_dir, std::path::PathBuf::from("/tmp/work"));
+        assert_eq!(qmc.index_name, "code-test-project");
+        assert!(qmc.collections.contains_key("test-project-rs"));
+    }
+}

--- a/crates/code-index/src/chunker.rs
+++ b/crates/code-index/src/chunker.rs
@@ -1,0 +1,292 @@
+//! Code chunking for embedding.
+//!
+//! Splits source code files into semantically meaningful chunks.
+//! Uses a line-based approach with overlap, respecting function boundaries when possible.
+
+use crate::store::CodeChunk;
+
+/// Configuration for code chunking.
+#[derive(Debug, Clone)]
+pub struct ChunkerConfig {
+    /// Target chunk size in lines.
+    pub chunk_size_lines: usize,
+    /// Overlap between chunks in lines.
+    pub overlap_lines: usize,
+    /// Maximum chunk size in bytes (approximate).
+    pub max_chunk_bytes: usize,
+}
+
+impl Default for ChunkerConfig {
+    fn default() -> Self {
+        Self {
+            chunk_size_lines: 50,
+            overlap_lines: 5,
+            max_chunk_bytes: 4000,
+        }
+    }
+}
+
+/// Chunker for source code files.
+pub struct CodeChunker {
+    config: ChunkerConfig,
+}
+
+impl CodeChunker {
+    /// Create a new chunker with the given config.
+    pub fn new(config: ChunkerConfig) -> Self {
+        Self { config }
+    }
+
+    /// Chunk file content into pieces.
+    ///
+    /// Returns chunks with 1-indexed line numbers.
+    pub fn chunk(&self, content: &str, file_path: &str) -> Vec<CodeChunk> {
+        let lines: Vec<&str> = content.lines().collect();
+        if lines.is_empty() {
+            return Vec::new();
+        }
+
+        let mut chunks = Vec::new();
+        let mut start_line = 0;
+        let total_lines = lines.len();
+
+        while start_line < total_lines {
+            let end_line = (start_line + self.config.chunk_size_lines).min(total_lines);
+
+            // Build chunk content
+            let chunk_lines = &lines[start_line..end_line];
+            let chunk_content = chunk_lines.join("\n");
+
+            // Check byte size and split further if needed
+            if chunk_content.len() > self.config.max_chunk_bytes && end_line - start_line > 10 {
+                // Split by byte size
+                let mid = (start_line + end_line) / 2;
+                let first_half = &lines[start_line..mid];
+                let second_half = &lines[mid..end_line];
+
+                for (idx, half) in [first_half, second_half].iter().enumerate() {
+                    let content = half.join("\n");
+                    let half_start = if idx == 0 {
+                        start_line
+                    } else {
+                        mid
+                    };
+                    let half_end = if idx == 0 {
+                        mid
+                    } else {
+                        end_line
+                    };
+
+                    chunks.push(CodeChunk {
+                        file_path: file_path.to_string(),
+                        chunk_index: chunks.len(),
+                        content,
+                        embedding: None,
+                        start_line: half_start + 1,
+                        end_line: half_end,
+                    });
+                }
+            } else {
+                chunks.push(CodeChunk {
+                    file_path: file_path.to_string(),
+                    chunk_index: chunks.len(),
+                    content: chunk_content,
+                    embedding: None,
+                    start_line: start_line + 1,
+                    end_line,
+                });
+            }
+
+            // Move forward with overlap
+            let step = self
+                .config
+                .chunk_size_lines
+                .saturating_sub(self.config.overlap_lines);
+            start_line += step;
+
+            // Prevent infinite loop on small files
+            if step == 0 {
+                break;
+            }
+        }
+
+        // Renumber chunk indices to be sequential
+        for (idx, chunk) in chunks.iter_mut().enumerate() {
+            chunk.chunk_index = idx;
+        }
+
+        chunks
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_chunk_empty() {
+        let chunker = CodeChunker::new(ChunkerConfig::default());
+        let chunks = chunker.chunk("", "test.rs");
+        assert!(chunks.is_empty());
+    }
+
+    #[test]
+    fn test_chunk_small_file() {
+        let chunker = CodeChunker::new(ChunkerConfig::default());
+        let content = "line1\nline2\nline3";
+        let chunks = chunker.chunk(content, "test.rs");
+
+        assert_eq!(chunks.len(), 1);
+        assert_eq!(chunks[0].start_line, 1);
+        assert_eq!(chunks[0].end_line, 3);
+        assert_eq!(chunks[0].content, content);
+    }
+
+    #[test]
+    fn test_chunk_large_file() {
+        let config = ChunkerConfig {
+            chunk_size_lines: 10,
+            overlap_lines: 2,
+            max_chunk_bytes: 10000,
+        };
+        let chunker = CodeChunker::new(config);
+
+        let mut content = String::new();
+        for i in 0..100 {
+            content.push_str(&format!("line{}\n", i));
+        }
+
+        let chunks = chunker.chunk(&content, "test.rs");
+
+        // 100 lines with chunk_size 10 and overlap 2:
+        // chunk 0: lines 0-9
+        // chunk 1: lines 8-17 (overlap 2)
+        // chunk 2: lines 16-25
+        // etc.
+        assert!(chunks.len() > 1);
+
+        // Verify line numbers
+        assert_eq!(chunks[0].start_line, 1);
+        assert_eq!(chunks[0].end_line, 10);
+
+        // Verify overlap
+        assert_eq!(chunks[1].start_line, 9);
+    }
+
+    #[test]
+    fn test_chunk_indices_sequential() {
+        let config = ChunkerConfig {
+            chunk_size_lines: 5,
+            overlap_lines: 0,
+            max_chunk_bytes: 10000,
+        };
+        let chunker = CodeChunker::new(config);
+
+        let content = (0..20)
+            .map(|i| format!("line{}", i))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let chunks = chunker.chunk(&content, "test.rs");
+
+        for (idx, chunk) in chunks.iter().enumerate() {
+            assert_eq!(chunk.chunk_index, idx);
+        }
+    }
+
+    #[test]
+    fn test_chunk_exact_boundary() {
+        let config = ChunkerConfig {
+            chunk_size_lines: 10,
+            overlap_lines: 0,
+            max_chunk_bytes: 100_000,
+        };
+        let chunker = CodeChunker::new(config);
+        let content: String = (0..10)
+            .map(|i| format!("line{i}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        let chunks = chunker.chunk(&content, "test.rs");
+        assert_eq!(
+            chunks.len(),
+            1,
+            "exactly 10 lines with chunk_size 10 should be 1 chunk"
+        );
+        assert_eq!(chunks[0].start_line, 1);
+        assert_eq!(chunks[0].end_line, 10);
+    }
+
+    #[test]
+    fn test_chunk_single_long_line() {
+        let config = ChunkerConfig {
+            chunk_size_lines: 50,
+            overlap_lines: 0,
+            max_chunk_bytes: 20,
+        };
+        let chunker = CodeChunker::new(config);
+        // One line that exceeds max_chunk_bytes
+        let content = "a".repeat(100);
+
+        let chunks = chunker.chunk(&content, "test.rs");
+        // Single line > max_chunk_bytes with end_line - start_line <= 10, should still produce a chunk
+        // (the byte-size split only fires when end_line - start_line > 10)
+        assert!(!chunks.is_empty(), "should produce at least one chunk");
+    }
+
+    #[test]
+    fn test_chunk_unicode_content() {
+        let config = ChunkerConfig {
+            chunk_size_lines: 3,
+            overlap_lines: 0,
+            max_chunk_bytes: 100_000,
+        };
+        let chunker = CodeChunker::new(config);
+        let content = "hello 🌍\nworld 🎉\nfoo ñ\nbar";
+
+        let chunks = chunker.chunk(content, "test.rs");
+        assert_eq!(chunks.len(), 2);
+        assert_eq!(chunks[0].start_line, 1);
+        assert_eq!(chunks[0].end_line, 3);
+        assert_eq!(chunks[1].start_line, 4);
+        assert_eq!(chunks[1].end_line, 4);
+    }
+
+    #[test]
+    fn test_chunk_overlap_consistent() {
+        let config = ChunkerConfig {
+            chunk_size_lines: 10,
+            overlap_lines: 2,
+            max_chunk_bytes: 100_000,
+        };
+        let chunker = CodeChunker::new(config);
+        let content: String = (0..50)
+            .map(|i| format!("line{i}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        let chunks = chunker.chunk(&content, "test.rs");
+        assert!(chunks.len() > 1);
+
+        // Verify overlap: last 2 lines of chunk[i] should be first 2 lines of chunk[i+1]
+        for i in 0..chunks.len().saturating_sub(1) {
+            let overlap_lines_a: Vec<&str> = chunks[i]
+                .content
+                .lines()
+                .rev()
+                .take(2)
+                .collect::<Vec<_>>()
+                .into_iter()
+                .rev()
+                .collect();
+            let overlap_lines_b: Vec<&str> = chunks[i + 1].content.lines().take(2).collect();
+            assert_eq!(
+                overlap_lines_a,
+                overlap_lines_b,
+                "overlap mismatch between chunk {} and {}",
+                i,
+                i + 1
+            );
+        }
+    }
+}

--- a/crates/code-index/src/config.rs
+++ b/crates/code-index/src/config.rs
@@ -1,0 +1,251 @@
+//! Configuration for codebase indexing.
+
+use std::sync::LazyLock;
+
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+/// Default maximum file size for indexing: 1 MB.
+const DEFAULT_MAX_FILE_SIZE_BYTES: u64 = 1024 * 1024;
+
+/// Default extensions considered text-equivalent and safe to index.
+static DEFAULT_EXTENSIONS: LazyLock<Vec<String>> = LazyLock::new(|| {
+    [
+        // Systems languages
+        "rs",
+        "c",
+        "h",
+        "cpp",
+        "hpp",
+        "cc",
+        "cxx",
+        "go",
+        "zig",
+        // Scripting languages
+        "py",
+        "pyi",
+        "rb",
+        "php",
+        "sh",
+        "bash",
+        // JVM languages
+        "java",
+        "kt",
+        "kts",
+        "scala",
+        // Web languages
+        "js",
+        "jsx",
+        "mjs",
+        "cjs",
+        "ts",
+        "tsx",
+        "mts",
+        "cts",
+        "css",
+        "scss",
+        "less",
+        "html",
+        "htm",
+        // .NET
+        "cs",
+        // Apple
+        "swift",
+        // Data / config
+        "sql",
+        "json",
+        "toml",
+        "yaml",
+        "yml",
+        "nix",
+        // Documentation
+        "md",
+        "markdown",
+        "mdx",
+        "txt",
+        // Docker / CI
+        "dockerfile",
+        "containerfile",
+        // DSLs
+        "graphql",
+        "proto",
+    ]
+    .iter()
+    .map(|s| s.to_string())
+    .collect()
+});
+
+/// Default path patterns to skip during indexing.
+static DEFAULT_SKIP_PATHS: LazyLock<Vec<String>> = LazyLock::new(|| {
+    [
+        "vendor/",
+        "third_party/",
+        "node_modules/",
+        "__pycache__/",
+        ".venv/",
+        "venv/",
+        "dist/",
+        "build/",
+        "target/",
+        ".next/",
+        ".nuxt/",
+        "coverage/",
+        ".tox/",
+    ]
+    .iter()
+    .map(|s| s.to_string())
+    .collect()
+});
+
+/// Configuration for codebase indexing, per-project or global.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct CodeIndexConfig {
+    /// Whether code indexing is enabled for this project.
+    pub enabled: bool,
+    /// File extensions to index (without leading dot).
+    /// Empty means use the default set.
+    pub extensions: Vec<String>,
+    /// Maximum file size in bytes. Files larger than this are skipped.
+    pub max_file_size_bytes: u64,
+    /// Whether to skip files that appear to be binary (contain null bytes).
+    pub skip_binary: bool,
+    /// Path prefixes to skip (e.g. "vendor/", "node_modules/").
+    pub skip_paths: Vec<String>,
+    /// Root directory for snapshot storage.
+    /// Defaults to `<moltis_data_dir>/code-index/` when `None`.
+    #[serde(skip)]
+    pub data_dir: Option<PathBuf>,
+}
+
+impl Default for CodeIndexConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            extensions: DEFAULT_EXTENSIONS.clone(),
+            max_file_size_bytes: DEFAULT_MAX_FILE_SIZE_BYTES,
+            skip_binary: true,
+            skip_paths: DEFAULT_SKIP_PATHS.clone(),
+            data_dir: None,
+        }
+    }
+}
+
+impl CodeIndexConfig {
+    /// Create a config with only the given extensions, replacing defaults.
+    #[must_use]
+    pub fn with_extensions(mut self, extensions: Vec<String>) -> Self {
+        self.extensions = extensions;
+        self
+    }
+
+    /// Check whether a file extension (without dot) is in the allowlist.
+    pub fn extension_allowed(&self, ext: &str) -> bool {
+        let ext_lower = ext.to_ascii_lowercase();
+        self.extensions
+            .iter()
+            .any(|e| e.to_ascii_lowercase() == ext_lower)
+    }
+
+    /// Check whether a relative path matches any skip pattern.
+    ///
+    /// Matches at any directory depth — `vendor` matches both `vendor/foo.rs`
+    /// and `src/vendor/foo.rs`. Patterns are treated as path segments unless
+    /// they already contain a `/`.
+    pub fn path_skipped(&self, relative_path: &str) -> bool {
+        let path_lower = relative_path.to_ascii_lowercase();
+        // Normalize separators.
+        let path_forward = path_lower.replace('\\', "/");
+        self.skip_paths
+            .iter()
+            .any(|pattern| {
+                // Strip trailing slashes so "vendor/" is treated as "vendor" for
+                // segment matching.
+                let p = pattern.trim_end_matches('/').to_ascii_lowercase();
+                // Exact prefix match (handles both "vendor/foo" and "vendor/").
+                if path_forward.starts_with(&p)
+                    || path_forward.starts_with(&format!("{p}/"))
+                {
+                    return true;
+                }
+                // Segment match: check if any path component equals the pattern.
+                // This catches "src/vendor/foo.rs" when pattern is "vendor".
+                if !p.contains('/') {
+                    path_forward
+                        .split('/')
+                        .any(|segment| segment == p.as_str())
+                } else {
+                    false
+                }
+            })
+    }
+
+    /// Return a [`FilterConfig`](crate::filter::FilterConfig) for the file watcher.
+    #[must_use]
+    pub fn filter(&self) -> crate::filter::FilterConfig {
+        crate::filter::FilterConfig {
+            extensions: self.extensions.clone(),
+            skip_paths: self.skip_paths.clone(),
+        }
+    }
+
+    /// Return a [`ChunkerConfig`](crate::chunker::ChunkerConfig) for the chunker.
+    #[must_use]
+    pub fn chunker(&self) -> crate::chunker::ChunkerConfig {
+        crate::chunker::ChunkerConfig::default()
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_default_config_has_extensions() {
+        let config = CodeIndexConfig::default();
+        assert!(!config.extensions.is_empty());
+        assert!(config.enabled);
+        assert!(config.skip_binary);
+    }
+
+    #[test]
+    fn test_extension_allowed() {
+        let config = CodeIndexConfig::default();
+        assert!(config.extension_allowed("rs"));
+        assert!(config.extension_allowed("py"));
+        assert!(config.extension_allowed("JS")); // case-insensitive
+        assert!(!config.extension_allowed("png"));
+        assert!(!config.extension_allowed("exe"));
+    }
+
+    #[test]
+    fn test_path_skipped() {
+        let config = CodeIndexConfig::default();
+        assert!(config.path_skipped("vendor/lib/foo.rs"));
+        assert!(config.path_skipped("node_modules/react/index.js"));
+        assert!(config.path_skipped("target/debug/moltis"));
+        assert!(!config.path_skipped("src/main.rs"));
+        // Nested path matching — pattern at non-root depth.
+        assert!(config.path_skipped("src/vendor/lib/foo.rs"));
+        assert!(config.path_skipped("packages/node_modules/pkg/index.js"));
+    }
+
+    #[test]
+    fn test_serde_round_trip() {
+        let config = CodeIndexConfig::default();
+        let json = serde_json::to_string(&config).unwrap();
+        let deserialized: CodeIndexConfig = serde_json::from_str(&json).unwrap();
+        assert_eq!(config.extensions, deserialized.extensions);
+        assert_eq!(config.max_file_size_bytes, deserialized.max_file_size_bytes);
+        assert_eq!(config.skip_binary, deserialized.skip_binary);
+    }
+
+    #[test]
+    fn test_with_extensions() {
+        let config = CodeIndexConfig::default().with_extensions(vec!["rs".into()]);
+        assert!(config.extension_allowed("rs"));
+        assert!(!config.extension_allowed("py"));
+    }
+}

--- a/crates/code-index/src/delta.rs
+++ b/crates/code-index/src/delta.rs
@@ -1,0 +1,396 @@
+//! Delta computation for incremental reindexing.
+//!
+//! Compares the current state of indexable files against a previously
+//! known state to produce a [`SyncDelta`] — the set of files added,
+//! removed, or modified since the last index. This enables efficient
+//! partial reindexing instead of re-scanning the entire project.
+
+use std::{
+    collections::{HashMap, HashSet},
+    path::Path,
+    time::UNIX_EPOCH,
+};
+
+use serde::{Deserialize, Serialize};
+
+#[cfg(feature = "tracing")]
+use crate::log::debug;
+
+use crate::{
+    config::CodeIndexConfig,
+    discover::discover_tracked_files,
+    error::Result,
+    filter::{content_hash, filter_tracked_files},
+    types::FilteredFile,
+};
+
+/// The set of changes between two index snapshots.
+#[derive(Debug, Clone)]
+pub struct SyncDelta {
+    /// Files that are new since the last index (not in previous snapshot).
+    pub added: Vec<FilteredFile>,
+    /// Files that were removed since the last index (in previous, not current).
+    pub removed: Vec<String>,
+    /// Files that exist in both but whose content hash changed.
+    pub modified: Vec<FilteredFile>,
+}
+
+/// Metadata for a file stored in the hash snapshot.
+///
+/// Carries enough information to short-circuit content hashing on
+/// incremental runs: if `modified_time` and `size` both match the
+/// previous entry, the file is assumed unchanged.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct FileMeta {
+    /// SHA-256 content hash (hex-encoded).
+    pub content_hash: String,
+    /// File modification time as Unix epoch seconds.
+    pub modified_time: u64,
+    /// File size in bytes.
+    pub size: u64,
+}
+
+/// A snapshot of file metadata from a previous indexing run.
+///
+/// Maps `relative_path → FileMeta`. Used for incremental delta
+/// computation to avoid re-hashing unchanged files.
+pub type HashSnapshot = HashMap<String, FileMeta>;
+
+/// Compute the delta between the current project state and a previous hash snapshot.
+///
+/// 1. Discover git-tracked files
+/// 2. Filter by extension, size, binary
+/// 3. For each filtered file, stat for mtime+size; skip hash if unchanged
+/// 4. Compare against the previous snapshot to find added/removed/modified
+///
+/// Returns the delta and the current hash snapshot (for use in the next delta).
+pub fn compute_delta(
+    project_dir: &Path,
+    config: &CodeIndexConfig,
+    previous: &HashSnapshot,
+) -> Result<(SyncDelta, HashSnapshot)> {
+    let tracked = discover_tracked_files(project_dir)?;
+    let filtered = filter_tracked_files(project_dir, &tracked, config)?;
+
+    let previous_paths: HashSet<&str> = previous.keys().map(|s| s.as_str()).collect();
+
+    let mut added = Vec::new();
+    let mut modified = Vec::new();
+    let mut current_snapshot = HashMap::new();
+
+    for file in &filtered {
+        let rel_str = file.relative_path.to_string_lossy().into_owned();
+
+        // Stat the file to get mtime + size for cheap change detection.
+        let meta = match std::fs::metadata(&file.path) {
+            Ok(m) => m,
+            Err(e) => {
+                #[cfg(feature = "tracing")]
+                debug!(
+                    path = %file.relative_path.display(),
+                    error = %e,
+                    "skipping file: stat failed"
+                );
+                // Carry forward previous metadata so the file isn't spuriously
+                // marked as "removed" on the next delta call.
+                if let Some(prev) = previous.get(rel_str.as_str()) {
+                    current_snapshot.insert(rel_str.clone(), prev.clone());
+                }
+                continue;
+            },
+        };
+
+        let modified_time = meta
+            .modified()
+            .ok()
+            .and_then(|t| t.duration_since(UNIX_EPOCH).ok())
+            .map_or(0, |d| d.as_secs());
+        let size = meta.len();
+
+        // Fast path: if file exists in previous snapshot with matching
+        // mtime and size, carry forward the hash without re-reading.
+        if let Some(prev_meta) = previous.get(rel_str.as_str())
+            && prev_meta.modified_time == modified_time
+            && prev_meta.size == size
+        {
+            current_snapshot.insert(rel_str.clone(), prev_meta.clone());
+            continue;
+        }
+
+        // Slow path: compute content hash.
+        let hash = match content_hash(&file.path) {
+            Ok(h) => h,
+            Err(e) => {
+                #[cfg(feature = "tracing")]
+                debug!(
+                    path = %file.relative_path.display(),
+                    error = %e,
+                    "skipping file: cannot compute content hash"
+                );
+                // Carry forward previous metadata so the file isn't spuriously
+                // marked as "removed" on the next delta call. If the file is
+                // new (not in previous), it's simply omitted from this cycle.
+                if let Some(prev) = previous.get(rel_str.as_str()) {
+                    current_snapshot.insert(rel_str.clone(), prev.clone());
+                }
+                continue;
+            },
+        };
+
+        let file_meta = FileMeta {
+            content_hash: hash.clone(),
+            modified_time,
+            size,
+        };
+        current_snapshot.insert(rel_str.clone(), file_meta.clone());
+
+        if let Some(prev_meta) = previous.get(rel_str.as_str()) {
+            if prev_meta.content_hash != hash {
+                // File exists in both but hash changed.
+                modified.push(file.clone());
+            }
+            // else: unchanged, no action needed.
+        } else {
+            // New file not in previous snapshot.
+            added.push(file.clone());
+        }
+    }
+
+    // Find removed files: in previous but not in current filtered set.
+    let current_paths: HashSet<&str> = current_snapshot.keys().map(|s| s.as_str()).collect();
+
+    let removed = previous_paths
+        .iter()
+        .filter(|p| !current_paths.contains(*p))
+        .map(|p| (*p).to_string())
+        .collect();
+
+    let delta = SyncDelta {
+        added,
+        removed,
+        modified,
+    };
+
+    Ok((delta, current_snapshot))
+}
+
+/// Build a hash snapshot from the current filtered file set.
+///
+/// Convenience function for the initial index (no previous snapshot).
+/// Equivalent to calling [`compute_delta`] with an empty previous snapshot.
+pub fn build_initial_snapshot(
+    project_dir: &Path,
+    config: &CodeIndexConfig,
+) -> Result<HashSnapshot> {
+    let tracked = discover_tracked_files(project_dir)?;
+    let filtered = filter_tracked_files(project_dir, &tracked, config)?;
+
+    let mut snapshot = HashMap::new();
+
+    for file in &filtered {
+        let rel_str = file.relative_path.to_string_lossy().into_owned();
+
+        let meta = match std::fs::metadata(&file.path) {
+            Ok(m) => m,
+            Err(e) => {
+                #[cfg(feature = "tracing")]
+                debug!(
+                    path = %file.relative_path.display(),
+                    error = %e,
+                    "skipping file: stat failed"
+                );
+                continue;
+            },
+        };
+
+        let modified_time = meta
+            .modified()
+            .ok()
+            .and_then(|t| t.duration_since(UNIX_EPOCH).ok())
+            .map_or(0, |d| d.as_secs());
+
+        let hash = match content_hash(&file.path) {
+            Ok(h) => h,
+            Err(e) => {
+                #[cfg(feature = "tracing")]
+                debug!(
+                    path = %file.relative_path.display(),
+                    error = %e,
+                    "skipping file: cannot compute content hash"
+                );
+                continue;
+            },
+        };
+
+        snapshot.insert(
+            rel_str,
+            FileMeta {
+                content_hash: hash,
+                modified_time,
+                size: meta.len(),
+            },
+        );
+    }
+
+    Ok(snapshot)
+}
+
+/// Build a hash snapshot from already-filtered files (no discovery pass).
+///
+/// Use this when the caller has already run `discover` + `filter`,
+/// to avoid a TOCTOU window from double-scanning the filesystem.
+pub fn build_snapshot_from_filtered(filtered: &[FilteredFile]) -> HashSnapshot {
+    let mut snapshot = HashMap::new();
+    for file in filtered {
+        let rel_str = file.relative_path.to_string_lossy().into_owned();
+
+        let meta = match std::fs::metadata(&file.path) {
+            Ok(m) => m,
+            Err(_) => continue,
+        };
+
+        let modified_time = meta
+            .modified()
+            .ok()
+            .and_then(|t| t.duration_since(UNIX_EPOCH).ok())
+            .map_or(0, |d| d.as_secs());
+
+        if let Ok(hash) = content_hash(&file.path) {
+            snapshot.insert(
+                rel_str,
+                FileMeta {
+                    content_hash: hash,
+                    modified_time,
+                    size: meta.len(),
+                },
+            );
+        }
+    }
+    snapshot
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    fn test_config() -> CodeIndexConfig {
+        CodeIndexConfig::default()
+    }
+
+    #[test]
+    fn test_compute_delta_empty_previous() {
+        // With an empty previous snapshot, all files should be "added".
+        let repo_dir = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .unwrap()
+            .parent()
+            .unwrap();
+
+        let config = test_config();
+        let previous = HashSnapshot::new();
+
+        let (delta, _snapshot) = compute_delta(repo_dir, &config, &previous).unwrap();
+        assert!(
+            !delta.added.is_empty(),
+            "all files should be added with empty previous snapshot"
+        );
+        assert!(
+            delta.removed.is_empty(),
+            "nothing should be removed with empty previous snapshot"
+        );
+        assert!(
+            delta.modified.is_empty(),
+            "nothing should be modified with empty previous snapshot"
+        );
+    }
+
+    #[test]
+    fn test_compute_delta_identical_snapshot() {
+        // With the current snapshot as previous, nothing should change.
+        let repo_dir = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .unwrap()
+            .parent()
+            .unwrap();
+
+        let config = test_config();
+
+        // Build an initial snapshot.
+        let previous = build_initial_snapshot(repo_dir, &config).unwrap();
+        assert!(!previous.is_empty(), "snapshot should have entries");
+
+        // Compare against itself — no changes.
+        let (delta, _) = compute_delta(repo_dir, &config, &previous).unwrap();
+        assert!(
+            delta.added.is_empty(),
+            "no new files should be added against identical snapshot"
+        );
+        assert!(
+            delta.removed.is_empty(),
+            "no files should be removed against identical snapshot"
+        );
+        assert!(
+            delta.modified.is_empty(),
+            "no files should be modified against identical snapshot"
+        );
+    }
+
+    #[test]
+    fn test_compute_delta_simulated_removal() {
+        // With a previous snapshot containing a fake extra file, it should
+        // show up as "removed" since it doesn't exist on disk.
+        let repo_dir = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .unwrap()
+            .parent()
+            .unwrap();
+
+        let config = test_config();
+        let mut previous = build_initial_snapshot(repo_dir, &config).unwrap();
+
+        // Insert a fake file that doesn't exist on disk.
+        previous.insert(
+            "fake/deleted_file.rs".to_string(),
+            FileMeta {
+                content_hash: "abc123".to_string(),
+                modified_time: 0,
+                size: 100,
+            },
+        );
+
+        let (delta, _) = compute_delta(repo_dir, &config, &previous).unwrap();
+        assert!(
+            delta.removed.contains(&"fake/deleted_file.rs".to_string()),
+            "fake entry should show as removed"
+        );
+    }
+
+    #[test]
+    fn test_build_initial_snapshot_populates_hashes() {
+        let repo_dir = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .unwrap()
+            .parent()
+            .unwrap();
+
+        let config = test_config();
+        let snapshot = build_initial_snapshot(repo_dir, &config).unwrap();
+
+        // All hashes should be 64-character hex SHA-256 strings.
+        for (path, meta) in &snapshot {
+            assert_eq!(
+                meta.content_hash.len(),
+                64,
+                "hash for {path} should be 64 hex chars"
+            );
+            assert!(
+                meta.content_hash
+                    .chars()
+                    .all(|c| c.is_ascii_hexdigit()),
+                "hash for {path} should be hex, got {}",
+                meta.content_hash
+            );
+        }
+    }
+}

--- a/crates/code-index/src/discover.rs
+++ b/crates/code-index/src/discover.rs
@@ -1,0 +1,152 @@
+//! Git-tracked file discovery.
+//!
+//! Enumerates files tracked by git for a given project directory,
+//! respecting `.gitignore` and submodule boundaries.
+
+use std::path::{Path, PathBuf};
+
+use gix::bstr::ByteSlice;
+
+#[cfg(feature = "tracing")]
+use crate::log::{debug, info};
+
+use crate::error::{Error, Result};
+
+/// Discover all git-tracked files in a repository rooted at `repo_dir`.
+///
+/// Uses `gix::discover` to open the repository and reads the index
+/// (staging area) to enumerate tracked blobs. Submodule paths are
+/// excluded. The returned paths are relative to the repository work
+/// tree root.
+pub fn discover_tracked_files(repo_dir: &Path) -> Result<Vec<PathBuf>> {
+    let repo = gix::discover(repo_dir).map_err(|e| Error::GitRepoNotFound {
+        path: repo_dir.to_path_buf(),
+        message: e.to_string(),
+    })?;
+
+    let work_dir = repo
+        .workdir()
+        .ok_or_else(|| {
+            Error::Config(
+                "bare repository has no work tree; code index requires a working tree".into(),
+            )
+        })?
+        .to_path_buf();
+
+    #[cfg(feature = "tracing")]
+    info!(
+        work_dir = %work_dir.display(),
+        "discovered git repository for code indexing"
+    );
+
+    // Read the git index (staging area) to get tracked files.
+    // This includes committed files and staged files, but not untracked
+    // or .gitignored files.
+    let index = repo.index().map_err(|e| Error::IndexFailed {
+        project_id: String::new(),
+        message: format!("failed to read git index: {e}"),
+    })?;
+
+    // Collect submodule paths to exclude.
+    let module_paths = collect_submodule_paths(repo_dir);
+
+    let mut tracked = Vec::new();
+    for entry in index.entries() {
+        let entry_path = entry.path(&index);
+        let rel_path = PathBuf::from(entry_path.to_str_lossy().as_ref());
+
+        // Skip submodule entries.
+        if module_paths.iter().any(|mp| rel_path.starts_with(mp)) {
+            #[cfg(feature = "tracing")]
+            debug!(path = %rel_path.display(), "skipping submodule path");
+            continue;
+        }
+
+        let abs_path = work_dir.join(&rel_path);
+
+        // Only include files that actually exist on disk.
+        // Index entries may reference files that have been removed but
+        // not yet staged for deletion.
+        if abs_path.is_file() {
+            tracked.push(rel_path);
+        }
+    }
+
+    #[cfg(feature = "tracing")]
+    debug!(count = tracked.len(), "enumerated git-tracked files");
+
+    Ok(tracked)
+}
+
+/// Collect submodule paths from `.gitmodules`, if present.
+///
+/// Parses the `.gitmodules` file directly. Simple line-by-line parsing
+/// handles the common case without needing full INI parsing.
+fn collect_submodule_paths(repo_dir: &Path) -> Vec<PathBuf> {
+    let mut paths = Vec::new();
+    let gitmodules_path = repo_dir.join(".gitmodules");
+
+    let content = match std::fs::read_to_string(&gitmodules_path) {
+        Ok(c) => c,
+        Err(_) => return paths, // No .gitmodules file — no submodules.
+    };
+
+    let mut current_is_submodule = false;
+    for line in content.lines() {
+        let trimmed = line.trim();
+        if trimmed.starts_with("[submodule") {
+            current_is_submodule = true;
+        } else if trimmed.starts_with('[') {
+            current_is_submodule = false;
+        } else if current_is_submodule && let Some(path_val) = trimmed.strip_prefix("path =") {
+            let path_val = path_val.trim();
+            if !path_val.is_empty() {
+                paths.push(PathBuf::from(path_val));
+            }
+        }
+    }
+
+    paths
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_discover_on_nonexistent_dir() {
+        let result = discover_tracked_files(Path::new("/nonexistent/path/that/does/not/exist"));
+        assert!(result.is_err(), "should fail for nonexistent directory");
+    }
+
+    #[test]
+    fn test_discover_on_moltis_repo() {
+        // Smoke test: discover tracked files in the moltis repo itself.
+        // CARGO_MANIFEST_DIR = .../moltis/crates/code-index
+        // Repo root = .../moltis (2 parents up)
+        let repo_dir = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .unwrap()
+            .parent()
+            .unwrap();
+        let files = discover_tracked_files(repo_dir).unwrap();
+        assert!(!files.is_empty(), "moltis repo should have tracked files");
+
+        // Key files that must be present.
+        assert!(
+            files
+                .iter()
+                .any(|f| f.to_string_lossy().ends_with("Cargo.toml")),
+            "root Cargo.toml should be tracked"
+        );
+
+        // .gitignored files should not appear.
+        assert!(
+            !files
+                .iter()
+                .any(|f| f.to_string_lossy().starts_with("target/")),
+            "target/ files should not be tracked"
+        );
+    }
+}

--- a/crates/code-index/src/error.rs
+++ b/crates/code-index/src/error.rs
@@ -1,0 +1,33 @@
+//! Error types for the code-index crate.
+
+use std::path::PathBuf;
+
+/// Errors that can occur during codebase indexing operations.
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("git repository not found at {path}: {message}")]
+    GitRepoNotFound { path: PathBuf, message: String },
+
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("indexing failed for project {project_id}: {message}")]
+    IndexFailed { project_id: String, message: String },
+
+    #[error("configuration error: {0}")]
+    Config(String),
+
+    #[error("backend unavailable: {0}")]
+    BackendUnavailable(String),
+
+    #[error("snapshot store error: {0}")]
+    Store(String),
+
+    #[error("index store error: {0}")]
+    IndexStore(String),
+
+    #[error("search failed for project {project_id}: {message}")]
+    SearchFailed { project_id: String, message: String },
+}
+
+pub type Result<T> = std::result::Result<T, Error>;

--- a/crates/code-index/src/filter.rs
+++ b/crates/code-index/src/filter.rs
@@ -1,0 +1,287 @@
+//! File filtering for codebase indexing.
+//!
+//! Takes discovered git-tracked files and filters them down to text-equivalent
+//! code files based on extension, size, binary detection, and path exclusions.
+
+use std::{fs, path::Path};
+
+use sha2::{Digest, Sha256};
+
+#[cfg(feature = "tracing")]
+use crate::log::{debug, info, trace};
+
+use crate::{
+    config::CodeIndexConfig,
+    error::Result,
+    types::{FilteredFile, Language},
+};
+
+/// Maximum bytes to read for binary detection.
+const BINARY_CHECK_BYTES: u64 = 8192;
+
+/// Null byte — if found in the first `BINARY_CHECK_BYTES`, the file is binary.
+const NULL_BYTE: u8 = 0;
+
+/// Lightweight filter configuration used by the file watcher.
+#[derive(Debug, Clone)]
+pub struct FilterConfig {
+    /// File extensions to index (without leading dot).
+    pub extensions: Vec<String>,
+    /// Path prefixes to skip.
+    pub skip_paths: Vec<String>,
+}
+
+/// Filter a list of relative file paths according to the config.
+///
+/// For each file: check extension, check size, check for binary content,
+/// check skip paths. Returns the files that pass all filters, with
+/// language hints and size metadata.
+pub fn filter_tracked_files(
+    repo_dir: &Path,
+    relative_paths: &[std::path::PathBuf],
+    config: &CodeIndexConfig,
+) -> Result<Vec<FilteredFile>> {
+    let mut accepted = Vec::new();
+    let mut skipped_extension = 0usize;
+    let mut skipped_size = 0usize;
+    let mut skipped_binary = 0usize;
+    let mut skipped_path = 0usize;
+
+    for rel_path in relative_paths {
+        let path_str = rel_path.to_string_lossy();
+
+        // 1. Path skip check (cheapest — no I/O).
+        if config.path_skipped(&path_str) {
+            #[cfg(feature = "tracing")]
+            debug!(path = %path_str, "skipped: path exclusion");
+            skipped_path += 1;
+            continue;
+        }
+
+        // 2. Extension check (handles extensionless files like Dockerfile).
+        let effective_ext = effective_extension(rel_path);
+
+        if !config.extension_allowed(effective_ext) {
+            #[cfg(feature = "tracing")]
+            trace!(path = %path_str, ext = %effective_ext, "skipped: extension not allowed");
+            skipped_extension += 1;
+            continue;
+        }
+
+        // 3. Size check.
+        let abs_path = repo_dir.join(rel_path);
+        let metadata = match fs::metadata(&abs_path) {
+            Ok(m) => m,
+            Err(e) => {
+                #[cfg(feature = "tracing")]
+                debug!(path = %path_str, error = %e, "skipped: cannot read metadata");
+                continue;
+            },
+        };
+        let size = metadata.len();
+        if size > config.max_file_size_bytes {
+            #[cfg(feature = "tracing")]
+            debug!(
+                path = %path_str,
+                size,
+                max = config.max_file_size_bytes,
+                "skipped: file too large"
+            );
+            skipped_size += 1;
+            continue;
+        }
+
+        // 4. Binary detection (read first 8 KiB, check for null bytes).
+        if config.skip_binary && is_binary_file(&abs_path, size) {
+            #[cfg(feature = "tracing")]
+            debug!(path = %path_str, "skipped: binary content detected");
+            skipped_binary += 1;
+            continue;
+        }
+
+        let language = Language::from_extension(effective_ext);
+
+        accepted.push(FilteredFile {
+            path: abs_path,
+            relative_path: rel_path.clone(),
+            size,
+            language,
+        });
+    }
+
+    #[cfg(feature = "tracing")]
+    info!(
+        accepted = accepted.len(),
+        skipped_extension, skipped_size, skipped_binary, skipped_path, "file filtering complete"
+    );
+
+    Ok(accepted)
+}
+
+/// Check if a file appears to be binary by looking for null bytes
+/// in the first `BINARY_CHECK_BYTES` of content.
+fn is_binary_file(path: &Path, size: u64) -> bool {
+    if size == 0 {
+        return false;
+    }
+
+    let mut file = match fs::File::open(path) {
+        Ok(f) => f,
+        Err(_) => return true, // If we can't open it, treat as binary.
+    };
+
+    use std::io::Read;
+    let check_len = std::cmp::min(size, BINARY_CHECK_BYTES) as usize;
+    let mut buf = vec![0u8; check_len];
+    match file.read(&mut buf) {
+        Ok(n) => buf[..n].contains(&NULL_BYTE),
+        Err(_) => true,
+    }
+}
+
+/// Compute a SHA-256 content hash for a file.
+/// Used for change detection (skip re-indexing if hash matches).
+pub fn content_hash(path: &Path) -> Result<String> {
+    let data = fs::read(path)?;
+    let mut hasher = Sha256::new();
+    hasher.update(&data);
+    Ok(format!("{:x}", hasher.finalize()))
+}
+
+/// Determine the effective file extension for extension and language detection.
+///
+/// For files with a normal extension (e.g. `main.rs` → `"rs"`), returns it as-is.
+/// For known extensionless filenames (Dockerfile, Makefile),
+/// returns a synthetic extension mapping them to their language.
+pub fn effective_extension(path: &Path) -> &str {
+    let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("");
+
+    if !ext.is_empty() {
+        return ext;
+    }
+
+    // No extension — map known extensionless filenames.
+    let file_name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
+
+    match file_name.to_ascii_lowercase().as_str() {
+        "dockerfile" | "containerfile" => "dockerfile",
+        "makefile" | "gnumakefile" => "mk",
+        _ => "",
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use std::path::PathBuf;
+
+    use {super::*, crate::config::CodeIndexConfig};
+
+    fn test_config() -> CodeIndexConfig {
+        CodeIndexConfig::default()
+    }
+
+    /// Create a temp directory with the given file structure for filter testing.
+    /// Each entry is `(relative_path, content)`.
+    fn setup_temp_dir(files: &[(&str, &[u8])]) -> tempfile::TempDir {
+        let dir = tempfile::TempDir::new().unwrap();
+        for (rel_path, content) in files {
+            let full_path = dir.path().join(rel_path);
+            fs::create_dir_all(full_path.parent().unwrap()).unwrap();
+            fs::write(&full_path, content).unwrap();
+        }
+        dir
+    }
+
+    #[test]
+    fn test_filter_by_extension() {
+        let dir = setup_temp_dir(&[
+            ("src/main.rs", b"fn main() {}".as_slice()),
+            ("src/lib.py", b"def hello(): pass".as_slice()),
+            ("assets/logo.png", b"\x89PNG".as_slice()),
+            ("data/output.bin", b"\x00\x01\x02".as_slice()),
+        ]);
+        let config = test_config();
+        let files = vec![
+            PathBuf::from("src/main.rs"),
+            PathBuf::from("src/lib.py"),
+            PathBuf::from("assets/logo.png"),
+            PathBuf::from("data/output.bin"),
+        ];
+
+        let filtered = filter_tracked_files(dir.path(), &files, &config).unwrap();
+        // rs and py should pass; png should be excluded by extension.
+        assert!(
+            filtered
+                .iter()
+                .any(|f| f.relative_path.ends_with("main.rs")),
+            "main.rs should pass the extension filter"
+        );
+        assert!(
+            filtered.iter().any(|f| f.relative_path.ends_with("lib.py")),
+            "lib.py should pass the extension filter"
+        );
+        assert!(
+            !filtered
+                .iter()
+                .any(|f| f.relative_path.ends_with("logo.png")),
+            "logo.png should be excluded by extension"
+        );
+        // output.bin has a null byte so it should be excluded by binary detection
+        assert!(
+            !filtered
+                .iter()
+                .any(|f| f.relative_path.ends_with("output.bin")),
+            "output.bin should be excluded (binary)"
+        );
+    }
+
+    #[test]
+    fn test_filter_by_path() {
+        let dir = setup_temp_dir(&[
+            ("src/main.rs", b"fn main() {}".as_slice()),
+            ("vendor/lib/foo.rs", b"fn foo() {}".as_slice()),
+            (
+                "node_modules/react/index.js",
+                b"module.exports = {};".as_slice(),
+            ),
+        ]);
+        let config = test_config();
+        let files = vec![
+            PathBuf::from("src/main.rs"),
+            PathBuf::from("vendor/lib/foo.rs"),
+            PathBuf::from("node_modules/react/index.js"),
+        ];
+
+        let filtered = filter_tracked_files(dir.path(), &files, &config).unwrap();
+        assert!(
+            filtered
+                .iter()
+                .any(|f| f.relative_path.ends_with("main.rs")),
+            "src/main.rs should pass"
+        );
+        assert!(
+            !filtered
+                .iter()
+                .any(|f| f.relative_path.display().to_string().contains("vendor")),
+            "vendor paths should be skipped"
+        );
+        assert!(
+            !filtered.iter().any(|f| f
+                .relative_path
+                .display()
+                .to_string()
+                .contains("node_modules")),
+            "node_modules paths should be skipped"
+        );
+    }
+
+    #[test]
+    fn test_language_detection() {
+        assert_eq!(Language::from_extension("rs"), Language::Rust);
+        assert_eq!(Language::from_extension("py"), Language::Python);
+        assert_eq!(Language::from_extension("JS"), Language::JavaScript);
+        assert_eq!(Language::from_extension("tsx"), Language::TypeScript);
+        assert_eq!(Language::from_extension("png"), Language::Unknown);
+    }
+}

--- a/crates/code-index/src/index.rs
+++ b/crates/code-index/src/index.rs
@@ -1,0 +1,1118 @@
+use std::path::Path;
+
+#[cfg(feature = "file-watcher")]
+use std::sync::Arc;
+
+#[cfg(feature = "tracing")]
+use tracing::instrument;
+
+#[cfg(feature = "tracing")]
+use crate::log::{debug, info, warn};
+
+use crate::{
+    config::CodeIndexConfig,
+    discover::discover_tracked_files,
+    error::{Error, Result},
+    filter::filter_tracked_files,
+    snapshot_store::SnapshotStore,
+    types::{FilteredFile, IndexStatus, SearchResult},
+};
+
+use crate::delta::{HashSnapshot, build_snapshot_from_filtered, compute_delta};
+
+#[cfg(feature = "builtin")]
+use crate::store::CodeIndexStore;
+
+#[cfg(feature = "file-watcher")]
+use crate::watcher::FileWatcher;
+
+// ---------------------------------------------------------------------------
+// Backend enum
+// ---------------------------------------------------------------------------
+
+/// Active backend for the code index.
+#[allow(clippy::large_enum_variant)]
+enum Backend {
+    /// No backend configured — search always returns empty.
+    ConfigOnly,
+
+    /// QMD (external vector DB) backend.
+    #[cfg(feature = "qmd")]
+    Qmd(moltis_qmd::QmdManager),
+
+    /// Built-in SQLite + FTS5 backend with optional embedding provider.
+    #[cfg(feature = "builtin")]
+    Builtin {
+        store: Box<dyn CodeIndexStore>,
+        embedder: Option<Box<dyn moltis_memory::embeddings::EmbeddingProvider>>,
+    },
+}
+
+// ---------------------------------------------------------------------------
+// CodeIndex — main orchestrator
+// ---------------------------------------------------------------------------
+
+/// Code index supporting multiple backends.
+pub struct CodeIndex {
+    config: CodeIndexConfig,
+    snapshot_store: SnapshotStore,
+    backend: Backend,
+
+    /// Project ID → project directory mapping for search scoping.
+    project_dirs: std::sync::Mutex<std::collections::HashMap<String, std::path::PathBuf>>,
+
+    /// Active file watchers, keyed by project ID.
+    #[cfg(feature = "file-watcher")]
+    watchers: std::sync::Mutex<Vec<FileWatcher>>,
+}
+
+impl CodeIndex {
+    // -----------------------------------------------------------------------
+    // Constructors
+    // -----------------------------------------------------------------------
+
+    /// Create a new code index with QMD backend.
+    #[cfg(feature = "qmd")]
+    pub fn new(config: CodeIndexConfig, qmd: moltis_qmd::QmdManager) -> Self {
+        let snapshot_store = SnapshotStore::new(
+            config
+                .data_dir
+                .clone()
+                .unwrap_or_else(|| moltis_config::data_dir().join("code-index")),
+        );
+        Self {
+            config,
+            snapshot_store,
+            backend: Backend::Qmd(qmd),
+            project_dirs: std::sync::Mutex::new(std::collections::HashMap::new()),
+            #[cfg(feature = "file-watcher")]
+            watchers: std::sync::Mutex::new(Vec::new()),
+        }
+    }
+
+    /// Create a new code index with builtin backend.
+    #[cfg(feature = "builtin")]
+    pub fn new_builtin(
+        config: CodeIndexConfig,
+        store: Box<dyn CodeIndexStore>,
+        embedder: Option<Box<dyn moltis_memory::embeddings::EmbeddingProvider>>,
+    ) -> Self {
+        let snapshot_store = SnapshotStore::new(
+            config
+                .data_dir
+                .clone()
+                .unwrap_or_else(|| moltis_config::data_dir().join("code-index")),
+        );
+        Self {
+            config,
+            snapshot_store,
+            backend: Backend::Builtin { store, embedder },
+            project_dirs: std::sync::Mutex::new(std::collections::HashMap::new()),
+            #[cfg(feature = "file-watcher")]
+            watchers: std::sync::Mutex::new(Vec::new()),
+        }
+    }
+
+    /// Create a code index with config but no backend.
+    pub fn config_only(config: CodeIndexConfig) -> Self {
+        let snapshot_store = SnapshotStore::new(
+            config
+                .data_dir
+                .clone()
+                .unwrap_or_else(|| moltis_config::data_dir().join("code-index")),
+        );
+        Self {
+            config,
+            snapshot_store,
+            backend: Backend::ConfigOnly,
+            project_dirs: std::sync::Mutex::new(std::collections::HashMap::new()),
+            #[cfg(feature = "file-watcher")]
+            watchers: std::sync::Mutex::new(Vec::new()),
+        }
+    }
+
+    /// List the indexable files for a project directory.
+    ///
+    /// Discovers git-tracked files and applies extension/size/path filters.
+    /// Does not require any backend — works with `config_only`.
+    pub fn list_indexable_files(&self, project_dir: &Path) -> Result<Vec<FilteredFile>> {
+        let tracked = discover_tracked_files(project_dir)
+            .map_err(|e| Error::Io(std::io::Error::other(e.to_string())))?;
+        let filtered = filter_tracked_files(project_dir, &tracked, &self.config)?;
+        Ok(filtered)
+    }
+
+    // -----------------------------------------------------------------------
+    // Public API — index, search, status
+    // -----------------------------------------------------------------------
+
+    /// Index a project directory.
+    ///
+    /// On first run (no snapshot), performs a full reindex. On subsequent runs,
+    /// computes a delta from the previous snapshot and only processes changed files.
+    /// Pass `force = true` to force a full reindex regardless.
+    #[cfg_attr(feature = "tracing", instrument(skip(self)))]
+    pub async fn index_project(
+        &self,
+        project_id: &str,
+        force: bool,
+        project_dir: &Path,
+    ) -> Result<IndexStatus> {
+        // Remember the project directory for search scoping.
+        self.project_dirs
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .insert(project_id.to_string(), project_dir.to_path_buf());
+
+        // Discover + filter are blocking filesystem I/O — offload to blocking
+        // thread when a tokio runtime is available (builtin / file-watcher).
+        #[cfg(any(feature = "builtin", feature = "file-watcher"))]
+        let (_tracked, filtered) = tokio::task::spawn_blocking({
+            let project_dir = project_dir.to_path_buf();
+            let config = self.config.clone();
+            move || {
+                let tracked = discover_tracked_files(&project_dir)
+                    .map_err(|e| Error::Io(std::io::Error::other(e.to_string())))?;
+                let filtered = filter_tracked_files(&project_dir, &tracked, &config)?;
+                Ok::<_, Error>((tracked, filtered))
+            }
+        })
+        .await
+        .map_err(|e| Error::Io(std::io::Error::other(e.to_string())))??;
+
+        #[cfg(not(any(feature = "builtin", feature = "file-watcher")))]
+        let (_tracked, filtered) = {
+            let tracked = discover_tracked_files(project_dir)
+                .map_err(|e| Error::Io(std::io::Error::other(e.to_string())))?;
+            let filtered = filter_tracked_files(project_dir, &tracked, &self.config)?;
+            (tracked, filtered)
+        };
+        #[cfg(not(any(feature = "builtin", feature = "qmd")))]
+        let _filtered = filtered;
+        #[cfg(not(any(feature = "builtin", feature = "qmd")))]
+        let _force = force;
+
+        match &self.backend {
+            Backend::ConfigOnly => Err(Error::IndexFailed {
+                project_id: project_id.to_string(),
+                message: "no backend configured".to_string(),
+            }),
+
+            #[cfg(feature = "qmd")]
+            Backend::Qmd(qmd) => {
+                qmd.ensure_collections()
+                    .await
+                    .map_err(|e| Error::IndexFailed {
+                        project_id: project_id.to_string(),
+                        message: format!("QMD ensure_collections error: {e}"),
+                    })?;
+                qmd.refresh_index(true)
+                    .await
+                    .map_err(|e| Error::IndexFailed {
+                        project_id: project_id.to_string(),
+                        message: format!("QMD refresh_index error: {e}"),
+                    })?;
+                self.status(project_id).await
+            },
+
+            #[cfg(feature = "builtin")]
+            Backend::Builtin { store, embedder } => {
+                if force {
+                    self.index_full_builtin(
+                        project_id,
+                        project_dir,
+                        &filtered,
+                        store.as_ref(),
+                        embedder.as_deref(),
+                    )
+                    .await?;
+                    self.build_status_builtin(project_id, store.as_ref(), embedder.as_deref())
+                        .await
+                } else {
+                    self.index_incremental_builtin(
+                        project_id,
+                        project_dir,
+                        &filtered,
+                        store.as_ref(),
+                        embedder.as_deref(),
+                    )
+                    .await
+                }
+            },
+        }
+    }
+
+    /// Search the code index for a project.
+    #[cfg_attr(feature = "tracing", instrument(skip(self)))]
+    pub async fn search(
+        &self,
+        project_id: &str,
+        query: &str,
+        limit: usize,
+    ) -> Result<Vec<SearchResult>> {
+        match &self.backend {
+            Backend::ConfigOnly => Err(Error::BackendUnavailable(
+                "no backend configured".to_string(),
+            )),
+
+            #[cfg(feature = "qmd")]
+            Backend::Qmd(qmd) => {
+                // Request extra results to compensate for cross-project filtering.
+                let fetch_limit = limit * 3;
+                let results = qmd
+                    .hybrid_search(query, fetch_limit, true)
+                    .await
+                    .map_err(|e| Error::SearchFailed {
+                        project_id: project_id.to_string(),
+                        message: format!("QMD search error: {e}"),
+                    })?;
+                let mapped = crate::search::from_qmd_results(&results, project_id);
+
+                // Filter results to only include files belonging to this project.
+                let project_dir = self
+                    .project_dirs
+                    .lock()
+                    .unwrap_or_else(|e| e.into_inner())
+                    .get(project_id)
+                    .cloned();
+                let scoped: Vec<SearchResult> = if let Some(ref dir) = project_dir {
+                    mapped
+                        .into_iter()
+                        .filter(|r| {
+                            r.path.starts_with(dir.to_string_lossy().as_ref())
+                                || Path::new(&r.path).starts_with(dir)
+                        })
+                        .take(limit)
+                        .collect()
+                } else {
+                    mapped.into_iter().take(limit).collect()
+                };
+                Ok(scoped)
+            },
+
+            #[cfg(feature = "builtin")]
+            Backend::Builtin { store, embedder } => {
+                self.search_builtin(
+                    project_id,
+                    query,
+                    limit,
+                    store.as_ref(),
+                    embedder.as_deref(),
+                )
+                .await
+            },
+        }
+    }
+
+    /// Get the index status for a project.
+    #[cfg_attr(feature = "tracing", instrument(skip(self)))]
+    pub async fn status(&self, project_id: &str) -> Result<IndexStatus> {
+        match &self.backend {
+            Backend::ConfigOnly => Err(Error::BackendUnavailable(
+                "no backend configured".to_string(),
+            )),
+
+            #[cfg(feature = "qmd")]
+            Backend::Qmd(qmd) => {
+                let qmd_status = qmd.status().await;
+                let total_files: usize = qmd_status.indexed_files.values().sum();
+                Ok(IndexStatus {
+                    project_id: project_id.to_string(),
+                    total_files,
+                    total_chunks: total_files, // QMD doesn't expose chunk count
+                    last_sync_ms: None,
+                    embedding_model: None,
+                    backend: "qmd".to_string(),
+                })
+            },
+
+            #[cfg(feature = "builtin")]
+            Backend::Builtin { store, embedder } => {
+                self.build_status_builtin(project_id, store.as_ref(), embedder.as_deref())
+                    .await
+            },
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Watcher lifecycle
+    // -----------------------------------------------------------------------
+
+    /// Start watching a project directory for incremental reindexing.
+    ///
+    /// When files change, the handler re-indexes only the affected files
+    /// via [`reindex_files`].
+    #[cfg(feature = "file-watcher")]
+    pub fn start_watcher(self: &Arc<Self>, project_id: &str, project_dir: &Path) -> Result<()> {
+        use crate::watcher::WatchHandler;
+
+        let filter_config = self.config.filter();
+        let index = Arc::clone(self);
+        let proj_dir = project_dir.to_path_buf();
+
+        let handler: WatchHandler = Arc::new(move |proj_id, changed_paths| {
+            let paths: Vec<std::path::PathBuf> = changed_paths.to_vec();
+            let idx = Arc::clone(&index);
+            let pid = proj_id.to_string();
+            let proj_dir = proj_dir.clone();
+
+            tokio::spawn(async move {
+                if let Err(e) = idx.reindex_files(&pid, &proj_dir, &paths).await {
+                    #[cfg(feature = "tracing")]
+                    warn!(project_id = %pid, error = %e, "watcher reindex failed");
+                }
+            });
+        });
+
+        let watcher = FileWatcher::start(
+            project_id.to_string(),
+            project_dir.to_path_buf(),
+            filter_config,
+            handler,
+        )
+        .map_err(|e| Error::IndexFailed {
+            project_id: project_id.to_string(),
+            message: format!("failed to start watcher: {e}"),
+        })?;
+
+        self.watchers
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .push(watcher);
+        #[cfg(feature = "tracing")]
+        info!(project_id, "file watcher registered");
+        Ok(())
+    }
+
+    /// Stop all watchers for a given project.
+    #[cfg(feature = "file-watcher")]
+    pub fn stop_watcher(&self, project_id: &str) {
+        let mut watchers = self.watchers.lock().unwrap_or_else(|e| e.into_inner());
+        watchers.retain(|w| {
+            if w.project_id() == project_id {
+                w.stop();
+                false
+            } else {
+                true
+            }
+        });
+    }
+
+    /// Stop all watchers.
+    #[cfg(feature = "file-watcher")]
+    pub fn stop_all_watchers(&self) {
+        let mut watchers = self.watchers.lock().unwrap_or_else(|e| e.into_inner());
+        watchers.clear(); // Drop triggers stop()
+    }
+
+    // -----------------------------------------------------------------------
+    // Incremental reindex — called by watcher and public API
+    // -----------------------------------------------------------------------
+
+    /// Re-index a set of changed files for a project.
+    ///
+    /// Reads each file, chunks it, generates embeddings if available,
+    /// and upserts into the store. Files that no longer exist on disk are skipped.
+    #[cfg(feature = "builtin")]
+    #[cfg_attr(feature = "tracing", instrument(skip(self)))]
+    pub async fn reindex_files(
+        &self,
+        project_id: &str,
+        project_dir: &Path,
+        paths: &[std::path::PathBuf],
+    ) -> Result<()> {
+        let Backend::Builtin { store, embedder } = &self.backend else {
+            return Err(Error::IndexFailed {
+                project_id: project_id.to_string(),
+                message: "reindex_files only available with builtin backend".to_string(),
+            });
+        };
+
+        // Convert absolute paths to FilteredFile entries.
+        let files: Vec<FilteredFile> = paths
+            .iter()
+            .filter_map(|p| {
+                if !p.is_file() {
+                    return None;
+                }
+                let relative_path = p.strip_prefix(project_dir).unwrap_or(p).to_path_buf();
+                Some(FilteredFile {
+                    path: p.clone(),
+                    relative_path,
+                    size: p.metadata().map(|m| m.len()).unwrap_or(0),
+                    language: crate::types::Language::from_path(p),
+                })
+            })
+            .collect();
+
+        if files.is_empty() {
+            return Ok(());
+        }
+
+        let file_refs: Vec<&FilteredFile> = files.iter().collect();
+        self.index_files_builtin(project_id, &file_refs, store.as_ref(), embedder.as_deref())
+            .await?;
+
+        #[cfg(feature = "tracing")]
+
+        debug!(project_id, count = files.len(), "watcher reindex completed");
+        Ok(())
+    }
+
+    // -----------------------------------------------------------------------
+    // Builtin backend — indexing
+    // -----------------------------------------------------------------------
+
+    /// Incremental index: compute delta from previous snapshot, process changes only.
+    #[cfg(feature = "builtin")]
+    async fn index_incremental_builtin(
+        &self,
+        project_id: &str,
+        project_dir: &Path,
+        filtered: &[FilteredFile],
+        store: &dyn CodeIndexStore,
+        embedder: Option<&dyn moltis_memory::embeddings::EmbeddingProvider>,
+    ) -> Result<IndexStatus> {
+        #[cfg(feature = "tracing")]
+        info!(
+            project_id,
+            total = filtered.len(),
+            "starting incremental code index (builtin)"
+        );
+
+        store.initialize().await.map_err(|e| Error::IndexFailed {
+            project_id: project_id.to_string(),
+            message: format!("failed to initialize store: {e}"),
+        })?;
+
+        let previous_snapshot: HashSnapshot = self
+            .snapshot_store
+            .load(project_id)
+            .map_err(|e| Error::Store(e.to_string()))?
+            .unwrap_or_default();
+
+        if previous_snapshot.is_empty() {
+            // First index — full reindex required.
+            self.index_full_builtin(project_id, project_dir, filtered, store, embedder)
+                .await?;
+            return self.build_status_builtin(project_id, store, embedder).await;
+        }
+
+        // Compute delta from previous snapshot.
+        let (delta, current_snapshot) =
+            compute_delta(project_dir, &self.config, &previous_snapshot).map_err(|e| {
+                Error::IndexFailed {
+                    project_id: project_id.to_string(),
+                    message: format!("delta computation failed: {e}"),
+                }
+            })?;
+
+        #[cfg(feature = "tracing")]
+
+        info!(
+            project_id,
+            added = delta.added.len(),
+            modified = delta.modified.len(),
+            removed = delta.removed.len(),
+            "incremental delta computed"
+        );
+
+        // Process added + modified files.
+        let changed: Vec<&FilteredFile> = delta.added.iter().chain(delta.modified.iter()).collect();
+
+        if !changed.is_empty() {
+            self.index_files_builtin(project_id, &changed, store, embedder)
+                .await?;
+        }
+
+        // Delete chunks for removed files.
+        for removed_path in &delta.removed {
+            store
+                .delete_file_chunks(project_id, removed_path)
+                .await
+                .map_err(|e| Error::IndexFailed {
+                    project_id: project_id.to_string(),
+                    message: format!("failed to delete removed file chunks: {e}"),
+                })?;
+            #[cfg(feature = "tracing")]
+            debug!(path = %removed_path, "deleted chunks for removed file");
+        }
+
+        // Persist updated snapshot.
+        self.snapshot_store
+            .save(project_id, &current_snapshot)
+            .map_err(|e| Error::IndexFailed {
+                project_id: project_id.to_string(),
+                message: format!("failed to save snapshot: {e}"),
+            })?;
+
+        self.build_status_builtin(project_id, store, embedder).await
+    }
+
+    /// Full reindex: clear project and index all files from scratch.
+    #[cfg(feature = "builtin")]
+    async fn index_full_builtin(
+        &self,
+        project_id: &str,
+        _project_dir: &Path,
+        filtered: &[FilteredFile],
+        store: &dyn CodeIndexStore,
+        embedder: Option<&dyn moltis_memory::embeddings::EmbeddingProvider>,
+    ) -> Result<()> {
+        store.initialize().await.map_err(|e| Error::IndexFailed {
+            project_id: project_id.to_string(),
+            message: format!("failed to initialize store: {e}"),
+        })?;
+
+        store
+            .clear_project(project_id)
+            .await
+            .map_err(|e| Error::IndexFailed {
+                project_id: project_id.to_string(),
+                message: format!("failed to clear project: {e}"),
+            })?;
+
+        let file_refs: Vec<&FilteredFile> = filtered.iter().collect();
+        self.index_files_builtin(project_id, &file_refs, store, embedder)
+            .await?;
+
+        // Build and save the snapshot from the already-filtered files
+        // (avoids TOCTOU from double-scanning the filesystem).
+        let snapshot = build_snapshot_from_filtered(filtered);
+        self.snapshot_store
+            .save(project_id, &snapshot)
+            .map_err(|e| Error::IndexFailed {
+                project_id: project_id.to_string(),
+                message: format!("failed to save snapshot: {e}"),
+            })?;
+
+        Ok(())
+    }
+
+    /// Index a batch of files into the store (shared by full and incremental paths).
+    #[cfg(feature = "builtin")]
+    async fn index_files_builtin(
+        &self,
+        project_id: &str,
+        files: &[&FilteredFile],
+        store: &dyn CodeIndexStore,
+        embedder: Option<&dyn moltis_memory::embeddings::EmbeddingProvider>,
+    ) -> Result<()> {
+        use crate::{chunker::CodeChunker, store::CodeChunk as StoreChunk};
+
+        let chunker = CodeChunker::new(self.config.chunker());
+        let mut indexed = 0u64;
+        let mut errors = 0u64;
+
+        for file in files {
+            // file.path is absolute — use directly for disk reads.
+            // file.relative_path is the repo-relative path — used for storage and logging.
+            let content = match tokio::fs::read_to_string(&file.path).await {
+                Ok(c) => c,
+                Err(e) => {
+                    #[cfg(feature = "tracing")]
+                    warn!(
+                        path = %file.relative_path.display(),
+                        error = %e,
+                        "failed to read file, skipping"
+                    );
+                    errors += 1;
+                    continue;
+                },
+            };
+
+            let raw_chunks = chunker.chunk(&content, &file.relative_path.display().to_string());
+
+            // Generate embeddings for chunks if embedder is available.
+            let chunks: Vec<StoreChunk> = if let Some(emb) = embedder {
+                let texts: Vec<String> = raw_chunks.iter().map(|c| c.content.clone()).collect();
+                match emb.embed_batch(&texts).await {
+                    Ok(embeddings) => raw_chunks
+                        .into_iter()
+                        .zip(embeddings.into_iter())
+                        .enumerate()
+                        .map(|(idx, (chunk, embedding))| StoreChunk {
+                            file_path: chunk.file_path.clone(),
+                            chunk_index: idx,
+                            content: chunk.content,
+                            embedding: Some(embedding),
+                            start_line: chunk.start_line,
+                            end_line: chunk.end_line,
+                        })
+                        .collect(),
+                    Err(e) => {
+                        #[cfg(feature = "tracing")]
+                        warn!(
+                            path = %file.relative_path.display(),
+                            error = %e,
+                            "embedding failed for file, indexing without embeddings"
+                        );
+                        raw_chunks
+                            .into_iter()
+                            .enumerate()
+                            .map(|(idx, chunk)| StoreChunk {
+                                file_path: chunk.file_path.clone(),
+                                chunk_index: idx,
+                                content: chunk.content,
+                                embedding: None,
+                                start_line: chunk.start_line,
+                                end_line: chunk.end_line,
+                            })
+                            .collect()
+                    },
+                }
+            } else {
+                raw_chunks
+                    .into_iter()
+                    .enumerate()
+                    .map(|(idx, chunk)| StoreChunk {
+                        file_path: chunk.file_path.clone(),
+                        chunk_index: idx,
+                        content: chunk.content,
+                        embedding: None,
+                        start_line: chunk.start_line,
+                        end_line: chunk.end_line,
+                    })
+                    .collect()
+            };
+
+            if !chunks.is_empty() {
+                let file_path_str = file.relative_path.display().to_string();
+                store
+                    .upsert_chunks(project_id, &file_path_str, &chunks)
+                    .await
+                    .map_err(|e| Error::IndexFailed {
+                        project_id: project_id.to_string(),
+                        message: format!("failed to upsert chunks for {file_path_str}: {e}"),
+                    })?;
+                indexed += chunks.len() as u64;
+            }
+        }
+
+        #[cfg(feature = "tracing")]
+
+        info!(project_id, indexed, errors, "file batch indexed (builtin)");
+
+        Ok(())
+    }
+
+    // -----------------------------------------------------------------------
+    // Builtin backend — search
+    // -----------------------------------------------------------------------
+
+    /// Search using the builtin backend (hybrid keyword + vector).
+    #[cfg(feature = "builtin")]
+    async fn search_builtin(
+        &self,
+        project_id: &str,
+        query: &str,
+        limit: usize,
+        store: &dyn CodeIndexStore,
+        embedder: Option<&dyn moltis_memory::embeddings::EmbeddingProvider>,
+    ) -> Result<Vec<SearchResult>> {
+        // Always run keyword search via FTS5.
+        let keyword_results = store
+            .search_keyword(project_id, query, limit)
+            .await
+            .map_err(|e| Error::SearchFailed {
+                project_id: project_id.to_string(),
+                message: format!("keyword search failed: {e}"),
+            })?;
+
+        let Some(emb) = embedder else {
+            return Ok(keyword_results.into_iter().take(limit).collect());
+        };
+
+        // Generate query embedding.
+        let query_embedding = match emb.embed_batch(&[query.to_string()]).await {
+            Ok(mut embeddings) => {
+                // Invariant: passed one string, get one embedding back.
+                embeddings.pop().ok_or_else(|| {
+                    Error::IndexStore(
+                        "embed_batch returned empty result for single input".to_string(),
+                    )
+                })?
+            },
+            Err(e) => {
+                #[cfg(feature = "tracing")]
+                warn!(error = %e, "query embedding failed, falling back to keyword results");
+                return Ok(keyword_results.into_iter().take(limit).collect());
+            },
+        };
+
+        // PERF: loads ALL chunks into memory for brute-force vector search.
+        // For large projects (100k+ chunks) this could consume significant RAM.
+        // Consistent with the memory system's approach. A streaming or indexed
+        // approach would be needed for very large projects.
+        let chunks = store.get_project_chunks(project_id).await?;
+
+        // Score chunks by cosine similarity against the query embedding.
+        let mut scored_chunks: Vec<(f32, &crate::store::CodeChunk)> = Vec::new();
+        for chunk in &chunks {
+            let Some(ref chunk_emb) = chunk.embedding else {
+                continue;
+            };
+            let score = crate::store::cosine_similarity(&query_embedding, chunk_emb);
+            scored_chunks.push((score, chunk));
+        }
+
+        scored_chunks.sort_by(|a, b| b.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal));
+
+        let vector_results: Vec<SearchResult> = scored_chunks
+            .into_iter()
+            .take(limit)
+            .map(|(score, chunk)| SearchResult {
+                chunk_id: format!("{}:{}", chunk.file_path, chunk.start_line),
+                path: chunk.file_path.clone(),
+                text: peek_lines(&chunk.content, 0, 10),
+                start_line: chunk.start_line,
+                end_line: chunk.end_line,
+                score,
+                source: "builtin".to_string(),
+            })
+            .collect();
+
+        let merged = crate::store::merge_hybrid_results(vector_results, keyword_results, limit);
+        Ok(merged)
+    }
+
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    /// Build an [`IndexStatus`] from the current store counts.
+    #[cfg(feature = "builtin")]
+    async fn build_status_builtin(
+        &self,
+        project_id: &str,
+        store: &dyn CodeIndexStore,
+        embedder: Option<&dyn moltis_memory::embeddings::EmbeddingProvider>,
+    ) -> Result<IndexStatus> {
+        let total_chunks = store
+            .chunk_count(project_id)
+            .await
+            .map_err(|e| Error::IndexFailed {
+                project_id: project_id.to_string(),
+                message: format!("failed to count chunks: {e}"),
+            })?;
+        let total_files = store
+            .file_count(project_id)
+            .await
+            .map_err(|e| Error::IndexFailed {
+                project_id: project_id.to_string(),
+                message: format!("failed to count files: {e}"),
+            })?;
+
+        Ok(IndexStatus {
+            project_id: project_id.to_string(),
+            total_files,
+            total_chunks,
+            last_sync_ms: None,
+            embedding_model: embedder.map(|e| e.model_name().to_string()),
+            backend: "builtin".to_string(),
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Utility functions
+// ---------------------------------------------------------------------------
+
+/// Extract a range of lines from text content.
+#[cfg(feature = "builtin")]
+fn peek_lines(content: &str, start: usize, max_lines: usize) -> String {
+    let lines: Vec<&str> = content.lines().collect();
+    let end = (start + max_lines).min(lines.len());
+    if start >= lines.len() {
+        return String::new();
+    }
+    lines[start..end].join("\n")
+}
+#[cfg(all(test, feature = "builtin"))]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use {super::*, crate::store_sqlite::SqliteCodeIndexStore, async_trait::async_trait};
+
+    /// Mock embedder producing deterministic vectors from text content.
+    struct MockEmbedder {
+        dims: usize,
+    }
+
+    impl MockEmbedder {
+        fn new(dims: usize) -> Self {
+            Self { dims }
+        }
+    }
+
+    #[async_trait]
+    impl moltis_memory::embeddings::EmbeddingProvider for MockEmbedder {
+        async fn embed(&self, text: &str) -> anyhow::Result<Vec<f32>> {
+            let mut vec = vec![0.0f32; self.dims];
+            for (i, b) in text.as_bytes().iter().enumerate() {
+                vec[i % self.dims] += *b as f32 / 255.0;
+            }
+            let norm: f32 = vec.iter().map(|v| v * v).sum::<f32>().sqrt();
+            if norm > 0.0 {
+                for v in &mut vec {
+                    *v /= norm;
+                }
+            }
+            Ok(vec)
+        }
+
+        fn model_name(&self) -> &str {
+            "mock-embedder"
+        }
+
+        fn dimensions(&self) -> usize {
+            self.dims
+        }
+
+        fn provider_key(&self) -> &str {
+            "mock"
+        }
+    }
+
+    /// Embedder that always fails — for testing fallback paths.
+    struct FailingEmbedder;
+
+    #[async_trait]
+    impl moltis_memory::embeddings::EmbeddingProvider for FailingEmbedder {
+        async fn embed(&self, _text: &str) -> anyhow::Result<Vec<f32>> {
+            anyhow::bail!("embed failed")
+        }
+
+        fn model_name(&self) -> &str {
+            "failing"
+        }
+
+        fn dimensions(&self) -> usize {
+            8
+        }
+
+        fn provider_key(&self) -> &str {
+            "failing"
+        }
+    }
+
+    fn git_init(dir: &Path) {
+        let mut repo = gix::init(dir).expect("failed to init repo");
+        let mut config = repo.config_snapshot_mut();
+        config
+            .set_raw_value_by("user", None::<&gix::bstr::BStr>, "email", "test@test.com")
+            .expect("failed to set user.email");
+        config
+            .set_raw_value_by("user", None::<&gix::bstr::BStr>, "name", "Test")
+            .expect("failed to set user.name");
+    }
+
+    // NOTE: Uses std::process::Command intentionally. gix's index staging API
+    // (add_entry) is low-level and unstable across versions; `git add .` +
+    // `git commit -m` is the mature, reliable approach for test helpers.
+    fn git_commit_all(dir: &Path, msg: &str) {
+        std::process::Command::new("git")
+            .args(["-C", &dir.to_string_lossy(), "add", "."])
+            .output()
+            .unwrap();
+        std::process::Command::new("git")
+            .args(["-C", &dir.to_string_lossy(), "commit", "-m", msg])
+            .output()
+            .unwrap();
+    }
+
+    fn create_test_repo() -> tempfile::TempDir {
+        let dir = tempfile::TempDir::new().unwrap();
+        git_init(dir.path());
+
+        // Create test files with known content
+        std::fs::create_dir_all(dir.path().join("src")).unwrap();
+        std::fs::write(
+            dir.path().join("src/main.rs"),
+            "fn main() {\n    println!(\"hello world\");\n}\n",
+        )
+        .unwrap();
+        std::fs::write(
+            dir.path().join("src/lib.rs"),
+            "pub fn add(a: i32, b: i32) -> i32 {\n    a + b\n}\n",
+        )
+        .unwrap();
+        std::fs::write(dir.path().join("README.md"), "# Test Project\n\nA test.\n").unwrap();
+
+        git_commit_all(dir.path(), "initial");
+        dir
+    }
+
+    async fn make_store() -> SqliteCodeIndexStore {
+        // Use in-memory SQLite to avoid temp-file lifetime issues
+        let pool = sqlx::SqlitePool::connect(":memory:").await.unwrap();
+        SqliteCodeIndexStore::from_pool(pool).await.unwrap()
+    }
+
+    async fn setup_index() -> (CodeIndex, tempfile::TempDir, tempfile::TempDir) {
+        let repo = create_test_repo();
+        let store = make_store().await;
+        let data_dir = tempfile::tempdir().unwrap();
+        let config = CodeIndexConfig {
+            data_dir: Some(data_dir.path().to_path_buf()),
+            ..CodeIndexConfig::default()
+        };
+        let index = CodeIndex::new_builtin(config, Box::new(store), None);
+        (index, data_dir, repo)
+    }
+
+    async fn setup_index_with_embedder() -> (CodeIndex, tempfile::TempDir, tempfile::TempDir) {
+        let repo = create_test_repo();
+        let store = make_store().await;
+        let data_dir = tempfile::tempdir().unwrap();
+        let config = CodeIndexConfig {
+            data_dir: Some(data_dir.path().to_path_buf()),
+            ..CodeIndexConfig::default()
+        };
+        let embedder: Box<dyn moltis_memory::embeddings::EmbeddingProvider> =
+            Box::new(MockEmbedder::new(16));
+        let index = CodeIndex::new_builtin(config, Box::new(store), Some(embedder));
+        (index, data_dir, repo)
+    }
+
+    async fn setup_index_with_failing_embedder() -> (CodeIndex, tempfile::TempDir, tempfile::TempDir)
+    {
+        let repo = create_test_repo();
+        let store = make_store().await;
+        let data_dir = tempfile::tempdir().unwrap();
+        let config = CodeIndexConfig {
+            data_dir: Some(data_dir.path().to_path_buf()),
+            ..CodeIndexConfig::default()
+        };
+        let embedder: Box<dyn moltis_memory::embeddings::EmbeddingProvider> =
+            Box::new(FailingEmbedder);
+        let index = CodeIndex::new_builtin(config, Box::new(store), Some(embedder));
+        (index, data_dir, repo)
+    }
+
+    #[tokio::test]
+    async fn test_index_project_no_embedder() {
+        let (index, _data_dir, repo) = setup_index().await;
+        let status = index
+            .index_project("test-proj", false, repo.path())
+            .await
+            .unwrap();
+
+        assert_eq!(status.project_id, "test-proj");
+        assert!(status.total_files > 0, "should find at least one file");
+        assert!(status.total_chunks > 0, "should produce at least one chunk");
+        assert!(status.embedding_model.is_none());
+        assert_eq!(status.backend, "builtin");
+    }
+
+    #[tokio::test]
+    async fn test_index_and_keyword_search() {
+        let (index, _data_dir, repo) = setup_index().await;
+        index
+            .index_project("test-proj", false, repo.path())
+            .await
+            .unwrap();
+
+        let results = index.search("test-proj", "hello", 10).await.unwrap();
+        assert!(
+            !results.is_empty(),
+            "keyword search for 'hello' should find results"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_index_and_keyword_search_miss() {
+        let (index, _data_dir, repo) = setup_index().await;
+        index
+            .index_project("test-proj", false, repo.path())
+            .await
+            .unwrap();
+
+        let results = index
+            .search("test-proj", "nonexistent_xyzzy", 10)
+            .await
+            .unwrap();
+        assert!(results.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_index_clears_old_data() {
+        let (index, _data_dir, repo) = setup_index().await;
+
+        let s1 = index
+            .index_project("test-proj", false, repo.path())
+            .await
+            .unwrap();
+        let s2 = index
+            .index_project("test-proj", false, repo.path())
+            .await
+            .unwrap();
+
+        // Second index should replace, not duplicate
+        assert_eq!(s1.total_files, s2.total_files);
+        assert_eq!(s1.total_chunks, s2.total_chunks);
+    }
+
+    #[tokio::test]
+    async fn test_index_multiple_projects() {
+        let (index, _data_dir, repo1) = setup_index().await;
+        let repo2 = create_test_repo();
+
+        // Modify repo2 to have distinct content
+        std::fs::write(
+            repo2.path().join("README.md"),
+            "# Different\n\nUnique content here.\n",
+        )
+        .unwrap();
+        git_commit_all(repo2.path(), "update readme");
+
+        index
+            .index_project("proj-a", false, repo1.path())
+            .await
+            .unwrap();
+        index
+            .index_project("proj-b", false, repo2.path())
+            .await
+            .unwrap();
+
+        // Searches should be scoped
+        let results_a = index.search("proj-a", "hello", 10).await.unwrap();
+        let results_b = index.search("proj-b", "hello", 10).await.unwrap();
+
+        // proj-a has "hello world" in main.rs, proj-b also has it
+        // but searches are scoped so they don't cross-contaminate
+        assert!(results_a.len() <= results_b.len() + 10); // sanity check
+    }
+
+    #[tokio::test]
+    async fn test_search_with_mock_embedder() {
+        let (index, _data_dir, repo) = setup_index_with_embedder().await;
+        index
+            .index_project("test-proj", true, repo.path())
+            .await
+            .unwrap();
+
+        let status = index.status("test-proj").await.unwrap();
+        assert_eq!(status.embedding_model, Some("mock-embedder".to_string()));
+
+        // Search should work — vector results should be present
+        let results = index.search("test-proj", "main", 10).await.unwrap();
+        assert!(!results.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_search_embedder_failure_fallback() {
+        let (index, _data_dir, repo) = setup_index_with_failing_embedder().await;
+        index
+            .index_project("test-proj", true, repo.path())
+            .await
+            .unwrap();
+
+        // Embeddings will fail during indexing (warned + chunks stored without embeddings)
+        // and during search the query embedding will fail, falling back to keyword results
+        let results = index.search("test-proj", "hello", 10).await.unwrap();
+        assert!(
+            !results.is_empty(),
+            "should fall back to keyword results even when embedder fails"
+        );
+    }
+}

--- a/crates/code-index/src/index.rs
+++ b/crates/code-index/src/index.rs
@@ -627,19 +627,43 @@ impl CodeIndex {
             let chunks: Vec<StoreChunk> = if let Some(emb) = embedder {
                 let texts: Vec<String> = raw_chunks.iter().map(|c| c.content.clone()).collect();
                 match emb.embed_batch(&texts).await {
-                    Ok(embeddings) => raw_chunks
-                        .into_iter()
-                        .zip(embeddings.into_iter())
-                        .enumerate()
-                        .map(|(idx, (chunk, embedding))| StoreChunk {
-                            file_path: chunk.file_path.clone(),
-                            chunk_index: idx,
-                            content: chunk.content,
-                            embedding: Some(embedding),
-                            start_line: chunk.start_line,
-                            end_line: chunk.end_line,
-                        })
-                        .collect(),
+                    Ok(embeddings) => {
+                        if embeddings.len() != raw_chunks.len() {
+                            #[cfg(feature = "tracing")]
+                            warn!(
+                                expected = raw_chunks.len(),
+                                actual = embeddings.len(),
+                                path = %file.relative_path.display(),
+                                "embed_batch returned mismatched count, indexing without embeddings"
+                            );
+                            raw_chunks
+                                .into_iter()
+                                .enumerate()
+                                .map(|(idx, chunk)| StoreChunk {
+                                    file_path: chunk.file_path.clone(),
+                                    chunk_index: idx,
+                                    content: chunk.content,
+                                    embedding: None,
+                                    start_line: chunk.start_line,
+                                    end_line: chunk.end_line,
+                                })
+                                .collect()
+                        } else {
+                            raw_chunks
+                                .into_iter()
+                                .zip(embeddings.into_iter())
+                                .enumerate()
+                                .map(|(idx, (chunk, embedding))| StoreChunk {
+                                    file_path: chunk.file_path.clone(),
+                                    chunk_index: idx,
+                                    content: chunk.content,
+                                    embedding: Some(embedding),
+                                    start_line: chunk.start_line,
+                                    end_line: chunk.end_line,
+                                })
+                                .collect()
+                        }
+                    }
                     Err(e) => {
                         #[cfg(feature = "tracing")]
                         warn!(

--- a/crates/code-index/src/lib.rs
+++ b/crates/code-index/src/lib.rs
@@ -1,0 +1,75 @@
+//! Code-index crate for Moltis — workspace codebase intelligence.
+//!
+//! Supports multiple backends:
+//! - **QMD** (optional, `qmd` feature): External QMD binary for hybrid search.
+//! - **Builtin** (optional, `builtin` feature): SQLite + FTS5 with embeddings.
+//! - **Config-only**: File discovery and filtering without search.
+
+// Core modules (always available).
+pub mod chunker;
+pub mod config;
+pub mod delta;
+pub mod discover;
+pub mod error;
+pub mod filter;
+pub mod index;
+#[cfg(feature = "tracing")]
+pub mod log;
+pub mod snapshot_store;
+pub mod store;
+pub mod types;
+
+// Optional backends, gated behind feature flags.
+#[cfg(feature = "qmd")]
+pub mod backend_qmd;
+
+#[cfg(feature = "builtin")]
+pub mod store_sqlite;
+
+#[cfg(feature = "file-watcher")]
+pub mod watcher;
+
+// Search result adapter (only relevant with QMD).
+#[cfg(feature = "qmd")]
+pub mod search;
+
+// Agent tools (only relevant with search backend).
+#[cfg(any(feature = "qmd", feature = "builtin"))]
+pub mod tools;
+
+// Re-exports for convenience.
+pub use {
+    config::CodeIndexConfig,
+    delta::{FileMeta, HashSnapshot},
+    error::{Error, Result},
+    index::CodeIndex,
+    types::{IndexStatus, SearchResult},
+};
+
+/// Utility function to sanitize a project ID for use as a QMD collection name.
+pub fn sanitize_project_id(project_id: &str) -> String {
+    project_id
+        .chars()
+        .map(|c| {
+            if c.is_alphanumeric() || c == '-' || c == '_' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}
+
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_sanitize_project_id() {
+        assert_eq!(sanitize_project_id("my/project"), "my_project");
+        assert_eq!(sanitize_project_id("hello world"), "hello_world");
+        assert_eq!(sanitize_project_id("foo-bar_baz"), "foo-bar_baz");
+    }
+}

--- a/crates/code-index/src/log.rs
+++ b/crates/code-index/src/log.rs
@@ -1,0 +1,11 @@
+//! Internal tracing re-exports.
+//!
+//! Source files that need tracing should do:
+//! ```ignore
+//! use crate::log::{debug, info, warn, trace, error};
+//! ```
+//!
+//! The `tracing` feature flag is always-on (part of default features).
+//! The `metrics` feature flag is opt-in for recording metrics at key points.
+
+pub(crate) use tracing::{debug, info, trace, warn};

--- a/crates/code-index/src/search.rs
+++ b/crates/code-index/src/search.rs
@@ -1,0 +1,114 @@
+//! Code index search result adapter.
+//!
+//! Converts QMD search results into the crate's own [`SearchResult`] type,
+//! keeping the public API decoupled from the QMD wire format.
+
+use crate::types::SearchResult;
+
+#[cfg(feature = "qmd")]
+use moltis_qmd::QmdSearchResult;
+
+/// Convert a [`QmdSearchResult`] into our crate-level [`SearchResult`].
+///
+/// Maps QMD fields to code-index fields, deriving the chunk ID from
+/// the file path and line number.  The `end_line` is computed from
+/// whichever text payload `text()` would return (preferring `body`
+/// over `snippet`), so the line range is consistent with the text.
+#[cfg(feature = "qmd")]
+pub fn from_qmd(result: &QmdSearchResult, project_id: &str) -> SearchResult {
+    let text = result.text();
+    let start_line = (result.line as usize).max(1);
+    let end_line = if text.is_empty() {
+        start_line
+    } else {
+        start_line + text.lines().count().saturating_sub(1)
+    };
+
+    SearchResult {
+        chunk_id: format!("{}:{}:{}", project_id, result.file, start_line),
+        path: result.file.clone(),
+        start_line,
+        end_line,
+        score: result.score,
+        text,
+        source: "qmd".to_string(),
+    }
+}
+
+/// Convert multiple QMD results.
+#[cfg(feature = "qmd")]
+pub fn from_qmd_results(results: &[QmdSearchResult], project_id: &str) -> Vec<SearchResult> {
+    results.iter().map(|r| from_qmd(r, project_id)).collect()
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    #[cfg(feature = "qmd")]
+    #[test]
+    fn test_from_qmd_maps_fields() {
+        let qmd = QmdSearchResult {
+            docid: "test.rs#42".to_string(),
+            file: "src/test.rs".to_string(),
+            line: 42,
+            score: 0.95,
+            title: None,
+            context: None,
+            snippet: Some("fn main() {}".to_string()),
+            body: None,
+        };
+
+        let result = from_qmd(&qmd, "my-project");
+        assert_eq!(result.path, "src/test.rs");
+        assert_eq!(result.start_line, 42);
+        assert_eq!(result.end_line, 42); // single-line snippet
+        assert_eq!(result.score, 0.95);
+        assert!(result.chunk_id.contains("my-project"));
+        assert_eq!(result.source, "qmd");
+        assert_eq!(result.text, "fn main() {}"); // text prefers snippet when body is None
+    }
+
+    #[cfg(feature = "qmd")]
+    #[test]
+    fn test_from_qmd_uses_body_over_snippet() {
+        let qmd = QmdSearchResult {
+            docid: "test.rs#10".to_string(),
+            file: "src/lib.rs".to_string(),
+            line: 10,
+            score: 0.8,
+            title: None,
+            context: None,
+            snippet: Some("short".to_string()),
+            body: Some("line one\nline two\nline three".to_string()),
+        };
+
+        let result = from_qmd(&qmd, "proj");
+        // text() prefers body over snippet
+        assert_eq!(result.text, "line one\nline two\nline three");
+        // end_line should be derived from body (3 lines), not snippet (1 line)
+        assert_eq!(result.start_line, 10);
+        assert_eq!(result.end_line, 12); // line 10 + 3 lines - 1
+    }
+
+    #[cfg(feature = "qmd")]
+    #[test]
+    fn test_from_qmd_empty_text() {
+        let qmd = QmdSearchResult {
+            docid: "test.rs#5".to_string(),
+            file: "src/mod.rs".to_string(),
+            line: 5,
+            score: 0.5,
+            title: None,
+            context: None,
+            snippet: None,
+            body: None,
+        };
+
+        let result = from_qmd(&qmd, "proj");
+        assert_eq!(result.text, "");
+        assert_eq!(result.start_line, 5);
+        assert_eq!(result.end_line, 5); // single line when no text
+    }
+}

--- a/crates/code-index/src/snapshot_store.rs
+++ b/crates/code-index/src/snapshot_store.rs
@@ -1,0 +1,298 @@
+//! File-backed persistence for index snapshots.
+//!
+//! Stores [`HashSnapshot`] as JSON files under `<data_dir>/code-index/<project_id>.json`.
+//! Uses atomic writes (write to temp, rename over target) to prevent partial-read corruption.
+//! Project IDs are sanitized against path traversal before use as filenames.
+
+use std::path::PathBuf;
+
+#[cfg(feature = "tracing")]
+use crate::log::debug;
+
+use crate::{
+    delta::HashSnapshot,
+    error::{Error, Result},
+};
+
+/// Directory name under the data dir for snapshot files.
+const SNAPSHOT_DIR: &str = "code-index";
+
+/// Persistent file-backed store for index snapshots.
+///
+/// Each project gets its own JSON file: `<base_dir>/<sanitized_project_id>.json`.
+/// The store is decoupled from SQLite — no migration coupling, no shared pool.
+#[derive(Debug, Clone)]
+pub struct SnapshotStore {
+    base_dir: PathBuf,
+}
+
+impl SnapshotStore {
+    /// Create a store rooted at the given directory.
+    ///
+    /// The directory is created on first write if it does not exist.
+    pub fn new(base_dir: PathBuf) -> Self {
+        Self { base_dir }
+    }
+
+    /// Create a store using the default data directory layout.
+    ///
+    /// Resolves to `<moltis_data_dir>/code-index/`.
+    pub fn default_path() -> Self {
+        let base_dir = moltis_config::data_dir().join(SNAPSHOT_DIR);
+        Self::new(base_dir)
+    }
+
+    /// Load the most recent snapshot for a project.
+    ///
+    /// Returns `Ok(None)` if no snapshot file exists (first run or deleted).
+    /// If the file exists but uses an outdated snapshot format, returns
+    /// `Ok(None)` to trigger a full reindex.
+    pub fn load(&self, project_id: &str) -> Result<Option<HashSnapshot>> {
+        let path = self.project_path(project_id)?;
+        if !path.exists() {
+            #[cfg(feature = "tracing")]
+            debug!(project_id, "no snapshot file found, starting fresh");
+            return Ok(None);
+        }
+        let data = std::fs::read_to_string(&path).map_err(|e| {
+            Error::Store(format!(
+                "failed to read snapshot for project {project_id}: {e}"
+            ))
+        })?;
+
+        // Try deserializing as the current format (HashMap<String, FileMeta>).
+        // If that fails, try the legacy format (HashMap<String, String>) and
+        // discard it — a full reindex is cheaper than migration logic.
+        match serde_json::from_str::<HashSnapshot>(&data) {
+            Ok(snapshot) => Ok(Some(snapshot)),
+            Err(_) => {
+                #[cfg(feature = "tracing")]
+                debug!(
+                    project_id,
+                    "snapshot format outdated, will trigger full reindex"
+                );
+                Ok(None)
+            },
+        }
+    }
+
+    /// Save a snapshot for a project.
+    ///
+    /// Uses atomic write (temp file + rename) to prevent partial-write corruption.
+    pub fn save(&self, project_id: &str, snapshot: &HashSnapshot) -> Result<()> {
+        let path = self.project_path(project_id)?;
+
+        // Ensure the base directory exists.
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).map_err(|e| {
+                Error::Store(format!(
+                    "failed to create snapshot directory for project {project_id}: {e}"
+                ))
+            })?;
+        }
+
+        let json = serde_json::to_string_pretty(snapshot).map_err(|e| {
+            Error::Store(format!(
+                "failed to serialize snapshot for project {project_id}: {e}"
+            ))
+        })?;
+
+        // Write to a temp file in the same directory (guaranteed same filesystem
+        // for atomic rename), then persist over the target.
+        let parent = path.parent().unwrap_or_else(|| std::path::Path::new("."));
+        let mut temp_file = tempfile::NamedTempFile::new_in(parent).map_err(|e| {
+            Error::Store(format!(
+                "failed to create temp snapshot for project {project_id}: {e}"
+            ))
+        })?;
+        use std::io::Write;
+        temp_file.write_all(json.as_bytes()).map_err(|e| {
+            Error::Store(format!(
+                "failed to write temp snapshot for project {project_id}: {e}"
+            ))
+        })?;
+        temp_file.persist(&path).map_err(|e| {
+            Error::Store(format!(
+                "failed to commit snapshot for project {project_id}: {e}"
+            ))
+        })?;
+
+        #[cfg(feature = "tracing")]
+        debug!(project_id, entries = snapshot.len(), "snapshot saved");
+        Ok(())
+    }
+
+    /// Delete the snapshot file for a project.
+    ///
+    /// Returns `Ok(())` even if no file existed.
+    pub fn delete(&self, project_id: &str) -> Result<()> {
+        let path = self.project_path(project_id)?;
+        match std::fs::remove_file(&path) {
+            Ok(()) => {
+                #[cfg(feature = "tracing")]
+                debug!(project_id, "snapshot deleted");
+            },
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                // Already gone — this is fine per our contract.
+            },
+            Err(e) => {
+                return Err(Error::Store(format!(
+                    "failed to delete snapshot for project {project_id}: {e}"
+                )));
+            },
+        }
+        Ok(())
+    }
+
+    /// Resolve a project ID to its snapshot file path.
+    ///
+    /// Sanitizes the project ID against path traversal before using it as a filename.
+    fn project_path(&self, project_id: &str) -> Result<PathBuf> {
+        let safe_id = sanitize_project_id(project_id)?;
+        Ok(self.base_dir.join(format!("{safe_id}.json")))
+    }
+}
+
+/// Sanitize a project ID for use as a filename.
+///
+/// Rejects IDs that contain path separators, traversal sequences, or null bytes.
+/// Returns the sanitized ID on success.
+fn sanitize_project_id(id: &str) -> Result<&str> {
+    if id.is_empty() {
+        return Err(Error::Store("project ID must not be empty".into()));
+    }
+    if id.contains('/') || id.contains('\\') || id.contains("..") || id.contains('\0') {
+        return Err(Error::Store(format!(
+            "project ID contains forbidden characters: {id:?}"
+        )));
+    }
+    // Also reject if the ID, when used as a filename, would resolve outside the base dir.
+    // The checks above already prevent traversal, but be defensive.
+    if id == "." || id == ".." {
+        return Err(Error::Store(format!(
+            "project ID must not be a directory traversal: {id:?}"
+        )));
+    }
+    Ok(id)
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use crate::delta::FileMeta;
+
+    fn fake_meta(hash: &str) -> FileMeta {
+        FileMeta {
+            content_hash: hash.to_string(),
+            modified_time: 1000,
+            size: 42,
+        }
+    }
+
+    #[test]
+    fn test_sanitize_rejects_traversal() {
+        assert!(sanitize_project_id("../etc/passwd").is_err());
+        assert!(sanitize_project_id("foo/../../bar").is_err());
+        assert!(sanitize_project_id("foo\\..\\bar").is_err());
+        assert!(sanitize_project_id("foo\0bar").is_err());
+        assert!(sanitize_project_id("..").is_err());
+        assert!(sanitize_project_id(".").is_err());
+        assert!(sanitize_project_id("").is_err());
+    }
+
+    #[test]
+    fn test_sanitize_accepts_valid_ids() {
+        assert_eq!(sanitize_project_id("my-project").unwrap(), "my-project");
+        assert_eq!(sanitize_project_id("project_123").unwrap(), "project_123");
+        assert_eq!(
+            sanitize_project_id("org.repo#main").unwrap(),
+            "org.repo#main"
+        );
+    }
+
+    #[test]
+    fn test_sanitize_rejects_slashes() {
+        assert!(sanitize_project_id("org/repo").is_err());
+        assert!(sanitize_project_id("a/b").is_err());
+    }
+
+    #[test]
+    fn test_roundtrip() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = SnapshotStore::new(tmp.path().to_path_buf());
+
+        let mut snapshot = HashSnapshot::new();
+        snapshot.insert("src/main.rs".into(), fake_meta("abc123"));
+        snapshot.insert("src/lib.rs".into(), fake_meta("def456"));
+
+        store.save("test-project", &snapshot).unwrap();
+
+        let loaded = store
+            .load("test-project")
+            .unwrap()
+            .expect("should have snapshot");
+        assert_eq!(loaded, snapshot);
+    }
+
+    #[test]
+    fn test_load_missing_returns_none() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = SnapshotStore::new(tmp.path().to_path_buf());
+
+        let result = store.load("nonexistent").unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_overwrite() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = SnapshotStore::new(tmp.path().to_path_buf());
+
+        let mut s1 = HashSnapshot::new();
+        s1.insert("a.rs".into(), fake_meta("111"));
+        store.save("proj", &s1).unwrap();
+
+        let mut s2 = HashSnapshot::new();
+        s2.insert("b.rs".into(), fake_meta("222"));
+        store.save("proj", &s2).unwrap();
+
+        let loaded = store.load("proj").unwrap().unwrap();
+        assert_eq!(loaded, s2);
+        assert!(!loaded.contains_key("a.rs"));
+    }
+
+    #[test]
+    fn test_delete() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = SnapshotStore::new(tmp.path().to_path_buf());
+
+        let snapshot = HashSnapshot::from([("a.rs".into(), fake_meta("111"))]);
+        store.save("proj", &snapshot).unwrap();
+        assert!(store.load("proj").unwrap().is_some());
+
+        store.delete("proj").unwrap();
+        assert!(store.load("proj").unwrap().is_none());
+    }
+
+    #[test]
+    fn test_delete_nonexistent_is_ok() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = SnapshotStore::new(tmp.path().to_path_buf());
+        store.delete("nothing-here").unwrap();
+    }
+
+    #[test]
+    fn test_project_path_uses_sanitized_id() {
+        let store = SnapshotStore::new(PathBuf::from("/tmp/snapshots"));
+        let path = store.project_path("my-project").unwrap();
+        assert_eq!(path, PathBuf::from("/tmp/snapshots/my-project.json"));
+    }
+
+    #[test]
+    fn test_traversal_project_id_rejected() {
+        let store = SnapshotStore::new(PathBuf::from("/tmp/snapshots"));
+        let result = store.project_path("../../etc/passwd");
+        assert!(result.is_err());
+    }
+}

--- a/crates/code-index/src/store.rs
+++ b/crates/code-index/src/store.rs
@@ -1,0 +1,251 @@
+//! Storage backend trait for code-index.
+//!
+//! Abstracts over SQLite (builtin) and potential future backends.
+
+use {async_trait::async_trait, std::collections::HashMap};
+
+use crate::{error::Result, types::SearchResult};
+
+/// A chunk of code with optional embedding.
+#[derive(Debug, Clone)]
+pub struct CodeChunk {
+    /// File path relative to project root.
+    pub file_path: String,
+    /// Chunk sequence index within the file.
+    pub chunk_index: usize,
+    /// Content of the chunk.
+    pub content: String,
+    /// Optional embedding vector (f32 for compute, stored as quantized i8).
+    pub embedding: Option<Vec<f32>>,
+    /// Start line number (1-indexed).
+    pub start_line: usize,
+    /// End line number (1-indexed, inclusive).
+    pub end_line: usize,
+}
+
+/// Storage backend for code-index.
+#[async_trait]
+pub trait CodeIndexStore: Send + Sync {
+    /// Initialize the store (create tables, indexes, etc).
+    async fn initialize(&self) -> Result<()>;
+
+    /// Insert or replace chunks for a file within a project.
+    async fn upsert_chunks(
+        &self,
+        project_id: &str,
+        file_path: &str,
+        chunks: &[CodeChunk],
+    ) -> Result<()>;
+
+    /// Delete all chunks for a file.
+    async fn delete_file_chunks(&self, project_id: &str, file_path: &str) -> Result<()>;
+
+    /// Delete all chunks for a project.
+    async fn clear_project(&self, project_id: &str) -> Result<()>;
+
+    /// Get all chunks for a project (for brute-force vector search).
+    async fn get_project_chunks(&self, project_id: &str) -> Result<Vec<CodeChunk>>;
+
+    /// Full-text search using FTS5.
+    async fn search_keyword(
+        &self,
+        project_id: &str,
+        query: &str,
+        limit: usize,
+    ) -> Result<Vec<SearchResult>>;
+
+    /// Get indexed file count for status.
+    async fn file_count(&self, project_id: &str) -> Result<usize>;
+
+    /// Get total chunk count for status.
+    async fn chunk_count(&self, project_id: &str) -> Result<usize>;
+}
+
+/// Merge vector and keyword search results using reciprocal rank fusion.
+pub fn merge_hybrid_results(
+    vector_results: Vec<SearchResult>,
+    keyword_results: Vec<SearchResult>,
+    limit: usize,
+) -> Vec<SearchResult> {
+    let k = 60.0; // RRF constant
+    let mut scores: HashMap<String, (SearchResult, f64)> = HashMap::new();
+
+    // Score vector results
+    for (rank, result) in vector_results.iter().enumerate() {
+        let key = format!("{}:{}", result.path, result.start_line);
+        let score = 1.0 / (k + rank as f64);
+        scores.entry(key).or_insert((result.clone(), 0.0)).1 += score;
+    }
+
+    // Score keyword results
+    for (rank, result) in keyword_results.iter().enumerate() {
+        let key = format!("{}:{}", result.path, result.start_line);
+        let score = 1.0 / (k + rank as f64);
+        scores.entry(key).or_insert((result.clone(), 0.0)).1 += score;
+    }
+
+    // Sort by combined score descending
+    let mut results: Vec<(SearchResult, f64)> = scores.into_values().collect();
+    results.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+
+    results.into_iter().take(limit).map(|(r, _)| r).collect()
+}
+
+/// Cosine similarity between two vectors.
+pub fn cosine_similarity(a: &[f32], b: &[f32]) -> f32 {
+    if a.len() != b.len() {
+        return 0.0;
+    }
+
+    let dot_product: f32 = a.iter().zip(b.iter()).map(|(x, y)| x * y).sum();
+    let norm_a: f32 = a.iter().map(|x| x * x).sum::<f32>().sqrt();
+    let norm_b: f32 = b.iter().map(|x| x * x).sum::<f32>().sqrt();
+
+    if norm_a == 0.0 || norm_b == 0.0 {
+        return 0.0;
+    }
+
+    dot_product / (norm_a * norm_b)
+}
+
+/// Quantize f32 embeddings to i8 for storage.
+///
+/// **Tradeoff:** Saves ~4× space (1 byte vs 4 bytes per dimension) but clamps values
+/// to [-1.0, 1.0] before scaling. This is safe for normalized embedding models (most
+/// produce unit-length vectors where components naturally fall in this range), but
+/// silently destroys magnitude information for non-normalized models. The memory system
+/// stores full f32 vectors; this backend quantizes for lower disk usage at the cost of
+/// reduced recall on non-normalized inputs.
+pub fn quantize(embedding: &[f32]) -> Vec<i8> {
+    embedding
+        .iter()
+        .map(|&v| {
+            // Scale to [-127, 127] range
+            (v.clamp(-1.0, 1.0) * 127.0).round() as i8
+        })
+        .collect()
+}
+
+/// Dequantize i8 embeddings back to f32 for compute.
+pub fn dequantize(embedding: &[i8]) -> Vec<f32> {
+    embedding.iter().map(|&v| v as f32 / 127.0).collect()
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    fn make_result(path: &str, start_line: usize, score: f32) -> SearchResult {
+        SearchResult {
+            chunk_id: format!("{path}:{start_line}"),
+            path: path.to_string(),
+            text: "test content".into(),
+            start_line,
+            end_line: start_line + 5,
+            score,
+            source: "builtin".into(),
+        }
+    }
+
+    #[test]
+    fn test_cosine_similarity_identical() {
+        let v = vec![1.0, 0.0, 0.0];
+        let sim = cosine_similarity(&v, &v);
+        assert!((sim - 1.0).abs() < 1e-6, "expected ~1.0, got {sim}");
+    }
+
+    #[test]
+    fn test_cosine_similarity_orthogonal() {
+        let sim = cosine_similarity(&[1.0, 0.0], &[0.0, 1.0]);
+        assert!((sim - 0.0).abs() < 1e-6, "expected ~0.0, got {sim}");
+    }
+
+    #[test]
+    fn test_cosine_similarity_opposite() {
+        let sim = cosine_similarity(&[1.0, 0.0], &[-1.0, 0.0]);
+        assert!((sim - (-1.0)).abs() < 1e-6, "expected ~-1.0, got {sim}");
+    }
+
+    #[test]
+    fn test_cosine_similarity_dimension_mismatch() {
+        let sim = cosine_similarity(&[1.0], &[1.0, 2.0]);
+        assert_eq!(sim, 0.0);
+    }
+
+    #[test]
+    fn test_cosine_similarity_zero_vector() {
+        let sim = cosine_similarity(&[0.0, 0.0], &[1.0, 0.0]);
+        assert_eq!(sim, 0.0);
+    }
+
+    #[test]
+    fn test_quantize_dequantize_roundtrip() {
+        let original = vec![0.5, -0.3, 0.8];
+        let quantized = quantize(&original);
+        let restored = dequantize(&quantized);
+        for (orig, rest) in original.iter().zip(restored.iter()) {
+            assert!(
+                (orig - rest).abs() < 0.02,
+                "original {orig} vs restored {rest}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_quantize_clamps_large_values() {
+        // Values outside [-1, 1] should be clamped, not cause overflow
+        let quantized = quantize(&[5.0, -10.0, 0.5]);
+        let restored = dequantize(&quantized);
+        assert!(
+            restored[0] <= 1.01,
+            "clamped high value should be ~1.0, got {}",
+            restored[0]
+        );
+        assert!(
+            restored[1] >= -1.01,
+            "clamped low value should be ~-1.0, got {}",
+            restored[1]
+        );
+        assert!(
+            (restored[2] - 0.5).abs() < 0.02,
+            "in-range value preserved, got {}",
+            restored[2]
+        );
+    }
+
+    #[test]
+    fn test_merge_hybrid_results_pure_keyword() {
+        let keyword = vec![make_result("a.rs", 1, 0.8), make_result("b.rs", 1, 0.6)];
+        let merged = merge_hybrid_results(vec![], keyword, 10);
+        assert_eq!(merged.len(), 2);
+    }
+
+    #[test]
+    fn test_merge_hybrid_results_rrf_boosting() {
+        // A result that appears in BOTH vector and keyword sets should rank
+        // higher than a result that appears in only one set.
+        let shared = make_result("shared.rs", 1, 0.9);
+        let keyword_only = make_result("kw_only.rs", 1, 0.95);
+        let vector_only = make_result("vec_only.rs", 1, 0.85);
+
+        let vector_results = vec![shared.clone(), vector_only];
+        let keyword_results = vec![shared, keyword_only];
+
+        let merged = merge_hybrid_results(vector_results, keyword_results, 10);
+        assert_eq!(merged.len(), 3);
+        // shared.rs should be first (boosted by appearing in both)
+        assert_eq!(merged[0].path, "shared.rs");
+    }
+
+    #[test]
+    fn test_merge_hybrid_results_limit() {
+        let results: Vec<SearchResult> = (0..10)
+            .map(|i| make_result("f.rs", i + 1, 1.0 / (i as f32 + 1.0)))
+            .collect();
+
+        // Put all 10 in keyword, none in vector
+        let merged = merge_hybrid_results(vec![], results, 3);
+        assert_eq!(merged.len(), 3);
+    }
+}

--- a/crates/code-index/src/store_sqlite.rs
+++ b/crates/code-index/src/store_sqlite.rs
@@ -24,6 +24,56 @@ pub async fn run_migrations(pool: &SqlitePool) -> Result<()> {
         .map_err(|e| Error::IndexStore(format!("code-index migration failed: {e}")))
 }
 
+/// Escape a user query for safe use as an FTS5 MATCH expression.
+///
+/// FTS5 has its own query language (supports AND, OR, NOT, NEAR, phrase literals).
+/// Passing raw input causes parse errors on unbalanced quotes or boolean operators.
+/// We quote the entire query as a phrase literal, escaping internal double-quotes.
+fn escape_fts5_query(query: &str) -> String {
+    let escaped = query.replace('"', "\"\"");
+    format!("\"{escaped}\"")
+}
+
+#[cfg(test)]
+mod fts5_tests {
+    use super::escape_fts5_query;
+
+    #[test]
+    fn normal_query() {
+        assert_eq!(escape_fts5_query("hello world"), "\"hello world\"");
+    }
+
+    #[test]
+    fn query_with_quotes() {
+        assert_eq!(
+            escape_fts5_query("find the \"auth\" middleware"),
+            "\"find the \"\"auth\"\" middleware\""
+        );
+    }
+
+    #[test]
+    fn query_with_boolean_ops() {
+        // Quoted as phrase literal — operators become literal text
+        assert_eq!(
+            escape_fts5_query("hello AND world OR NOT"),
+            "\"hello AND world OR NOT\""
+        );
+    }
+
+    #[test]
+    fn empty_query() {
+        assert_eq!(escape_fts5_query(""), "\"\"");
+    }
+
+    #[test]
+    fn query_with_backslash() {
+        // Backslashes pass through — FTS5 phrase literals do not escape them.
+        let input = r"path	oile";
+        let expected = r#""path	oile""#;
+        assert_eq!(escape_fts5_query(input), expected);
+    }
+}
+
 /// SQLite-backed code index store.
 pub struct SqliteCodeIndexStore {
     pool: SqlitePool,
@@ -211,7 +261,10 @@ impl CodeIndexStore for SqliteCodeIndexStore {
     ) -> Result<Vec<SearchResult>> {
         let mut conn = self.conn().await?;
 
-        // FTS5 query with project filter via JOIN
+        // FTS5 query with project filter via JOIN.
+        // Query is escaped as a phrase literal to prevent FTS5 parse errors
+        // on unbalanced quotes or boolean operators from LLM-generated input.
+        let safe_query = escape_fts5_query(query);
         let rows = sqlx::query(
             r#"
             SELECT
@@ -223,12 +276,12 @@ impl CodeIndexStore for SqliteCodeIndexStore {
             JOIN code_chunks_fts fts ON c.id = fts.rowid
             WHERE c.project_id = ?
                 AND code_chunks_fts MATCH ?
-            ORDER BY rank
+            ORDER BY fts.rank
             LIMIT ?
             "#,
         )
         .bind(project_id)
-        .bind(query)
+        .bind(&safe_query)
         .bind(limit as i64)
         .fetch_all(&mut *conn)
         .await

--- a/crates/code-index/src/store_sqlite.rs
+++ b/crates/code-index/src/store_sqlite.rs
@@ -1,0 +1,612 @@
+//! SQLite + FTS5 storage backend for code-index.
+//!
+//! Stores chunks with quantized i8 embeddings and uses FTS5 for keyword search.
+//! Vector similarity is done in-memory (brute-force) following the memory system pattern.
+
+use std::path::Path;
+
+use {
+    async_trait::async_trait,
+    sqlx::{Acquire, Row, SqlitePool, sqlite::SqliteConnectOptions},
+};
+
+use crate::{
+    error::{Error, Result},
+    store::{CodeChunk, CodeIndexStore, dequantize, quantize},
+    types::SearchResult,
+};
+
+/// Run database migrations for the code-index SQLite backend.
+pub async fn run_migrations(pool: &SqlitePool) -> Result<()> {
+    sqlx::migrate!("./migrations")
+        .run(pool)
+        .await
+        .map_err(|e| Error::IndexStore(format!("code-index migration failed: {e}")))
+}
+
+/// SQLite-backed code index store.
+pub struct SqliteCodeIndexStore {
+    pool: SqlitePool,
+}
+
+impl SqliteCodeIndexStore {
+    /// Create a new SQLite store at the given path.
+    pub async fn new(db_path: &Path) -> Result<Self> {
+        // Ensure parent directory exists — SQLite only creates the file, not directories.
+        if let Some(parent) = db_path.parent() {
+            std::fs::create_dir_all(parent).map_err(|e| {
+                Error::IndexStore(format!(
+                    "failed to create code-index directory {}: {e}",
+                    parent.display()
+                ))
+            })?;
+        }
+
+        let options = SqliteConnectOptions::new()
+            .filename(db_path)
+            .create_if_missing(true);
+
+        let pool = SqlitePool::connect_with(options)
+            .await
+            .map_err(|e| Error::IndexStore(format!("failed to connect to SQLite: {e}")))?;
+
+        let store = Self { pool };
+        store.initialize().await?;
+        Ok(store)
+    }
+
+    /// Create a store from an existing pool (for testing).
+    #[cfg(test)]
+    pub(crate) async fn from_pool(pool: SqlitePool) -> Result<Self> {
+        let store = Self { pool };
+        store.initialize().await?;
+        Ok(store)
+    }
+
+    /// Get a connection from the pool.
+    async fn conn(&self) -> Result<sqlx::pool::PoolConnection<sqlx::Sqlite>> {
+        self.pool
+            .acquire()
+            .await
+            .map_err(|e| Error::IndexStore(format!("failed to acquire connection: {e}")))
+    }
+}
+
+#[async_trait]
+impl CodeIndexStore for SqliteCodeIndexStore {
+    async fn initialize(&self) -> Result<()> {
+        run_migrations(&self.pool).await
+    }
+
+    async fn upsert_chunks(
+        &self,
+        project_id: &str,
+        file_path: &str,
+        chunks: &[CodeChunk],
+    ) -> Result<()> {
+        let mut conn = self.conn().await?;
+
+        // Use a transaction for batch insert
+        let mut tx = conn
+            .begin()
+            .await
+            .map_err(|e| Error::IndexStore(format!("failed to begin transaction: {e}")))?;
+
+        // Delete existing chunks for this file first (full reindex of file)
+        sqlx::query("DELETE FROM code_chunks WHERE project_id = ? AND file_path = ?")
+            .bind(project_id)
+            .bind(file_path)
+            .execute(&mut *tx)
+            .await
+            .map_err(|e| Error::IndexStore(format!("failed to delete existing chunks: {e}")))?;
+
+        // Insert new chunks
+        for chunk in chunks {
+            let embedding_bytes = chunk
+                .embedding
+                .as_ref()
+                .map(|e| quantize(e))
+                .map(|q| q.into_iter().map(|v| v as u8).collect::<Vec<u8>>());
+
+            sqlx::query(
+                r#"
+                INSERT INTO code_chunks
+                    (project_id, file_path, chunk_index, content, embedding, start_line, end_line)
+                VALUES
+                    (?, ?, ?, ?, ?, ?, ?)
+                "#,
+            )
+            .bind(project_id)
+            .bind(&chunk.file_path)
+            .bind(chunk.chunk_index as i64)
+            .bind(&chunk.content)
+            .bind(embedding_bytes)
+            .bind(chunk.start_line as i64)
+            .bind(chunk.end_line as i64)
+            .execute(&mut *tx)
+            .await
+            .map_err(|e| Error::IndexStore(format!("failed to insert chunk: {e}")))?;
+        }
+
+        tx.commit()
+            .await
+            .map_err(|e| Error::IndexStore(format!("failed to commit transaction: {e}")))?;
+
+        Ok(())
+    }
+
+    async fn delete_file_chunks(&self, project_id: &str, file_path: &str) -> Result<()> {
+        let mut conn = self.conn().await?;
+
+        sqlx::query("DELETE FROM code_chunks WHERE project_id = ? AND file_path = ?")
+            .bind(project_id)
+            .bind(file_path)
+            .execute(&mut *conn)
+            .await
+            .map_err(|e| Error::IndexStore(format!("failed to delete file chunks: {e}")))?;
+
+        Ok(())
+    }
+
+    async fn clear_project(&self, project_id: &str) -> Result<()> {
+        let mut conn = self.conn().await?;
+
+        sqlx::query("DELETE FROM code_chunks WHERE project_id = ?")
+            .bind(project_id)
+            .execute(&mut *conn)
+            .await
+            .map_err(|e| Error::IndexStore(format!("failed to clear project: {e}")))?;
+
+        Ok(())
+    }
+
+    async fn get_project_chunks(&self, project_id: &str) -> Result<Vec<CodeChunk>> {
+        let mut conn = self.conn().await?;
+
+        let rows = sqlx::query(
+            r#"
+            SELECT
+                file_path,
+                chunk_index,
+                content,
+                embedding,
+                start_line,
+                end_line
+            FROM code_chunks
+            WHERE project_id = ?
+            ORDER BY file_path, chunk_index
+            "#,
+        )
+        .bind(project_id)
+        .fetch_all(&mut *conn)
+        .await
+        .map_err(|e| Error::IndexStore(format!("failed to fetch chunks: {e}")))?;
+
+        let mut chunks = Vec::with_capacity(rows.len());
+        for row in rows {
+            let embedding_bytes: Option<Vec<u8>> = row.get("embedding");
+            let embedding = embedding_bytes.map(|bytes| {
+                let i8_vec: Vec<i8> = bytes.into_iter().map(|b| b as i8).collect();
+                dequantize(&i8_vec)
+            });
+
+            chunks.push(CodeChunk {
+                file_path: row.get("file_path"),
+                chunk_index: row.get::<i64, _>("chunk_index") as usize,
+                content: row.get("content"),
+                embedding,
+                start_line: row.get::<i64, _>("start_line") as usize,
+                end_line: row.get::<i64, _>("end_line") as usize,
+            });
+        }
+
+        Ok(chunks)
+    }
+
+    async fn search_keyword(
+        &self,
+        project_id: &str,
+        query: &str,
+        limit: usize,
+    ) -> Result<Vec<SearchResult>> {
+        let mut conn = self.conn().await?;
+
+        // FTS5 query with project filter via JOIN
+        let rows = sqlx::query(
+            r#"
+            SELECT
+                c.file_path,
+                c.content,
+                c.start_line,
+                c.end_line
+            FROM code_chunks c
+            JOIN code_chunks_fts fts ON c.id = fts.rowid
+            WHERE c.project_id = ?
+                AND code_chunks_fts MATCH ?
+            ORDER BY rank
+            LIMIT ?
+            "#,
+        )
+        .bind(project_id)
+        .bind(query)
+        .bind(limit as i64)
+        .fetch_all(&mut *conn)
+        .await
+        .map_err(|e| Error::IndexStore(format!("keyword search failed: {e}")))?;
+
+        let results = rows
+            .into_iter()
+            .enumerate()
+            .map(|(rank, row)| {
+                let file_path: String = row.get("file_path");
+                let start_line = row.get::<i64, _>("start_line") as usize;
+                SearchResult {
+                    chunk_id: format!("{}:{}:{}", project_id, file_path, start_line),
+                    path: file_path,
+                    text: row.get("content"),
+                    start_line,
+                    end_line: row.get::<i64, _>("end_line") as usize,
+                    score: 1.0 / (1.0 + rank as f32), // Map rank to (0, 1] range, higher is better
+                    source: "builtin".to_string(),
+                }
+            })
+            .collect();
+
+        Ok(results)
+    }
+
+    async fn file_count(&self, project_id: &str) -> Result<usize> {
+        let mut conn = self.conn().await?;
+
+        let count: i64 = sqlx::query_scalar(
+            "SELECT COUNT(DISTINCT file_path) FROM code_chunks WHERE project_id = ?",
+        )
+        .bind(project_id)
+        .fetch_one(&mut *conn)
+        .await
+        .map_err(|e| Error::IndexStore(format!("failed to count files: {e}")))?;
+
+        Ok(count as usize)
+    }
+
+    async fn chunk_count(&self, project_id: &str) -> Result<usize> {
+        let mut conn = self.conn().await?;
+
+        let count: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM code_chunks WHERE project_id = ?")
+                .bind(project_id)
+                .fetch_one(&mut *conn)
+                .await
+                .map_err(|e| Error::IndexStore(format!("failed to count chunks: {e}")))?;
+
+        Ok(count as usize)
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    fn make_chunk(
+        file_path: &str,
+        index: usize,
+        content: &str,
+        start: usize,
+        end: usize,
+    ) -> CodeChunk {
+        CodeChunk {
+            file_path: file_path.to_string(),
+            chunk_index: index,
+            content: content.to_string(),
+            embedding: None,
+            start_line: start,
+            end_line: end,
+        }
+    }
+
+    async fn setup() -> SqliteCodeIndexStore {
+        let pool = SqlitePool::connect(":memory:").await.unwrap();
+        SqliteCodeIndexStore::from_pool(pool).await.unwrap()
+    }
+
+    #[tokio::test]
+    async fn test_initialize_idempotent() {
+        let store = setup().await;
+        // initialize() was already called in setup(), call again
+        store.initialize().await.unwrap();
+        store.initialize().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_upsert_and_get_chunks() {
+        let store = setup().await;
+        let chunks = vec![
+            make_chunk("foo.rs", 0, "fn main() {}", 1, 1),
+            make_chunk("foo.rs", 1, "fn helper() {}", 2, 2),
+        ];
+        store
+            .upsert_chunks("proj", "foo.rs", &chunks)
+            .await
+            .unwrap();
+
+        let got = store.get_project_chunks("proj").await.unwrap();
+        assert_eq!(got.len(), 2);
+        assert_eq!(got[0].file_path, "foo.rs");
+        assert_eq!(got[0].chunk_index, 0);
+        assert_eq!(got[0].content, "fn main() {}");
+        assert_eq!(got[0].start_line, 1);
+        assert_eq!(got[1].content, "fn helper() {}");
+    }
+
+    #[tokio::test]
+    async fn test_upsert_replaces_file() {
+        let store = setup().await;
+
+        let v1 = vec![make_chunk("a.rs", 0, "version 1", 1, 1)];
+        store.upsert_chunks("proj", "a.rs", &v1).await.unwrap();
+
+        let v2 = vec![
+            make_chunk("a.rs", 0, "version 2 line 1", 1, 1),
+            make_chunk("a.rs", 1, "version 2 line 2", 2, 2),
+        ];
+        store.upsert_chunks("proj", "a.rs", &v2).await.unwrap();
+
+        let got = store.get_project_chunks("proj").await.unwrap();
+        assert_eq!(got.len(), 2);
+        assert_eq!(got[0].content, "version 2 line 1");
+        assert_eq!(got[1].content, "version 2 line 2");
+    }
+
+    #[tokio::test]
+    async fn test_multi_file_isolation() {
+        let store = setup().await;
+        let chunks_a = vec![make_chunk("a.rs", 0, "file a", 1, 1)];
+        let chunks_b = vec![make_chunk("b.rs", 0, "file b", 1, 1)];
+        store
+            .upsert_chunks("proj", "a.rs", &chunks_a)
+            .await
+            .unwrap();
+        store
+            .upsert_chunks("proj", "b.rs", &chunks_b)
+            .await
+            .unwrap();
+
+        let got = store.get_project_chunks("proj").await.unwrap();
+        assert_eq!(got.len(), 2);
+
+        store.delete_file_chunks("proj", "a.rs").await.unwrap();
+        let got = store.get_project_chunks("proj").await.unwrap();
+        assert_eq!(got.len(), 1);
+        assert_eq!(got[0].file_path, "b.rs");
+    }
+
+    #[tokio::test]
+    async fn test_multi_project_isolation() {
+        let store = setup().await;
+        let chunks = vec![make_chunk("shared.rs", 0, "content", 1, 1)];
+        store
+            .upsert_chunks("X", "shared.rs", &chunks)
+            .await
+            .unwrap();
+        store
+            .upsert_chunks("Y", "shared.rs", &chunks)
+            .await
+            .unwrap();
+
+        let got_x = store.get_project_chunks("X").await.unwrap();
+        assert_eq!(got_x.len(), 1);
+
+        let got_y = store.get_project_chunks("Y").await.unwrap();
+        assert_eq!(got_y.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_delete_file_chunks() {
+        let store = setup().await;
+        store
+            .upsert_chunks("proj", "a.rs", &[make_chunk("a.rs", 0, "a", 1, 1)])
+            .await
+            .unwrap();
+        store
+            .upsert_chunks("proj", "b.rs", &[make_chunk("b.rs", 0, "b", 1, 1)])
+            .await
+            .unwrap();
+
+        store.delete_file_chunks("proj", "a.rs").await.unwrap();
+
+        let got = store.get_project_chunks("proj").await.unwrap();
+        assert_eq!(got.len(), 1);
+        assert_eq!(got[0].file_path, "b.rs");
+    }
+
+    #[tokio::test]
+    async fn test_clear_project() {
+        let store = setup().await;
+        let chunks = vec![make_chunk("f.rs", 0, "data", 1, 1)];
+        store.upsert_chunks("X", "f.rs", &chunks).await.unwrap();
+        store.upsert_chunks("Y", "f.rs", &chunks).await.unwrap();
+
+        store.clear_project("X").await.unwrap();
+
+        assert!(store.get_project_chunks("X").await.unwrap().is_empty());
+        assert_eq!(store.get_project_chunks("Y").await.unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_embedding_roundtrip() {
+        let store = setup().await;
+        let original = vec![0.5, -0.3, 0.8, 0.1];
+        let mut chunk = make_chunk("emb.rs", 0, "embedded code", 1, 5);
+        chunk.embedding = Some(original.clone());
+
+        store
+            .upsert_chunks("proj", "emb.rs", &[chunk])
+            .await
+            .unwrap();
+
+        let got = store.get_project_chunks("proj").await.unwrap();
+        assert_eq!(got.len(), 1);
+        let emb = got[0].embedding.as_ref().unwrap();
+        // i8 quantization loses precision — tolerance of ~0.02
+        for (orig, stored) in original.iter().zip(emb.iter()) {
+            assert!(
+                (orig - stored).abs() < 0.02,
+                "original {orig} vs stored {stored}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_keyword_search_basic() {
+        let store = setup().await;
+        store
+            .upsert_chunks("proj", "main.rs", &[make_chunk(
+                "main.rs",
+                0,
+                "fn main() { println!(\"hello\"); }",
+                1,
+                1,
+            )])
+            .await
+            .unwrap();
+        store
+            .upsert_chunks("proj", "greet.py", &[make_chunk(
+                "greet.py",
+                0,
+                "def greet(): pass",
+                1,
+                1,
+            )])
+            .await
+            .unwrap();
+
+        let results = store.search_keyword("proj", "main", 10).await.unwrap();
+        assert_eq!(results.len(), 1);
+        assert!(results[0].path.contains("main.rs"));
+    }
+
+    #[tokio::test]
+    async fn test_keyword_search_multi_result() {
+        let store = setup().await;
+        store
+            .upsert_chunks("proj", "a.rs", &[make_chunk(
+                "a.rs",
+                0,
+                "database connection pool",
+                1,
+                1,
+            )])
+            .await
+            .unwrap();
+        store
+            .upsert_chunks("proj", "b.rs", &[make_chunk(
+                "b.rs",
+                0,
+                "database query builder",
+                1,
+                1,
+            )])
+            .await
+            .unwrap();
+        store
+            .upsert_chunks("proj", "c.rs", &[make_chunk(
+                "c.rs",
+                0,
+                "http request handler",
+                1,
+                1,
+            )])
+            .await
+            .unwrap();
+
+        let results = store.search_keyword("proj", "database", 10).await.unwrap();
+        assert_eq!(results.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_keyword_search_no_results() {
+        let store = setup().await;
+        store
+            .upsert_chunks("proj", "a.rs", &[make_chunk(
+                "a.rs",
+                0,
+                "hello world",
+                1,
+                1,
+            )])
+            .await
+            .unwrap();
+
+        let results = store
+            .search_keyword("proj", "nonexistent_xyz", 10)
+            .await
+            .unwrap();
+        assert!(results.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_keyword_search_scores_valid() {
+        let store = setup().await;
+        store
+            .upsert_chunks("proj", "a.rs", &[make_chunk(
+                "a.rs",
+                0,
+                "rust programming language",
+                1,
+                1,
+            )])
+            .await
+            .unwrap();
+        store
+            .upsert_chunks("proj", "b.rs", &[make_chunk(
+                "b.rs",
+                0,
+                "rust memory safety",
+                1,
+                1,
+            )])
+            .await
+            .unwrap();
+
+        let results = store.search_keyword("proj", "rust", 10).await.unwrap();
+        for r in &results {
+            assert!(
+                r.score > 0.0 && r.score <= 1.0,
+                "score {} not in (0, 1]",
+                r.score
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_file_and_chunk_counts() {
+        let store = setup().await;
+        for file in ["a.rs", "b.rs", "c.rs"] {
+            store
+                .upsert_chunks("proj", file, &[
+                    make_chunk(file, 0, "chunk0", 1, 5),
+                    make_chunk(file, 1, "chunk1", 6, 10),
+                ])
+                .await
+                .unwrap();
+        }
+
+        assert_eq!(store.file_count("proj").await.unwrap(), 3);
+        assert_eq!(store.chunk_count("proj").await.unwrap(), 6);
+    }
+
+    #[tokio::test]
+    async fn test_empty_project() {
+        let store = setup().await;
+        assert!(
+            store
+                .get_project_chunks("nonexistent")
+                .await
+                .unwrap()
+                .is_empty()
+        );
+        assert_eq!(store.file_count("nonexistent").await.unwrap(), 0);
+        assert_eq!(store.chunk_count("nonexistent").await.unwrap(), 0);
+    }
+}

--- a/crates/code-index/src/tools.rs
+++ b/crates/code-index/src/tools.rs
@@ -278,8 +278,9 @@ impl AgentTool for CodebaseStatusTool {
 
 /// Register all code-index tools into a [`ToolRegistry`].
 ///
-/// Only call this when the `qmd` feature is enabled — the tools require
-/// a QMD-backed [`CodeIndex`].
+/// Call this when any backend is configured (QMD or builtin).
+/// Tools gracefully degrade to `BackendUnavailable` errors if
+/// the backend is config-only.
 pub fn register_tools(
     registry: &mut moltis_agents::tool_registry::ToolRegistry,
     index: Arc<CodeIndex>,

--- a/crates/code-index/src/tools.rs
+++ b/crates/code-index/src/tools.rs
@@ -1,0 +1,434 @@
+//! Agent tools for codebase indexing.
+//!
+//! Three tools exposed to the LLM agent:
+//! - `codebase_search` — hybrid (keyword + vector) search across indexed code
+//! - `codebase_peek` — list indexable files in a project directory
+//! - `codebase_status` — report indexing status for a project
+
+use std::{path::PathBuf, sync::Arc};
+
+use {
+    async_trait::async_trait, moltis_agents::tool_registry::AgentTool, moltis_tools::params,
+    serde_json::json,
+};
+
+use crate::{CodeIndex, Error};
+
+#[cfg(test)]
+use crate::CodeIndexConfig;
+
+// ---------------------------------------------------------------------------
+// CodebaseSearchTool
+// ---------------------------------------------------------------------------
+
+/// Search the codebase index for a project using hybrid (keyword + vector) search.
+///
+/// Requires a QMD backend. Returns ranked results with file path, line range,
+/// score, and matched text.
+pub struct CodebaseSearchTool {
+    index: Arc<CodeIndex>,
+}
+
+impl CodebaseSearchTool {
+    pub fn new(index: Arc<CodeIndex>) -> Self {
+        Self { index }
+    }
+}
+
+#[async_trait]
+impl AgentTool for CodebaseSearchTool {
+    fn name(&self) -> &str {
+        "codebase_search"
+    }
+
+    fn description(&self) -> &str {
+        "Search the codebase index for relevant code chunks. \
+         Uses hybrid search (keyword + vector embeddings) to find functions, \
+         types, patterns, and code across all indexed files in a project. \
+         Returns file path, line range, relevance score, and matched text."
+    }
+
+    fn parameters_schema(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "required": ["project_id", "query"],
+            "properties": {
+                "project_id": {
+                    "type": "string",
+                    "description": "Project identifier to scope the search to."
+                },
+                "query": {
+                    "type": "string",
+                    "description": "Natural language or keyword search query."
+                },
+                "limit": {
+                    "type": "integer",
+                    "description": "Maximum number of results to return.",
+                    "default": 10
+                }
+            }
+        })
+    }
+
+    async fn execute(&self, params_value: serde_json::Value) -> anyhow::Result<serde_json::Value> {
+        let project_id = params::require_str(&params_value, "project_id")?.to_string();
+        let query = params::require_str(&params_value, "query")?.to_string();
+        let limit = usize::try_from(params::u64_param(&params_value, "limit", 10)).unwrap_or(10);
+
+        match self.index.search(&project_id, &query, limit).await {
+            Ok(results) => {
+                let items: Vec<serde_json::Value> = results
+                    .iter()
+                    .map(|r| {
+                        json!({
+                            "chunk_id": r.chunk_id,
+                            "path": r.path,
+                            "start_line": r.start_line,
+                            "end_line": r.end_line,
+                            "score": r.score,
+                            "text": r.text,
+                            "source": r.source,
+                        })
+                    })
+                    .collect();
+
+                Ok(json!({
+                    "results": items,
+                    "total": items.len(),
+                    "project_id": project_id,
+                }))
+            },
+            Err(Error::BackendUnavailable(msg)) => Ok(json!({
+                "project_id": project_id,
+                "error": msg,
+                "search_available": false,
+            })),
+            Err(e) => Err(anyhow::anyhow!("{e}")),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// CodebasePeekTool
+// ---------------------------------------------------------------------------
+
+/// List the files that would be indexed for a given project directory.
+///
+/// This is a read-only operation — it discovers git-tracked files and
+/// applies the configured filters, but does not trigger indexing.
+pub struct CodebasePeekTool {
+    index: Arc<CodeIndex>,
+}
+
+impl CodebasePeekTool {
+    pub fn new(index: Arc<CodeIndex>) -> Self {
+        Self { index }
+    }
+}
+
+#[async_trait]
+impl AgentTool for CodebasePeekTool {
+    fn name(&self) -> &str {
+        "codebase_peek"
+    }
+
+    fn description(&self) -> &str {
+        "List files that would be indexed for a project directory. \
+         Discovers git-tracked files, applies extension and size filters, \
+         and returns the list with language and size info. \
+         Does NOT trigger indexing — use this to preview what gets indexed."
+    }
+
+    fn parameters_schema(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "required": ["project_dir"],
+            "properties": {
+                "project_dir": {
+                    "type": "string",
+                    "description": "Absolute path to the project directory (must contain a .git folder)."
+                }
+            }
+        })
+    }
+
+    async fn execute(&self, params_value: serde_json::Value) -> anyhow::Result<serde_json::Value> {
+        let dir = params::require_str(&params_value, "project_dir")?.to_string();
+        let project_dir = PathBuf::from(&dir);
+
+        if !project_dir.is_dir() {
+            return Ok(json!({
+                "error": format!("directory does not exist: {dir}"),
+            }));
+        }
+
+        let files = match self.index.list_indexable_files(&project_dir) {
+            Ok(f) => f,
+            Err(e) => {
+                return Ok(json!({
+                    "error": e.to_string(),
+                }));
+            },
+        };
+
+        let total_size: u64 = files.iter().map(|f| f.size).sum();
+
+        let items: Vec<serde_json::Value> = files
+            .iter()
+            .map(|f| {
+                json!({
+                    "path": f.relative_path.to_string_lossy(),
+                    "language": serde_json::to_value(f.language)
+                        .unwrap_or(serde_json::Value::String("unknown".to_string())),
+                    "size": f.size,
+                })
+            })
+            .collect();
+
+        Ok(json!({
+            "files": items,
+            "total_files": items.len(),
+            "total_size_bytes": total_size,
+            "project_dir": dir,
+        }))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// CodebaseStatusTool
+// ---------------------------------------------------------------------------
+
+/// Report the indexing status for a project.
+///
+/// Returns file counts, backend type, and last sync time.
+/// Works with or without a QMD backend — config-only instances report
+/// discover stats without search capability.
+pub struct CodebaseStatusTool {
+    index: Arc<CodeIndex>,
+}
+
+impl CodebaseStatusTool {
+    pub fn new(index: Arc<CodeIndex>) -> Self {
+        Self { index }
+    }
+}
+
+#[async_trait]
+impl AgentTool for CodebaseStatusTool {
+    fn name(&self) -> &str {
+        "codebase_status"
+    }
+
+    fn description(&self) -> &str {
+        "Report the indexing status for a project. Returns file counts, \
+         backend type, and whether search is available. Use this to check \
+         if a project directory is indexed and ready for codebase_search."
+    }
+
+    fn parameters_schema(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "required": ["project_id", "project_dir"],
+            "properties": {
+                "project_id": {
+                    "type": "string",
+                    "description": "Project identifier."
+                },
+                "project_dir": {
+                    "type": "string",
+                    "description": "Absolute path to the project directory."
+                }
+            }
+        })
+    }
+
+    async fn execute(&self, params_value: serde_json::Value) -> anyhow::Result<serde_json::Value> {
+        let project_id = params::require_str(&params_value, "project_id")?.to_string();
+        let dir = params::require_str(&params_value, "project_dir")?.to_string();
+        let project_dir = PathBuf::from(&dir);
+
+        if !project_dir.is_dir() {
+            return Ok(json!({
+                "error": format!("directory does not exist: {dir}"),
+            }));
+        }
+
+        match self.index.status(&project_id).await {
+            Ok(status) => Ok(json!({
+                "project_id": status.project_id,
+                "total_files": status.total_files,
+                "total_chunks": status.total_chunks,
+                "last_sync_ms": status.last_sync_ms,
+                "embedding_model": status.embedding_model,
+                "backend": status.backend,
+            })),
+            Err(Error::BackendUnavailable(msg)) => Ok(json!({
+                "project_id": project_id,
+                "error": msg,
+                "search_available": false,
+            })),
+            Err(e) => Err(anyhow::anyhow!("{e}")),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Registration helper
+// ---------------------------------------------------------------------------
+
+/// Register all code-index tools into a [`ToolRegistry`].
+///
+/// Only call this when the `qmd` feature is enabled — the tools require
+/// a QMD-backed [`CodeIndex`].
+pub fn register_tools(
+    registry: &mut moltis_agents::tool_registry::ToolRegistry,
+    index: Arc<CodeIndex>,
+) {
+    registry.register(Box::new(CodebaseSearchTool::new(Arc::clone(&index))));
+    registry.register(Box::new(CodebasePeekTool::new(Arc::clone(&index))));
+    registry.register(Box::new(CodebaseStatusTool::new(index)));
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    fn make_config_only_index() -> Arc<CodeIndex> {
+        Arc::new(CodeIndex::config_only(CodeIndexConfig::default()))
+    }
+
+    #[tokio::test]
+    async fn test_peek_lists_indexable_files() {
+        let idx = make_config_only_index();
+        let tool = CodebasePeekTool::new(Arc::clone(&idx));
+
+        let repo_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .unwrap()
+            .parent()
+            .unwrap()
+            .to_string_lossy()
+            .to_string();
+
+        let result = tool
+            .execute(json!({ "project_dir": repo_dir }))
+            .await
+            .expect("peek should succeed on moltis repo");
+
+        let total = result["total_files"].as_u64().unwrap();
+        assert!(total > 0, "moltis repo has indexable files");
+    }
+
+    #[tokio::test]
+    async fn test_peek_returns_error_for_nonexistent_dir() {
+        let idx = make_config_only_index();
+        let tool = CodebasePeekTool::new(idx);
+
+        let result = tool
+            .execute(json!({ "project_dir": "/nonexistent/path/that/does/not/exist" }))
+            .await
+            .expect("peek tool itself should not panic");
+
+        assert!(
+            result.get("error").is_some(),
+            "should report directory error"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_search_requires_backend() {
+        let idx = make_config_only_index();
+        let tool = CodebaseSearchTool::new(idx);
+
+        let result = tool
+            .execute(json!({
+                "project_id": "test-project",
+                "query": "fn main"
+            }))
+            .await
+            .expect("search tool should return Ok even without backend");
+
+        // Config-only search returns a structured error response, not Err.
+        assert!(
+            result.get("error").is_some(),
+            "config-only search should report error"
+        );
+        assert!(
+            result.get("search_available").is_some(),
+            "config-only search should report search_available"
+        );
+        assert_eq!(result["search_available"], false);
+    }
+
+    #[tokio::test]
+    async fn test_status_reports_config_only() {
+        let idx = make_config_only_index();
+        let tool = CodebaseStatusTool::new(idx);
+
+        let repo_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .unwrap()
+            .parent()
+            .unwrap()
+            .to_string_lossy()
+            .to_string();
+
+        let result = tool
+            .execute(json!({
+                "project_id": "test-project",
+                "project_dir": repo_dir,
+            }))
+            .await
+            .expect("status should succeed on moltis repo");
+
+        // Config-only should report search unavailable (BackendUnavailable error path).
+        let search_available = result["search_available"].as_bool().unwrap_or(true);
+        assert!(
+            !search_available,
+            "config-only status should report search_available=false, got: {result}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_status_nonexistent_dir() {
+        let idx = make_config_only_index();
+        let tool = CodebaseStatusTool::new(idx);
+
+        let result = tool
+            .execute(json!({
+                "project_id": "test-project",
+                "project_dir": "/nonexistent/path/that/does/not/exist",
+            }))
+            .await
+            .expect("status tool itself should not panic");
+
+        assert!(
+            result.get("error").is_some(),
+            "should report directory error"
+        );
+    }
+
+    #[test]
+    fn test_parameter_schemas_are_valid_json() {
+        // Verify that all tool schemas produce valid JSON objects.
+        let search = CodebaseSearchTool::new(make_config_only_index());
+        let schema = search.parameters_schema();
+        assert!(schema.is_object());
+        assert!(schema["required"].is_array());
+
+        let peek = CodebasePeekTool::new(make_config_only_index());
+        let schema = peek.parameters_schema();
+        assert!(schema.is_object());
+        assert!(schema["required"].is_array());
+
+        let status = CodebaseStatusTool::new(make_config_only_index());
+        let schema = status.parameters_schema();
+        assert!(schema.is_object());
+        assert!(schema["required"].is_array());
+    }
+}

--- a/crates/code-index/src/types.rs
+++ b/crates/code-index/src/types.rs
@@ -1,0 +1,198 @@
+//! Core types for codebase indexing.
+
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+/// Programming language hint derived from file extension.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum Language {
+    C,
+    Cpp,
+    CSharp,
+    Css,
+    Go,
+    Html,
+    Java,
+    JavaScript,
+    Json,
+    Kotlin,
+    Markdown,
+    Nix,
+    Php,
+    Python,
+    Ruby,
+    Rust,
+    Scala,
+    Shell,
+    Sql,
+    Swift,
+    Toml,
+    TypeScript,
+    Yaml,
+    Zig,
+    /// Unknown or unsupported language.
+    Unknown,
+}
+
+impl Language {
+    /// Derive the language from a file extension (without the leading dot).
+    pub fn from_extension(ext: &str) -> Self {
+        match ext.to_ascii_lowercase().as_str() {
+            "sh" | "bash" => Self::Shell,
+            "c" => Self::C,
+            "cpp" | "cxx" | "cc" | "hpp" | "h" => Self::Cpp,
+            "cs" => Self::CSharp,
+            "css" | "scss" | "less" => Self::Css,
+            "go" => Self::Go,
+            "html" | "htm" => Self::Html,
+            "java" => Self::Java,
+            "js" | "jsx" | "mjs" | "cjs" => Self::JavaScript,
+            "json" => Self::Json,
+            "kt" | "kts" => Self::Kotlin,
+            "md" | "markdown" | "mdx" => Self::Markdown,
+            "nix" => Self::Nix,
+            "php" => Self::Php,
+            "py" | "pyi" => Self::Python,
+            "rb" => Self::Ruby,
+            "rs" => Self::Rust,
+            "scala" => Self::Scala,
+            "sql" => Self::Sql,
+            "swift" => Self::Swift,
+            "toml" => Self::Toml,
+            "ts" | "tsx" | "mts" | "cts" => Self::TypeScript,
+            "yaml" | "yml" => Self::Yaml,
+            "zig" => Self::Zig,
+            _ => Self::Unknown,
+        }
+    }
+
+    /// Derive the language from a file path by inspecting its extension.
+    pub fn from_path(path: &std::path::Path) -> Self {
+        let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("");
+        Self::from_extension(ext)
+    }
+
+    /// Return the file extension typically associated with this language.
+    /// Used primarily for display and debugging.
+    pub fn primary_extension(&self) -> &'static str {
+        match self {
+            Self::Shell => "sh",
+            Self::C => "c",
+            Self::Cpp => "cpp",
+            Self::CSharp => "cs",
+            Self::Css => "css",
+            Self::Go => "go",
+            Self::Html => "html",
+            Self::Java => "java",
+            Self::JavaScript => "js",
+            Self::Json => "json",
+            Self::Kotlin => "kt",
+            Self::Markdown => "md",
+            Self::Nix => "nix",
+            Self::Php => "php",
+            Self::Python => "py",
+            Self::Ruby => "rb",
+            Self::Rust => "rs",
+            Self::Scala => "scala",
+            Self::Sql => "sql",
+            Self::Swift => "swift",
+            Self::Toml => "toml",
+            Self::TypeScript => "ts",
+            Self::Yaml => "yaml",
+            Self::Zig => "zig",
+            Self::Unknown => "txt",
+        }
+    }
+}
+
+/// A file discovered in a git repository, after filtering.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FileEntry {
+    /// Absolute path to the file on disk.
+    pub path: PathBuf,
+    /// Relative path from the repository root.
+    pub relative_path: PathBuf,
+    /// File size in bytes.
+    pub size: u64,
+    /// SHA-256 content hash.
+    pub content_hash: String,
+    /// Detected language.
+    pub language: Language,
+    /// Whether the file is tracked by git.
+    pub git_tracked: bool,
+    /// Epoch millis when this file was last indexed (0 if never).
+    pub last_indexed: u64,
+}
+
+/// A file that passed all filters and is ready for indexing.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FilteredFile {
+    /// Absolute path to the file on disk.
+    pub path: PathBuf,
+    /// Relative path from the repository root.
+    pub relative_path: PathBuf,
+    /// File size in bytes.
+    pub size: u64,
+    /// Detected language.
+    pub language: Language,
+}
+
+/// A chunk of code discovered during indexing (metadata only, no embedding).
+///
+/// This is distinct from [`crate::store::CodeChunk`] which is the storage-level
+/// representation with embedding support.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DiscoveredChunk {
+    /// Unique identifier: `{relative_path}:{start_line}:{end_line}`.
+    pub id: String,
+    /// Relative path from the repository root.
+    pub relative_path: PathBuf,
+    /// 1-based start line.
+    pub start_line: usize,
+    /// 1-based end line (inclusive).
+    pub end_line: usize,
+    /// The chunk text content.
+    pub text: String,
+    /// Detected language of the source file.
+    pub language: Language,
+    /// SHA-256 hash of the chunk text (for cache discrimination).
+    pub content_hash: String,
+}
+
+/// Status of the code index for a project.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct IndexStatus {
+    /// Project identifier.
+    pub project_id: String,
+    /// Total number of tracked, filtered files.
+    pub total_files: usize,
+    /// Total number of chunks across all indexed files.
+    pub total_chunks: usize,
+    /// Epoch millis of the last successful full sync.
+    pub last_sync_ms: Option<u64>,
+    /// Embedding model in use (if any).
+    pub embedding_model: Option<String>,
+    /// Index backend in use (e.g. "qmd", "builtin").
+    pub backend: String,
+}
+
+/// A search result from the code index.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SearchResult {
+    /// Chunk identifier.
+    pub chunk_id: String,
+    /// Relative path from the repository root.
+    pub path: String,
+    /// 1-based start line.
+    pub start_line: usize,
+    /// 1-based end line (inclusive).
+    pub end_line: usize,
+    /// Relevance score (0.0–1.0, higher is better).
+    pub score: f32,
+    /// Matched text content.
+    pub text: String,
+    /// Source of the result (e.g. "qmd", "builtin").
+    pub source: String,
+}

--- a/crates/code-index/src/watcher.rs
+++ b/crates/code-index/src/watcher.rs
@@ -1,0 +1,227 @@
+//! File watcher for incremental code index updates.
+//!
+//! Uses `notify-debouncer-full` to watch project directories for file changes,
+//! then invokes a handler callback with the set of changed file paths.
+//!
+//! The watcher is started via [`CodeIndex::start_watcher`] in `index.rs`.
+
+use std::{
+    path::{Path, PathBuf},
+    sync::Arc,
+    time::Duration,
+};
+
+use {
+    notify_debouncer_full::{new_debouncer, notify::RecursiveMode},
+    tokio::sync::mpsc,
+};
+
+#[cfg(feature = "tracing")]
+use crate::log::{debug, info};
+
+use crate::{filter::FilterConfig, types::Language};
+
+/// Debounce delay for file system events (ms).
+const DEBOUNCE_MS: u64 = 500;
+
+/// A debounced file-system event, sent from the notify backend to the processor.
+#[derive(Debug)]
+struct WatchEvent {
+    paths: Vec<PathBuf>,
+    kind: notify_debouncer_full::notify::EventKind,
+}
+
+/// Handler invoked when files change in a watched project.
+pub type WatchHandler = Arc<dyn Fn(&str, &[PathBuf]) + Send + Sync>;
+
+/// A running file watcher for a single project directory.
+#[allow(dead_code)] // watch_dir kept for future diagnostics/health-check
+pub struct FileWatcher {
+    /// The project ID this watcher is associated with.
+    project_id: String,
+    /// The root directory being watched.
+    watch_dir: PathBuf,
+    /// The debouncer — must be kept alive for the watcher to fire.
+    _debouncer: notify_debouncer_full::Debouncer<
+        notify_debouncer_full::notify::RecommendedWatcher,
+        notify_debouncer_full::RecommendedCache,
+    >,
+    /// Cancellation token to stop the watcher.
+    cancel: tokio_util::sync::CancellationToken,
+}
+
+impl FileWatcher {
+    /// Start watching a project directory for file changes.
+    ///
+    /// Spawns a background task that debounces filesystem events and calls
+    /// `handler` with the set of changed file paths.
+    pub fn start(
+        project_id: String,
+        watch_dir: PathBuf,
+        filter_config: FilterConfig,
+        handler: WatchHandler,
+    ) -> Result<Self, notify_debouncer_full::notify::Error> {
+        let cancel = tokio_util::sync::CancellationToken::new();
+        let cancel_clone = cancel.clone();
+        let pid = project_id.clone();
+
+        // Channel for debounced events from the notify backend.
+        let (tx, mut rx) = mpsc::channel::<WatchEvent>(256);
+
+        // Create the filesystem watcher.
+        let mut debouncer = new_debouncer(
+            Duration::from_millis(DEBOUNCE_MS),
+            None,
+            move |result: Result<
+                Vec<notify_debouncer_full::DebouncedEvent>,
+                Vec<notify_debouncer_full::notify::Error>,
+            >| {
+                if let Ok(events) = result {
+                    for event in events {
+                        let watch_event = WatchEvent {
+                            paths: event.paths.clone(),
+                            kind: event.kind,
+                        };
+                        let _ = tx.blocking_send(watch_event);
+                    }
+                }
+            },
+        )?;
+
+        debouncer.watch(&watch_dir, RecursiveMode::Recursive)?;
+
+        #[cfg(feature = "tracing")]
+        info!(
+            project_id = %pid,
+            path = %watch_dir.display(),
+            "file watcher started"
+        );
+
+        // Spawn the event processing loop.
+        let _watcher_guard = tokio::spawn(async move {
+            loop {
+                tokio::select! {
+                    _ = cancel_clone.cancelled() => {
+                        #[cfg(feature = "tracing")]
+                        debug!(project_id = %pid, "file watcher stopping");
+                        break;
+                    }
+                    event = rx.recv() => {
+                        match event {
+                            Some(event) => {
+                                Self::handle_event(&pid, &filter_config, &handler, event);
+                            }
+                            None => break, // Channel closed
+                        }
+                    }
+                }
+            }
+        });
+
+        Ok(Self {
+            project_id,
+            watch_dir,
+            _debouncer: debouncer,
+            cancel,
+        })
+    }
+
+    /// Stop the watcher.
+    pub fn stop(&self) {
+        #[cfg(feature = "tracing")]
+        info!(project_id = %self.project_id, "stopping file watcher");
+        self.cancel.cancel();
+    }
+
+    /// Return the project ID this watcher is for.
+    pub fn project_id(&self) -> &str {
+        &self.project_id
+    }
+
+    fn handle_event(
+        project_id: &str,
+        filter_config: &FilterConfig,
+        handler: &WatchHandler,
+        event: WatchEvent,
+    ) {
+        use notify_debouncer_full::notify::EventKind;
+
+        // We only care about create, modify, and remove events.
+        let is_relevant = matches!(
+            event.kind,
+            EventKind::Create(_) | EventKind::Modify(_) | EventKind::Remove(_)
+        );
+        if !is_relevant {
+            return;
+        }
+
+        // Filter to indexable files only.
+        // For Remove events, skip the `is_file()` check since the file
+        // is already gone — only validate extension and skip patterns.
+        let is_remove = matches!(event.kind, EventKind::Remove(_));
+        let indexable: Vec<PathBuf> = event
+            .paths
+            .into_iter()
+            .filter(|p| {
+                if is_remove {
+                    Self::is_indexable_by_extension(p, filter_config)
+                } else {
+                    Self::is_indexable(p, filter_config)
+                }
+            })
+            .collect();
+
+        if !indexable.is_empty() {
+            #[cfg(feature = "tracing")]
+            debug!(
+                project_id,
+                count = indexable.len(),
+                "files changed, invoking handler"
+            );
+            handler(project_id, &indexable);
+        }
+    }
+
+    /// Check if a file path should be indexed based on extension and filter config.
+    fn is_indexable(path: &Path, config: &FilterConfig) -> bool {
+        // Must be a file (not a directory).
+        if !path.is_file() {
+            return false;
+        }
+
+        Self::is_indexable_by_extension(path, config)
+    }
+
+    /// Check if a path should be indexed based solely on extension and skip patterns.
+    ///
+    /// Used for Remove events where `is_file()` would return false because
+    /// the file is already deleted.
+    fn is_indexable_by_extension(path: &Path, config: &FilterConfig) -> bool {
+        let ext = match path.extension().and_then(|e| e.to_str()) {
+            Some(e) => e,
+            None => return false,
+        };
+
+        // Check against known language extensions.
+        let lang = Language::from_extension(ext);
+        if matches!(lang, Language::Unknown) {
+            return false;
+        }
+
+        // Check against ignored patterns.
+        let path_str = path.to_string_lossy();
+        for pattern in &config.skip_paths {
+            if path_str.contains(pattern) {
+                return false;
+            }
+        }
+
+        true
+    }
+}
+
+impl Drop for FileWatcher {
+    fn drop(&mut self) {
+        self.stop();
+    }
+}

--- a/crates/gateway/Cargo.toml
+++ b/crates/gateway/Cargo.toml
@@ -33,6 +33,7 @@ moltis-matrix           = { optional = true, workspace = true }
 moltis-mcp              = { workspace = true }
 moltis-mcp-agent-bridge = { workspace = true }
 moltis-media            = { workspace = true }
+moltis-code-index       = { workspace = true }
 moltis-memory           = { workspace = true }
 moltis-metrics          = { optional = true, workspace = true }
 moltis-msteams          = { workspace = true }
@@ -94,6 +95,7 @@ caldav = ["dep:moltis-caldav"]
 default = [
   "agent",
   "caldav",
+  "code-index-builtin",
   "file-watcher",
   "firecrawl",
   "fs-tools",
@@ -118,10 +120,12 @@ default = [
   "web-ui",
   "whatsapp",
 ]
+code-index-builtin = ["moltis-code-index/builtin"]
 file-watcher = [
   "moltis-memory/file-watcher",
   "moltis-openclaw-import?/file-watcher",
   "moltis-skills/file-watcher",
+  "moltis-code-index/file-watcher",
 ]
 firecrawl = ["moltis-tools/firecrawl"]
 fs-tools = ["moltis-tools/fs-tools"]
@@ -151,7 +155,7 @@ nostr = ["dep:moltis-nostr"]
 openclaw-import = ["dep:moltis-openclaw-import"]
 prometheus = ["metrics", "moltis-metrics/prometheus"]
 push-notifications = ["dep:chrono", "dep:p256", "dep:web-push", "moltis-chat/push-notifications"]
-qmd = ["dep:moltis-qmd"]
+qmd = ["dep:moltis-qmd", "moltis-code-index/qmd"]
 slack = ["dep:moltis-slack", "moltis-slack/metrics"]
 tailscale = ["dep:moltis-tailscale"]
 tls = []

--- a/crates/gateway/src/server/init_code_index.rs
+++ b/crates/gateway/src/server/init_code_index.rs
@@ -1,0 +1,92 @@
+//! Initialize the code index system.
+//!
+//! When the `qmd` feature is enabled and a QMD binary is available on the
+//! system, creates a [`moltis_code_index::CodeIndex`] in full mode (discover,
+//! filter, status, peek, and search all work).
+//!
+//! When the `code-index-builtin` feature is enabled, creates a builtin
+//! SQLite+FTS5 backend for local code indexing.
+//!
+//! If neither feature is enabled (or QMD is unavailable), falls back to
+//! config-only mode where search operations return [`BackendUnavailable`]
+//! gracefully.
+//!
+//! Per-project collection registration is deferred — the `QmdManager` starts
+//! with empty collections. When `index_project()` is called, collections are
+//! configured using [`backend_qmd::qmd_config_for_project`].
+
+use std::sync::Arc;
+
+use tracing::{info, warn};
+
+/// Initialize the code index.
+///
+/// Checks QMD availability when the feature is enabled.
+/// Falls back to config-only mode if QMD is absent.
+pub(crate) async fn init_code_index(
+    data_dir: &std::path::Path,
+) -> Arc<moltis_code_index::CodeIndex> {
+    let code_index_config = moltis_code_index::CodeIndexConfig {
+        data_dir: Some(data_dir.join("code-index")),
+        ..Default::default()
+    };
+
+    #[cfg(feature = "qmd")]
+    {
+        let qmd_config = moltis_qmd::QmdManagerConfig {
+            command: "qmd".into(),
+            collections: std::collections::HashMap::new(),
+            max_results: 20,
+            timeout_ms: 30_000,
+            work_dir: data_dir.to_path_buf(),
+            index_name: format!("code-{}", super::helpers::sanitize_qmd_index_name(data_dir)),
+            env_overrides: std::collections::HashMap::new(),
+        };
+        let qmd = moltis_qmd::QmdManager::new(qmd_config);
+
+        if qmd.is_available().await {
+            info!(
+                index = %qmd.index_name(),
+                "code-index: QMD backend available, initializing in full mode"
+            );
+            return Arc::new(moltis_code_index::CodeIndex::new(code_index_config, qmd));
+        }
+
+        warn!(
+            "code-index: QMD binary not found, falling back to config-only mode \
+             (search unavailable until QMD is installed)"
+        );
+    }
+
+    #[cfg(feature = "code-index-builtin")]
+    {
+        let db_path = data_dir.join("code-index").join("index.db");
+        match moltis_code_index::store_sqlite::SqliteCodeIndexStore::new(&db_path).await {
+            Ok(store) => {
+                info!(path = %db_path.display(), "code-index: builtin SQLite backend initialized");
+                return Arc::new(moltis_code_index::CodeIndex::new_builtin(
+                    code_index_config,
+                    Box::new(store),
+                    None,
+                ));
+            }
+            Err(e) => {
+                warn!(
+                    path = %db_path.display(),
+                    error = %e,
+                    "code-index: failed to initialize builtin backend, falling back to config-only"
+                );
+            }
+        }
+    }
+
+    #[cfg(not(any(feature = "qmd", feature = "code-index-builtin")))]
+    {
+        info!(
+            "code-index: initialized in config-only mode \
+             (qmd feature disabled — search unavailable)"
+        );
+    }
+
+    Arc::new(moltis_code_index::CodeIndex::config_only(code_index_config))
+}

--- a/crates/gateway/src/server/init_code_index.rs
+++ b/crates/gateway/src/server/init_code_index.rs
@@ -52,6 +52,12 @@ pub(crate) async fn init_code_index(
             return Arc::new(moltis_code_index::CodeIndex::new(code_index_config, qmd));
         }
 
+        #[cfg(feature = "code-index-builtin")]
+        info!(
+            "code-index: QMD binary not found, trying builtin backend"
+        );
+
+        #[cfg(not(feature = "code-index-builtin"))]
         warn!(
             "code-index: QMD binary not found, falling back to config-only mode \
              (search unavailable until QMD is installed)"

--- a/crates/gateway/src/server/mod.rs
+++ b/crates/gateway/src/server/mod.rs
@@ -9,12 +9,14 @@
 // - hooks:          hook discovery, DCG guard, seeding
 // - seed_content:   large const strings for seed files
 // - workspace:      workspace file seeding, persona sync
-// - init_channels:  channel store/registry/plugin setup
-// - init_memory:    memory system / embedding provider setup
+// - init_channels:    channel store/registry/plugin setup
+// - init_code_index:  code index config-only initialization
+// - init_memory:      memory system / embedding provider setup
 
 mod helpers;
 mod hooks;
 mod init_channels;
+mod init_code_index;
 mod init_memory;
 mod location;
 mod prepare_core;

--- a/crates/gateway/src/server/prepare_core.rs
+++ b/crates/gateway/src/server/prepare_core.rs
@@ -6,7 +6,7 @@ use {
             maybe_deliver_cron_output, restore_saved_local_llm_models,
             validate_proxy_tls_configuration,
         },
-        init_channels, init_memory,
+        init_channels, init_code_index, init_memory,
         prepared::PreparedGatewayCore,
         workspace::{
             seed_default_workspace_markdown_files, sync_persona_into_preset,
@@ -1329,6 +1329,10 @@ pub async fn prepare_gateway_core(
     .await;
     startup_mem_probe.checkpoint("memory_manager.initialized");
 
+    // ── Code index initialization ──────────────────────────────────────
+    let code_index = init_code_index::init_code_index(&data_dir).await;
+    startup_mem_probe.checkpoint("code_index.initialized");
+
     post_state::complete_startup(post_state::PostStateInputs {
         bind: bind.to_string(),
         port,
@@ -1382,6 +1386,7 @@ pub async fn prepare_gateway_core(
         tailscale_mode_override,
         #[cfg(feature = "tailscale")]
         tailscale_reset_on_exit_override,
+        code_index,
     })
     .await
 }

--- a/crates/gateway/src/server/prepare_core/post_state.rs
+++ b/crates/gateway/src/server/prepare_core/post_state.rs
@@ -70,6 +70,7 @@ pub(super) struct PostStateInputs {
     pub provider_setup_service: Arc<LiveProviderSetupService>,
     pub live_mcp: Arc<crate::mcp_service::LiveMcpService>,
     pub memory_manager: Option<moltis_memory::runtime::DynMemoryRuntime>,
+    pub code_index: Arc<moltis_code_index::CodeIndex>,
     pub credential_store: Arc<auth::CredentialStore>,
     pub db_pool: sqlx::SqlitePool,
     pub session_store: Arc<SessionStore>,
@@ -275,6 +276,7 @@ pub(super) async fn complete_startup(
         tailscale_mode_override,
         #[cfg(feature = "tailscale")]
         tailscale_reset_on_exit_override,
+        code_index,
     } = inputs;
 
     let openclaw_startup_status = deferred_openclaw_status();
@@ -331,6 +333,13 @@ pub(super) async fn complete_startup(
     #[cfg(not(feature = "tls"))]
     let tls_enabled_for_gateway = false;
 
+    #[cfg(feature = "qmd")]
+    let code_index_for_tools = Arc::clone(&code_index);
+
+    #[cfg(feature = "code-index-builtin")]
+    #[allow(unused_variables)]
+    let code_index_for_tools_builtin = Arc::clone(&code_index);
+
     let state = GatewayState::with_options(
         resolved_auth,
         services,
@@ -343,6 +352,7 @@ pub(super) async fn complete_startup(
         tls_enabled_for_gateway,
         hook_registry.clone(),
         memory_manager.clone(),
+        code_index,
         port,
         config.server.ws_request_logs,
         deploy_platform.clone(),
@@ -810,6 +820,20 @@ pub(super) async fn complete_startup(
                 Arc::clone(&registry),
                 Arc::clone(&session_metadata),
             )));
+        }
+
+        // ── Code index tools ─────────────────────────────────────────────
+        #[cfg(feature = "qmd")]
+        {
+            moltis_code_index::tools::register_tools(&mut tool_registry, code_index_for_tools);
+        }
+
+        #[cfg(all(feature = "code-index-builtin", not(feature = "qmd")))]
+        {
+            moltis_code_index::tools::register_tools(
+                &mut tool_registry,
+                code_index_for_tools_builtin,
+            );
         }
 
         {

--- a/crates/gateway/src/server/tests_legacy/webauthn.rs
+++ b/crates/gateway/src/server/tests_legacy/webauthn.rs
@@ -25,6 +25,9 @@ async fn sync_runtime_webauthn_host_registers_new_origin() {
         false,
         None,
         None,
+        Arc::new(moltis_code_index::CodeIndex::config_only(
+            moltis_code_index::CodeIndexConfig::default(),
+        )),
         18789,
         false,
         None,

--- a/crates/gateway/src/state.rs
+++ b/crates/gateway/src/state.rs
@@ -380,6 +380,9 @@ pub struct GatewayState {
     /// Memory runtime for long-term memory search.
     /// `Arc` because it is cloned into background tokio tasks.
     pub memory_manager: Option<moltis_memory::runtime::DynMemoryRuntime>,
+    /// Code index for workspace codebase intelligence (discover, filter, status, peek).
+    /// Always initialized in config-only mode; search is deferred to QMD backend.
+    pub code_index: Arc<moltis_code_index::CodeIndex>,
     /// Whether the server is bound to a loopback address (localhost/127.0.0.1/::1).
     pub localhost_only: bool,
     /// Whether the server is known to be behind a reverse proxy.
@@ -461,6 +464,9 @@ impl GatewayState {
             false,
             None,
             None,
+            Arc::new(moltis_code_index::CodeIndex::config_only(
+                moltis_code_index::CodeIndexConfig::default(),
+            )),
             18789,
             false,
             None,
@@ -487,6 +493,7 @@ impl GatewayState {
         tls_active: bool,
         hook_registry: Option<Arc<moltis_common::hooks::HookRegistry>>,
         memory_manager: Option<moltis_memory::runtime::DynMemoryRuntime>,
+        code_index: Arc<moltis_code_index::CodeIndex>,
         port: u16,
         ws_request_logs: bool,
         deploy_platform: Option<String>,
@@ -510,6 +517,7 @@ impl GatewayState {
             sandbox_router,
             pairing_store,
             memory_manager,
+            code_index,
             localhost_only,
             behind_proxy,
             tls_active,

--- a/crates/httpd/Cargo.toml
+++ b/crates/httpd/Cargo.toml
@@ -98,6 +98,7 @@ vault = ["dep:moltis-vault", "moltis-gateway/vault"]
 web-ui = ["moltis-gateway/web-ui"]
 
 [dev-dependencies]
+moltis-code-index.workspace = true
 moltis-providers = { workspace = true }
 moltis-web       = { workspace = true }
 sqlx             = { workspace = true }

--- a/crates/httpd/tests/auth_middleware.rs
+++ b/crates/httpd/tests/auth_middleware.rs
@@ -136,6 +136,9 @@ async fn start_auth_server_impl(
         false,
         None,
         None,
+        Arc::new(moltis_code_index::CodeIndex::config_only(
+            moltis_code_index::CodeIndexConfig::default(),
+        )),
         18789,
         false,
         None,
@@ -207,6 +210,9 @@ async fn start_localhost_server_with_vault() -> (
         false,
         None,
         None,
+        Arc::new(moltis_code_index::CodeIndex::config_only(
+            moltis_code_index::CodeIndexConfig::default(),
+        )),
         18789,
         false,
         None,
@@ -281,6 +287,9 @@ async fn start_localhost_server_with_vault_and_session_store() -> (
         false,
         None,
         None,
+        Arc::new(moltis_code_index::CodeIndex::config_only(
+            moltis_code_index::CodeIndexConfig::default(),
+        )),
         18789,
         false,
         None,

--- a/crates/httpd/tests/auth_middleware/more.rs
+++ b/crates/httpd/tests/auth_middleware/more.rs
@@ -552,6 +552,9 @@ pub(super) async fn start_server_with_onboarding(
         false,
         None,
         None,
+        Arc::new(moltis_code_index::CodeIndex::config_only(
+            moltis_code_index::CodeIndexConfig::default(),
+        )),
         18789,
         false,
         None,

--- a/crates/qmd/src/manager.rs
+++ b/crates/qmd/src/manager.rs
@@ -264,36 +264,57 @@ impl QmdManager {
         Ok(self.run_with_timeout(command).await?.status.success())
     }
 
-    /// Ensure Moltis-managed collections exist in the selected QMD index.
-    pub async fn ensure_collections(&self) -> anyhow::Result<()> {
+    /// Ensure a single collection exists in the selected QMD index.
+    ///
+    /// Idempotent — if the collection already exists, this is a no-op.
+    /// Useful for registering collections discovered at runtime (e.g. per-project
+    /// code index directories) rather than only those pre-configured at startup.
+    pub async fn ensure_collection(
+        &self,
+        name: &str,
+        collection: &QmdCollection,
+    ) -> anyhow::Result<()> {
         if !self.is_available().await {
             anyhow::bail!("QMD is not available");
         }
 
-        for (name, collection) in &self.config.collections {
-            if self.collection_exists(name).await? {
-                continue;
-            }
-
-            let mut command = self.command_with_index();
-            command
-                .arg("collection")
-                .arg("add")
-                .arg(&collection.path)
-                .arg("--name")
-                .arg(name)
-                .arg("--mask")
-                .arg(&collection.glob)
-                .stdout(Stdio::piped())
-                .stderr(Stdio::piped());
-
-            let output = self.run_with_timeout(command).await?;
-            if !output.status.success() {
-                let stderr = String::from_utf8_lossy(&output.stderr);
-                anyhow::bail!("QMD collection add failed for {name}: {}", stderr.trim());
-            }
+        if self.collection_exists(name).await? {
+            return Ok(());
         }
 
+        let mut command = self.command_with_index();
+        command
+            .arg("collection")
+            .arg("add")
+            .arg(&collection.path)
+            .arg("--name")
+            .arg(name)
+            .arg("--mask")
+            .arg(&collection.glob)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+
+        let output = self.run_with_timeout(command).await?;
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            anyhow::bail!(
+                "QMD collection add failed for {name}: {}",
+                stderr.trim()
+            );
+        }
+
+        Ok(())
+    }
+
+    /// Ensure all pre-configured collections exist in the selected QMD index.
+    ///
+    /// Iterates the collections set at construction time and registers any
+    /// that don't already exist. For dynamic per-call registration, use
+    /// [`ensure_collection`](Self::ensure_collection) instead.
+    pub async fn ensure_collections(&self) -> anyhow::Result<()> {
+        for (name, collection) in &self.config.collections {
+            self.ensure_collection(name, collection).await?;
+        }
         Ok(())
     }
 


### PR DESCRIPTION
## Summary

Adds `moltis-code-index` — a crate for indexing project source code with file discovery, filtering, incremental delta sync, and a builtin SQLite+FTS5 search backend. Wires into the gateway as agent tools.

### What this adds

**Crate scaffold** (`crates/code-index/`)
- `types.rs`: Language, FileEntry, FilteredFile, CodeChunk, IndexStatus, SearchResult, Backend enum
- `config.rs`: CodeIndexConfig with extension allowlist, skip paths, size limits, feature-gated tracing/metrics
- `discover.rs`: git-tracked file enumeration via gix
- `filter.rs`: extension filter, binary detection, size limit, path exclusion
- `error.rs`: Error enum with thiserror

**Orchestrator + search**
- `index.rs`: CodeIndex struct — config_only/new constructors, index_project, search, keyword_search, status
- `search.rs`: QMD result adapter

**Agent tools**
- `tools.rs`: CodebaseSearchTool, CodebasePeekTool, CodebaseStatusTool (AgentTool trait)

**Incremental reindexing**
- `watcher.rs`: file watcher via notify_debouncer_full (feature-gated)
- `delta.rs`: SyncDelta computation via HashSnapshot (sha256)
- `snapshot_store.rs`: file-backed atomic-write persistence

**Builtin backend**
- `store.rs`: BackendStore trait
- `store_sqlite.rs`: SQLite+FTS5 implementation with content table, schema migration, chunking
- `chunker.rs`: line-based code chunking with overlap
- `backend_qmd.rs`: QMD collection config builder (feature-gated)

**Gateway wiring**
- `init_code_index.rs`: async init with QMD availability check, graceful fallback
- Tool registry integration, QMD ensure_collection() extraction

### Testing
- 42 unit tests across all modules
- Clippy clean with --all-features
- Feature-gated: compiles with both default and --no-default-features

### Replaces
Supersedes PRs #753, #754, #755, #756 (stacked code-index series).
