### PR TITLE
fix(task_list): list all tasks by default and add list_lists action

### DIFF
--- a/crates/tools/src/task_list.rs
+++ b/crates/tools/src/task_list.rs
@@ -67,10 +67,10 @@ pub struct Task {
     pub blocked_by: Vec<String>,
     pub created_at: u64,
     pub updated_at: u64,
-    /// Which list this task belongs to. Populated when returned from
-    /// cross-list queries (wildcard `list_id="*"`). Empty string for
-    /// single-list responses.
-    #[serde(default, skip_serializing_if = "String::is_empty")]
+    /// Which list this task belongs to. Always populated since creation
+    /// associates tasks with a list. Persisted to disk as part of the
+    /// task JSON; deserialization defaults to empty for legacy files.
+    #[serde(default)]
     pub list_id: String,
 }
 
@@ -187,6 +187,11 @@ impl TaskStore {
 
     /// Return all list IDs that have persisted files or contain tasks.
     /// Filters out phantom in-memory lists created by failed lookups.
+    ///
+    /// Note: this scans the filesystem and holds a read lock, so results
+    /// may be stale if a concurrent write creates or deletes a list file
+    /// between the directory scan and the filter. This is acceptable for
+    /// a discovery API — callers should not assume strong consistency.
     pub async fn list_ids(&self) -> crate::Result<Vec<String>> {
         // Ensure every persisted list is loaded.
         if self.data_dir.exists() {

--- a/crates/tools/src/task_list.rs
+++ b/crates/tools/src/task_list.rs
@@ -67,6 +67,11 @@ pub struct Task {
     pub blocked_by: Vec<String>,
     pub created_at: u64,
     pub updated_at: u64,
+    /// Which list this task belongs to. Populated when returned from
+    /// cross-list queries (wildcard `list_id="*"`). Empty string for
+    /// single-list responses.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub list_id: String,
 }
 
 /// File-backed store for one logical task list.
@@ -172,6 +177,7 @@ impl TaskStore {
             blocked_by: Vec::new(),
             created_at: now,
             updated_at: now,
+            list_id: list_id.to_string(),
         };
         list.tasks.insert(id, task.clone());
         drop(lists);
@@ -179,7 +185,8 @@ impl TaskStore {
         Ok(task)
     }
 
-    /// Return all list IDs currently known (loaded in memory or on disk).
+    /// Return all list IDs that have persisted files or contain tasks.
+    /// Filters out phantom in-memory lists created by failed lookups.
     pub async fn list_ids(&self) -> crate::Result<Vec<String>> {
         // Ensure every persisted list is loaded.
         if self.data_dir.exists() {
@@ -203,7 +210,14 @@ impl TaskStore {
             }
         }
         let lists = self.lists.read().await;
-        let mut ids: Vec<String> = lists.keys().cloned().collect();
+        let mut ids: Vec<String> = lists
+            .iter()
+            .filter(|(id, list)| {
+                // Keep if persisted on disk or has tasks.
+                self.file_path(id).exists() || !list.tasks.is_empty()
+            })
+            .map(|(id, _)| id.clone())
+            .collect();
         ids.sort();
         Ok(ids)
     }
@@ -237,7 +251,7 @@ impl TaskStore {
     async fn list_all_tasks(&self, status_filter: Option<&TaskStatus>) -> crate::Result<Vec<Task>> {
         let ids = self.list_ids().await?;
         // Collect as (list_id, numeric_id, task) for stable cross-list ordering.
-        let mut all: Vec<(&str, u64, Task)> = Vec::new();
+        let mut all: Vec<(String, u64, Task)> = Vec::new();
         let lists = self.lists.read().await;
         for id in &ids {
             let Some(list) = lists.get(id) else {
@@ -248,10 +262,12 @@ impl TaskStore {
                 .values()
                 .filter(|t| status_filter.is_none_or(|s| &t.status == s))
             {
-                all.push((id, task.id.parse::<u64>().unwrap_or(0), task.clone()));
+                let mut t = task.clone();
+                t.list_id = id.clone();
+                all.push((id.clone(), t.id.parse::<u64>().unwrap_or(0), t));
             }
         }
-        all.sort_by_key(|(list_id, num, _)| (list_id.to_string(), *num));
+        all.sort_by_key(|(list_id, num, _)| (list_id.clone(), *num));
         Ok(all.into_iter().map(|(_, _, t)| t).collect())
     }
 
@@ -382,7 +398,7 @@ impl AgentTool for TaskListTool {
 
     fn description(&self) -> &str {
         "Manage a shared task list for coordinated multi-agent execution. \
-         Actions: create, list, get, update, claim."
+         Actions: create, list, list_lists, get, update, claim."
     }
 
     fn parameters_schema(&self) -> serde_json::Value {
@@ -800,6 +816,88 @@ mod tests {
             .await?;
         assert_eq!(result["count"], 1);
         assert_eq!(result["tasks"][0]["subject"], "in-default");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn wildcard_list_includes_list_id_field() -> TestResult<()> {
+        let tmp = tempfile::tempdir()?;
+        let task_tool = tool(&tmp);
+
+        task_tool
+            .execute(serde_json::json!({
+                "action": "create",
+                "list_id": "LIST_A",
+                "subject": "a-task"
+            }))
+            .await?;
+
+        let result = task_tool
+            .execute(serde_json::json!({
+                "action": "list",
+                "list_id": "*"
+            }))
+            .await?;
+        assert_eq!(result["count"], 1);
+        assert_eq!(result["tasks"][0]["list_id"], "LIST_A");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn single_list_includes_list_id_field() -> TestResult<()> {
+        let tmp = tempfile::tempdir()?;
+        let task_tool = tool(&tmp);
+
+        task_tool
+            .execute(serde_json::json!({
+                "action": "create",
+                "list_id": "X",
+                "subject": "x-task"
+            }))
+            .await?;
+
+        let result = task_tool
+            .execute(serde_json::json!({
+                "action": "list",
+                "list_id": "X"
+            }))
+            .await?;
+        assert_eq!(result["tasks"][0]["list_id"], "X");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn list_lists_excludes_phantom_empty_lists() -> TestResult<()> {
+        let tmp = tempfile::tempdir()?;
+        let task_tool = tool(&tmp);
+
+        // Create a real list with a task.
+        task_tool
+            .execute(serde_json::json!({
+                "action": "create",
+                "list_id": "REAL",
+                "subject": "real-task"
+            }))
+            .await?;
+
+        // Try to get from a non-existent list — this creates a phantom empty list.
+        let get_result = task_tool
+            .execute(serde_json::json!({
+                "action": "get",
+                "list_id": "PHANTOM",
+                "id": "999"
+            }))
+            .await?;
+        assert_eq!(get_result["ok"], false);
+
+        // list_lists should only return REAL, not PHANTOM.
+        let result = task_tool
+            .execute(serde_json::json!({
+                "action": "list_lists"
+            }))
+            .await?;
+        assert_eq!(result["count"], 1);
+        assert_eq!(result["list_ids"][0], "REAL");
         Ok(())
     }
 }

--- a/crates/tools/src/task_list.rs
+++ b/crates/tools/src/task_list.rs
@@ -234,26 +234,25 @@ impl TaskStore {
     }
 
     /// List tasks across every known list.
-    async fn list_all_tasks(
-        &self,
-        status_filter: Option<&TaskStatus>,
-    ) -> crate::Result<Vec<Task>> {
+    async fn list_all_tasks(&self, status_filter: Option<&TaskStatus>) -> crate::Result<Vec<Task>> {
         let ids = self.list_ids().await?;
-        let mut all: Vec<Task> = Vec::new();
+        // Collect as (list_id, numeric_id, task) for stable cross-list ordering.
+        let mut all: Vec<(&str, u64, Task)> = Vec::new();
         let lists = self.lists.read().await;
         for id in &ids {
             let Some(list) = lists.get(id) else {
                 continue;
             };
-            all.extend(
-                list.tasks
-                    .values()
-                    .filter(|t| status_filter.is_none_or(|s| &t.status == s))
-                    .cloned(),
-            );
+            for task in list
+                .tasks
+                .values()
+                .filter(|t| status_filter.is_none_or(|s| &t.status == s))
+            {
+                all.push((id, task.id.parse::<u64>().unwrap_or(0), task.clone()));
+            }
         }
-        all.sort_by_key(|t| t.id.parse::<u64>().unwrap_or(0));
-        Ok(all)
+        all.sort_by_key(|(list_id, num, _)| (list_id.to_string(), *num));
+        Ok(all.into_iter().map(|(_, _, t)| t).collect())
     }
 
     pub async fn get(&self, list_id: &str, task_id: &str) -> crate::Result<Option<Task>> {
@@ -397,7 +396,7 @@ impl AgentTool for TaskListTool {
                 },
                 "list_id": {
                     "type": "string",
-                    "description": "Task list identifier. Use \"*\" to list across all lists, or omit for \"default\". Use the \"list_lists\" action to discover available lists."
+                    "description": "Task list identifier. Use \"*\" (or omit) to list across all lists. Pass a specific ID to scope to one list."
                 },
                 "id": {
                     "type": "string",
@@ -448,7 +447,10 @@ impl AgentTool for TaskListTool {
                 let status = str_param(&params, "status")
                     .map(str::parse::<TaskStatus>)
                     .transpose()?;
-                let effective_id = if list_id == "default" && params.get("list_id").is_none() && params.get("listId").is_none() {
+                let effective_id = if list_id == "default"
+                    && params.get("list_id").is_none()
+                    && params.get("listId").is_none()
+                {
                     // When list_id is truly omitted, default to "*" so agents
                     // see tasks from all lists without guessing.
                     "*"

--- a/crates/tools/src/task_list.rs
+++ b/crates/tools/src/task_list.rs
@@ -179,11 +179,44 @@ impl TaskStore {
         Ok(task)
     }
 
+    /// Return all list IDs currently known (loaded in memory or on disk).
+    pub async fn list_ids(&self) -> crate::Result<Vec<String>> {
+        // Ensure every persisted list is loaded.
+        if self.data_dir.exists() {
+            let mut entries = tokio::fs::read_dir(&self.data_dir)
+                .await
+                .map_err(|e| Error::message(format!("failed to read task dir: {e}")))?;
+            while let Some(entry) = entries
+                .next_entry()
+                .await
+                .map_err(|e| Error::message(format!("failed to read task dir entry: {e}")))?
+            {
+                let path = entry.path();
+                if path.extension().is_some_and(|ext| ext == "json") {
+                    let stem = path
+                        .file_stem()
+                        .and_then(|s| s.to_str())
+                        .unwrap_or("")
+                        .to_string();
+                    self.ensure_list(&stem).await?;
+                }
+            }
+        }
+        let lists = self.lists.read().await;
+        let mut ids: Vec<String> = lists.keys().cloned().collect();
+        ids.sort();
+        Ok(ids)
+    }
+
+    /// List tasks from a single list, or all lists when `list_id` is `"*"`.
     pub async fn list_tasks(
         &self,
         list_id: &str,
         status_filter: Option<&TaskStatus>,
     ) -> crate::Result<Vec<Task>> {
+        if list_id == "*" {
+            return self.list_all_tasks(status_filter).await;
+        }
         self.ensure_list(list_id).await?;
         let lists = self.lists.read().await;
         let list = lists
@@ -198,6 +231,29 @@ impl TaskStore {
             .collect();
         tasks.sort_by_key(|t| t.id.parse::<u64>().unwrap_or(0));
         Ok(tasks)
+    }
+
+    /// List tasks across every known list.
+    async fn list_all_tasks(
+        &self,
+        status_filter: Option<&TaskStatus>,
+    ) -> crate::Result<Vec<Task>> {
+        let ids = self.list_ids().await?;
+        let mut all: Vec<Task> = Vec::new();
+        let lists = self.lists.read().await;
+        for id in &ids {
+            let Some(list) = lists.get(id) else {
+                continue;
+            };
+            all.extend(
+                list.tasks
+                    .values()
+                    .filter(|t| status_filter.is_none_or(|s| &t.status == s))
+                    .cloned(),
+            );
+        }
+        all.sort_by_key(|t| t.id.parse::<u64>().unwrap_or(0));
+        Ok(all)
     }
 
     pub async fn get(&self, list_id: &str, task_id: &str) -> crate::Result<Option<Task>> {
@@ -336,12 +392,12 @@ impl AgentTool for TaskListTool {
             "properties": {
                 "action": {
                     "type": "string",
-                    "enum": ["create", "list", "get", "update", "claim"],
-                    "description": "Task list action to perform."
+                    "enum": ["create", "list", "list_lists", "get", "update", "claim"],
+                    "description": "Task list action to perform. Use list_lists to discover all lists. Use list with list_id=\"*\" for all tasks."
                 },
                 "list_id": {
                     "type": "string",
-                    "description": "Task list identifier (default: default)."
+                    "description": "Task list identifier. Use \"*\" to list across all lists, or omit for \"default\". Use the \"list_lists\" action to discover available lists."
                 },
                 "id": {
                     "type": "string",
@@ -392,11 +448,26 @@ impl AgentTool for TaskListTool {
                 let status = str_param(&params, "status")
                     .map(str::parse::<TaskStatus>)
                     .transpose()?;
-                let tasks = self.store.list_tasks(list_id, status.as_ref()).await?;
+                let effective_id = if list_id == "default" && params.get("list_id").is_none() && params.get("listId").is_none() {
+                    // When list_id is truly omitted, default to "*" so agents
+                    // see tasks from all lists without guessing.
+                    "*"
+                } else {
+                    list_id
+                };
+                let tasks = self.store.list_tasks(effective_id, status.as_ref()).await?;
                 Ok(serde_json::json!({
                     "ok": true,
                     "tasks": tasks,
                     "count": tasks.len(),
+                }))
+            },
+            "list_lists" => {
+                let ids = self.store.list_ids().await?;
+                Ok(serde_json::json!({
+                    "ok": true,
+                    "list_ids": ids,
+                    "count": ids.len(),
                 }))
             },
             "get" => {
@@ -586,6 +657,147 @@ mod tests {
             .err()
             .ok_or_else(|| std::io::Error::other("expected blocked claim failure"))?;
         assert!(err.to_string().contains("blocked by incomplete tasks"));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn list_without_list_id_returns_all_tasks() -> TestResult<()> {
+        let tmp = tempfile::tempdir()?;
+        let task_tool = tool(&tmp);
+
+        // Create tasks in two different lists.
+        task_tool
+            .execute(serde_json::json!({
+                "action": "create",
+                "list_id": "CURRICULUM_1",
+                "subject": "task-a",
+                "description": "in list 1"
+            }))
+            .await?;
+        task_tool
+            .execute(serde_json::json!({
+                "action": "create",
+                "list_id": "CURRICULUM_2",
+                "subject": "task-b",
+                "description": "in list 2"
+            }))
+            .await?;
+
+        // Omitting list_id should now default to "*" and return both.
+        let result = task_tool
+            .execute(serde_json::json!({
+                "action": "list"
+            }))
+            .await?;
+        assert_eq!(result["count"], 2);
+
+        let subjects: Vec<&str> = result["tasks"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|t| t["subject"].as_str().unwrap())
+            .collect();
+        assert!(subjects.contains(&"task-a"));
+        assert!(subjects.contains(&"task-b"));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn list_with_wildcard_returns_all_tasks() -> TestResult<()> {
+        let tmp = tempfile::tempdir()?;
+        let task_tool = tool(&tmp);
+
+        task_tool
+            .execute(serde_json::json!({
+                "action": "create",
+                "list_id": "ALPHA",
+                "subject": "alpha-task"
+            }))
+            .await?;
+        task_tool
+            .execute(serde_json::json!({
+                "action": "create",
+                "subject": "default-task"
+            }))
+            .await?;
+
+        let result = task_tool
+            .execute(serde_json::json!({
+                "action": "list",
+                "list_id": "*"
+            }))
+            .await?;
+        assert_eq!(result["count"], 2);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn list_lists_returns_all_known_ids() -> TestResult<()> {
+        let tmp = tempfile::tempdir()?;
+        let task_tool = tool(&tmp);
+
+        task_tool
+            .execute(serde_json::json!({
+                "action": "create",
+                "list_id": "LIST_X",
+                "subject": "x"
+            }))
+            .await?;
+        task_tool
+            .execute(serde_json::json!({
+                "action": "create",
+                "list_id": "LIST_Y",
+                "subject": "y"
+            }))
+            .await?;
+
+        let result = task_tool
+            .execute(serde_json::json!({
+                "action": "list_lists"
+            }))
+            .await?;
+        assert_eq!(result["count"], 2);
+
+        let ids: Vec<&str> = result["list_ids"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|v| v.as_str().unwrap())
+            .collect();
+        assert!(ids.contains(&"LIST_X"));
+        assert!(ids.contains(&"LIST_Y"));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn explicit_default_list_id_still_scopes() -> TestResult<()> {
+        let tmp = tempfile::tempdir()?;
+        let task_tool = tool(&tmp);
+
+        task_tool
+            .execute(serde_json::json!({
+                "action": "create",
+                "list_id": "default",
+                "subject": "in-default"
+            }))
+            .await?;
+        task_tool
+            .execute(serde_json::json!({
+                "action": "create",
+                "list_id": "OTHER",
+                "subject": "in-other"
+            }))
+            .await?;
+
+        // Explicitly passing list_id="default" should only return default tasks.
+        let result = task_tool
+            .execute(serde_json::json!({
+                "action": "list",
+                "list_id": "default"
+            }))
+            .await?;
+        assert_eq!(result["count"], 1);
+        assert_eq!(result["tasks"][0]["subject"], "in-default");
         Ok(())
     }
 }


### PR DESCRIPTION
Fixes #776

## Problem

When `task_list.list` was called without specifying `list_id`, it defaulted to `"default"`. Tasks created under custom list IDs (e.g. `"CURRICULUM_1"`) were invisible unless the agent explicitly knew to pass that ID. There was also no way to discover what lists existed.

## Changes

- **Omitting `list_id` on `list` action now defaults to `"*"`** (all lists) instead of `"default"`. Explicitly passing `list_id="default"` still scopes to that list only.
- **Wildcard `list_id="*"`** queries across every known list.
- **New `list_lists` action** returns all known list IDs by scanning persisted JSON files, filtering out phantom empty lists.
- **`Task` struct gains `list_id` field** — always populated on creation, enabling agents to issue follow-up `get`/`update`/`claim` from cross-list query results. Forward-compatible with legacy files via `#[serde(default)]`.
- **`TaskStore` gains `list_ids()` and `list_all_tasks()` methods.**
- **Schema and description updated** to document all new behavior.
- Cross-list sort uses `(list_id, numeric_id)` tuple for stable ordering.

## Testing

7 new tests (11 total), all passing:
- `list_without_list_id_returns_all_tasks` — omit sees all lists
- `list_with_wildcard_returns_all_tasks` — explicit `*` sees all lists
- `list_lists_returns_all_known_ids` — discovers list IDs
- `explicit_default_list_id_still_scopes` — explicit `default` still scopes
- `wildcard_list_includes_list_id_field` — cross-list tasks carry `list_id`
- `single_list_includes_list_id_field` — single-list tasks carry `list_id`
- `list_lists_excludes_phantom_empty_lists` — no phantom lists

## Validation

- `cargo fmt --check` ✅
- `cargo clippy -D warnings` ✅ (on `moltis-tools`)
- `cargo test -p moltis-tools --lib task_list` ✅ 11/11

## Blast Radius

Single-file change (`crates/tools/src/task_list.rs`). No other crate imports `Task`, `TaskList`, `TaskStore`, or `TaskStatus`. The `TaskListTool::new()` constructor signature is unchanged. Persisted JSON is forward-compatible.