### PR TITLE
fix(sandbox): add observability and prevent repeated package provisioning

### DIFF
--- a/crates/tools/src/sandbox/docker.rs
+++ b/crates/tools/src/sandbox/docker.rs
@@ -20,7 +20,7 @@ use {
         },
         types::{
             BuildImageResult, DEFAULT_SANDBOX_IMAGE, NetworkPolicy, SANDBOX_HOME_DIR, Sandbox,
-            SandboxConfig, SandboxId, WorkspaceMount, canonical_sandbox_packages,
+            SandboxConfig, SandboxId, WorkspaceMount, canonical_sandbox_packages, tail_lines,
             truncate_output_for_display,
         },
     },
@@ -56,7 +56,7 @@ pub struct DockerSandbox {
     backend_label: &'static str,
     /// Container names that have already been provisioned in this process.
     /// Prevents repeated `apt-get install` runs on the same container.
-    provisioned: Mutex<HashSet<String>>,
+    pub(crate) provisioned: Mutex<HashSet<String>>,
 }
 
 impl DockerSandbox {
@@ -377,15 +377,25 @@ impl Sandbox for DockerSandbox {
         // Skip provisioning if the image is a pre-built instance sandbox image
         // (packages are already baked in — including /home/sandbox from the Dockerfile).
         if !is_prebuilt {
-            let already_provisioned = self.provisioned.lock().await.contains(&name);
-            if already_provisioned {
+            let needs_provisioning = {
+                let mut provisioned = self.provisioned.lock().await;
+                if provisioned.contains(&name) {
+                    false
+                } else {
+                    provisioned.insert(name.clone());
+                    true
+                }
+            };
+            if needs_provisioning {
+                if let Err(e) = provision_packages(self.cli, &name, &self.config.packages).await {
+                    self.provisioned.lock().await.remove(&name);
+                    return Err(e);
+                }
+            } else {
                 debug!(
                     container = %name,
                     "skipping provisioning, already completed for container"
                 );
-            } else {
-                provision_packages(self.cli, &name, &self.config.packages).await?;
-                self.provisioned.lock().await.insert(name);
             }
         }
 
@@ -683,17 +693,4 @@ pub(crate) fn podman_resolve_host_ip() -> Option<String> {
     } else {
         Some(gateway)
     }
-}
-
-/// Return the last `n` lines of `text`, or the full text if it has fewer lines.
-fn tail_lines(text: &str, n: usize) -> String {
-    let lines: Vec<&str> = text.lines().collect();
-    if lines.len() <= n {
-        return text.to_string();
-    }
-    format!(
-        "... [{} lines truncated]\n{}",
-        lines.len() - n,
-        lines[lines.len() - n..].join("\n")
-    )
 }

--- a/crates/tools/src/sandbox/docker.rs
+++ b/crates/tools/src/sandbox/docker.rs
@@ -2,6 +2,8 @@
 
 use {
     async_trait::async_trait,
+    std::collections::HashSet,
+    tokio::sync::Mutex,
     tracing::{debug, info, warn},
 };
 
@@ -52,6 +54,9 @@ pub struct DockerSandbox {
     kind: BackendKind,
     cli: &'static str,
     backend_label: &'static str,
+    /// Container names that have already been provisioned in this process.
+    /// Prevents repeated `apt-get install` runs on the same container.
+    provisioned: Mutex<HashSet<String>>,
 }
 
 impl DockerSandbox {
@@ -61,6 +66,7 @@ impl DockerSandbox {
             kind: BackendKind::Docker,
             cli: "docker",
             backend_label: "docker",
+            provisioned: Mutex::new(HashSet::new()),
         }
     }
 
@@ -70,6 +76,7 @@ impl DockerSandbox {
             kind: BackendKind::Podman,
             cli: "podman",
             backend_label: "podman",
+            provisioned: Mutex::new(HashSet::new()),
         }
     }
 
@@ -266,6 +273,7 @@ impl DockerSandbox {
 
     async fn resolve_local_image(&self, requested_image: &str) -> Result<String> {
         if sandbox_image_exists(self.cli, requested_image).await {
+            debug!(image = requested_image, "sandbox image found locally");
             return Ok(requested_image.to_string());
         }
 
@@ -318,6 +326,7 @@ impl Sandbox for DockerSandbox {
         if let Ok(output) = check {
             let stdout = String::from_utf8_lossy(&output.stdout);
             if stdout.trim() == "true" {
+                debug!(container = %name, "sandbox container already running");
                 return Ok(());
             }
         }
@@ -326,8 +335,10 @@ impl Sandbox for DockerSandbox {
         let requested_image = image_override.unwrap_or_else(|| self.image());
         let image = self.resolve_local_image(requested_image).await?;
         let is_prebuilt = image.starts_with(&format!("{}:", self.image_repo()));
+        debug!(container = %name, %image, is_prebuilt, "resolved sandbox image");
 
         // Start a new container.
+        info!(container = %name, %image, "starting new sandbox container");
         let mut args = vec![
             "run".to_string(),
             "-d".to_string(),
@@ -366,7 +377,16 @@ impl Sandbox for DockerSandbox {
         // Skip provisioning if the image is a pre-built instance sandbox image
         // (packages are already baked in — including /home/sandbox from the Dockerfile).
         if !is_prebuilt {
-            provision_packages(self.cli, &name, &self.config.packages).await?;
+            let already_provisioned = self.provisioned.lock().await.contains(&name);
+            if already_provisioned {
+                debug!(
+                    container = %name,
+                    "skipping provisioning, already completed for container"
+                );
+            } else {
+                provision_packages(self.cli, &name, &self.config.packages).await?;
+                self.provisioned.lock().await.insert(name);
+            }
         }
 
         Ok(())
@@ -418,7 +438,15 @@ impl Sandbox for DockerSandbox {
 
         let output = output?;
         if !output.status.success() {
+            let stdout = String::from_utf8_lossy(&output.stdout);
             let stderr = String::from_utf8_lossy(&output.stderr);
+            warn!(
+                tag,
+                stdout = %tail_lines(&stdout, 20),
+                stderr = %stderr.trim(),
+                "{} build failed",
+                self.cli,
+            );
             return Err(Error::message(format!(
                 "{} build failed for {tag}: {}",
                 self.cli,
@@ -426,6 +454,8 @@ impl Sandbox for DockerSandbox {
             )));
         }
 
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        debug!(tag, output = %tail_lines(&stdout, 20), "docker build output");
         info!(tag, "pre-built sandbox image ready");
         Ok(Some(BuildImageResult { tag, built: true }))
     }
@@ -543,6 +573,7 @@ impl Sandbox for DockerSandbox {
 
     async fn cleanup(&self, id: &SandboxId) -> Result<()> {
         let name = self.container_name(id);
+        self.provisioned.lock().await.remove(&name);
         let _ = tokio::process::Command::new(self.cli)
             .args(["rm", "-f", &name])
             .output()
@@ -652,4 +683,17 @@ pub(crate) fn podman_resolve_host_ip() -> Option<String> {
     } else {
         Some(gateway)
     }
+}
+
+/// Return the last `n` lines of `text`, or the full text if it has fewer lines.
+fn tail_lines(text: &str, n: usize) -> String {
+    let lines: Vec<&str> = text.lines().collect();
+    if lines.len() <= n {
+        return text.to_string();
+    }
+    format!(
+        "... [{} lines truncated]\n{}",
+        lines.len() - n,
+        lines[lines.len() - n..].join("\n")
+    )
 }

--- a/crates/tools/src/sandbox/host.rs
+++ b/crates/tools/src/sandbox/host.rs
@@ -3,7 +3,10 @@
 use tracing::{debug, info, warn};
 
 use {
-    super::containers::{container_exec_shell_args, is_cli_available},
+    super::{
+        containers::{container_exec_shell_args, is_cli_available},
+        types::tail_lines,
+    },
     crate::error::Result,
 };
 
@@ -325,17 +328,4 @@ pub async fn provision_host_packages(packages: &[String]) -> Result<Option<HostP
             }))
         },
     }
-}
-
-/// Return the last `n` lines of `text`, or the full text if it has fewer lines.
-fn tail_lines(text: &str, n: usize) -> String {
-    let lines: Vec<&str> = text.lines().collect();
-    if lines.len() <= n {
-        return text.to_string();
-    }
-    format!(
-        "... [{} lines truncated]\n{}",
-        lines.len() - n,
-        lines[lines.len() - n..].join("\n")
-    )
 }

--- a/crates/tools/src/sandbox/host.rs
+++ b/crates/tools/src/sandbox/host.rs
@@ -1,6 +1,6 @@
 //! Host package provisioning (Debian/Ubuntu apt-get).
 
-use tracing::{info, warn};
+use tracing::{debug, info, warn};
 
 use {
     super::containers::{container_exec_shell_args, is_cli_available},
@@ -24,15 +24,26 @@ pub(crate) async fn provision_packages(
         .args(container_exec_shell_args(
             cli,
             container_name,
-            format!("apt-get update -qq && apt-get install -y -qq {pkg_list} 2>&1 | tail -5"),
+            format!("apt-get update -qq && apt-get install -y -qq {pkg_list}"),
         ))
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
         .output()
         .await?;
-    if !output.status.success() {
+    if output.status.success() {
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        if !stdout.trim().is_empty() {
+            let tail = tail_lines(&stdout, 20);
+            debug!(container = container_name, output = %tail, "package provisioning output");
+        }
+    } else {
+        let stdout = String::from_utf8_lossy(&output.stdout);
         let stderr = String::from_utf8_lossy(&output.stderr);
         warn!(
             container = container_name,
-            %stderr,
+            exit_code = output.status.code().unwrap_or(-1),
+            stdout = %tail_lines(&stdout, 20),
+            stderr = %stderr.trim(),
             "package provisioning failed (non-fatal)"
         );
     }
@@ -314,4 +325,17 @@ pub async fn provision_host_packages(packages: &[String]) -> Result<Option<HostP
             }))
         },
     }
+}
+
+/// Return the last `n` lines of `text`, or the full text if it has fewer lines.
+fn tail_lines(text: &str, n: usize) -> String {
+    let lines: Vec<&str> = text.lines().collect();
+    if lines.len() <= n {
+        return text.to_string();
+    }
+    format!(
+        "... [{} lines truncated]\n{}",
+        lines.len() - n,
+        lines[lines.len() - n..].join("\n")
+    )
 }

--- a/crates/tools/src/sandbox/tests/core.rs
+++ b/crates/tools/src/sandbox/tests/core.rs
@@ -1,5 +1,5 @@
 #![allow(clippy::unwrap_used, clippy::expect_used)]
-use super::*;
+use {super::*, crate::sandbox::types::tail_lines};
 
 #[test]
 fn test_sandbox_mode_display() {
@@ -551,4 +551,78 @@ async fn test_docker_list_files_remaps_mounted_workspace_paths() {
         guest_root.join("todo.txt").display().to_string(),
     ]);
     assert!(!files.truncated);
+}
+
+#[tokio::test]
+async fn test_provisioning_guard_skips_second_call() {
+    let docker = DockerSandbox::new(SandboxConfig::default());
+    let name = "moltis-sandbox-test-guard";
+
+    // First insertion succeeds.
+    {
+        let mut guard = docker.provisioned.lock().await;
+        assert!(!guard.contains(name));
+        guard.insert(name.to_string());
+    }
+
+    // Second check shows already provisioned.
+    {
+        let guard = docker.provisioned.lock().await;
+        assert!(guard.contains(name));
+    }
+}
+
+#[tokio::test]
+async fn test_provisioning_guard_cleared_on_cleanup_entry() {
+    let docker = DockerSandbox::new(SandboxConfig::default());
+    let name = "moltis-sandbox-test-cleanup";
+
+    // Mark as provisioned.
+    docker.provisioned.lock().await.insert(name.to_string());
+    assert!(docker.provisioned.lock().await.contains(name));
+
+    // Simulate cleanup clearing the entry.
+    docker.provisioned.lock().await.remove(name);
+    assert!(!docker.provisioned.lock().await.contains(name));
+}
+
+#[tokio::test]
+async fn test_provisioning_guard_independent_containers() {
+    let docker = DockerSandbox::new(SandboxConfig::default());
+
+    docker
+        .provisioned
+        .lock()
+        .await
+        .insert("container-a".to_string());
+
+    let guard = docker.provisioned.lock().await;
+    assert!(guard.contains("container-a"));
+    assert!(!guard.contains("container-b"));
+}
+
+#[test]
+fn test_tail_lines_fewer_than_n() {
+    let text = "line1\nline2\nline3";
+    assert_eq!(tail_lines(text, 5), text);
+}
+
+#[test]
+fn test_tail_lines_exact_n() {
+    let text = "line1\nline2\nline3";
+    assert_eq!(tail_lines(text, 3), text);
+}
+
+#[test]
+fn test_tail_lines_more_than_n() {
+    let text = "line1\nline2\nline3\nline4\nline5";
+    let result = tail_lines(text, 2);
+    assert!(result.starts_with("... [3 lines truncated]"));
+    assert!(result.contains("line4\nline5"));
+    assert!(!result.contains("line3"));
+}
+
+#[test]
+fn test_tail_lines_empty() {
+    assert_eq!(tail_lines("", 5), "");
 }

--- a/crates/tools/src/sandbox/types.rs
+++ b/crates/tools/src/sandbox/types.rs
@@ -25,6 +25,19 @@ pub(crate) fn truncate_output_for_display(output: &mut String, max_output_bytes:
     output.push_str("\n... [output truncated]");
 }
 
+/// Return the last `n` lines of `text`, or the full text if it has fewer lines.
+pub(crate) fn tail_lines(text: &str, n: usize) -> String {
+    let lines: Vec<&str> = text.lines().collect();
+    if lines.len() <= n {
+        return text.to_string();
+    }
+    format!(
+        "... [{} lines truncated]\n{}",
+        lines.len() - n,
+        lines[lines.len() - n..].join("\n")
+    )
+}
+
 /// Default container image used when none is configured.
 pub const DEFAULT_SANDBOX_IMAGE: &str = "ubuntu:25.10";
 


### PR DESCRIPTION
## Summary

Addresses #781 — users see unexplained `dpkg` processes with no moltis logs explaining what's happening.

- **Logging**: Added `debug!`/`info!`/`warn!` logs at every sandbox lifecycle decision point — container already running, starting new container, image resolution, docker build output, package provisioning output and failures (with exit codes).
- **Provisioning guard**: Track which containers have been provisioned in a `HashSet<String>` on `DockerSandbox` to prevent repeated `apt-get install` runs on the same container. Cleared on `cleanup()` so re-provisioning works after container recreation.
- **Full output capture**: Removed `2>&1 | tail -5` pipe from `provision_packages` so full apt-get output is captured for logging instead of being silently discarded.

## Validation

### Completed
- [x] `cargo check -p moltis-tools`
- [x] `cargo test -p moltis-tools sandbox` — 216 tests pass
- [x] `cargo +nightly-2025-11-30 fmt -p moltis-tools -- --check`
- [x] `cargo clippy -p moltis-tools -- -D warnings` (lib target)

### Remaining
- [ ] `./scripts/local-validate.sh <PR_NUMBER>`

## Manual QA

Run moltis with `RUST_LOG=moltis_tools=debug` and trigger a sandbox command. Verify logs show:
- `"sandbox container already running"` (debug, on repeat calls)
- `"starting new sandbox container"` (info, on first call)
- `"resolved sandbox image"` with `is_prebuilt` (debug)
- Docker build output (debug, last 20 lines)
- `"provisioning sandbox packages"` (info) + apt-get output (debug)
- `"skipping provisioning, already completed for container"` (debug, on repeat)