### PR TITLE
[AutoDoc] docs: rotisserie batch — audit and fix 4 stale docs

### DIFF
--- a/docs/src/session-state.md
+++ b/docs/src/session-state.md
@@ -8,8 +8,8 @@ and the agent itself to persist context across messages within a session.
 Session state is scoped to a `(session_key, namespace, key)` triple, backed by
 SQLite. Each entry stores a string value and is automatically timestamped.
 
-The agent accesses state through the `session_state` tool, which supports three
-operations: `get`, `set`, and `list`.
+The agent accesses state through the `session_state` tool, which supports five
+operations: `get`, `set`, `delete`, `list`, and `clear`.
 
 ## Agent Tool
 
@@ -20,31 +20,60 @@ session.
 
 ```json
 {
-  "op": "get",
+  "operation": "get",
   "namespace": "my-skill",
   "key": "last_query"
 }
 ```
 
+Returns `{ "value": "<value or null>" }`.
+
 ### Set a value
 
 ```json
 {
-  "op": "set",
+  "operation": "set",
   "namespace": "my-skill",
   "key": "last_query",
   "value": "SELECT * FROM users"
 }
 ```
 
+Returns `{ "ok": true }`. Insert-or-update semantics.
+
 ### List all keys in a namespace
 
 ```json
 {
-  "op": "list",
+  "operation": "list",
   "namespace": "my-skill"
 }
 ```
+
+Returns `{ "entries": [{ "key": "...", "value": "..." }] }`.
+
+### Delete a single key
+
+```json
+{
+  "operation": "delete",
+  "namespace": "my-skill",
+  "key": "last_query"
+}
+```
+
+Returns `{ "deleted": true }` if the key existed, `{ "deleted": false }` otherwise.
+
+### Clear all keys in a namespace
+
+```json
+{
+  "operation": "clear",
+  "namespace": "my-skill"
+}
+```
+
+Returns `{ "deleted": <count> }` with the number of entries removed.
 
 ## Namespacing
 

--- a/docs/src/slack.md
+++ b/docs/src/slack.md
@@ -99,6 +99,8 @@ offered = ["slack"]
 | `stream_mode` | no | `"edit_in_place"` | Streaming mode: `"edit_in_place"`, `"native"`, or `"off"` |
 | `edit_throttle_ms` | no | `500` | Minimum milliseconds between streaming edit updates |
 | `thread_replies` | no | `true` | Reply in threads |
+| `channel_overrides` | no | `{}` | Per-channel model/provider overrides (see below) |
+| `user_overrides` | no | `{}` | Per-user model/provider overrides (see below) |
 
 ```admonish important title="Allowlist values are strings"
 All allowlist entries must be **strings**. Use Slack user IDs like
@@ -125,6 +127,15 @@ model_provider = "anthropic"
 stream_mode = "edit_in_place"
 edit_throttle_ms = 500
 thread_replies = true
+
+# Per-channel override: use a different model in a specific Slack channel
+[channels.slack.my-bot.channel_overrides.C0123456789]
+model = "gpt-4o"
+
+# Per-user override: use a specific model/provider for a Slack user
+[channels.slack.my-bot.user_overrides.U0123456789]
+model = "claude-sonnet-4-20250514"
+model_provider = "anthropic"
 ```
 
 ### Events API Mode

--- a/docs/src/sqlite-migration.md
+++ b/docs/src/sqlite-migration.md
@@ -165,7 +165,7 @@ pub async fn run_migrations(pool: &sqlx::SqlitePool) -> anyhow::Result<()> {
 }
 ```
 
-4. Call it from `server.rs` in the appropriate order:
+4. Call it from `prepare_core.rs` in the appropriate order:
 
 ```rust
 moltis_new_feature::run_migrations(&db_pool).await?;
@@ -250,7 +250,7 @@ In production, migrations handle schema creation.
 
 ### Migration Order Issues
 
-If you see foreign key errors, verify the migration order in `server.rs`. Parent
+If you see foreign key errors, verify the migration order in `prepare_core.rs`. Parent
 tables must be created before child tables with FK references.
 
 ### Checking Migration Status
@@ -282,4 +282,4 @@ cargo run  # Creates fresh database with all migrations
 - Modify existing migration files after deployment
 - Reuse timestamps across crates
 - Put multiple crates' tables in one migration file
-- Skip the dependency order in `server.rs`
+- Skip the dependency order in `prepare_core.rs`

--- a/docs/src/sqlite-migration.md
+++ b/docs/src/sqlite-migration.md
@@ -52,7 +52,7 @@ Each crate is autonomous and owns its schema:
 | Crate | Database | Tables | Migration File |
 |-------|----------|--------|----------------|
 | `moltis-projects` | `moltis.db` | `projects` | `20240205100000_init.sql` |
-| `moltis-sessions` | `moltis.db` | `sessions`, `channel_sessions`, `session_state` | `20240205100001_init.sql` + 8 migrations |
+| `moltis-sessions` | `moltis.db` | `sessions`, `channel_sessions`, `session_state` | `20240205100001_init.sql` + 9 migrations |
 | `moltis-cron` | `moltis.db` | `cron_jobs`, `cron_runs` | `20240205100002_init.sql` + 1 migration |
 | `moltis-gateway` | `moltis.db` | `auth_*`, `passkeys`, `api_keys`, `env_variables`, `message_log`, `channels`, `agents`, `session_shares`, `device_pairing`, `ssh_keys`, `ssh_targets`, `auth_audit_log` | `20240205100003_init.sql` + 12 migrations |
 | `moltis-webhooks` | `moltis.db` | `webhooks`, `webhook_deliveries`, `webhook_response_actions` | `20260407000000_initial.sql` + 1 migration |

--- a/docs/src/sqlite-migration.md
+++ b/docs/src/sqlite-migration.md
@@ -18,7 +18,7 @@ crates/
 │   └── src/lib.rs                     # run_migrations()
 ├── sessions/
 │   ├── migrations/
-│   │   └── 20240205100001_init.sql   # sessions, channel_sessions
+│   │   └── 20240205100001_init.sql   # sessions, channel_sessions, session_state
 │   └── src/lib.rs                     # run_migrations()
 ├── cron/
 │   ├── migrations/
@@ -26,8 +26,17 @@ crates/
 │   └── src/lib.rs                     # run_migrations()
 ├── gateway/
 │   ├── migrations/
-│   │   └── 20240205100003_init.sql   # auth, message_log, channels
-│   └── src/server.rs                  # orchestrates moltis.db migrations
+│   │   └── 20240205100003_init.sql   # auth, message_log, channels, agents, ...
+│   └── src/server/
+│       └── prepare_core.rs            # orchestrates moltis.db migrations
+├── webhooks/
+│   ├── migrations/
+│   │   └── 20260407000000_initial.sql # webhooks, webhook_deliveries, ...
+│   └── src/lib.rs                     # run_migrations()
+├── vault/
+│   ├── migrations/
+│   │   └── 20260214000001_vault_metadata.sql  # vault_metadata
+│   └── src/lib.rs                     # run_migrations() (feature-gated)
 └── memory/
     ├── migrations/
     │   └── 20240205100004_init.sql   # files, chunks, embedding_cache, FTS
@@ -43,25 +52,31 @@ Each crate is autonomous and owns its schema:
 | Crate | Database | Tables | Migration File |
 |-------|----------|--------|----------------|
 | `moltis-projects` | `moltis.db` | `projects` | `20240205100000_init.sql` |
-| `moltis-sessions` | `moltis.db` | `sessions`, `channel_sessions` | `20240205100001_init.sql` |
-| `moltis-cron` | `moltis.db` | `cron_jobs`, `cron_runs` | `20240205100002_init.sql` |
-| `moltis-gateway` | `moltis.db` | `auth_*`, `passkeys`, `api_keys`, `env_variables`, `message_log`, `channels` | `20240205100003_init.sql` |
+| `moltis-sessions` | `moltis.db` | `sessions`, `channel_sessions`, `session_state` | `20240205100001_init.sql` + 8 migrations |
+| `moltis-cron` | `moltis.db` | `cron_jobs`, `cron_runs` | `20240205100002_init.sql` + 1 migration |
+| `moltis-gateway` | `moltis.db` | `auth_*`, `passkeys`, `api_keys`, `env_variables`, `message_log`, `channels`, `agents`, `session_shares`, `device_pairing`, `ssh_keys`, `ssh_targets`, `auth_audit_log` | `20240205100003_init.sql` + 12 migrations |
+| `moltis-webhooks` | `moltis.db` | `webhooks`, `webhook_deliveries`, `webhook_response_actions` | `20260407000000_initial.sql` + 1 migration |
+| `moltis-vault` | `moltis.db` | `vault_metadata` | `20260214000001_vault_metadata.sql` (feature-gated) |
 | `moltis-memory` | `memory.db` | `files`, `chunks`, `embedding_cache`, `chunks_fts` | `20240205100004_init.sql` |
 
 ### Startup Sequence
 
-The gateway runs migrations in dependency order:
+The gateway runs migrations in dependency order via
+`crates/gateway/src/server/prepare_core.rs`:
 
 ```rust
-// server.rs
-moltis_projects::run_migrations(&db_pool).await?;   // 1. projects first
-moltis_sessions::run_migrations(&db_pool).await?;   // 2. sessions (FK → projects)
-moltis_cron::run_migrations(&db_pool).await?;       // 3. cron (independent)
-sqlx::migrate!("./migrations").run(&db_pool).await?; // 4. gateway tables
+moltis_projects::run_migrations(&db_pool).await?;    // 1. projects first
+moltis_sessions::run_migrations(&db_pool).await?;    // 2. sessions (FK → projects)
+moltis_cron::run_migrations(&db_pool).await?;        // 3. cron (independent)
+moltis_webhooks::run_migrations(&db_pool).await?;    // 4. webhooks (independent)
+crate::run_migrations(&db_pool).await?;              // 5. gateway tables
+#[cfg(feature = "vault")]
+moltis_vault::run_migrations(&db_pool).await?;      // 6. vault (feature-gated)
 ```
 
 Sessions depends on projects due to a foreign key (`sessions.project_id` references
-`projects.id`), so projects must migrate first.
+`projects.id`), so projects must migrate first. Memory runs separately against
+its own `memory.db` pool.
 
 ### Version Tracking
 
@@ -78,7 +93,7 @@ must be globally unique across all crates.
 
 | Database | Location | Crates |
 |----------|----------|--------|
-| `moltis.db` | `~/.moltis/moltis.db` | projects, sessions, cron, gateway |
+| `moltis.db` | `~/.moltis/moltis.db` | projects, sessions, cron, gateway, webhooks, vault |
 | `memory.db` | `~/.moltis/memory.db` | memory (separate, managed internally) |
 
 ## Adding New Migrations

--- a/docs/src/streaming.md
+++ b/docs/src/streaming.md
@@ -19,10 +19,16 @@ LLM response:
 
 ```rust
 pub enum StreamEvent {
-    /// Text content delta - a chunk of text from the LLM.
+    /// Text content delta.
     Delta(String),
 
-    /// A tool call has started (for providers with native tool support).
+    /// Raw provider event payload (for debugging API responses).
+    ProviderRaw(serde_json::Value),
+
+    /// Reasoning/planning text delta (not user-visible final answer text).
+    ReasoningDelta(String),
+
+    /// A tool call has started (content_block_start with tool_use).
     ToolCallStart { id: String, name: String, index: usize },
 
     /// Streaming delta for tool call arguments (JSON fragment).
@@ -31,7 +37,7 @@ pub enum StreamEvent {
     /// A tool call's arguments are complete.
     ToolCallComplete { index: usize },
 
-    /// Stream completed successfully with token usage.
+    /// Stream completed successfully.
     Done(Usage),
 
     /// An error occurred.
@@ -43,12 +49,15 @@ pub enum StreamEvent {
 
 The `LlmProvider` trait defines two streaming methods:
 
-- `stream()` - Basic streaming without tool support
-- `stream_with_tools()` - Streaming with tool schemas passed to the API
+- `stream()` — Basic streaming without tool support
+- `stream_with_tools()` — Streaming with tool schemas passed to the API
 
-Providers that support streaming with tools (like Anthropic) override
-`stream_with_tools()`. Others fall back to `stream()` which ignores the tools
-parameter.
+Both accept `Vec<ChatMessage>` (not raw JSON). Providers that support
+streaming with tools override `stream_with_tools()`. Others fall back to
+`stream()` via the default implementation, which ignores the tools parameter.
+
+The trait also exposes `supports_tools()`, `reasoning_effort()`, and
+`with_reasoning_effort()` for provider capability discovery.
 
 ### 3. Anthropic Provider (`crates/agents/src/providers/anthropic.rs`)
 
@@ -69,7 +78,7 @@ The Anthropic provider implements streaming by:
 | `message_stop` | `Done` |
 | `error` | `Error` |
 
-### 4. Agent Runner (`crates/agents/src/runner.rs`)
+### 4. Agent Runner (`crates/agents/src/runner/streaming.rs`)
 
 The `run_agent_loop_streaming()` function orchestrates the streaming agent
 loop:
@@ -101,12 +110,12 @@ loop:
 └─────────────────────────────────────────────────────────┘
 ```
 
-### 5. Gateway (`crates/gateway/src/chat.rs`)
+### 5. Chat Service (`crates/chat/src/run_with_tools.rs`)
 
-The gateway's `run_with_tools()` function:
+The chat service's `run_with_tools()` function:
 
 1. Sets up an event callback that broadcasts `RunnerEvent`s via WebSocket
-2. Calls `run_agent_loop_streaming()`
+2. Calls `run_agent_loop_streaming()` from `crates/agents/src/runner/streaming.rs`
 3. Broadcasts events to connected clients as JSON frames
 
 Event types broadcast to the UI:
@@ -115,10 +124,17 @@ Event types broadcast to the UI:
 |-------------|-----------------|
 | `Thinking` | `thinking` |
 | `ThinkingDone` | `thinking_done` |
+| `ThinkingText(text)` | `thinking_text` |
 | `TextDelta(text)` | `delta` with `text` field |
 | `ToolCallStart` | `tool_call_start` |
 | `ToolCallEnd` | `tool_call_end` |
+| `ToolCallRejected` | `tool_call_end` with `rejected: true` |
 | `Iteration(n)` | `iteration` |
+| `SubAgentStart` | `sub_agent_start` |
+| `SubAgentEnd` | `sub_agent_end` |
+| `AutoContinue` | `notice` ("Auto-continue") |
+| `RetryingAfterError` | `retrying` |
+| `LoopInterventionFired` | `notice` ("Loop detected") |
 
 ### 6. Web Crate (`crates/web/`)
 
@@ -165,7 +181,7 @@ function handleChatDelta(p, isActive, isChatPage) {
                                                                       │
                                                                       ▼
 ┌──────────────┐   WebSocket  ┌──────────────┐   Routes/WS   ┌──────────────┐    Callback     ┌──────────────┐
-│   Browser    │◀─────────────│  Web Crate   │◀──────────────│   Gateway    │◀────────────────│   Callback   │
+│   Browser    │◀─────────────│  Web Crate   │◀──────────────│ Chat Service │◀────────────────│   Callback   │
 │              │              │  (moltis-web)│               │              │                 │   (on_event) │
 └──────────────┘              └──────────────┘               └──────────────┘                 └──────────────┘
 ```
@@ -187,8 +203,8 @@ Example skeleton:
 ```rust
 fn stream_with_tools(
     &self,
-    messages: Vec<serde_json::Value>,
-    tools: Vec<serde_json::Value>,
+    messages: Vec<ChatMessage>,
+    _tools: Vec<serde_json::Value>,
 ) -> Pin<Box<dyn Stream<Item = StreamEvent> + Send + '_>> {
     Box::pin(async_stream::stream! {
         // Make streaming request to provider API


### PR DESCRIPTION
## Doc Rotisserie — Batch 2

Automated audit of 4 stale docs against current source. 105 insertions, 34 deletions.

### Changes

| Doc | Fix |
|-----|-----|
| `session-state.md` | 3→5 operations, `op`→`operation` param fix, added return value docs |
| `slack.md` | Missing `channel_overrides`/`user_overrides` config fields |
| `sqlite-migration.md` | Missing webhooks/vault crates, wrong startup sequence path, incomplete table lists |
| `streaming.md` | Missing `ProviderRaw`/`ReasoningDelta` StreamEvent variants, 7 new RunnerEvent→WebSocket mappings, wrong code paths |
