### PR TITLE
refactor: add thiserror Error types to 8 library crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7184,7 +7184,6 @@ dependencies = [
 name = "moltis-auth"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "argon2",
  "async-trait",
  "axum",
@@ -7203,6 +7202,7 @@ dependencies = [
  "sha2 0.10.9",
  "sqlx",
  "tempfile",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "webauthn-rs",
@@ -7265,6 +7265,7 @@ dependencies = [
  "secrecy 0.8.0",
  "serde",
  "serde_json",
+ "thiserror 2.0.18",
  "tokio",
  "tower-http",
  "tower-service",
@@ -7625,6 +7626,7 @@ dependencies = [
  "sqlx",
  "sysinfo",
  "tempfile",
+ "thiserror 2.0.18",
  "time",
  "tokio",
  "tokio-tungstenite 0.26.2",
@@ -7697,6 +7699,7 @@ dependencies = [
  "moltis-mcp",
  "moltis-metrics",
  "serde_json",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
 ]
@@ -7740,6 +7743,7 @@ dependencies = [
  "sqlx",
  "tempfile",
  "text-splitter",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "tree-sitter-bash",
@@ -7823,7 +7827,6 @@ dependencies = [
 name = "moltis-node-host"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "futures",
  "moltis-config",
  "moltis-metrics",
@@ -7833,6 +7836,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sysinfo",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-tungstenite 0.26.2",
  "tracing",
@@ -8041,6 +8045,7 @@ dependencies = [
  "sha2 0.10.9",
  "sqlx",
  "tempfile",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
 ]
@@ -8114,7 +8119,6 @@ dependencies = [
 name = "moltis-skills"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "async-trait",
  "flate2",
  "moltis-config",
@@ -8127,6 +8131,7 @@ dependencies = [
  "serde_yaml",
  "tar",
  "tempfile",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "walkdir",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7699,7 +7699,6 @@ dependencies = [
  "moltis-mcp",
  "moltis-metrics",
  "serde_json",
- "thiserror 2.0.18",
  "tokio",
  "tracing",
 ]

--- a/crates/auth/Cargo.toml
+++ b/crates/auth/Cargo.toml
@@ -9,7 +9,6 @@ default = []
 vault   = ["dep:moltis-vault"]
 
 [dependencies]
-anyhow            = { workspace = true }
 argon2            = { workspace = true }
 async-trait       = { workspace = true }
 axum              = { workspace = true }
@@ -26,6 +25,7 @@ serde             = { workspace = true }
 serde_json        = { workspace = true }
 sha2              = { workspace = true }
 sqlx              = { workspace = true }
+thiserror         = { workspace = true }
 tokio             = { workspace = true }
 tracing           = { workspace = true }
 webauthn-rs       = { features = ["danger-allow-state-serialisation"], workspace = true }

--- a/crates/auth/src/credential_store/api_keys.rs
+++ b/crates/auth/src/credential_store/api_keys.rs
@@ -75,10 +75,7 @@ impl CredentialStore {
     /// `None` if invalid or revoked.
     ///
     /// Supports both salted (HMAC-SHA256) and legacy unsalted (SHA-256) keys.
-    pub async fn verify_api_key(
-        &self,
-        raw_key: &str,
-    ) -> Result<Option<ApiKeyVerification>> {
+    pub async fn verify_api_key(&self, raw_key: &str) -> Result<Option<ApiKeyVerification>> {
         let rows: Vec<(i64, String, Option<String>, Option<String>)> = sqlx::query_as(
             "SELECT id, key_hash, scopes, key_salt FROM api_keys WHERE revoked_at IS NULL",
         )

--- a/crates/auth/src/credential_store/api_keys.rs
+++ b/crates/auth/src/credential_store/api_keys.rs
@@ -1,6 +1,9 @@
-use crate::credential_store::{
-    ApiKeyEntry, ApiKeyVerification, CredentialStore,
-    util::{generate_token, hmac_sha256_hex, sha256_hex},
+use crate::{
+    Result,
+    credential_store::{
+        ApiKeyEntry, ApiKeyVerification, CredentialStore,
+        util::{generate_token, hmac_sha256_hex, sha256_hex},
+    },
 };
 
 impl CredentialStore {
@@ -10,7 +13,7 @@ impl CredentialStore {
         &self,
         label: &str,
         scopes: Option<&[String]>,
-    ) -> anyhow::Result<(i64, String)> {
+    ) -> Result<(i64, String)> {
         let raw_key = format!("mk_{}", generate_token());
         let prefix = &raw_key[..raw_key.len().min(11)];
         let salt = generate_token();
@@ -34,7 +37,7 @@ impl CredentialStore {
     }
 
     /// List all API keys (active only, not revoked).
-    pub async fn list_api_keys(&self) -> anyhow::Result<Vec<ApiKeyEntry>> {
+    pub async fn list_api_keys(&self) -> Result<Vec<ApiKeyEntry>> {
         let rows: Vec<(i64, String, String, String, Option<String>)> = sqlx::query_as(
             "SELECT id, label, key_prefix, strftime('%Y-%m-%dT%H:%M:%SZ', created_at), scopes FROM api_keys WHERE revoked_at IS NULL ORDER BY created_at DESC",
         )
@@ -58,7 +61,7 @@ impl CredentialStore {
     }
 
     /// Revoke an API key by id.
-    pub async fn revoke_api_key(&self, key_id: i64) -> anyhow::Result<()> {
+    pub async fn revoke_api_key(&self, key_id: i64) -> Result<()> {
         sqlx::query(
             "UPDATE api_keys SET revoked_at = datetime('now') WHERE id = ? AND revoked_at IS NULL",
         )
@@ -75,7 +78,7 @@ impl CredentialStore {
     pub async fn verify_api_key(
         &self,
         raw_key: &str,
-    ) -> anyhow::Result<Option<ApiKeyVerification>> {
+    ) -> Result<Option<ApiKeyVerification>> {
         let rows: Vec<(i64, String, Option<String>, Option<String>)> = sqlx::query_as(
             "SELECT id, key_hash, scopes, key_salt FROM api_keys WHERE revoked_at IS NULL",
         )

--- a/crates/auth/src/credential_store/env_vars.rs
+++ b/crates/auth/src/credential_store/env_vars.rs
@@ -4,12 +4,12 @@ use std::sync::Arc;
 #[cfg(feature = "vault")]
 use moltis_vault::Vault;
 
+#[cfg(feature = "vault")]
+use crate::Error;
 use crate::{
     Result,
     credential_store::{CredentialStore, EnvVarEntry},
 };
-#[cfg(feature = "vault")]
-use crate::Error;
 
 impl CredentialStore {
     /// List all environment variables (names only, no values).

--- a/crates/auth/src/credential_store/env_vars.rs
+++ b/crates/auth/src/credential_store/env_vars.rs
@@ -4,11 +4,16 @@ use std::sync::Arc;
 #[cfg(feature = "vault")]
 use moltis_vault::Vault;
 
-use crate::credential_store::{CredentialStore, EnvVarEntry};
+use crate::{
+    Result,
+    credential_store::{CredentialStore, EnvVarEntry},
+};
+#[cfg(feature = "vault")]
+use crate::Error;
 
 impl CredentialStore {
     /// List all environment variables (names only, no values).
-    pub async fn list_env_vars(&self) -> anyhow::Result<Vec<EnvVarEntry>> {
+    pub async fn list_env_vars(&self) -> Result<Vec<EnvVarEntry>> {
         let rows: Vec<(i64, String, String, String, i64)> = sqlx::query_as(
             "SELECT id, key, strftime('%Y-%m-%dT%H:%M:%SZ', created_at), strftime('%Y-%m-%dT%H:%M:%SZ', updated_at), COALESCE(encrypted, 0) FROM env_variables ORDER BY key ASC",
         )
@@ -29,13 +34,16 @@ impl CredentialStore {
     /// Set (upsert) an environment variable.
     ///
     /// When the vault feature is enabled and the vault is unsealed, the value is encrypted before storage.
-    pub async fn set_env_var(&self, key: &str, value: &str) -> anyhow::Result<i64> {
+    pub async fn set_env_var(&self, key: &str, value: &str) -> Result<i64> {
         #[cfg(feature = "vault")]
         let (store_value, encrypted) = {
             if let Some(ref vault) = self.vault {
                 if vault.is_unsealed().await {
                     let aad = format!("env:{key}");
-                    let enc = vault.encrypt_string(value, &aad).await?;
+                    let enc = vault
+                        .encrypt_string(value, &aad)
+                        .await
+                        .map_err(|e| Error::Crypto(e.to_string()))?;
                     (enc, 1_i64)
                 } else {
                     (value.to_owned(), 0_i64)
@@ -60,7 +68,7 @@ impl CredentialStore {
     }
 
     /// Delete an environment variable by id. Returns the key name if found.
-    pub async fn delete_env_var(&self, id: i64) -> anyhow::Result<Option<String>> {
+    pub async fn delete_env_var(&self, id: i64) -> Result<Option<String>> {
         let key: Option<(String,)> = sqlx::query_as("SELECT key FROM env_variables WHERE id = ?")
             .bind(id)
             .fetch_optional(&self.pool)
@@ -73,7 +81,7 @@ impl CredentialStore {
     }
 
     /// Get all environment variable key-value pairs (internal use for sandbox injection).
-    pub async fn get_all_env_values(&self) -> anyhow::Result<Vec<(String, String)>> {
+    pub async fn get_all_env_values(&self) -> Result<Vec<(String, String)>> {
         let rows: Vec<(String, String, i64)> = sqlx::query_as(
             "SELECT key, value, COALESCE(encrypted, 0) FROM env_variables ORDER BY key ASC",
         )

--- a/crates/auth/src/credential_store/passkeys.rs
+++ b/crates/auth/src/credential_store/passkeys.rs
@@ -1,4 +1,7 @@
-use crate::{Result, credential_store::{CredentialStore, PasskeyEntry}};
+use crate::{
+    Result,
+    credential_store::{CredentialStore, PasskeyEntry},
+};
 
 impl CredentialStore {
     /// Store a new passkey credential.

--- a/crates/auth/src/credential_store/passkeys.rs
+++ b/crates/auth/src/credential_store/passkeys.rs
@@ -1,4 +1,4 @@
-use crate::credential_store::{CredentialStore, PasskeyEntry};
+use crate::{Result, credential_store::{CredentialStore, PasskeyEntry}};
 
 impl CredentialStore {
     /// Store a new passkey credential.
@@ -7,7 +7,7 @@ impl CredentialStore {
         credential_id: &[u8],
         name: &str,
         passkey_data: &[u8],
-    ) -> anyhow::Result<i64> {
+    ) -> Result<i64> {
         let result = sqlx::query(
             "INSERT INTO passkeys (credential_id, name, passkey_data) VALUES (?, ?, ?)",
         )
@@ -21,7 +21,7 @@ impl CredentialStore {
     }
 
     /// List all registered passkeys.
-    pub async fn list_passkeys(&self) -> anyhow::Result<Vec<PasskeyEntry>> {
+    pub async fn list_passkeys(&self) -> Result<Vec<PasskeyEntry>> {
         let rows: Vec<(i64, String, String)> =
             sqlx::query_as("SELECT id, name, strftime('%Y-%m-%dT%H:%M:%SZ', created_at) FROM passkeys ORDER BY created_at DESC")
                 .fetch_all(&self.pool)
@@ -37,7 +37,7 @@ impl CredentialStore {
     }
 
     /// Remove a passkey by id.
-    pub async fn remove_passkey(&self, passkey_id: i64) -> anyhow::Result<()> {
+    pub async fn remove_passkey(&self, passkey_id: i64) -> Result<()> {
         sqlx::query("DELETE FROM passkeys WHERE id = ?")
             .bind(passkey_id)
             .execute(&self.pool)
@@ -47,7 +47,7 @@ impl CredentialStore {
     }
 
     /// Rename a passkey.
-    pub async fn rename_passkey(&self, passkey_id: i64, name: &str) -> anyhow::Result<()> {
+    pub async fn rename_passkey(&self, passkey_id: i64, name: &str) -> Result<()> {
         sqlx::query("UPDATE passkeys SET name = ? WHERE id = ?")
             .bind(name)
             .bind(passkey_id)
@@ -57,7 +57,7 @@ impl CredentialStore {
     }
 
     /// Load all passkey data blobs (for WebAuthn authentication).
-    pub async fn load_all_passkey_data(&self) -> anyhow::Result<Vec<(i64, Vec<u8>)>> {
+    pub async fn load_all_passkey_data(&self) -> Result<Vec<(i64, Vec<u8>)>> {
         let rows: Vec<(i64, Vec<u8>)> = sqlx::query_as("SELECT id, passkey_data FROM passkeys")
             .fetch_all(&self.pool)
             .await?;
@@ -65,7 +65,7 @@ impl CredentialStore {
     }
 
     /// Check if any passkeys are registered (for login page UI).
-    pub async fn has_passkeys(&self) -> anyhow::Result<bool> {
+    pub async fn has_passkeys(&self) -> Result<bool> {
         let row: Option<(i64,)> = sqlx::query_as("SELECT id FROM passkeys LIMIT 1")
             .fetch_optional(&self.pool)
             .await?;

--- a/crates/auth/src/credential_store/sessions.rs
+++ b/crates/auth/src/credential_store/sessions.rs
@@ -8,9 +8,12 @@ use sqlx::SqlitePool;
 #[cfg(feature = "vault")]
 use moltis_vault::Vault;
 
-use crate::credential_store::{
-    CredentialStore,
-    util::{DUMMY_ARGON2_HASH, generate_token, hash_password, verify_password},
+use crate::{
+    Error, Result,
+    credential_store::{
+        CredentialStore,
+        util::{DUMMY_ARGON2_HASH, generate_token, hash_password, verify_password},
+    },
 };
 
 impl CredentialStore {
@@ -18,7 +21,7 @@ impl CredentialStore {
     const MAX_SESSIONS: i64 = 10;
 
     /// Open a database at the given path, reset all auth, and close it.
-    pub async fn reset_from_db_path(db_path: &std::path::Path) -> anyhow::Result<()> {
+    pub async fn reset_from_db_path(db_path: &std::path::Path) -> Result<()> {
         let db_url = format!("sqlite:{}", db_path.display());
         let pool = SqlitePool::connect(&db_url).await?;
         let store = Self::new(pool).await?;
@@ -27,7 +30,7 @@ impl CredentialStore {
 
     /// Create a new store and initialize tables.
     /// Reads `auth.disabled` from the discovered config file.
-    pub async fn new(pool: SqlitePool) -> anyhow::Result<Self> {
+    pub async fn new(pool: SqlitePool) -> Result<Self> {
         let config = moltis_config::discover_and_load();
         Self::with_config(pool, &config.auth).await
     }
@@ -36,7 +39,7 @@ impl CredentialStore {
     pub async fn with_config(
         pool: SqlitePool,
         auth_config: &moltis_config::AuthConfig,
-    ) -> anyhow::Result<Self> {
+    ) -> Result<Self> {
         let store = Self {
             pool,
             setup_complete: std::sync::atomic::AtomicBool::new(false),
@@ -68,7 +71,7 @@ impl CredentialStore {
         pool: SqlitePool,
         auth_config: &moltis_config::AuthConfig,
         vault: Option<Arc<Vault>>,
-    ) -> anyhow::Result<Self> {
+    ) -> Result<Self> {
         let store = Self {
             pool,
             setup_complete: std::sync::atomic::AtomicBool::new(false),
@@ -98,7 +101,7 @@ impl CredentialStore {
     /// **Note**: Schema is now managed by sqlx migrations. This method is a no-op
     /// when running with the gateway (migrations have already run). It's retained
     /// for standalone tests that use in-memory databases.
-    async fn init(&self) -> anyhow::Result<()> {
+    async fn init(&self) -> Result<()> {
         sqlx::query(
             "CREATE TABLE IF NOT EXISTS auth_password (
                 id            INTEGER PRIMARY KEY CHECK (id = 1),
@@ -229,12 +232,12 @@ impl CredentialStore {
     }
 
     /// Clear the auth-disabled flag (e.g. after completing localhost setup without a password).
-    pub async fn clear_auth_disabled(&self) -> anyhow::Result<()> {
+    pub async fn clear_auth_disabled(&self) -> Result<()> {
         self.auth_disabled.store(false, Ordering::Relaxed);
         self.persist_auth_disabled(false).await
     }
 
-    async fn persist_auth_disabled(&self, disabled: bool) -> anyhow::Result<()> {
+    async fn persist_auth_disabled(&self, disabled: bool) -> Result<()> {
         sqlx::query(
             "INSERT INTO auth_state (id, auth_disabled, updated_at)
              VALUES (1, ?, datetime('now'))
@@ -253,7 +256,7 @@ impl CredentialStore {
     }
 
     /// Whether a password has been set.
-    pub async fn has_password(&self) -> anyhow::Result<bool> {
+    pub async fn has_password(&self) -> Result<bool> {
         let row: Option<(i64,)> = sqlx::query_as("SELECT id FROM auth_password WHERE id = 1")
             .fetch_optional(&self.pool)
             .await?;
@@ -261,9 +264,9 @@ impl CredentialStore {
     }
 
     /// Set the initial password (first-run setup). Fails if already set.
-    pub async fn set_initial_password(&self, password: &str) -> anyhow::Result<()> {
+    pub async fn set_initial_password(&self, password: &str) -> Result<()> {
         if self.is_setup_complete() {
-            anyhow::bail!("password already set");
+            return Err(Error::Validation("password already set".into()));
         }
         let hash = hash_password(password)?;
         sqlx::query("INSERT INTO auth_password (id, password_hash) VALUES (1, ?)")
@@ -279,9 +282,9 @@ impl CredentialStore {
     /// Add a password when none exists yet (e.g. after passkey-only setup).
     ///
     /// This marks setup complete so auth is enforced immediately.
-    pub async fn add_password(&self, password: &str) -> anyhow::Result<()> {
+    pub async fn add_password(&self, password: &str) -> Result<()> {
         if self.has_password().await? {
-            anyhow::bail!("password already set");
+            return Err(Error::Validation("password already set".into()));
         }
         let hash = hash_password(password)?;
         sqlx::query("INSERT INTO auth_password (id, password_hash) VALUES (1, ?)")
@@ -295,11 +298,13 @@ impl CredentialStore {
     /// Mark initial setup as complete without setting a password (e.g. passkey-only setup).
     ///
     /// Requires at least one credential (password or passkey) to already exist.
-    pub async fn mark_setup_complete(&self) -> anyhow::Result<()> {
+    pub async fn mark_setup_complete(&self) -> Result<()> {
         let has_password = self.has_password().await?;
         let has_passkeys = self.has_passkeys().await?;
         if !has_password && !has_passkeys {
-            anyhow::bail!("cannot mark setup complete without any credentials");
+            return Err(Error::Validation(
+                "cannot mark setup complete without any credentials".into(),
+            ));
         }
         self.setup_complete.store(true, Ordering::Relaxed);
         self.auth_disabled.store(false, Ordering::Relaxed);
@@ -308,7 +313,7 @@ impl CredentialStore {
     }
 
     /// Recompute `setup_complete` from the current credentials in the database.
-    pub(crate) async fn recompute_setup_complete(&self) -> anyhow::Result<()> {
+    pub(crate) async fn recompute_setup_complete(&self) -> Result<()> {
         let has = self.has_password().await? || self.has_passkeys().await?;
         self.setup_complete.store(has, Ordering::Relaxed);
         Ok(())
@@ -318,7 +323,7 @@ impl CredentialStore {
     ///
     /// When no password is set, a dummy Argon2 verification is performed
     /// to prevent timing side channels that would reveal whether a password exists.
-    pub async fn verify_password(&self, password: &str) -> anyhow::Result<bool> {
+    pub async fn verify_password(&self, password: &str) -> Result<bool> {
         let row: Option<(String,)> =
             sqlx::query_as("SELECT password_hash FROM auth_password WHERE id = 1")
                 .fetch_optional(&self.pool)
@@ -336,9 +341,9 @@ impl CredentialStore {
     /// Change the password (requires correct current password).
     ///
     /// Invalidates all existing sessions for defense-in-depth.
-    pub async fn change_password(&self, current: &str, new_password: &str) -> anyhow::Result<()> {
+    pub async fn change_password(&self, current: &str, new_password: &str) -> Result<()> {
         if !self.verify_password(current).await? {
-            anyhow::bail!("current password is incorrect");
+            return Err(Error::Validation("current password is incorrect".into()));
         }
         let hash = hash_password(new_password)?;
         sqlx::query(
@@ -359,7 +364,7 @@ impl CredentialStore {
     ///
     /// Enforces a cap of [`MAX_SESSIONS`] active (non-expired) sessions.
     /// When the cap is reached, the oldest sessions are deleted to make room.
-    pub async fn create_session(&self) -> anyhow::Result<String> {
+    pub async fn create_session(&self) -> Result<String> {
         sqlx::query("DELETE FROM auth_sessions WHERE expires_at <= datetime('now')")
             .execute(&self.pool)
             .await?;
@@ -388,7 +393,7 @@ impl CredentialStore {
     }
 
     /// Validate a session token. Returns true if valid and not expired.
-    pub async fn validate_session(&self, token: &str) -> anyhow::Result<bool> {
+    pub async fn validate_session(&self, token: &str) -> Result<bool> {
         let row: Option<(String,)> = sqlx::query_as(
             "SELECT token FROM auth_sessions WHERE token = ? AND expires_at > datetime('now')",
         )
@@ -399,7 +404,7 @@ impl CredentialStore {
     }
 
     /// Delete a session (logout).
-    pub async fn delete_session(&self, token: &str) -> anyhow::Result<()> {
+    pub async fn delete_session(&self, token: &str) -> Result<()> {
         sqlx::query("DELETE FROM auth_sessions WHERE token = ?")
             .bind(token)
             .execute(&self.pool)
@@ -408,7 +413,7 @@ impl CredentialStore {
     }
 
     /// Clean up expired sessions.
-    pub async fn cleanup_expired_sessions(&self) -> anyhow::Result<u64> {
+    pub async fn cleanup_expired_sessions(&self) -> Result<u64> {
         let result = sqlx::query("DELETE FROM auth_sessions WHERE expires_at <= datetime('now')")
             .execute(&self.pool)
             .await?;
@@ -417,7 +422,7 @@ impl CredentialStore {
 
     /// Remove all authentication data: password, sessions, passkeys, API keys.
     /// After this, `is_setup_complete()` returns false and the middleware passes all requests through.
-    pub async fn reset_all(&self) -> anyhow::Result<()> {
+    pub async fn reset_all(&self) -> Result<()> {
         sqlx::query("DELETE FROM auth_password")
             .execute(&self.pool)
             .await?;

--- a/crates/auth/src/credential_store/ssh.rs
+++ b/crates/auth/src/credential_store/ssh.rs
@@ -4,7 +4,9 @@ use secrecy::Secret;
 
 use crate::{
     Error, Result,
-    credential_store::{CredentialStore, SshAuthMode, SshKeyEntry, SshResolvedTarget, SshTargetEntry},
+    credential_store::{
+        CredentialStore, SshAuthMode, SshKeyEntry, SshResolvedTarget, SshTargetEntry,
+    },
 };
 
 impl CredentialStore {
@@ -424,10 +426,7 @@ impl CredentialStore {
         }))
     }
 
-    pub async fn resolve_ssh_target(
-        &self,
-        node_ref: &str,
-    ) -> Result<Option<SshResolvedTarget>> {
+    pub async fn resolve_ssh_target(&self, node_ref: &str) -> Result<Option<SshResolvedTarget>> {
         if let Some(id_str) = node_ref.strip_prefix("ssh:target:")
             && let Ok(id) = id_str.parse::<i64>()
         {
@@ -456,10 +455,7 @@ impl CredentialStore {
         }))
     }
 
-    pub async fn resolve_ssh_target_by_id(
-        &self,
-        id: i64,
-    ) -> Result<Option<SshResolvedTarget>> {
+    pub async fn resolve_ssh_target_by_id(&self, id: i64) -> Result<Option<SshResolvedTarget>> {
         let row: Option<(
             i64,
             String,

--- a/crates/auth/src/credential_store/ssh.rs
+++ b/crates/auth/src/credential_store/ssh.rs
@@ -2,12 +2,13 @@ use std::convert::TryFrom;
 
 use secrecy::Secret;
 
-use crate::credential_store::{
-    CredentialStore, SshAuthMode, SshKeyEntry, SshResolvedTarget, SshTargetEntry,
+use crate::{
+    Error, Result,
+    credential_store::{CredentialStore, SshAuthMode, SshKeyEntry, SshResolvedTarget, SshTargetEntry},
 };
 
 impl CredentialStore {
-    pub async fn list_ssh_keys(&self) -> anyhow::Result<Vec<SshKeyEntry>> {
+    pub async fn list_ssh_keys(&self) -> Result<Vec<SshKeyEntry>> {
         let rows: Vec<(i64, String, String, String, String, String, i64, i64)> = sqlx::query_as(
             "SELECT
                 k.id,
@@ -58,10 +59,10 @@ impl CredentialStore {
         private_key: &str,
         public_key: &str,
         fingerprint: &str,
-    ) -> anyhow::Result<i64> {
+    ) -> Result<i64> {
         let name = name.trim();
         if name.is_empty() {
-            anyhow::bail!("ssh key name is required");
+            return Err(Error::Ssh("ssh key name is required".into()));
         }
 
         #[cfg(feature = "vault")]
@@ -69,7 +70,10 @@ impl CredentialStore {
             if let Some(ref vault) = self.vault {
                 if vault.is_unsealed().await {
                     let aad = format!("ssh-key:{name}");
-                    let enc = vault.encrypt_string(private_key, &aad).await?;
+                    let enc = vault
+                        .encrypt_string(private_key, &aad)
+                        .await
+                        .map_err(|e| Error::Crypto(e.to_string()))?;
                     (enc, 1_i64)
                 } else {
                     (private_key.to_owned(), 0_i64)
@@ -96,7 +100,7 @@ impl CredentialStore {
         Ok(result.last_insert_rowid())
     }
 
-    pub async fn delete_ssh_key(&self, id: i64) -> anyhow::Result<()> {
+    pub async fn delete_ssh_key(&self, id: i64) -> Result<()> {
         let deleted = sqlx::query(
             "DELETE FROM ssh_keys
              WHERE id = ?
@@ -114,13 +118,15 @@ impl CredentialStore {
                     .fetch_optional(&self.pool)
                     .await?;
             if in_use.is_some_and(|(count,)| count > 0) {
-                anyhow::bail!("ssh key is still assigned to one or more targets");
+                return Err(Error::Ssh(
+                    "ssh key is still assigned to one or more targets".into(),
+                ));
             }
         }
         Ok(())
     }
 
-    pub async fn get_ssh_private_key(&self, key_id: i64) -> anyhow::Result<Option<Secret<String>>> {
+    pub async fn get_ssh_private_key(&self, key_id: i64) -> Result<Option<Secret<String>>> {
         let row: Option<(String, String, i64)> = sqlx::query_as(
             "SELECT name, private_key, COALESCE(encrypted, 0) FROM ssh_keys WHERE id = ?",
         )
@@ -136,10 +142,15 @@ impl CredentialStore {
         {
             if encrypted != 0 {
                 let Some(ref vault) = self.vault else {
-                    anyhow::bail!("vault not available for encrypted ssh key");
+                    return Err(Error::Crypto(
+                        "vault not available for encrypted ssh key".into(),
+                    ));
                 };
                 let aad = format!("ssh-key:{name}");
-                let decrypted = vault.decrypt_string(&private_key, &aad).await?;
+                let decrypted = vault
+                    .decrypt_string(&private_key, &aad)
+                    .await
+                    .map_err(|e| Error::Crypto(e.to_string()))?;
                 return Ok(Some(Secret::new(decrypted)));
             }
         }
@@ -149,7 +160,7 @@ impl CredentialStore {
         Ok(Some(Secret::new(private_key)))
     }
 
-    pub async fn list_ssh_targets(&self) -> anyhow::Result<Vec<SshTargetEntry>> {
+    pub async fn list_ssh_targets(&self) -> Result<Vec<SshTargetEntry>> {
         let rows: Vec<(
             i64,
             String,
@@ -225,7 +236,7 @@ impl CredentialStore {
         auth_mode: SshAuthMode,
         key_id: Option<i64>,
         is_default: bool,
-    ) -> anyhow::Result<i64> {
+    ) -> Result<i64> {
         let label = label.trim();
         let target = target.trim();
         let known_host = known_host
@@ -233,24 +244,24 @@ impl CredentialStore {
             .filter(|value| !value.is_empty())
             .map(ToOwned::to_owned);
         if label.is_empty() {
-            anyhow::bail!("ssh target label is required");
+            return Err(Error::Ssh("ssh target label is required".into()));
         }
         if target.is_empty() {
-            anyhow::bail!("ssh target is required");
+            return Err(Error::Ssh("ssh target is required".into()));
         }
 
         let key_id = match auth_mode {
             SshAuthMode::System => None,
             SshAuthMode::Managed => {
                 let Some(key_id) = key_id else {
-                    anyhow::bail!("managed ssh targets require a key");
+                    return Err(Error::Ssh("managed ssh targets require a key".into()));
                 };
                 let exists: Option<(i64,)> = sqlx::query_as("SELECT id FROM ssh_keys WHERE id = ?")
                     .bind(key_id)
                     .fetch_optional(&self.pool)
                     .await?;
                 if exists.is_none() {
-                    anyhow::bail!("selected ssh key does not exist");
+                    return Err(Error::Ssh("selected ssh key does not exist".into()));
                 }
                 Some(key_id)
             },
@@ -286,7 +297,7 @@ impl CredentialStore {
         Ok(result.last_insert_rowid())
     }
 
-    pub async fn delete_ssh_target(&self, id: i64) -> anyhow::Result<()> {
+    pub async fn delete_ssh_target(&self, id: i64) -> Result<()> {
         let mut tx = self.pool.begin().await?;
         let was_default: Option<(i64,)> =
             sqlx::query_as("SELECT COALESCE(is_default, 0) FROM ssh_targets WHERE id = ?")
@@ -319,7 +330,7 @@ impl CredentialStore {
         Ok(())
     }
 
-    pub async fn set_default_ssh_target(&self, id: i64) -> anyhow::Result<()> {
+    pub async fn set_default_ssh_target(&self, id: i64) -> Result<()> {
         let mut tx = self.pool.begin().await?;
         sqlx::query("UPDATE ssh_targets SET is_default = 0")
             .execute(&mut *tx)
@@ -331,7 +342,7 @@ impl CredentialStore {
         .execute(&mut *tx)
         .await?;
         if updated.rows_affected() == 0 {
-            anyhow::bail!("ssh target not found");
+            return Err(Error::Ssh("ssh target not found".into()));
         }
         tx.commit().await?;
         Ok(())
@@ -341,7 +352,7 @@ impl CredentialStore {
         &self,
         id: i64,
         known_host: Option<&str>,
-    ) -> anyhow::Result<()> {
+    ) -> Result<()> {
         let known_host = known_host
             .map(str::trim)
             .filter(|value| !value.is_empty())
@@ -354,12 +365,12 @@ impl CredentialStore {
         .execute(&self.pool)
         .await?;
         if result.rows_affected() == 0 {
-            anyhow::bail!("ssh target not found");
+            return Err(Error::Ssh("ssh target not found".into()));
         }
         Ok(())
     }
 
-    pub async fn ssh_target_count(&self) -> anyhow::Result<usize> {
+    pub async fn ssh_target_count(&self) -> Result<usize> {
         let row: Option<(i64,)> = sqlx::query_as("SELECT COUNT(1) FROM ssh_targets")
             .fetch_optional(&self.pool)
             .await?;
@@ -367,7 +378,7 @@ impl CredentialStore {
         Ok(usize::try_from(count).unwrap_or_default())
     }
 
-    pub async fn get_default_ssh_target(&self) -> anyhow::Result<Option<SshResolvedTarget>> {
+    pub async fn get_default_ssh_target(&self) -> Result<Option<SshResolvedTarget>> {
         let row: Option<(
             i64,
             String,
@@ -416,7 +427,7 @@ impl CredentialStore {
     pub async fn resolve_ssh_target(
         &self,
         node_ref: &str,
-    ) -> anyhow::Result<Option<SshResolvedTarget>> {
+    ) -> Result<Option<SshResolvedTarget>> {
         if let Some(id_str) = node_ref.strip_prefix("ssh:target:")
             && let Ok(id) = id_str.parse::<i64>()
         {
@@ -448,7 +459,7 @@ impl CredentialStore {
     pub async fn resolve_ssh_target_by_id(
         &self,
         id: i64,
-    ) -> anyhow::Result<Option<SshResolvedTarget>> {
+    ) -> Result<Option<SshResolvedTarget>> {
         let row: Option<(
             i64,
             String,

--- a/crates/auth/src/credential_store/types.rs
+++ b/crates/auth/src/credential_store/types.rs
@@ -96,7 +96,9 @@ impl SshAuthMode {
         match value {
             "system" => Ok(Self::System),
             "managed" => Ok(Self::Managed),
-            _ => Err(crate::Error::Ssh(format!("unknown ssh auth mode '{value}'"))),
+            _ => Err(crate::Error::Ssh(format!(
+                "unknown ssh auth mode '{value}'"
+            ))),
         }
     }
 }

--- a/crates/auth/src/credential_store/types.rs
+++ b/crates/auth/src/credential_store/types.rs
@@ -92,11 +92,11 @@ impl SshAuthMode {
         }
     }
 
-    pub(super) fn parse_db(value: &str) -> anyhow::Result<Self> {
+    pub(super) fn parse_db(value: &str) -> crate::Result<Self> {
         match value {
             "system" => Ok(Self::System),
             "managed" => Ok(Self::Managed),
-            _ => anyhow::bail!("unknown ssh auth mode '{value}'"),
+            _ => Err(crate::Error::Ssh(format!("unknown ssh auth mode '{value}'"))),
         }
     }
 }

--- a/crates/auth/src/credential_store/util.rs
+++ b/crates/auth/src/credential_store/util.rs
@@ -15,12 +15,12 @@ pub fn is_loopback(ip: &str) -> bool {
     ip == "127.0.0.1" || ip.starts_with("127.") || ip == "::1" || ip.starts_with("::ffff:127.")
 }
 
-pub(crate) fn hash_password(password: &str) -> anyhow::Result<String> {
+pub(crate) fn hash_password(password: &str) -> crate::Result<String> {
     let salt = SaltString::generate(&mut OsRng);
     let argon2 = Argon2::default();
     let hash = argon2
         .hash_password(password.as_bytes(), &salt)
-        .map_err(|e| anyhow::anyhow!("failed to hash password: {e}"))?;
+        .map_err(|e| crate::Error::Crypto(format!("failed to hash password: {e}")))?;
     Ok(hash.to_string())
 }
 

--- a/crates/auth/src/error.rs
+++ b/crates/auth/src/error.rs
@@ -1,0 +1,40 @@
+use thiserror::Error;
+
+/// Errors produced by the `moltis-auth` crate.
+#[derive(Debug, Error)]
+pub enum Error {
+    /// SQLite / sqlx database error.
+    #[error(transparent)]
+    Database(#[from] sqlx::Error),
+
+    /// I/O error.
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+
+    /// Configuration file read/write error.
+    #[error(transparent)]
+    Config(#[from] moltis_config::Error),
+
+    /// JSON serialization / deserialization error.
+    #[error(transparent)]
+    Json(#[from] serde_json::Error),
+
+    /// Password hashing or vault encryption/decryption failure.
+    #[error("{0}")]
+    Crypto(String),
+
+    /// Business-logic validation failure (e.g. "password already set").
+    #[error("{0}")]
+    Validation(String),
+
+    /// WebAuthn protocol error.
+    #[error("{0}")]
+    WebAuthn(String),
+
+    /// SSH key/target validation error.
+    #[error("{0}")]
+    Ssh(String),
+}
+
+/// Crate-level result alias.
+pub type Result<T> = std::result::Result<T, Error>;

--- a/crates/auth/src/lib.rs
+++ b/crates/auth/src/lib.rs
@@ -6,11 +6,13 @@
 //! - Connection locality detection for auth decisions
 
 pub mod credential_store;
+pub mod error;
 pub mod locality;
 pub mod webauthn;
 
 pub use {
     credential_store::*,
+    error::{Error, Result},
     locality::{has_proxy_headers, is_local_connection},
     webauthn::{WebAuthnRegistry, WebAuthnState, load_passkeys},
 };

--- a/crates/auth/src/webauthn.rs
+++ b/crates/auth/src/webauthn.rs
@@ -2,7 +2,7 @@ use std::time::Instant;
 
 use {dashmap::DashMap, webauthn_rs::prelude::*};
 
-use crate::credential_store::CredentialStore;
+use crate::{Error, Result, credential_store::CredentialStore};
 
 /// Challenge TTL: 5 minutes.
 const CHALLENGE_TTL_SECS: u64 = 300;
@@ -80,16 +80,16 @@ impl WebAuthnState {
     /// `rp_origin` is the full origin URL (e.g. "https://localhost:18080").
     /// `extra_origins` are additional origins accepted during verification (e.g.
     /// `http://m4max.local:18080` when accessing via mDNS hostname).
-    pub fn new(rp_id: &str, rp_origin: &Url, extra_origins: &[Url]) -> anyhow::Result<Self> {
+    pub fn new(rp_id: &str, rp_origin: &Url, extra_origins: &[Url]) -> Result<Self> {
         let mut builder = WebauthnBuilder::new(rp_id, rp_origin)
-            .map_err(|e| anyhow::anyhow!("webauthn builder error: {e}"))?;
+            .map_err(|e| Error::WebAuthn(format!("webauthn builder error: {e}")))?;
         for origin in extra_origins {
             builder = builder.append_allowed_origin(origin);
         }
         let webauthn = builder
             .rp_name("moltis")
             .build()
-            .map_err(|e| anyhow::anyhow!("webauthn build error: {e}"))?;
+            .map_err(|e| Error::WebAuthn(format!("webauthn build error: {e}")))?;
 
         Ok(Self {
             webauthn,
@@ -102,7 +102,7 @@ impl WebAuthnState {
     pub fn start_registration(
         &self,
         existing_passkeys: &[Passkey],
-    ) -> anyhow::Result<(String, CreationChallengeResponse)> {
+    ) -> Result<(String, CreationChallengeResponse)> {
         self.cleanup_expired();
 
         // Single-user model: fixed user ID.
@@ -122,7 +122,7 @@ impl WebAuthnState {
         let (ccr, reg_state) = self
             .webauthn
             .start_passkey_registration(user_id, "owner", "Owner", exclude_opt)
-            .map_err(|e| anyhow::anyhow!("start_passkey_registration: {e}"))?;
+            .map_err(|e| Error::WebAuthn(format!("start_passkey_registration: {e}")))?;
 
         let challenge_id = Uuid::new_v4().to_string();
         self.pending_registrations
@@ -139,20 +139,22 @@ impl WebAuthnState {
         &self,
         challenge_id: &str,
         response: &RegisterPublicKeyCredential,
-    ) -> anyhow::Result<Passkey> {
+    ) -> Result<Passkey> {
         let (_, pending) = self
             .pending_registrations
             .remove(challenge_id)
-            .ok_or_else(|| anyhow::anyhow!("no pending registration for this challenge"))?;
+            .ok_or_else(|| {
+                Error::WebAuthn("no pending registration for this challenge".into())
+            })?;
 
         if pending.created_at.elapsed().as_secs() > CHALLENGE_TTL_SECS {
-            anyhow::bail!("registration challenge expired");
+            return Err(Error::WebAuthn("registration challenge expired".into()));
         }
 
         let passkey = self
             .webauthn
             .finish_passkey_registration(response, &pending.state)
-            .map_err(|e| anyhow::anyhow!("finish_passkey_registration: {e}"))?;
+            .map_err(|e| Error::WebAuthn(format!("finish_passkey_registration: {e}")))?;
 
         Ok(passkey)
     }
@@ -161,17 +163,17 @@ impl WebAuthnState {
     pub fn start_authentication(
         &self,
         credentials: &[Passkey],
-    ) -> anyhow::Result<(String, RequestChallengeResponse)> {
+    ) -> Result<(String, RequestChallengeResponse)> {
         self.cleanup_expired();
 
         if credentials.is_empty() {
-            anyhow::bail!("no passkeys registered");
+            return Err(Error::WebAuthn("no passkeys registered".into()));
         }
 
         let (rcr, auth_state) = self
             .webauthn
             .start_passkey_authentication(credentials)
-            .map_err(|e| anyhow::anyhow!("start_passkey_authentication: {e}"))?;
+            .map_err(|e| Error::WebAuthn(format!("start_passkey_authentication: {e}")))?;
 
         let challenge_id = Uuid::new_v4().to_string();
         self.pending_authentications
@@ -188,20 +190,22 @@ impl WebAuthnState {
         &self,
         challenge_id: &str,
         response: &PublicKeyCredential,
-    ) -> anyhow::Result<AuthenticationResult> {
+    ) -> Result<AuthenticationResult> {
         let (_, pending) = self
             .pending_authentications
             .remove(challenge_id)
-            .ok_or_else(|| anyhow::anyhow!("no pending authentication for this challenge"))?;
+            .ok_or_else(|| {
+                Error::WebAuthn("no pending authentication for this challenge".into())
+            })?;
 
         if pending.created_at.elapsed().as_secs() > CHALLENGE_TTL_SECS {
-            anyhow::bail!("authentication challenge expired");
+            return Err(Error::WebAuthn("authentication challenge expired".into()));
         }
 
         let result = self
             .webauthn
             .finish_passkey_authentication(response, &pending.state)
-            .map_err(|e| anyhow::anyhow!("finish_passkey_authentication: {e}"))?;
+            .map_err(|e| Error::WebAuthn(format!("finish_passkey_authentication: {e}")))?;
 
         Ok(result)
     }
@@ -309,7 +313,7 @@ impl WebAuthnRegistry {
 }
 
 /// Load all stored passkeys from the credential store as `webauthn_rs::Passkey` objects.
-pub async fn load_passkeys(store: &CredentialStore) -> anyhow::Result<Vec<Passkey>> {
+pub async fn load_passkeys(store: &CredentialStore) -> Result<Vec<Passkey>> {
     let rows = store.load_all_passkey_data().await?;
     let mut passkeys = Vec::with_capacity(rows.len());
     for (_id, data) in rows {

--- a/crates/auth/src/webauthn.rs
+++ b/crates/auth/src/webauthn.rs
@@ -143,9 +143,7 @@ impl WebAuthnState {
         let (_, pending) = self
             .pending_registrations
             .remove(challenge_id)
-            .ok_or_else(|| {
-                Error::WebAuthn("no pending registration for this challenge".into())
-            })?;
+            .ok_or_else(|| Error::WebAuthn("no pending registration for this challenge".into()))?;
 
         if pending.created_at.elapsed().as_secs() > CHALLENGE_TTL_SECS {
             return Err(Error::WebAuthn("registration challenge expired".into()));

--- a/crates/caldav/Cargo.toml
+++ b/crates/caldav/Cargo.toml
@@ -18,6 +18,7 @@ moltis-config = { workspace = true }
 secrecy       = { workspace = true }
 serde         = { workspace = true }
 serde_json    = { workspace = true }
+thiserror     = { workspace = true }
 tokio         = { workspace = true }
 tower-http    = { features = ["auth"], workspace = true }
 tower-service = { workspace = true }

--- a/crates/caldav/src/client.rs
+++ b/crates/caldav/src/client.rs
@@ -3,13 +3,15 @@
 use std::sync::Arc;
 
 use {
-    anyhow::{Result, anyhow},
     async_trait::async_trait,
     secrecy::{ExposeSecret, Secret},
 };
 
-use crate::types::{
-    CalendarInfo, CreatedEvent, EventSummary, NewEvent, TimeRange, UpdateEvent, UpdatedEvent,
+use crate::{
+    error::{Error, Result},
+    types::{
+        CalendarInfo, CreatedEvent, EventSummary, NewEvent, TimeRange, UpdateEvent, UpdatedEvent,
+    },
 };
 
 /// Trait for CalDAV server interactions.
@@ -71,11 +73,11 @@ impl LibDavCalDavClient {
     ) -> Result<Self> {
         let uri: http::Uri = base_url
             .parse()
-            .map_err(|e| anyhow!("invalid CalDAV URL '{base_url}': {e}"))?;
+            .map_err(|e| Error::InvalidUrl(format!("invalid CalDAV URL '{base_url}': {e}")))?;
 
         let https_connector = hyper_rustls::HttpsConnectorBuilder::new()
             .with_native_roots()
-            .map_err(|e| anyhow!("failed to load native TLS roots: {e}"))?
+            .map_err(|e| Error::Protocol(format!("failed to load native TLS roots: {e}")))?
             .https_or_http()
             .enable_http1()
             .build();
@@ -94,7 +96,7 @@ impl LibDavCalDavClient {
 
         let caldav_client = libdav::CalDavClient::bootstrap_via_service_discovery(webdav)
             .await
-            .map_err(|e| anyhow!("CalDAV service discovery failed: {e}"))?;
+            .map_err(|e| Error::Protocol(format!("CalDAV service discovery failed: {e}")))?;
 
         Ok(Self {
             inner: caldav_client,
@@ -107,7 +109,7 @@ impl LibDavCalDavClient {
             .inner
             .find_current_user_principal()
             .await
-            .map_err(|e| anyhow!("failed to find user principal: {e}"))?;
+            .map_err(|e| Error::Protocol(format!("failed to find user principal: {e}")))?;
 
         match principal {
             Some(principal_uri) => {
@@ -115,7 +117,9 @@ impl LibDavCalDavClient {
                     .inner
                     .request(libdav::caldav::FindCalendarHomeSet::new(&principal_uri))
                     .await
-                    .map_err(|e| anyhow!("failed to find calendar home set: {e}"))?;
+                    .map_err(|e| {
+                        Error::Protocol(format!("failed to find calendar home set: {e}"))
+                    })?;
                 if response.home_sets.is_empty() {
                     Ok(vec![self.inner.base_url().clone()])
                 } else {
@@ -138,7 +142,7 @@ impl CalDavClient for LibDavCalDavClient {
                 .inner
                 .request(libdav::caldav::FindCalendars::new(home_url))
                 .await
-                .map_err(|e| anyhow!("failed to find calendars: {e}"))?;
+                .map_err(|e| Error::Protocol(format!("failed to find calendars: {e}")))?;
 
             for cal in found.calendars {
                 let display_name = self
@@ -193,7 +197,7 @@ impl CalDavClient for LibDavCalDavClient {
             .inner
             .request(libdav::caldav::GetCalendarResources::new(calendar_href))
             .await
-            .map_err(|e| anyhow!("failed to fetch calendar resources: {e}"))?;
+            .map_err(|e| Error::Protocol(format!("failed to fetch calendar resources: {e}")))?;
 
         let mut events = Vec::new();
         for resource in &response.resources {
@@ -228,7 +232,7 @@ impl CalDavClient for LibDavCalDavClient {
             .inner
             .request(put_request)
             .await
-            .map_err(|e| anyhow!("failed to create event: {e}"))?;
+            .map_err(|e| Error::Protocol(format!("failed to create event: {e}")))?;
 
         Ok(CreatedEvent {
             href: event_href,
@@ -248,17 +252,16 @@ impl CalDavClient for LibDavCalDavClient {
             .inner
             .request(libdav::caldav::GetCalendarResources::new(href).with_hrefs([href]))
             .await
-            .map_err(|e| anyhow!("failed to fetch event for update: {e}"))?;
+            .map_err(|e| Error::Protocol(format!("failed to fetch event for update: {e}")))?;
 
         let resource = resources
             .resources
             .first()
-            .ok_or_else(|| anyhow!("event not found at {href}"))?;
+            .ok_or_else(|| Error::NotFound(format!("event not found at {href}")))?;
 
-        let content = resource
-            .content
-            .as_ref()
-            .map_err(|status| anyhow!("server returned {status} for event at {href}"))?;
+        let content = resource.content.as_ref().map_err(|status| {
+            Error::Protocol(format!("server returned {status} for event at {href}"))
+        })?;
 
         let merged = crate::ical::merge_updates(&content.data, &updates)?;
 
@@ -268,7 +271,7 @@ impl CalDavClient for LibDavCalDavClient {
             .inner
             .request(put_request)
             .await
-            .map_err(|e| anyhow!("failed to update event: {e}"))?;
+            .map_err(|e| Error::Protocol(format!("failed to update event: {e}")))?;
 
         Ok(UpdatedEvent {
             href: href.to_string(),
@@ -282,7 +285,7 @@ impl CalDavClient for LibDavCalDavClient {
         self.inner
             .request(delete_request)
             .await
-            .map_err(|e| anyhow!("failed to delete event: {e}"))?;
+            .map_err(|e| Error::Protocol(format!("failed to delete event: {e}")))?;
 
         Ok(())
     }

--- a/crates/caldav/src/error.rs
+++ b/crates/caldav/src/error.rs
@@ -1,0 +1,35 @@
+//! Crate-level error types for `moltis-caldav`.
+
+use thiserror::Error;
+
+/// Errors returned by CalDAV operations.
+#[derive(Debug, Error)]
+pub enum Error {
+    /// I/O error (file, network socket, etc.).
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+
+    /// The supplied URL could not be parsed or is otherwise invalid.
+    #[error("{0}")]
+    InvalidUrl(String),
+
+    /// A CalDAV/WebDAV protocol-level error (discovery failure, unexpected
+    /// server response, etc.).
+    #[error("{0}")]
+    Protocol(String),
+
+    /// Failed to parse iCalendar (RFC 5545) data.
+    #[error("{0}")]
+    IcalParse(String),
+
+    /// A required parameter was missing or had an invalid value.
+    #[error("{0}")]
+    Validation(String),
+
+    /// The requested resource was not found on the server.
+    #[error("{0}")]
+    NotFound(String),
+}
+
+/// Convenience alias used throughout this crate.
+pub type Result<T> = std::result::Result<T, Error>;

--- a/crates/caldav/src/ical.rs
+++ b/crates/caldav/src/ical.rs
@@ -1,11 +1,11 @@
 //! iCalendar build/parse helpers using the `icalendar` crate.
 
-use {
-    anyhow::{Result, anyhow},
-    icalendar::{Calendar, Component, Event, EventLike},
-};
+use icalendar::{Calendar, Component, Event, EventLike};
 
-use crate::types::{EventSummary, NewEvent, UpdateEvent};
+use crate::{
+    error::{Error, Result},
+    types::{EventSummary, NewEvent, UpdateEvent},
+};
 
 /// Build a VCALENDAR string containing a single VEVENT from the given parameters.
 #[must_use]
@@ -42,7 +42,7 @@ pub fn build_vevent(event: &NewEvent, uid: &str) -> String {
 pub fn parse_events(ical_data: &str, href: &str, etag: &str) -> Result<Vec<EventSummary>> {
     let calendar: Calendar = ical_data
         .parse()
-        .map_err(|e| anyhow!("failed to parse iCalendar data: {e}"))?;
+        .map_err(|e| Error::IcalParse(format!("failed to parse iCalendar data: {e}")))?;
 
     let mut events = Vec::new();
     for component in &calendar.components {
@@ -76,7 +76,7 @@ pub fn parse_events(ical_data: &str, href: &str, etag: &str) -> Result<Vec<Event
 pub fn merge_updates(existing: &str, updates: &UpdateEvent) -> Result<String> {
     let mut calendar: Calendar = existing
         .parse()
-        .map_err(|e| anyhow!("failed to parse existing iCalendar data: {e}"))?;
+        .map_err(|e| Error::IcalParse(format!("failed to parse existing iCalendar data: {e}")))?;
 
     let mut new_components = Vec::new();
     for component in calendar.components.drain(..) {

--- a/crates/caldav/src/lib.rs
+++ b/crates/caldav/src/lib.rs
@@ -6,6 +6,9 @@
 
 pub mod client;
 pub mod discovery;
+pub mod error;
 pub mod ical;
 pub mod tool;
 pub mod types;
+
+pub use error::Error;

--- a/crates/caldav/src/tool.rs
+++ b/crates/caldav/src/tool.rs
@@ -3,7 +3,7 @@
 use std::{collections::HashMap, sync::Arc};
 
 use {
-    anyhow::{Result, anyhow},
+    anyhow::anyhow,
     async_trait::async_trait,
     moltis_agents::tool_registry::AgentTool,
     moltis_config::CalDavConfig,
@@ -13,6 +13,7 @@ use {
 use crate::{
     client::{LibDavCalDavClient, SharedCalDavClient},
     discovery,
+    error::Error,
     types::{NewEvent, TimeRange, UpdateEvent},
 };
 
@@ -39,7 +40,10 @@ impl CalDavTool {
     }
 
     /// Resolve which account to use and return its client.
-    async fn resolve_client(&self, account: Option<&str>) -> Result<SharedCalDavClient> {
+    async fn resolve_client(
+        &self,
+        account: Option<&str>,
+    ) -> crate::error::Result<SharedCalDavClient> {
         let account_name = account
             .or(self.config.default_account.as_deref())
             .or_else(|| {
@@ -52,11 +56,11 @@ impl CalDavTool {
             })
             .ok_or_else(|| {
                 let names: Vec<&str> = self.config.accounts.keys().map(String::as_str).collect();
-                anyhow!(
+                Error::Validation(format!(
                     "multiple CalDAV accounts configured ({}), \
                      specify 'account' parameter or set caldav.default_account",
                     names.join(", ")
-                )
+                ))
             })?;
 
         // Check if already connected
@@ -68,32 +72,29 @@ impl CalDavTool {
         }
 
         // Need to connect — get config and build client
-        let account_config = self
-            .config
-            .accounts
-            .get(account_name)
-            .ok_or_else(|| anyhow!("unknown CalDAV account '{account_name}'"))?;
+        let account_config =
+            self.config.accounts.get(account_name).ok_or_else(|| {
+                Error::Validation(format!("unknown CalDAV account '{account_name}'"))
+            })?;
 
         let base_url = discovery::resolve_base_url(
             account_config.provider.as_deref(),
             account_config.url.as_deref(),
         )
         .ok_or_else(|| {
-            anyhow!(
+            Error::Validation(format!(
                 "CalDAV account '{account_name}' has no URL and provider '{}' requires one",
                 account_config.provider.as_deref().unwrap_or("generic")
-            )
+            ))
         })?;
 
-        let username = account_config
-            .username
-            .as_deref()
-            .ok_or_else(|| anyhow!("CalDAV account '{account_name}' has no username"))?;
+        let username = account_config.username.as_deref().ok_or_else(|| {
+            Error::Validation(format!("CalDAV account '{account_name}' has no username"))
+        })?;
 
-        let password = account_config
-            .password
-            .as_ref()
-            .ok_or_else(|| anyhow!("CalDAV account '{account_name}' has no password"))?;
+        let password = account_config.password.as_ref().ok_or_else(|| {
+            Error::Validation(format!("CalDAV account '{account_name}' has no password"))
+        })?;
 
         #[cfg(feature = "tracing")]
         tracing::info!(
@@ -186,7 +187,7 @@ impl AgentTool for CalDavTool {
         })
     }
 
-    async fn execute(&self, params: Value) -> Result<Value> {
+    async fn execute(&self, params: Value) -> anyhow::Result<Value> {
         let operation = params
             .get("operation")
             .and_then(|v| v.as_str())
@@ -315,7 +316,7 @@ impl AgentTool for CalDavTool {
                 Ok(json!({ "ok": true }))
             },
 
-            _ => anyhow::bail!("unknown operation: {operation}"),
+            _ => Err(anyhow!("unknown operation: {operation}")),
         }
     }
 }
@@ -333,7 +334,7 @@ pub(crate) struct MockCalDavClient {
 #[cfg(test)]
 #[async_trait]
 impl crate::client::CalDavClient for MockCalDavClient {
-    async fn list_calendars(&self) -> Result<Vec<crate::types::CalendarInfo>> {
+    async fn list_calendars(&self) -> crate::error::Result<Vec<crate::types::CalendarInfo>> {
         Ok(self.calendars.clone())
     }
 
@@ -341,7 +342,7 @@ impl crate::client::CalDavClient for MockCalDavClient {
         &self,
         _calendar_href: &str,
         _range: Option<TimeRange>,
-    ) -> Result<Vec<crate::types::EventSummary>> {
+    ) -> crate::error::Result<Vec<crate::types::EventSummary>> {
         let events = self
             .events
             .lock()
@@ -354,7 +355,7 @@ impl crate::client::CalDavClient for MockCalDavClient {
         &self,
         _calendar_href: &str,
         _event: NewEvent,
-    ) -> Result<crate::types::CreatedEvent> {
+    ) -> crate::error::Result<crate::types::CreatedEvent> {
         let uid = format!("mock-{}@moltis", uuid::Uuid::new_v4());
         Ok(crate::types::CreatedEvent {
             href: format!("/cal/{uid}.ics"),
@@ -368,14 +369,14 @@ impl crate::client::CalDavClient for MockCalDavClient {
         href: &str,
         _etag: &str,
         _updates: UpdateEvent,
-    ) -> Result<crate::types::UpdatedEvent> {
+    ) -> crate::error::Result<crate::types::UpdatedEvent> {
         Ok(crate::types::UpdatedEvent {
             href: href.to_string(),
             etag: Some("\"mock-etag-updated\"".to_string()),
         })
     }
 
-    async fn delete_event(&self, _href: &str, _etag: &str) -> Result<()> {
+    async fn delete_event(&self, _href: &str, _etag: &str) -> crate::error::Result<()> {
         Ok(())
     }
 }

--- a/crates/chat/src/memory_tools/tests.rs
+++ b/crates/chat/src/memory_tools/tests.rs
@@ -29,7 +29,7 @@ struct MockEmbedder;
 
 #[async_trait]
 impl EmbeddingProvider for MockEmbedder {
-    async fn embed(&self, text: &str) -> anyhow::Result<Vec<f32>> {
+    async fn embed(&self, text: &str) -> moltis_memory::Result<Vec<f32>> {
         let lower = text.to_lowercase();
         Ok(KEYWORDS
             .iter()

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -450,6 +450,7 @@ async fn main() -> anyhow::Result<()> {
                 extra_routes,
             )
             .await
+            .map_err(Into::into)
         },
         Some(Commands::Agent { message, .. }) => {
             let result = moltis_agents::runner::run_agent("default", "main", &message).await?;

--- a/crates/cli/src/node_commands.rs
+++ b/crates/cli/src/node_commands.rs
@@ -123,7 +123,8 @@ pub async fn handle_node(action: NodeAction) -> Result<()> {
                 };
 
                 let node = moltis_node_host::NodeHost::new(config);
-                node.run().await
+                node.run().await?;
+                Ok(())
             } else {
                 let data_dir = moltis_config::data_dir();
                 let svc_config = moltis_node_host::ServiceConfig {
@@ -177,7 +178,8 @@ pub async fn handle_node(action: NodeAction) -> Result<()> {
             };
 
             let node = moltis_node_host::NodeHost::new(node_config);
-            node.run().await
+            node.run().await?;
+            Ok(())
         },
 
         NodeAction::Remove => {

--- a/crates/code-index/src/config.rs
+++ b/crates/code-index/src/config.rs
@@ -157,28 +157,22 @@ impl CodeIndexConfig {
         let path_lower = relative_path.to_ascii_lowercase();
         // Normalize separators.
         let path_forward = path_lower.replace('\\', "/");
-        self.skip_paths
-            .iter()
-            .any(|pattern| {
-                // Strip trailing slashes so "vendor/" is treated as "vendor" for
-                // segment matching.
-                let p = pattern.trim_end_matches('/').to_ascii_lowercase();
-                // Exact prefix match (handles both "vendor/foo" and "vendor/").
-                if path_forward.starts_with(&p)
-                    || path_forward.starts_with(&format!("{p}/"))
-                {
-                    return true;
-                }
-                // Segment match: check if any path component equals the pattern.
-                // This catches "src/vendor/foo.rs" when pattern is "vendor".
-                if !p.contains('/') {
-                    path_forward
-                        .split('/')
-                        .any(|segment| segment == p.as_str())
-                } else {
-                    false
-                }
-            })
+        self.skip_paths.iter().any(|pattern| {
+            // Strip trailing slashes so "vendor/" is treated as "vendor" for
+            // segment matching.
+            let p = pattern.trim_end_matches('/').to_ascii_lowercase();
+            // Exact prefix match (handles both "vendor/foo" and "vendor/").
+            if path_forward.starts_with(&p) || path_forward.starts_with(&format!("{p}/")) {
+                return true;
+            }
+            // Segment match: check if any path component equals the pattern.
+            // This catches "src/vendor/foo.rs" when pattern is "vendor".
+            if !p.contains('/') {
+                path_forward.split('/').any(|segment| segment == p.as_str())
+            } else {
+                false
+            }
+        })
     }
 
     /// Return a [`FilterConfig`](crate::filter::FilterConfig) for the file watcher.

--- a/crates/code-index/src/delta.rs
+++ b/crates/code-index/src/delta.rs
@@ -222,14 +222,11 @@ pub fn build_initial_snapshot(
             },
         };
 
-        snapshot.insert(
-            rel_str,
-            FileMeta {
-                content_hash: hash,
-                modified_time,
-                size: meta.len(),
-            },
-        );
+        snapshot.insert(rel_str, FileMeta {
+            content_hash: hash,
+            modified_time,
+            size: meta.len(),
+        });
     }
 
     Ok(snapshot)
@@ -256,14 +253,11 @@ pub fn build_snapshot_from_filtered(filtered: &[FilteredFile]) -> HashSnapshot {
             .map_or(0, |d| d.as_secs());
 
         if let Ok(hash) = content_hash(&file.path) {
-            snapshot.insert(
-                rel_str,
-                FileMeta {
-                    content_hash: hash,
-                    modified_time,
-                    size: meta.len(),
-                },
-            );
+            snapshot.insert(rel_str, FileMeta {
+                content_hash: hash,
+                modified_time,
+                size: meta.len(),
+            });
         }
     }
     snapshot
@@ -350,14 +344,11 @@ mod tests {
         let mut previous = build_initial_snapshot(repo_dir, &config).unwrap();
 
         // Insert a fake file that doesn't exist on disk.
-        previous.insert(
-            "fake/deleted_file.rs".to_string(),
-            FileMeta {
-                content_hash: "abc123".to_string(),
-                modified_time: 0,
-                size: 100,
-            },
-        );
+        previous.insert("fake/deleted_file.rs".to_string(), FileMeta {
+            content_hash: "abc123".to_string(),
+            modified_time: 0,
+            size: 100,
+        });
 
         let (delta, _) = compute_delta(repo_dir, &config, &previous).unwrap();
         assert!(
@@ -385,9 +376,7 @@ mod tests {
                 "hash for {path} should be 64 hex chars"
             );
             assert!(
-                meta.content_hash
-                    .chars()
-                    .all(|c| c.is_ascii_hexdigit()),
+                meta.content_hash.chars().all(|c| c.is_ascii_hexdigit()),
                 "hash for {path} should be hex, got {}",
                 meta.content_hash
             );

--- a/crates/code-index/src/index.rs
+++ b/crates/code-index/src/index.rs
@@ -663,7 +663,7 @@ impl CodeIndex {
                                 })
                                 .collect()
                         }
-                    }
+                    },
                     Err(e) => {
                         #[cfg(feature = "tracing")]
                         warn!(
@@ -870,7 +870,7 @@ mod tests {
 
     #[async_trait]
     impl moltis_memory::embeddings::EmbeddingProvider for MockEmbedder {
-        async fn embed(&self, text: &str) -> anyhow::Result<Vec<f32>> {
+        async fn embed(&self, text: &str) -> moltis_memory::error::Result<Vec<f32>> {
             let mut vec = vec![0.0f32; self.dims];
             for (i, b) in text.as_bytes().iter().enumerate() {
                 vec[i % self.dims] += *b as f32 / 255.0;
@@ -902,8 +902,8 @@ mod tests {
 
     #[async_trait]
     impl moltis_memory::embeddings::EmbeddingProvider for FailingEmbedder {
-        async fn embed(&self, _text: &str) -> anyhow::Result<Vec<f32>> {
-            anyhow::bail!("embed failed")
+        async fn embed(&self, _text: &str) -> moltis_memory::error::Result<Vec<f32>> {
+            Err(moltis_memory::Error::Embedding("embed failed".into()))
         }
 
         fn model_name(&self) -> &str {

--- a/crates/code-index/src/lib.rs
+++ b/crates/code-index/src/lib.rs
@@ -60,7 +60,6 @@ pub fn sanitize_project_id(project_id: &str) -> String {
         .collect()
 }
 
-
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {

--- a/crates/code-index/src/snapshot_store.rs
+++ b/crates/code-index/src/snapshot_store.rs
@@ -179,8 +179,7 @@ fn sanitize_project_id(id: &str) -> Result<&str> {
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
-    use super::*;
-    use crate::delta::FileMeta;
+    use {super::*, crate::delta::FileMeta};
 
     fn fake_meta(hash: &str) -> FileMeta {
         FileMeta {

--- a/crates/gateway/src/server/helpers.rs
+++ b/crates/gateway/src/server/helpers.rs
@@ -618,7 +618,7 @@ pub(crate) async fn start_skill_hot_reload_watcher() -> anyhow::Result<(
         .await
         .map_err(|error| anyhow::anyhow!("skills watcher task failed: {error}"))??;
 
-    moltis_skills::watcher::SkillWatcher::start(watch_specs)
+    Ok(moltis_skills::watcher::SkillWatcher::start(watch_specs)?)
 }
 
 // ── Local-LLM model restoration ─────────────────────────────────────────────

--- a/crates/gateway/src/server/init_code_index.rs
+++ b/crates/gateway/src/server/init_code_index.rs
@@ -53,9 +53,7 @@ pub(crate) async fn init_code_index(
         }
 
         #[cfg(feature = "code-index-builtin")]
-        info!(
-            "code-index: QMD binary not found, trying builtin backend"
-        );
+        info!("code-index: QMD binary not found, trying builtin backend");
 
         #[cfg(not(feature = "code-index-builtin"))]
         warn!(
@@ -75,14 +73,14 @@ pub(crate) async fn init_code_index(
                     Box::new(store),
                     None,
                 ));
-            }
+            },
             Err(e) => {
                 warn!(
                     path = %db_path.display(),
                     error = %e,
                     "code-index: failed to initialize builtin backend, falling back to config-only"
                 );
-            }
+            },
         }
     }
 

--- a/crates/httpd/Cargo.toml
+++ b/crates/httpd/Cargo.toml
@@ -49,6 +49,7 @@ serde                 = { workspace = true }
 serde_json            = { workspace = true }
 sysinfo               = { workspace = true }
 tempfile              = { workspace = true }
+thiserror             = { workspace = true }
 time                  = { workspace = true }
 tokio                 = { workspace = true }
 tokio-tungstenite     = { workspace = true }

--- a/crates/httpd/src/error.rs
+++ b/crates/httpd/src/error.rs
@@ -19,9 +19,6 @@ pub enum Error {
 
     #[error("{0}")]
     Ngrok(String),
-
-    #[error(transparent)]
-    Other(#[from] Box<dyn std::error::Error + Send + Sync>),
 }
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/crates/httpd/src/error.rs
+++ b/crates/httpd/src/error.rs
@@ -1,0 +1,27 @@
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+
+    #[error("{0}")]
+    Config(String),
+
+    #[error("{0}")]
+    Tls(String),
+
+    #[error("{0}")]
+    Ssh(String),
+
+    #[error("{0}")]
+    Protocol(String),
+
+    #[error("{0}")]
+    Ngrok(String),
+
+    #[error(transparent)]
+    Other(#[from] Box<dyn std::error::Error + Send + Sync>),
+}
+
+pub type Result<T> = std::result::Result<T, Error>;

--- a/crates/httpd/src/lib.rs
+++ b/crates/httpd/src/lib.rs
@@ -11,6 +11,7 @@ pub mod auth_middleware;
 pub mod auth_routes;
 pub mod channel_webhook_middleware;
 pub mod env_routes;
+pub mod error;
 pub mod login_guard;
 pub mod request_throttle;
 pub mod server;
@@ -18,6 +19,8 @@ pub mod ssh_routes;
 pub mod tools_routes;
 pub mod upload_routes;
 pub mod ws;
+
+pub use error::Error;
 
 #[cfg(feature = "graphql")]
 pub mod graphql_routes;

--- a/crates/httpd/src/server/gateway.rs
+++ b/crates/httpd/src/server/gateway.rs
@@ -44,7 +44,7 @@ pub async fn prepare_gateway(
     #[cfg(feature = "tailscale")] tailscale_opts: Option<TailscaleOpts>,
     extra_routes: Option<RouteEnhancer>,
     session_event_bus: Option<SessionEventBus>,
-) -> anyhow::Result<PreparedGateway> {
+) -> crate::error::Result<PreparedGateway> {
     // Install a process-level rustls CryptoProvider early, before any channel
     // plugin (Slack, Discord, etc.) creates outbound TLS connections via
     // hyper-rustls.  Without this, `--no-tls` deployments skip the TLS cert
@@ -73,7 +73,8 @@ pub async fn prepare_gateway(
         tailscale_reset_on_exit_override,
         session_event_bus,
     )
-    .await?;
+    .await
+    .map_err(|e| crate::Error::Config(e.to_string()))?;
 
     let PreparedGatewayCore {
         state,

--- a/crates/httpd/src/server/ngrok.rs
+++ b/crates/httpd/src/server/ngrok.rs
@@ -69,7 +69,7 @@ impl NgrokController {
     pub async fn apply(
         &self,
         ngrok_config: &moltis_config::NgrokConfig,
-    ) -> anyhow::Result<Option<NgrokRuntimeStatus>> {
+    ) -> crate::error::Result<Option<NgrokRuntimeStatus>> {
         self.stop().await?;
 
         if !ngrok_config.enabled {
@@ -94,11 +94,11 @@ impl NgrokController {
     async fn start(
         &self,
         ngrok_config: &moltis_config::NgrokConfig,
-    ) -> anyhow::Result<NgrokActiveTunnel> {
+    ) -> crate::error::Result<NgrokActiveTunnel> {
         let app = {
             let stored = self.inner.app.read().await;
             stored.clone().ok_or_else(|| {
-                anyhow::anyhow!("ngrok tunnel cannot start before the HTTP app is ready")
+                crate::Error::Ngrok("ngrok tunnel cannot start before the HTTP app is ready".into())
             })?
         };
 
@@ -111,7 +111,7 @@ impl NgrokController {
         .await
     }
 
-    pub async fn stop(&self) -> anyhow::Result<()> {
+    pub async fn stop(&self) -> crate::error::Result<()> {
         use ngrok::prelude::TunnelCloser;
 
         let active_tunnel = {

--- a/crates/httpd/src/server/runtime.rs
+++ b/crates/httpd/src/server/runtime.rs
@@ -79,7 +79,7 @@ pub(super) fn instance_slug(config: &moltis_config::MoltisConfig) -> String {
 
 pub(super) async fn finalize_prepared_gateway(
     args: FinalizeGatewayArgs<'_>,
-) -> anyhow::Result<PreparedGateway> {
+) -> crate::error::Result<PreparedGateway> {
     let FinalizeGatewayArgs {
         bind,
         port,
@@ -134,14 +134,17 @@ pub(super) async fn finalize_prepared_gateway(
             (ca, cert, key)
         } else if tls_config.auto_generate {
             // Auto-generate certificates.
-            let mgr = moltis_tls::FsCertManager::new()?;
+            let mgr =
+                moltis_tls::FsCertManager::new().map_err(|e| crate::Error::Tls(e.to_string()))?;
             let runtime_sans = tls_runtime_sans(bind);
-            let (ca, cert, key) = mgr.ensure_certs(&runtime_sans)?;
+            let (ca, cert, key) = mgr
+                .ensure_certs(&runtime_sans)
+                .map_err(|e| crate::Error::Tls(e.to_string()))?;
             (Some(ca), cert, key)
         } else {
-            anyhow::bail!(
-                "TLS is enabled but no certificates configured and auto_generate is false"
-            );
+            return Err(crate::Error::Tls(
+                "TLS is enabled but no certificates configured and auto_generate is false".into(),
+            ));
         };
 
         // Add /certs/ca.pem route to the main HTTPS app if we have a CA cert.
@@ -866,7 +869,7 @@ pub async fn prepare_gateway_embedded(
     data_dir: Option<PathBuf>,
     extra_routes: Option<RouteEnhancer>,
     session_event_bus: Option<SessionEventBus>,
-) -> anyhow::Result<PreparedGateway> {
+) -> crate::error::Result<PreparedGateway> {
     let prepared = prepare_gateway(
         bind,
         port,
@@ -913,7 +916,7 @@ pub(super) async fn start_ngrok_tunnel(
     gateway: Arc<GatewayState>,
     webauthn_registry: Option<SharedWebAuthnRegistry>,
     ngrok_config: &moltis_config::NgrokConfig,
-) -> anyhow::Result<NgrokActiveTunnel> {
+) -> crate::error::Result<NgrokActiveTunnel> {
     use ::ngrok::prelude::{EndpointInfo, ForwarderBuilder};
 
     let internal_listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
@@ -939,7 +942,7 @@ pub(super) async fn start_ngrok_tunnel(
 
     let forward_to = format!("http://{internal_addr}")
         .parse()
-        .map_err(|error| anyhow::anyhow!("invalid ngrok forward target: {error}"))?;
+        .map_err(|error| crate::Error::Ngrok(format!("invalid ngrok forward target: {error}")))?;
 
     let mut session_builder = ::ngrok::Session::builder();
     if let Some(authtoken) = ngrok_config.authtoken.as_ref() {
@@ -954,7 +957,7 @@ pub(super) async fn start_ngrok_tunnel(
             if let Err(join_error) = loopback_task.await {
                 warn!(%join_error, "ngrok loopback server task join failed during startup");
             }
-            return Err(error.into());
+            return Err(crate::Error::Ngrok(error.to_string()));
         },
     };
 
@@ -973,7 +976,7 @@ pub(super) async fn start_ngrok_tunnel(
             if let Err(join_error) = loopback_task.await {
                 warn!(%join_error, "ngrok loopback server task join failed during startup");
             }
-            return Err(error.into());
+            return Err(crate::Error::Ngrok(error.to_string()));
         },
     };
     let public_url = forwarder.url().to_string();
@@ -1017,7 +1020,7 @@ pub async fn start_gateway(
     data_dir: Option<PathBuf>,
     #[cfg(feature = "tailscale")] tailscale_opts: Option<TailscaleOpts>,
     extra_routes: Option<RouteEnhancer>,
-) -> anyhow::Result<()> {
+) -> crate::error::Result<()> {
     let prepared = prepare_gateway(
         bind,
         port,
@@ -1039,7 +1042,7 @@ pub async fn start_gateway(
 
     let ip: std::net::IpAddr = bind
         .parse()
-        .map_err(|e| anyhow::anyhow!("invalid bind address '{bind}': {e}"))?;
+        .map_err(|e| crate::Error::Config(format!("invalid bind address '{bind}': {e}")))?;
     let addr = SocketAddr::new(ip, port);
 
     #[cfg_attr(not(feature = "tls"), allow(unused_variables))]
@@ -1106,20 +1109,26 @@ pub async fn start_gateway(
             (ca, cert, key)
         } else if tls_config.auto_generate {
             // Auto-generate certificates.
-            let mgr = moltis_tls::FsCertManager::new()?;
+            let mgr =
+                moltis_tls::FsCertManager::new().map_err(|e| crate::Error::Tls(e.to_string()))?;
             let runtime_sans = tls_runtime_sans(bind);
-            let (ca, cert, key) = mgr.ensure_certs(&runtime_sans)?;
+            let (ca, cert, key) = mgr
+                .ensure_certs(&runtime_sans)
+                .map_err(|e| crate::Error::Tls(e.to_string()))?;
             (Some(ca), cert, key)
         } else {
-            anyhow::bail!(
-                "TLS is enabled but no certificates configured and auto_generate is false"
-            );
+            return Err(crate::Error::Tls(
+                "TLS is enabled but no certificates configured and auto_generate is false".into(),
+            ));
         };
 
         ca_cert_path = ca_path.clone();
 
-        let mgr = moltis_tls::FsCertManager::new()?;
-        rustls_config = Some(mgr.build_rustls_config(&cert_path, &key_path)?);
+        let mgr = moltis_tls::FsCertManager::new().map_err(|e| crate::Error::Tls(e.to_string()))?;
+        rustls_config = Some(
+            mgr.build_rustls_config(&cert_path, &key_path)
+                .map_err(|e| crate::Error::Tls(e.to_string()))?,
+        );
         // Note: /certs/ca.pem route is already registered by prepare_gateway.
     }
 
@@ -1390,7 +1399,8 @@ pub async fn start_gateway(
             browser_tool_for_warmup.clone(),
         );
         moltis_tls::serve_tls_with_http_redirect(tcp_listener, Arc::new(tls_cfg), app, port, bind)
-            .await?;
+            .await
+            .map_err(|e| crate::Error::Tls(e.to_string()))?;
         return Ok(());
     }
 

--- a/crates/httpd/src/ssh_routes.rs
+++ b/crates/httpd/src/ssh_routes.rs
@@ -769,7 +769,9 @@ fn build_ssh_test_response(
     }
 }
 
-async fn generate_ssh_key_material(name: &str) -> anyhow::Result<(SecretString, String, String)> {
+async fn generate_ssh_key_material(
+    name: &str,
+) -> crate::error::Result<(SecretString, String, String)> {
     let dir = tempfile::tempdir()?;
     let key_path = dir.path().join("moltis_deploy_key");
     let output = Command::new("ssh-keygen")
@@ -784,7 +786,9 @@ async fn generate_ssh_key_material(name: &str) -> anyhow::Result<(SecretString, 
         .output()
         .await?;
     if !output.status.success() {
-        anyhow::bail!("{}", String::from_utf8_lossy(&output.stderr).trim());
+        return Err(crate::Error::Ssh(
+            String::from_utf8_lossy(&output.stderr).trim().to_string(),
+        ));
     }
 
     let private_key = SecretString::new(tokio::fs::read_to_string(&key_path).await?);
@@ -796,7 +800,7 @@ async fn generate_ssh_key_material(name: &str) -> anyhow::Result<(SecretString, 
 async fn inspect_imported_private_key(
     private_key: &SecretString,
     passphrase: Option<&SecretString>,
-) -> anyhow::Result<(SecretString, String, String)> {
+) -> crate::error::Result<(SecretString, String, String)> {
     let dir = tempfile::tempdir()?;
     let key_path = dir.path().join("imported_key");
     tokio::fs::write(&key_path, private_key.expose_secret()).await?;
@@ -824,11 +828,12 @@ async fn inspect_imported_private_key(
             .trim()
             .to_string();
         if passphrase.is_none() && looks_like_passphrase_error(&stderr) {
-            anyhow::bail!(
+            return Err(crate::Error::Ssh(
                 "this private key is passphrase-protected, provide the passphrase to import it"
-            );
+                    .into(),
+            ));
         }
-        anyhow::bail!(stderr);
+        return Err(crate::Error::Ssh(stderr));
     }
 
     if let Some(passphrase) = passphrase {
@@ -843,13 +848,20 @@ async fn inspect_imported_private_key(
         let _decrypt_askpass = configure_ssh_askpass(&mut decrypt_command, passphrase)?;
         let decrypt_output = decrypt_command.output().await?;
         if !decrypt_output.status.success() {
-            anyhow::bail!("{}", String::from_utf8_lossy(&decrypt_output.stderr).trim());
+            return Err(crate::Error::Ssh(
+                String::from_utf8_lossy(&decrypt_output.stderr)
+                    .trim()
+                    .to_string(),
+            ));
         }
     }
 
     let fingerprint = ssh_keygen_fingerprint(&key_path).await?;
     let decrypted_private_key = SecretString::new(tokio::fs::read_to_string(&key_path).await?);
-    let public_key = String::from_utf8(public_output.stdout)?.trim().to_string();
+    let public_key = String::from_utf8(public_output.stdout)
+        .map_err(|e| crate::Error::Ssh(e.to_string()))?
+        .trim()
+        .to_string();
     Ok((decrypted_private_key, public_key, fingerprint))
 }
 
@@ -871,7 +883,7 @@ fn looks_like_passphrase_error(stderr: &str) -> bool {
 fn configure_ssh_askpass(
     command: &mut Command,
     passphrase: &SecretString,
-) -> anyhow::Result<tempfile::TempDir> {
+) -> crate::error::Result<tempfile::TempDir> {
     let dir = tempfile::tempdir()?;
     let askpass_path = dir.path().join("askpass.sh");
     let passphrase_path = dir.path().join("askpass.sh.pass");
@@ -890,19 +902,23 @@ fn configure_ssh_askpass(
     Ok(dir)
 }
 
-async fn ssh_keygen_fingerprint(path: &std::path::Path) -> anyhow::Result<String> {
+async fn ssh_keygen_fingerprint(path: &std::path::Path) -> crate::error::Result<String> {
     let output = Command::new("ssh-keygen")
         .arg("-lf")
         .arg(path)
         .output()
         .await?;
     if !output.status.success() {
-        anyhow::bail!("{}", String::from_utf8_lossy(&output.stderr).trim());
+        return Err(crate::Error::Ssh(
+            String::from_utf8_lossy(&output.stderr).trim().to_string(),
+        ));
     }
-    Ok(String::from_utf8(output.stdout)?.trim().to_string())
+    String::from_utf8(output.stdout)
+        .map(|s| s.trim().to_string())
+        .map_err(|e| crate::Error::Ssh(e.to_string()))
 }
 
-async fn validate_known_host_entry(known_host: &str) -> anyhow::Result<()> {
+async fn validate_known_host_entry(known_host: &str) -> crate::error::Result<()> {
     let dir = tempfile::tempdir()?;
     let known_hosts_path = dir.path().join("known_hosts");
     tokio::fs::write(&known_hosts_path, format!("{known_host}\n")).await?;
@@ -913,7 +929,9 @@ async fn validate_known_host_entry(known_host: &str) -> anyhow::Result<()> {
     }
     let _ = ssh_keygen_fingerprint(&known_hosts_path)
         .await
-        .map_err(|_| anyhow::anyhow!("known host entry is not a valid known_hosts line"))?;
+        .map_err(|_| {
+            crate::Error::Ssh("known host entry is not a valid known_hosts line".into())
+        })?;
     Ok(())
 }
 
@@ -962,7 +980,7 @@ fn fallback_scan_host(target: &str) -> String {
 async fn resolve_scan_target(
     target: &str,
     port: Option<u16>,
-) -> anyhow::Result<ResolvedScanTarget> {
+) -> crate::error::Result<ResolvedScanTarget> {
     let output = Command::new("ssh")
         .arg("-G")
         .arg("--")
@@ -992,10 +1010,12 @@ async fn resolve_scan_target(
 async fn scan_target_known_host(
     target: &str,
     port: Option<u16>,
-) -> anyhow::Result<ScannedKnownHost> {
+) -> crate::error::Result<ScannedKnownHost> {
     let resolved = resolve_scan_target(target, port).await?;
     if resolved.host.is_empty() {
-        anyhow::bail!("could not resolve a hostname for ssh target '{target}'");
+        return Err(crate::Error::Ssh(format!(
+            "could not resolve a hostname for ssh target '{target}'"
+        )));
     }
 
     let mut command = Command::new("ssh-keyscan");
@@ -1006,18 +1026,23 @@ async fn scan_target_known_host(
     command.arg(&resolved.host);
     let output = command.output().await?;
     if !output.status.success() {
-        anyhow::bail!("{}", String::from_utf8_lossy(&output.stderr).trim());
+        return Err(crate::Error::Ssh(
+            String::from_utf8_lossy(&output.stderr).trim().to_string(),
+        ));
     }
-    let known_host = String::from_utf8(output.stdout)?.trim().to_string();
+    let known_host = String::from_utf8(output.stdout)
+        .map_err(|e| crate::Error::Ssh(e.to_string()))?
+        .trim()
+        .to_string();
     if known_host.is_empty() {
-        anyhow::bail!(
+        return Err(crate::Error::Ssh(format!(
             "ssh-keyscan did not return any host keys for {}{}",
             resolved.host,
             resolved
                 .port
                 .map(|value| format!(":{value}"))
                 .unwrap_or_default()
-        );
+        )));
     }
     validate_known_host_entry(&known_host).await?;
 

--- a/crates/httpd/src/ws.rs
+++ b/crates/httpd/src/ws.rs
@@ -661,19 +661,27 @@ async fn graceful_writer_shutdown(
 /// Wait for the first `connect` request frame. Tries v4 format first, falls back to v3.
 async fn wait_for_connect(
     rx: &mut futures::stream::SplitStream<WebSocket>,
-) -> anyhow::Result<ConnectResult> {
+) -> crate::error::Result<ConnectResult> {
     while let Some(msg) = rx.next().await {
-        let text = match msg? {
+        let text = match msg.map_err(|e| crate::Error::Protocol(e.to_string()))? {
             Message::Text(t) => t.to_string(),
-            Message::Close(_) => anyhow::bail!("connection closed before handshake"),
+            Message::Close(_) => {
+                return Err(crate::Error::Protocol(
+                    "connection closed before handshake".into(),
+                ));
+            },
             _ => continue,
         };
 
-        let frame: GatewayFrame = serde_json::from_str(&text)?;
+        let frame: GatewayFrame =
+            serde_json::from_str(&text).map_err(|e| crate::Error::Protocol(e.to_string()))?;
         match frame {
             GatewayFrame::Request(req) => {
                 if req.method != "connect" {
-                    anyhow::bail!("first message must be 'connect', got '{}'", req.method);
+                    return Err(crate::Error::Protocol(format!(
+                        "first message must be 'connect', got '{}'",
+                        req.method
+                    )));
                 }
                 let raw = req.params.unwrap_or(serde_json::Value::Null);
 
@@ -687,15 +695,22 @@ async fn wait_for_connect(
                 }
 
                 // Fall back to v3 flat format.
-                let params: ConnectParams = serde_json::from_value(raw)?;
+                let params: ConnectParams = serde_json::from_value(raw)
+                    .map_err(|e| crate::Error::Protocol(e.to_string()))?;
                 return Ok(ConnectResult {
                     request_id: req.id,
                     params,
                     is_v4: false,
                 });
             },
-            _ => anyhow::bail!("first message must be a request frame"),
+            _ => {
+                return Err(crate::Error::Protocol(
+                    "first message must be a request frame".into(),
+                ));
+            },
         }
     }
-    anyhow::bail!("connection closed before handshake")
+    Err(crate::Error::Protocol(
+        "connection closed before handshake".into(),
+    ))
 }

--- a/crates/mcp-agent-bridge/Cargo.toml
+++ b/crates/mcp-agent-bridge/Cargo.toml
@@ -11,6 +11,7 @@ moltis-agents  = { workspace = true }
 moltis-mcp     = { workspace = true }
 moltis-metrics = { optional = true, workspace = true }
 serde_json     = { workspace = true }
+thiserror      = { workspace = true }
 tokio          = { workspace = true }
 tracing        = { optional = true, workspace = true }
 

--- a/crates/mcp-agent-bridge/Cargo.toml
+++ b/crates/mcp-agent-bridge/Cargo.toml
@@ -11,7 +11,6 @@ moltis-agents  = { workspace = true }
 moltis-mcp     = { workspace = true }
 moltis-metrics = { optional = true, workspace = true }
 serde_json     = { workspace = true }
-thiserror      = { workspace = true }
 tokio          = { workspace = true }
 tracing        = { optional = true, workspace = true }
 

--- a/crates/mcp-agent-bridge/src/adapter.rs
+++ b/crates/mcp-agent-bridge/src/adapter.rs
@@ -35,9 +35,9 @@ impl AgentTool for McpToolAdapter {
     }
 
     async fn execute(&self, params: serde_json::Value) -> anyhow::Result<serde_json::Value> {
-        McpAgentTool::execute(&self.0, params)
+        Ok(McpAgentTool::execute(&self.0, params)
             .await
-            .map_err(anyhow::Error::from)
+            .map_err(crate::error::Error::from)?)
     }
 }
 

--- a/crates/mcp-agent-bridge/src/adapter.rs
+++ b/crates/mcp-agent-bridge/src/adapter.rs
@@ -35,9 +35,7 @@ impl AgentTool for McpToolAdapter {
     }
 
     async fn execute(&self, params: serde_json::Value) -> anyhow::Result<serde_json::Value> {
-        Ok(McpAgentTool::execute(&self.0, params)
-            .await
-            .map_err(crate::error::Error::from)?)
+        Ok(McpAgentTool::execute(&self.0, params).await?)
     }
 }
 

--- a/crates/mcp-agent-bridge/src/error.rs
+++ b/crates/mcp-agent-bridge/src/error.rs
@@ -1,0 +1,9 @@
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error(transparent)]
+    Mcp(#[from] moltis_mcp::error::Error),
+}
+
+pub type Result<T> = std::result::Result<T, Error>;

--- a/crates/mcp-agent-bridge/src/error.rs
+++ b/crates/mcp-agent-bridge/src/error.rs
@@ -1,9 +1,3 @@
-use thiserror::Error;
-
-#[derive(Debug, Error)]
-pub enum Error {
-    #[error(transparent)]
-    Mcp(#[from] moltis_mcp::error::Error),
-}
+pub type Error = moltis_mcp::error::Error;
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/crates/mcp-agent-bridge/src/lib.rs
+++ b/crates/mcp-agent-bridge/src/lib.rs
@@ -1,3 +1,7 @@
 mod adapter;
+pub mod error;
 
-pub use adapter::{McpToolAdapter, sync_mcp_tools};
+pub use {
+    adapter::{McpToolAdapter, sync_mcp_tools},
+    error::Error,
+};

--- a/crates/memory/Cargo.toml
+++ b/crates/memory/Cargo.toml
@@ -47,6 +47,7 @@ reqwest                = { workspace = true }
 secrecy                = { workspace = true }
 serde                  = { workspace = true }
 serde_json             = { workspace = true }
+thiserror              = { workspace = true }
 sha2                   = { workspace = true }
 sqlx                   = { workspace = true }
 text-splitter          = { optional = true, workspace = true }

--- a/crates/memory/src/embeddings.rs
+++ b/crates/memory/src/embeddings.rs
@@ -1,14 +1,16 @@
 /// Provider-agnostic embedding trait for generating vectors from text.
 use async_trait::async_trait;
 
+use crate::error::Result;
+
 #[async_trait]
 pub trait EmbeddingProvider: Send + Sync {
     /// Generate an embedding for a single text.
-    async fn embed(&self, text: &str) -> anyhow::Result<Vec<f32>>;
+    async fn embed(&self, text: &str) -> Result<Vec<f32>>;
 
     /// Generate embeddings for a batch of texts.
     /// Default implementation calls `embed` sequentially.
-    async fn embed_batch(&self, texts: &[String]) -> anyhow::Result<Vec<Vec<f32>>> {
+    async fn embed_batch(&self, texts: &[String]) -> Result<Vec<Vec<f32>>> {
         let mut results = Vec::with_capacity(texts.len());
         for text in texts {
             results.push(self.embed(text).await?);

--- a/crates/memory/src/embeddings_batch.rs
+++ b/crates/memory/src/embeddings_batch.rs
@@ -3,7 +3,7 @@
 /// When enabled and the number of texts exceeds `batch_threshold`, uploads a JSONL file
 /// to the batch API, polls for completion, and downloads results. Falls back to sequential
 /// embedding on failure or timeout.
-use anyhow::Result;
+use crate::error::{Error, Result};
 use {
     async_trait::async_trait,
     secrecy::{ExposeSecret, Secret},
@@ -107,7 +107,9 @@ impl BatchEmbeddingProvider {
 
         loop {
             if tokio::time::Instant::now() > deadline {
-                anyhow::bail!("batch embedding timed out after 60 minutes");
+                return Err(Error::Embedding(
+                    "batch embedding timed out after 60 minutes".into(),
+                ));
             }
 
             tokio::time::sleep(poll_interval).await;
@@ -127,9 +129,9 @@ impl BatchEmbeddingProvider {
 
             match status.status.as_str() {
                 "completed" => {
-                    let output_file_id = status
-                        .output_file_id
-                        .ok_or_else(|| anyhow::anyhow!("batch completed but no output file"))?;
+                    let output_file_id = status.output_file_id.ok_or_else(|| {
+                        Error::Embedding("batch completed but no output file".into())
+                    })?;
 
                     // 5. Download results
                     let content = self
@@ -157,7 +159,7 @@ impl BatchEmbeddingProvider {
                             .strip_prefix("emb-")
                             .and_then(|s| s.parse().ok())
                             .ok_or_else(|| {
-                                anyhow::anyhow!("invalid custom_id: {}", entry.custom_id)
+                                Error::Embedding(format!("invalid custom_id: {}", entry.custom_id))
                             })?;
                         if let Some(body) = entry.response.body
                             && let Some(first) = body.data.into_iter().next()
@@ -172,11 +174,11 @@ impl BatchEmbeddingProvider {
                         results.into_iter().map(|(_, emb)| emb).collect();
 
                     if embeddings.len() != texts.len() {
-                        anyhow::bail!(
+                        return Err(Error::Embedding(format!(
                             "batch returned {} embeddings for {} texts",
                             embeddings.len(),
                             texts.len()
-                        );
+                        )));
                     }
 
                     info!(
@@ -187,7 +189,10 @@ impl BatchEmbeddingProvider {
                     return Ok(embeddings);
                 },
                 "failed" | "expired" | "cancelled" => {
-                    anyhow::bail!("batch {} ended with status: {}", batch_id, status.status);
+                    return Err(Error::Embedding(format!(
+                        "batch {} ended with status: {}",
+                        batch_id, status.status
+                    )));
                 },
                 _ => continue, // in_progress, validating, etc.
             }

--- a/crates/memory/src/embeddings_fallback.rs
+++ b/crates/memory/src/embeddings_fallback.rs
@@ -103,7 +103,7 @@ impl FallbackEmbeddingProvider {
 
 #[async_trait]
 impl EmbeddingProvider for FallbackEmbeddingProvider {
-    async fn embed(&self, text: &str) -> anyhow::Result<Vec<f32>> {
+    async fn embed(&self, text: &str) -> crate::error::Result<Vec<f32>> {
         let mut errors = Vec::new();
         let start_idx = self.active.load(Ordering::SeqCst);
 
@@ -136,10 +136,13 @@ impl EmbeddingProvider for FallbackEmbeddingProvider {
             }
         }
 
-        anyhow::bail!("all embedding providers failed: {}", errors.join("; "))
+        Err(crate::error::Error::Embedding(format!(
+            "all embedding providers failed: {}",
+            errors.join("; ")
+        )))
     }
 
-    async fn embed_batch(&self, texts: &[String]) -> anyhow::Result<Vec<Vec<f32>>> {
+    async fn embed_batch(&self, texts: &[String]) -> crate::error::Result<Vec<Vec<f32>>> {
         let mut errors = Vec::new();
         let start_idx = self.active.load(Ordering::SeqCst);
 
@@ -172,10 +175,10 @@ impl EmbeddingProvider for FallbackEmbeddingProvider {
             }
         }
 
-        anyhow::bail!(
+        Err(crate::error::Error::Embedding(format!(
             "all embedding providers failed (batch): {}",
             errors.join("; ")
-        )
+        )))
     }
 
     fn model_name(&self) -> &str {
@@ -206,8 +209,8 @@ mod tests {
 
     #[async_trait]
     impl EmbeddingProvider for FailingProvider {
-        async fn embed(&self, _text: &str) -> anyhow::Result<Vec<f32>> {
-            anyhow::bail!("always fails")
+        async fn embed(&self, _text: &str) -> crate::error::Result<Vec<f32>> {
+            Err(crate::error::Error::Embedding("always fails".into()))
         }
 
         fn model_name(&self) -> &str {
@@ -229,7 +232,7 @@ mod tests {
 
     #[async_trait]
     impl EmbeddingProvider for SuccessProvider {
-        async fn embed(&self, _text: &str) -> anyhow::Result<Vec<f32>> {
+        async fn embed(&self, _text: &str) -> crate::error::Result<Vec<f32>> {
             Ok(vec![1.0; 8])
         }
 

--- a/crates/memory/src/embeddings_local.rs
+++ b/crates/memory/src/embeddings_local.rs
@@ -146,13 +146,14 @@ fn embed_sync(backend: &LlamaBackend, model: &LlamaModel, text: &str) -> Result<
 
 #[async_trait]
 impl EmbeddingProvider for LocalGgufEmbeddingProvider {
-    async fn embed(&self, text: &str) -> Result<Vec<f32>> {
+    async fn embed(&self, text: &str) -> crate::error::Result<Vec<f32>> {
         let model = self.model.lock().await;
         let text = text.to_string();
         // llama-cpp-2 is CPU-bound; use block_in_place to avoid starving the async runtime
         let backend = &self.backend.0;
         let model_ref = &*model;
-        let result = tokio::task::block_in_place(move || embed_sync(backend, model_ref, &text))?;
+        let result = tokio::task::block_in_place(move || embed_sync(backend, model_ref, &text))
+            .map_err(|e| crate::error::Error::Embedding(e.to_string()))?;
         Ok(result)
     }
 

--- a/crates/memory/src/embeddings_openai.rs
+++ b/crates/memory/src/embeddings_openai.rs
@@ -101,14 +101,14 @@ struct EmbeddingData {
 
 #[async_trait]
 impl EmbeddingProvider for OpenAiEmbeddingProvider {
-    async fn embed(&self, text: &str) -> anyhow::Result<Vec<f32>> {
+    async fn embed(&self, text: &str) -> crate::error::Result<Vec<f32>> {
         self.embed_batch(&[text.to_string()])
             .await?
             .pop()
-            .ok_or_else(|| anyhow::anyhow!("empty embedding response"))
+            .ok_or_else(|| crate::error::Error::Embedding("empty embedding response".into()))
     }
 
-    async fn embed_batch(&self, texts: &[String]) -> anyhow::Result<Vec<Vec<f32>>> {
+    async fn embed_batch(&self, texts: &[String]) -> crate::error::Result<Vec<Vec<f32>>> {
         #[cfg(feature = "metrics")]
         let start = std::time::Instant::now();
 

--- a/crates/memory/src/error.rs
+++ b/crates/memory/src/error.rs
@@ -1,0 +1,32 @@
+//! Crate-level error type for `moltis-memory`.
+
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error(transparent)]
+    Database(#[from] sqlx::Error),
+
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+
+    #[error(transparent)]
+    Json(#[from] serde_json::Error),
+
+    #[error(transparent)]
+    Http(#[from] reqwest::Error),
+
+    #[error(transparent)]
+    Migration(#[from] sqlx::migrate::MigrateError),
+
+    #[error("{0}")]
+    Embedding(String),
+
+    #[error("{0}")]
+    Validation(String),
+
+    #[error("{0}")]
+    Reranking(String),
+}
+
+pub type Result<T> = std::result::Result<T, Error>;

--- a/crates/memory/src/lib.rs
+++ b/crates/memory/src/lib.rs
@@ -11,6 +11,7 @@ pub mod embeddings_fallback;
 #[allow(unsafe_code)] // FFI wrappers for llama-cpp-2 require unsafe Send/Sync impls.
 pub mod embeddings_local;
 pub mod embeddings_openai;
+pub mod error;
 pub mod manager;
 pub mod reranking;
 pub mod runtime;
@@ -26,4 +27,7 @@ pub mod watcher;
 pub mod writer;
 
 // Re-export run_migrations for consistency with other crates.
-pub use schema::run_migrations;
+pub use {
+    error::{Error, Result},
+    schema::run_migrations,
+};

--- a/crates/memory/src/manager.rs
+++ b/crates/memory/src/manager.rs
@@ -14,6 +14,7 @@ use crate::{
     chunker::chunk_content,
     config::MemoryConfig,
     embeddings::EmbeddingProvider,
+    error::Result,
     schema::{ChunkRow, FileRow},
     search::{self, SearchResult},
     store::{CacheEntry, MemoryStore},
@@ -99,10 +100,7 @@ impl MemoryManager {
     }
 
     /// Resolve a file path by a content-hash prefix.
-    pub async fn resolve_file_by_hash_prefix(
-        &self,
-        hash_prefix: &str,
-    ) -> anyhow::Result<Option<String>> {
+    pub async fn resolve_file_by_hash_prefix(&self, hash_prefix: &str) -> Result<Option<String>> {
         let prefix = hash_prefix.trim_start_matches('#');
         let files = self.store.list_files().await?;
         Ok(files
@@ -112,7 +110,7 @@ impl MemoryManager {
     }
 
     /// Synchronize: walk configured directories, detect changed files, re-chunk and re-embed.
-    pub async fn sync(&self) -> anyhow::Result<SyncReport> {
+    pub async fn sync(&self) -> Result<SyncReport> {
         let mut report = SyncReport::default();
 
         let mut discovered_paths = Vec::new();
@@ -194,14 +192,14 @@ impl MemoryManager {
     }
 
     /// Sync a single file by path. Returns true if it was updated.
-    pub async fn sync_path(&self, path: &Path) -> anyhow::Result<bool> {
+    pub async fn sync_path(&self, path: &Path) -> Result<bool> {
         let path_str = path.to_string_lossy().to_string();
         let mut report = SyncReport::default();
         self.sync_file(path, &path_str, &mut report).await
     }
 
     /// Remove a file path from the memory index after the backing file is gone.
-    pub async fn remove_path(&self, path: &Path) -> anyhow::Result<bool> {
+    pub async fn remove_path(&self, path: &Path) -> Result<bool> {
         let path_str = path.to_string_lossy().to_string();
         let had_file = self.store.get_file(&path_str).await?.is_some();
         let had_chunks = !self.store.get_chunks_for_file(&path_str).await?.is_empty();
@@ -219,7 +217,7 @@ impl MemoryManager {
         path: &Path,
         path_str: &str,
         report: &mut SyncReport,
-    ) -> anyhow::Result<bool> {
+    ) -> Result<bool> {
         let metadata = tokio::fs::metadata(path).await?;
         let mtime = metadata
             .modified()?
@@ -378,7 +376,7 @@ impl MemoryManager {
     /// Search memory. Uses hybrid (vector + keyword) when embeddings are available,
     /// falls back to keyword-only search otherwise.
     #[tracing::instrument(skip(self), fields(query_len = query.len(), limit))]
-    pub async fn search(&self, query: &str, limit: usize) -> anyhow::Result<Vec<SearchResult>> {
+    pub async fn search(&self, query: &str, limit: usize) -> Result<Vec<SearchResult>> {
         if let Some(ref embedder) = self.embedder {
             search::hybrid_search(
                 self.store.as_ref(),
@@ -396,12 +394,12 @@ impl MemoryManager {
     }
 
     /// Get a specific chunk by ID.
-    pub async fn get_chunk(&self, id: &str) -> anyhow::Result<Option<ChunkRow>> {
+    pub async fn get_chunk(&self, id: &str) -> Result<Option<ChunkRow>> {
         self.store.get_chunk_by_id(id).await
     }
 
     /// Get status information about the memory system.
-    pub async fn status(&self) -> anyhow::Result<MemoryStatus> {
+    pub async fn status(&self) -> Result<MemoryStatus> {
         let files = self.store.list_files().await?;
         let mut total_chunks = 0usize;
         for file in &files {
@@ -545,7 +543,7 @@ mod tests {
 
     #[async_trait]
     impl EmbeddingProvider for MockEmbedder {
-        async fn embed(&self, text: &str) -> anyhow::Result<Vec<f32>> {
+        async fn embed(&self, text: &str) -> Result<Vec<f32>> {
             Ok(keyword_embedding(text))
         }
 
@@ -863,7 +861,7 @@ mod tests {
 
     #[async_trait]
     impl EmbeddingProvider for CountingEmbedder {
-        async fn embed(&self, text: &str) -> anyhow::Result<Vec<f32>> {
+        async fn embed(&self, text: &str) -> Result<Vec<f32>> {
             self.embed_count
                 .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
             Ok(keyword_embedding(text))
@@ -909,7 +907,7 @@ mod tests {
 
         #[async_trait]
         impl EmbeddingProvider for ArcEmbedder {
-            async fn embed(&self, text: &str) -> anyhow::Result<Vec<f32>> {
+            async fn embed(&self, text: &str) -> Result<Vec<f32>> {
                 self.0.embed(text).await
             }
 

--- a/crates/memory/src/reranking.rs
+++ b/crates/memory/src/reranking.rs
@@ -10,7 +10,10 @@ use {
     tracing::{debug, warn},
 };
 
-use crate::search::SearchResult;
+use crate::{
+    error::{Error, Result},
+    search::SearchResult,
+};
 
 /// Trait for LLM reranking providers.
 #[async_trait]
@@ -22,7 +25,7 @@ pub trait RerankerProvider: Send + Sync {
         query: &str,
         results: Vec<SearchResult>,
         top_k: usize,
-    ) -> anyhow::Result<Vec<SearchResult>>;
+    ) -> Result<Vec<SearchResult>>;
 }
 
 /// A reranker that uses an LLM to score and reorder results.
@@ -39,7 +42,7 @@ pub struct LlmReranker {
 #[async_trait]
 pub trait LlmClient: Send + Sync {
     /// Send a completion request and get the response text.
-    async fn complete(&self, prompt: &str, model: Option<&str>) -> anyhow::Result<String>;
+    async fn complete(&self, prompt: &str, model: Option<&str>) -> Result<String>;
 }
 
 impl LlmReranker {
@@ -95,7 +98,7 @@ impl LlmReranker {
     }
 
     /// Parse the LLM response into scores.
-    fn parse_scores(&self, response: &str, expected_count: usize) -> anyhow::Result<Vec<f32>> {
+    fn parse_scores(&self, response: &str, expected_count: usize) -> Result<Vec<f32>> {
         // Try to extract JSON array from response
         let response = response.trim();
 
@@ -107,7 +110,11 @@ impl LlmReranker {
         let scores: Vec<f32> = serde_json::from_str(json_str)?;
 
         if scores.len() != expected_count {
-            anyhow::bail!("expected {} scores, got {}", expected_count, scores.len());
+            return Err(Error::Reranking(format!(
+                "expected {} scores, got {}",
+                expected_count,
+                scores.len()
+            )));
         }
 
         // Clamp scores to 0.0-1.0 range
@@ -122,7 +129,7 @@ impl RerankerProvider for LlmReranker {
         query: &str,
         mut results: Vec<SearchResult>,
         top_k: usize,
-    ) -> anyhow::Result<Vec<SearchResult>> {
+    ) -> Result<Vec<SearchResult>> {
         if results.is_empty() {
             return Ok(results);
         }
@@ -201,7 +208,7 @@ impl RerankerProvider for NoOpReranker {
         _query: &str,
         results: Vec<SearchResult>,
         top_k: usize,
-    ) -> anyhow::Result<Vec<SearchResult>> {
+    ) -> Result<Vec<SearchResult>> {
         Ok(results.into_iter().take(top_k).collect())
     }
 }
@@ -217,7 +224,7 @@ mod tests {
 
     #[async_trait]
     impl LlmClient for MockLlmClient {
-        async fn complete(&self, _prompt: &str, _model: Option<&str>) -> anyhow::Result<String> {
+        async fn complete(&self, _prompt: &str, _model: Option<&str>) -> Result<String> {
             Ok(self.response.clone())
         }
     }

--- a/crates/memory/src/runtime.rs
+++ b/crates/memory/src/runtime.rs
@@ -4,6 +4,7 @@ use {async_trait::async_trait, moltis_agents::memory_writer::MemoryWriter};
 
 use crate::{
     config::CitationMode,
+    error::Result,
     manager::{MemoryManager, MemoryStatus, SyncReport},
     schema::ChunkRow,
     search::SearchResult,
@@ -23,17 +24,17 @@ pub trait MemoryRuntime: MemoryWriter + Send + Sync {
 
     fn llm_reranking_enabled(&self) -> bool;
 
-    async fn sync(&self) -> anyhow::Result<SyncReport>;
+    async fn sync(&self) -> Result<SyncReport>;
 
-    async fn sync_path(&self, path: &Path) -> anyhow::Result<bool>;
+    async fn sync_path(&self, path: &Path) -> Result<bool>;
 
-    async fn remove_path(&self, path: &Path) -> anyhow::Result<bool>;
+    async fn remove_path(&self, path: &Path) -> Result<bool>;
 
-    async fn search(&self, query: &str, limit: usize) -> anyhow::Result<Vec<SearchResult>>;
+    async fn search(&self, query: &str, limit: usize) -> Result<Vec<SearchResult>>;
 
-    async fn get_chunk(&self, id: &str) -> anyhow::Result<Option<ChunkRow>>;
+    async fn get_chunk(&self, id: &str) -> Result<Option<ChunkRow>>;
 
-    async fn status(&self) -> anyhow::Result<MemoryStatus>;
+    async fn status(&self) -> Result<MemoryStatus>;
 }
 
 #[async_trait]
@@ -58,27 +59,27 @@ impl MemoryRuntime for MemoryManager {
         MemoryManager::llm_reranking_enabled(self)
     }
 
-    async fn sync(&self) -> anyhow::Result<SyncReport> {
+    async fn sync(&self) -> Result<SyncReport> {
         MemoryManager::sync(self).await
     }
 
-    async fn sync_path(&self, path: &Path) -> anyhow::Result<bool> {
+    async fn sync_path(&self, path: &Path) -> Result<bool> {
         MemoryManager::sync_path(self, path).await
     }
 
-    async fn remove_path(&self, path: &Path) -> anyhow::Result<bool> {
+    async fn remove_path(&self, path: &Path) -> Result<bool> {
         MemoryManager::remove_path(self, path).await
     }
 
-    async fn search(&self, query: &str, limit: usize) -> anyhow::Result<Vec<SearchResult>> {
+    async fn search(&self, query: &str, limit: usize) -> Result<Vec<SearchResult>> {
         MemoryManager::search(self, query, limit).await
     }
 
-    async fn get_chunk(&self, id: &str) -> anyhow::Result<Option<ChunkRow>> {
+    async fn get_chunk(&self, id: &str) -> Result<Option<ChunkRow>> {
         MemoryManager::get_chunk(self, id).await
     }
 
-    async fn status(&self) -> anyhow::Result<MemoryStatus> {
+    async fn status(&self) -> Result<MemoryStatus> {
         MemoryManager::status(self).await
     }
 }

--- a/crates/memory/src/schema.rs
+++ b/crates/memory/src/schema.rs
@@ -30,7 +30,7 @@ pub struct ChunkRow {
 /// This creates the `files`, `chunks`, `embedding_cache` tables and the
 /// `chunks_fts` full-text search virtual table. Memory uses its own database
 /// (`memory.db`) separate from the main `moltis.db`.
-pub async fn run_migrations(pool: &sqlx::SqlitePool) -> anyhow::Result<()> {
+pub async fn run_migrations(pool: &sqlx::SqlitePool) -> crate::error::Result<()> {
     sqlx::migrate!("./migrations")
         .set_ignore_missing(true)
         .run(pool)

--- a/crates/memory/src/search.rs
+++ b/crates/memory/src/search.rs
@@ -62,7 +62,7 @@ pub async fn hybrid_search(
     vector_weight: f32,
     keyword_weight: f32,
     merge_strategy: MergeStrategy,
-) -> anyhow::Result<Vec<SearchResult>> {
+) -> crate::error::Result<Vec<SearchResult>> {
     #[cfg(feature = "metrics")]
     let start = std::time::Instant::now();
 
@@ -115,7 +115,7 @@ pub async fn keyword_only_search(
     store: &dyn MemoryStore,
     query: &str,
     limit: usize,
-) -> anyhow::Result<Vec<SearchResult>> {
+) -> crate::error::Result<Vec<SearchResult>> {
     #[cfg(feature = "metrics")]
     let start = std::time::Instant::now();
 

--- a/crates/memory/src/session_export.rs
+++ b/crates/memory/src/session_export.rs
@@ -201,7 +201,7 @@ impl SessionExporter {
     }
 
     /// Export a session transcript to a markdown file.
-    pub async fn export(&self, transcript: &SessionTranscript) -> anyhow::Result<PathBuf> {
+    pub async fn export(&self, transcript: &SessionTranscript) -> crate::error::Result<PathBuf> {
         // Ensure export directory exists
         fs::create_dir_all(&self.config.export_dir).await?;
 
@@ -233,7 +233,7 @@ impl SessionExporter {
     }
 
     /// Clean up old exports based on configuration limits.
-    async fn cleanup(&self) -> anyhow::Result<()> {
+    async fn cleanup(&self) -> crate::error::Result<()> {
         let mut entries = Vec::new();
         let mut dir = fs::read_dir(&self.config.export_dir).await?;
 

--- a/crates/memory/src/store.rs
+++ b/crates/memory/src/store.rs
@@ -2,6 +2,7 @@
 use async_trait::async_trait;
 
 use crate::{
+    error::Result,
     schema::{ChunkRow, FileRow},
     search::SearchResult,
 };
@@ -18,16 +19,16 @@ pub struct CacheEntry<'a> {
 #[async_trait]
 pub trait MemoryStore: Send + Sync {
     // ---- files ----
-    async fn upsert_file(&self, file: &FileRow) -> anyhow::Result<()>;
-    async fn get_file(&self, path: &str) -> anyhow::Result<Option<FileRow>>;
-    async fn delete_file(&self, path: &str) -> anyhow::Result<()>;
-    async fn list_files(&self) -> anyhow::Result<Vec<FileRow>>;
+    async fn upsert_file(&self, file: &FileRow) -> Result<()>;
+    async fn get_file(&self, path: &str) -> Result<Option<FileRow>>;
+    async fn delete_file(&self, path: &str) -> Result<()>;
+    async fn list_files(&self) -> Result<Vec<FileRow>>;
 
     // ---- chunks ----
-    async fn upsert_chunks(&self, chunks: &[ChunkRow]) -> anyhow::Result<()>;
-    async fn get_chunks_for_file(&self, path: &str) -> anyhow::Result<Vec<ChunkRow>>;
-    async fn delete_chunks_for_file(&self, path: &str) -> anyhow::Result<()>;
-    async fn get_chunk_by_id(&self, id: &str) -> anyhow::Result<Option<ChunkRow>>;
+    async fn upsert_chunks(&self, chunks: &[ChunkRow]) -> Result<()>;
+    async fn get_chunks_for_file(&self, path: &str) -> Result<Vec<ChunkRow>>;
+    async fn delete_chunks_for_file(&self, path: &str) -> Result<()>;
+    async fn get_chunk_by_id(&self, id: &str) -> Result<Option<ChunkRow>>;
 
     // ---- embedding cache ----
     async fn get_cached_embedding(
@@ -35,7 +36,7 @@ pub trait MemoryStore: Send + Sync {
         provider: &str,
         model: &str,
         hash: &str,
-    ) -> anyhow::Result<Option<Vec<f32>>>;
+    ) -> Result<Option<Vec<f32>>>;
 
     async fn put_cached_embedding(
         &self,
@@ -44,23 +45,23 @@ pub trait MemoryStore: Send + Sync {
         provider_key: &str,
         hash: &str,
         embedding: &[f32],
-    ) -> anyhow::Result<()>;
+    ) -> Result<()>;
 
     /// Batch-insert multiple embedding cache entries in a single transaction.
-    async fn put_cached_embeddings_batch(&self, entries: &[CacheEntry<'_>]) -> anyhow::Result<()>;
+    async fn put_cached_embeddings_batch(&self, entries: &[CacheEntry<'_>]) -> Result<()>;
 
     /// Count the number of rows in the embedding cache.
-    async fn count_cached_embeddings(&self) -> anyhow::Result<usize>;
+    async fn count_cached_embeddings(&self) -> Result<usize>;
 
     /// Evict the oldest cache rows, keeping at most `keep` entries.
-    async fn evict_embedding_cache(&self, keep: usize) -> anyhow::Result<usize>;
+    async fn evict_embedding_cache(&self, keep: usize) -> Result<usize>;
 
     // ---- search ----
     async fn vector_search(
         &self,
         query_embedding: &[f32],
         limit: usize,
-    ) -> anyhow::Result<Vec<SearchResult>>;
+    ) -> Result<Vec<SearchResult>>;
 
-    async fn keyword_search(&self, query: &str, limit: usize) -> anyhow::Result<Vec<SearchResult>>;
+    async fn keyword_search(&self, query: &str, limit: usize) -> Result<Vec<SearchResult>>;
 }

--- a/crates/memory/src/store_sqlite.rs
+++ b/crates/memory/src/store_sqlite.rs
@@ -128,7 +128,7 @@ impl Ord for ScoredResult {
 
 #[async_trait]
 impl MemoryStore for SqliteMemoryStore {
-    async fn upsert_file(&self, file: &FileRow) -> anyhow::Result<()> {
+    async fn upsert_file(&self, file: &FileRow) -> crate::error::Result<()> {
         sqlx::query(
             "INSERT INTO files (path, source, hash, mtime, size) VALUES (?, ?, ?, ?, ?)
              ON CONFLICT(path) DO UPDATE SET source=excluded.source, hash=excluded.hash, mtime=excluded.mtime, size=excluded.size",
@@ -143,7 +143,7 @@ impl MemoryStore for SqliteMemoryStore {
         Ok(())
     }
 
-    async fn get_file(&self, path: &str) -> anyhow::Result<Option<FileRow>> {
+    async fn get_file(&self, path: &str) -> crate::error::Result<Option<FileRow>> {
         let row: Option<(String, String, String, i64, i64)> =
             sqlx::query_as("SELECT path, source, hash, mtime, size FROM files WHERE path = ?")
                 .bind(path)
@@ -158,7 +158,7 @@ impl MemoryStore for SqliteMemoryStore {
         }))
     }
 
-    async fn delete_file(&self, path: &str) -> anyhow::Result<()> {
+    async fn delete_file(&self, path: &str) -> crate::error::Result<()> {
         sqlx::query("DELETE FROM files WHERE path = ?")
             .bind(path)
             .execute(&self.pool)
@@ -166,7 +166,7 @@ impl MemoryStore for SqliteMemoryStore {
         Ok(())
     }
 
-    async fn list_files(&self) -> anyhow::Result<Vec<FileRow>> {
+    async fn list_files(&self) -> crate::error::Result<Vec<FileRow>> {
         let rows: Vec<(String, String, String, i64, i64)> =
             sqlx::query_as("SELECT path, source, hash, mtime, size FROM files")
                 .fetch_all(&self.pool)
@@ -183,7 +183,7 @@ impl MemoryStore for SqliteMemoryStore {
             .collect())
     }
 
-    async fn upsert_chunks(&self, chunks: &[ChunkRow]) -> anyhow::Result<()> {
+    async fn upsert_chunks(&self, chunks: &[ChunkRow]) -> crate::error::Result<()> {
         let mut tx = self.pool.begin().await?;
         for chunk in chunks {
             let emb_blob = chunk.embedding.as_deref();
@@ -212,7 +212,7 @@ impl MemoryStore for SqliteMemoryStore {
         Ok(())
     }
 
-    async fn get_chunks_for_file(&self, path: &str) -> anyhow::Result<Vec<ChunkRow>> {
+    async fn get_chunks_for_file(&self, path: &str) -> crate::error::Result<Vec<ChunkRow>> {
         let rows: Vec<(String, String, String, i64, i64, String, String, String, Option<Vec<u8>>, String)> =
             sqlx::query_as(
                 "SELECT id, path, source, start_line, end_line, hash, model, text, embedding, updated_at FROM chunks WHERE path = ? ORDER BY start_line",
@@ -252,7 +252,7 @@ impl MemoryStore for SqliteMemoryStore {
             .collect())
     }
 
-    async fn delete_chunks_for_file(&self, path: &str) -> anyhow::Result<()> {
+    async fn delete_chunks_for_file(&self, path: &str) -> crate::error::Result<()> {
         sqlx::query("DELETE FROM chunks WHERE path = ?")
             .bind(path)
             .execute(&self.pool)
@@ -260,7 +260,7 @@ impl MemoryStore for SqliteMemoryStore {
         Ok(())
     }
 
-    async fn get_chunk_by_id(&self, id: &str) -> anyhow::Result<Option<ChunkRow>> {
+    async fn get_chunk_by_id(&self, id: &str) -> crate::error::Result<Option<ChunkRow>> {
         let row: Option<(String, String, String, i64, i64, String, String, String, Option<Vec<u8>>, String)> =
             sqlx::query_as(
                 "SELECT id, path, source, start_line, end_line, hash, model, text, embedding, updated_at FROM chunks WHERE id = ?",
@@ -291,7 +291,7 @@ impl MemoryStore for SqliteMemoryStore {
         provider: &str,
         model: &str,
         hash: &str,
-    ) -> anyhow::Result<Option<Vec<f32>>> {
+    ) -> crate::error::Result<Option<Vec<f32>>> {
         let row: Option<(Vec<u8>,)> = sqlx::query_as(
             "SELECT embedding FROM embedding_cache WHERE provider = ? AND model = ? AND hash = ?",
         )
@@ -310,7 +310,7 @@ impl MemoryStore for SqliteMemoryStore {
         provider_key: &str,
         hash: &str,
         embedding: &[f32],
-    ) -> anyhow::Result<()> {
+    ) -> crate::error::Result<()> {
         let blob = vec_to_blob(embedding);
         let dims = embedding.len() as i64;
         sqlx::query(
@@ -330,7 +330,10 @@ impl MemoryStore for SqliteMemoryStore {
         Ok(())
     }
 
-    async fn put_cached_embeddings_batch(&self, entries: &[CacheEntry<'_>]) -> anyhow::Result<()> {
+    async fn put_cached_embeddings_batch(
+        &self,
+        entries: &[CacheEntry<'_>],
+    ) -> crate::error::Result<()> {
         let mut tx = self.pool.begin().await?;
         for entry in entries {
             let blob = vec_to_blob(entry.embedding);
@@ -354,14 +357,14 @@ impl MemoryStore for SqliteMemoryStore {
         Ok(())
     }
 
-    async fn count_cached_embeddings(&self) -> anyhow::Result<usize> {
+    async fn count_cached_embeddings(&self) -> crate::error::Result<usize> {
         let (count,): (i64,) = sqlx::query_as("SELECT COUNT(*) FROM embedding_cache")
             .fetch_one(&self.pool)
             .await?;
         Ok(count as usize)
     }
 
-    async fn evict_embedding_cache(&self, keep: usize) -> anyhow::Result<usize> {
+    async fn evict_embedding_cache(&self, keep: usize) -> crate::error::Result<usize> {
         let result = sqlx::query(
             "DELETE FROM embedding_cache WHERE rowid IN (
                 SELECT rowid FROM embedding_cache ORDER BY updated_at ASC LIMIT MAX(0, (SELECT COUNT(*) FROM embedding_cache) - ?)
@@ -377,7 +380,7 @@ impl MemoryStore for SqliteMemoryStore {
         &self,
         query_embedding: &[f32],
         limit: usize,
-    ) -> anyhow::Result<Vec<SearchResult>> {
+    ) -> crate::error::Result<Vec<SearchResult>> {
         use {futures::TryStreamExt, std::collections::BinaryHeap};
 
         // Stream rows one at a time, keeping only the top-K results in a
@@ -438,7 +441,11 @@ impl MemoryStore for SqliteMemoryStore {
         Ok(results)
     }
 
-    async fn keyword_search(&self, query: &str, limit: usize) -> anyhow::Result<Vec<SearchResult>> {
+    async fn keyword_search(
+        &self,
+        query: &str,
+        limit: usize,
+    ) -> crate::error::Result<Vec<SearchResult>> {
         let sanitized = sanitize_fts5_query(query);
         if sanitized.is_empty() {
             return Ok(Vec::new());

--- a/crates/memory/src/tools.rs
+++ b/crates/memory/src/tools.rs
@@ -324,7 +324,7 @@ fn resolve_memory_tool_path(manager: &dyn MemoryRuntime, file: &str) -> anyhow::
     let data_dir = manager
         .data_dir()
         .ok_or_else(|| anyhow::anyhow!("memory writes are disabled (no data_dir configured)"))?;
-    validate_memory_path(data_dir, file)
+    Ok(validate_memory_path(data_dir, file)?)
 }
 
 async fn checkpoint_memory_path(
@@ -365,7 +365,7 @@ mod tests {
 
     #[async_trait]
     impl EmbeddingProvider for MockEmbedder {
-        async fn embed(&self, text: &str) -> anyhow::Result<Vec<f32>> {
+        async fn embed(&self, text: &str) -> crate::error::Result<Vec<f32>> {
             let lower = text.to_lowercase();
             Ok(KEYWORDS
                 .iter()

--- a/crates/memory/src/writer.rs
+++ b/crates/memory/src/writer.rs
@@ -11,18 +11,24 @@ const MEMORY_DIR_PREFIX: &str = "memory/";
 /// - `MEMORY.md`
 /// - `memory.md`
 /// - `memory/<name>.md` (single segment only)
-pub fn validate_memory_path(data_dir: &Path, file: &str) -> anyhow::Result<PathBuf> {
+pub fn validate_memory_path(data_dir: &Path, file: &str) -> crate::error::Result<PathBuf> {
     let path = file.trim();
     if path.is_empty() {
-        anyhow::bail!("memory path cannot be empty");
+        return Err(crate::error::Error::Validation(
+            "memory path cannot be empty".into(),
+        ));
     }
 
     if Path::new(path).is_absolute() {
-        anyhow::bail!("memory path must be relative");
+        return Err(crate::error::Error::Validation(
+            "memory path must be relative".into(),
+        ));
     }
 
     if path.contains('\\') {
-        anyhow::bail!("memory path must use '/' separators");
+        return Err(crate::error::Error::Validation(
+            "memory path must use '/' separators".into(),
+        ));
     }
 
     if ROOT_MEMORY_FILES.contains(&path) {
@@ -30,15 +36,15 @@ pub fn validate_memory_path(data_dir: &Path, file: &str) -> anyhow::Result<PathB
     }
 
     let Some(name) = path.strip_prefix(MEMORY_DIR_PREFIX) else {
-        anyhow::bail!(
+        return Err(crate::error::Error::Validation(format!(
             "invalid memory path '{path}': allowed targets are MEMORY.md, memory.md, or memory/<name>.md"
-        );
+        )));
     };
 
     if !is_valid_memory_file_name(name) {
-        anyhow::bail!(
+        return Err(crate::error::Error::Validation(format!(
             "invalid memory path '{path}': allowed targets are MEMORY.md, memory.md, or memory/<name>.md"
-        );
+        )));
     }
 
     Ok(data_dir.join(MEMORY_DIR_PREFIX).join(name))
@@ -60,9 +66,11 @@ pub fn remove_exact_text(
     content: &str,
     snippet: &str,
     remove_all: bool,
-) -> anyhow::Result<TextRemovalResult> {
+) -> crate::error::Result<TextRemovalResult> {
     if snippet.trim().is_empty() {
-        anyhow::bail!("text to remove cannot be empty");
+        return Err(crate::error::Error::Validation(
+            "text to remove cannot be empty".into(),
+        ));
     }
 
     let variants = text_variants(snippet);
@@ -88,7 +96,9 @@ pub fn remove_exact_text(
         });
     }
 
-    anyhow::bail!("text to remove was not found in the target memory file")
+    Err(crate::error::Error::Validation(
+        "text to remove was not found in the target memory file".into(),
+    ))
 }
 
 fn text_variants(snippet: &str) -> Vec<String> {

--- a/crates/node-host/Cargo.toml
+++ b/crates/node-host/Cargo.toml
@@ -8,7 +8,6 @@ default = ["metrics"]
 metrics = ["dep:moltis-metrics"]
 
 [dependencies]
-anyhow            = { workspace = true }
 futures           = { workspace = true }
 moltis-config     = { workspace = true }
 moltis-metrics    = { optional = true, workspace = true }
@@ -18,6 +17,7 @@ rustls            = { workspace = true }
 serde             = { workspace = true }
 serde_json        = { workspace = true }
 sysinfo           = { workspace = true }
+thiserror         = { workspace = true }
 tokio             = { workspace = true }
 tokio-tungstenite = { features = ["rustls-tls-webpki-roots"], workspace = true }
 tracing           = { workspace = true }

--- a/crates/node-host/src/error.rs
+++ b/crates/node-host/src/error.rs
@@ -1,0 +1,46 @@
+//! Crate-level error type for `moltis-node-host`.
+
+use thiserror::Error;
+
+/// Errors produced by the node-host crate.
+#[derive(Debug, Error)]
+pub enum Error {
+    /// I/O failure (file read/write, process spawn, etc.).
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+
+    /// JSON serialization / deserialization failure.
+    #[error(transparent)]
+    Json(#[from] serde_json::Error),
+
+    /// Invalid URL.
+    #[error(transparent)]
+    Url(#[from] url::ParseError),
+
+    /// WebSocket transport error.
+    #[error(transparent)]
+    WebSocket(#[from] tokio_tungstenite::tungstenite::Error),
+
+    /// Configuration problem (missing file, bad value, etc.).
+    #[error("{0}")]
+    Config(String),
+
+    /// Protocol-level error (unexpected frame, handshake failure, etc.).
+    #[error("{0}")]
+    Protocol(String),
+
+    /// OS-service management error (launchd / systemd).
+    #[error("{0}")]
+    Service(String),
+
+    /// Command execution error (missing args, timeout, etc.).
+    #[error("{0}")]
+    Command(String),
+
+    /// The current platform does not support the requested service operation.
+    #[error("service operation not supported on this platform")]
+    UnsupportedPlatform,
+}
+
+/// Convenience alias used throughout this crate.
+pub type Result<T> = std::result::Result<T, Error>;

--- a/crates/node-host/src/lib.rs
+++ b/crates/node-host/src/lib.rs
@@ -6,10 +6,12 @@
 //! authenticates with a device token, and handles `system.run` commands
 //! by executing them locally.
 
+pub mod error;
 pub mod runner;
 pub mod service;
 
 pub use {
+    error::Error,
     runner::{NodeConfig, NodeHost},
     service::ServiceConfig,
 };

--- a/crates/node-host/src/runner.rs
+++ b/crates/node-host/src/runner.rs
@@ -9,6 +9,8 @@ use {
     tracing::{debug, error, info, warn},
 };
 
+use crate::error::{Error, Result};
+
 use moltis_protocol::{
     ClientInfo, ConnectAuth, ConnectParamsV4, GatewayFrame, PROTOCOL_VERSION, ProtocolRange,
     RequestFrame, ResponseFrame, roles,
@@ -128,7 +130,7 @@ impl NodeHost {
     /// Connect to the gateway and run the message loop until disconnected.
     ///
     /// Returns `Ok(())` on clean shutdown, `Err` on connection/protocol errors.
-    pub async fn run(&self) -> anyhow::Result<()> {
+    pub async fn run(&self) -> Result<()> {
         // Install a rustls CryptoProvider before any TLS connection.
         // Without this, `connect_async` on a `wss://` URL panics because
         // tokio-tungstenite uses rustls under the hood and no provider is
@@ -201,24 +203,32 @@ impl NodeHost {
             Ok(Some(Ok(Message::Text(text)))) => {
                 let resp: ResponseFrame = serde_json::from_str(&text)?;
                 if resp.id != connect_id {
-                    anyhow::bail!(
+                    return Err(Error::Protocol(format!(
                         "unexpected response id: expected {connect_id}, got {}",
                         resp.id
-                    );
+                    )));
                 }
                 if !resp.ok {
                     let err_msg = resp
                         .error
                         .map(|e| format!("{}: {}", e.code, e.message))
                         .unwrap_or_else(|| "unknown error".into());
-                    anyhow::bail!("handshake failed: {err_msg}");
+                    return Err(Error::Protocol(format!("handshake failed: {err_msg}")));
                 }
                 resp
             },
-            Ok(Some(Ok(_))) => anyhow::bail!("unexpected non-text message during handshake"),
-            Ok(Some(Err(e))) => anyhow::bail!("websocket error during handshake: {e}"),
-            Ok(None) => anyhow::bail!("connection closed during handshake"),
-            Err(_) => anyhow::bail!("handshake timeout"),
+            Ok(Some(Ok(_))) => {
+                return Err(Error::Protocol(
+                    "unexpected non-text message during handshake".into(),
+                ));
+            },
+            Ok(Some(Err(e))) => {
+                return Err(Error::Protocol(format!(
+                    "websocket error during handshake: {e}"
+                )));
+            },
+            Ok(None) => return Err(Error::Protocol("connection closed during handshake".into())),
+            Err(_) => return Err(Error::Protocol("handshake timeout".into())),
         };
 
         info!(
@@ -344,7 +354,7 @@ impl NodeHost {
             "system.providers" => self.handle_system_providers().await,
             other => {
                 warn!(command = %other, "unsupported invoke command");
-                Err(anyhow::anyhow!("unsupported command: {other}"))
+                Err(Error::Command(format!("unsupported command: {other}")))
             },
         };
 
@@ -359,14 +369,11 @@ impl NodeHost {
         }
     }
 
-    async fn handle_system_run(
-        &self,
-        args: &serde_json::Value,
-    ) -> anyhow::Result<serde_json::Value> {
+    async fn handle_system_run(&self, args: &serde_json::Value) -> Result<serde_json::Value> {
         let command = args
             .get("command")
             .and_then(|v| v.as_str())
-            .ok_or_else(|| anyhow::anyhow!("missing 'command' in args"))?;
+            .ok_or_else(|| Error::Command("missing 'command' in args".into()))?;
 
         let timeout_ms = args
             .get("timeout")
@@ -416,19 +423,18 @@ impl NodeHost {
                     "exitCode": exit_code,
                 }))
             },
-            Ok(Err(e)) => Err(anyhow::anyhow!("failed to execute command: {e}")),
-            Err(_) => Err(anyhow::anyhow!("command timed out after {timeout_ms}ms")),
+            Ok(Err(e)) => Err(Error::Command(format!("failed to execute command: {e}"))),
+            Err(_) => Err(Error::Command(format!(
+                "command timed out after {timeout_ms}ms"
+            ))),
         }
     }
 
-    async fn handle_system_which(
-        &self,
-        args: &serde_json::Value,
-    ) -> anyhow::Result<serde_json::Value> {
+    async fn handle_system_which(&self, args: &serde_json::Value) -> Result<serde_json::Value> {
         let binary = args
             .get("binary")
             .and_then(|v| v.as_str())
-            .ok_or_else(|| anyhow::anyhow!("missing 'binary' in args"))?;
+            .ok_or_else(|| Error::Command("missing 'binary' in args".into()))?;
 
         let output = Command::new("which").arg(binary).output().await?;
 
@@ -441,7 +447,7 @@ impl NodeHost {
         }))
     }
 
-    async fn handle_system_providers(&self) -> anyhow::Result<serde_json::Value> {
+    async fn handle_system_providers(&self) -> Result<serde_json::Value> {
         let mut providers = Vec::new();
 
         // Check Ollama at localhost:11434.

--- a/crates/node-host/src/service.rs
+++ b/crates/node-host/src/service.rs
@@ -16,6 +16,8 @@ use {
     tracing::{debug, info},
 };
 
+use crate::error::{Error, Result};
+
 // ── Persisted connection config ────────────────────────────────────────────
 
 /// Connection parameters saved to `~/.moltis/node.json` so the service can
@@ -40,16 +42,16 @@ fn default_timeout() -> u64 {
 
 impl ServiceConfig {
     /// Load from `<data_dir>/node.json`.
-    pub fn load(data_dir: &Path) -> anyhow::Result<Self> {
+    pub fn load(data_dir: &Path) -> Result<Self> {
         let path = data_dir.join("node.json");
         let contents = fs::read_to_string(&path)
-            .map_err(|e| anyhow::anyhow!("cannot read {}: {e}", path.display()))?;
+            .map_err(|e| Error::Config(format!("cannot read {}: {e}", path.display())))?;
         let config: Self = serde_json::from_str(&contents)?;
         Ok(config)
     }
 
     /// Save to `<data_dir>/node.json`.
-    pub fn save(&self, data_dir: &Path) -> anyhow::Result<()> {
+    pub fn save(&self, data_dir: &Path) -> Result<()> {
         fs::create_dir_all(data_dir)?;
         let path = data_dir.join("node.json");
         let json = serde_json::to_string_pretty(self)?;
@@ -72,7 +74,7 @@ const SYSTEMD_UNIT: &str = "moltis-node.service";
 /// Install the node as an OS service.
 ///
 /// Saves the connection config, generates the service file, and enables it.
-pub fn install(data_dir: &Path, config: &ServiceConfig) -> anyhow::Result<()> {
+pub fn install(data_dir: &Path, config: &ServiceConfig) -> Result<()> {
     config.save(data_dir)?;
 
     let moltis_bin = resolve_binary()?;
@@ -83,21 +85,18 @@ pub fn install(data_dir: &Path, config: &ServiceConfig) -> anyhow::Result<()> {
     } else if cfg!(target_os = "linux") {
         install_systemd(&moltis_bin, config, &log_path)
     } else {
-        anyhow::bail!("service install not supported on {}", std::env::consts::OS)
+        Err(Error::UnsupportedPlatform)
     }
 }
 
 /// Uninstall the service and remove generated files.
-pub fn uninstall(data_dir: &Path) -> anyhow::Result<()> {
+pub fn uninstall(data_dir: &Path) -> Result<()> {
     if cfg!(target_os = "macos") {
         uninstall_launchd()
     } else if cfg!(target_os = "linux") {
         uninstall_systemd()
     } else {
-        anyhow::bail!(
-            "service uninstall not supported on {}",
-            std::env::consts::OS
-        )
+        Err(Error::UnsupportedPlatform)
     }?;
 
     // Remove persisted config.
@@ -111,35 +110,35 @@ pub fn uninstall(data_dir: &Path) -> anyhow::Result<()> {
 }
 
 /// Print the service status.
-pub fn status() -> anyhow::Result<ServiceStatus> {
+pub fn status() -> Result<ServiceStatus> {
     if cfg!(target_os = "macos") {
         status_launchd()
     } else if cfg!(target_os = "linux") {
         status_systemd()
     } else {
-        anyhow::bail!("service status not supported on {}", std::env::consts::OS)
+        Err(Error::UnsupportedPlatform)
     }
 }
 
 /// Stop the service.
-pub fn stop() -> anyhow::Result<()> {
+pub fn stop() -> Result<()> {
     if cfg!(target_os = "macos") {
         stop_launchd()
     } else if cfg!(target_os = "linux") {
         stop_systemd()
     } else {
-        anyhow::bail!("service stop not supported on {}", std::env::consts::OS)
+        Err(Error::UnsupportedPlatform)
     }
 }
 
 /// Restart the service.
-pub fn restart() -> anyhow::Result<()> {
+pub fn restart() -> Result<()> {
     if cfg!(target_os = "macos") {
         restart_launchd()
     } else if cfg!(target_os = "linux") {
         restart_systemd()
     } else {
-        anyhow::bail!("service restart not supported on {}", std::env::consts::OS)
+        Err(Error::UnsupportedPlatform)
     }
 }
 
@@ -172,7 +171,7 @@ impl std::fmt::Display for ServiceStatus {
 
 // ── Binary resolution ──────────────────────────────────────────────────────
 
-fn resolve_binary() -> anyhow::Result<PathBuf> {
+fn resolve_binary() -> Result<PathBuf> {
     // Prefer the running binary if it looks right.
     if let Ok(exe) = std::env::current_exe() {
         let name = exe.file_name().unwrap_or_default().to_string_lossy();
@@ -183,13 +182,13 @@ fn resolve_binary() -> anyhow::Result<PathBuf> {
 
     // Fall back to PATH lookup.
     which::which("moltis").map_err(|_| {
-        anyhow::anyhow!("cannot find 'moltis' binary; ensure it is installed and in PATH")
+        Error::Config("cannot find 'moltis' binary; ensure it is installed and in PATH".into())
     })
 }
 
 // ── macOS launchd ──────────────────────────────────────────────────────────
 
-fn launchd_plist_path() -> anyhow::Result<PathBuf> {
+fn launchd_plist_path() -> Result<PathBuf> {
     let home = home_dir()?;
     Ok(home
         .join("Library")
@@ -273,11 +272,7 @@ pub fn generate_launchd_plist(
     )
 }
 
-fn install_launchd(
-    moltis_bin: &Path,
-    config: &ServiceConfig,
-    log_path: &Path,
-) -> anyhow::Result<()> {
+fn install_launchd(moltis_bin: &Path, config: &ServiceConfig, log_path: &Path) -> Result<()> {
     let plist_path = launchd_plist_path()?;
 
     // Unload first if already loaded (ignore errors).
@@ -307,18 +302,22 @@ fn install_launchd(
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
-        anyhow::bail!("launchctl bootstrap failed: {stderr}");
+        return Err(Error::Service(format!(
+            "launchctl bootstrap failed: {stderr}"
+        )));
     }
 
     info!("node service installed and started");
     Ok(())
 }
 
-fn uninstall_launchd() -> anyhow::Result<()> {
+fn uninstall_launchd() -> Result<()> {
     let plist_path = launchd_plist_path()?;
 
     if !plist_path.exists() {
-        anyhow::bail!("service not installed (plist not found)");
+        return Err(Error::Service(
+            "service not installed (plist not found)".into(),
+        ));
     }
 
     let _ = Command::new("launchctl")
@@ -335,7 +334,7 @@ fn uninstall_launchd() -> anyhow::Result<()> {
     Ok(())
 }
 
-fn status_launchd() -> anyhow::Result<ServiceStatus> {
+fn status_launchd() -> Result<ServiceStatus> {
     let plist_path = launchd_plist_path()?;
     if !plist_path.exists() {
         return Ok(ServiceStatus::NotInstalled);
@@ -364,10 +363,10 @@ fn status_launchd() -> anyhow::Result<ServiceStatus> {
     Ok(ServiceStatus::Running { pid })
 }
 
-fn stop_launchd() -> anyhow::Result<()> {
+fn stop_launchd() -> Result<()> {
     let plist_path = launchd_plist_path()?;
     if !plist_path.exists() {
-        anyhow::bail!("service not installed");
+        return Err(Error::Service("service not installed".into()));
     }
 
     let output = Command::new("launchctl")
@@ -378,7 +377,7 @@ fn stop_launchd() -> anyhow::Result<()> {
         let stderr = String::from_utf8_lossy(&output.stderr);
         // "No such process" is fine — already stopped.
         if !stderr.contains("No such process") && !stderr.contains("3: No such process") {
-            anyhow::bail!("launchctl kill failed: {stderr}");
+            return Err(Error::Service(format!("launchctl kill failed: {stderr}")));
         }
     }
 
@@ -386,10 +385,10 @@ fn stop_launchd() -> anyhow::Result<()> {
     Ok(())
 }
 
-fn restart_launchd() -> anyhow::Result<()> {
+fn restart_launchd() -> Result<()> {
     let plist_path = launchd_plist_path()?;
     if !plist_path.exists() {
-        anyhow::bail!("service not installed");
+        return Err(Error::Service("service not installed".into()));
     }
 
     // kickstart -k kills and restarts the service.
@@ -399,7 +398,9 @@ fn restart_launchd() -> anyhow::Result<()> {
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
-        anyhow::bail!("launchctl kickstart failed: {stderr}");
+        return Err(Error::Service(format!(
+            "launchctl kickstart failed: {stderr}"
+        )));
     }
 
     info!("node service restarted");
@@ -408,7 +409,7 @@ fn restart_launchd() -> anyhow::Result<()> {
 
 // ── Linux systemd ──────────────────────────────────────────────────────────
 
-fn systemd_unit_path() -> anyhow::Result<PathBuf> {
+fn systemd_unit_path() -> Result<PathBuf> {
     let home = home_dir()?;
     Ok(home
         .join(".config")
@@ -460,11 +461,7 @@ WantedBy=default.target
     )
 }
 
-fn install_systemd(
-    moltis_bin: &Path,
-    config: &ServiceConfig,
-    log_path: &Path,
-) -> anyhow::Result<()> {
+fn install_systemd(moltis_bin: &Path, config: &ServiceConfig, log_path: &Path) -> Result<()> {
     let unit_path = systemd_unit_path()?;
 
     // Stop if already running (ignore errors).
@@ -489,11 +486,13 @@ fn install_systemd(
     Ok(())
 }
 
-fn uninstall_systemd() -> anyhow::Result<()> {
+fn uninstall_systemd() -> Result<()> {
     let unit_path = systemd_unit_path()?;
 
     if !unit_path.exists() {
-        anyhow::bail!("service not installed (unit file not found)");
+        return Err(Error::Service(
+            "service not installed (unit file not found)".into(),
+        ));
     }
 
     let _ = run_systemctl(&["stop", SYSTEMD_UNIT]);
@@ -507,7 +506,7 @@ fn uninstall_systemd() -> anyhow::Result<()> {
     Ok(())
 }
 
-fn status_systemd() -> anyhow::Result<ServiceStatus> {
+fn status_systemd() -> Result<ServiceStatus> {
     let unit_path = systemd_unit_path()?;
     if !unit_path.exists() {
         return Ok(ServiceStatus::NotInstalled);
@@ -544,27 +543,27 @@ fn status_systemd() -> anyhow::Result<ServiceStatus> {
     }
 }
 
-fn stop_systemd() -> anyhow::Result<()> {
+fn stop_systemd() -> Result<()> {
     let unit_path = systemd_unit_path()?;
     if !unit_path.exists() {
-        anyhow::bail!("service not installed");
+        return Err(Error::Service("service not installed".into()));
     }
     run_systemctl(&["stop", SYSTEMD_UNIT])?;
     info!("node service stopped");
     Ok(())
 }
 
-fn restart_systemd() -> anyhow::Result<()> {
+fn restart_systemd() -> Result<()> {
     let unit_path = systemd_unit_path()?;
     if !unit_path.exists() {
-        anyhow::bail!("service not installed");
+        return Err(Error::Service("service not installed".into()));
     }
     run_systemctl(&["restart", SYSTEMD_UNIT])?;
     info!("node service restarted");
     Ok(())
 }
 
-fn run_systemctl(args: &[&str]) -> anyhow::Result<()> {
+fn run_systemctl(args: &[&str]) -> Result<()> {
     let mut full_args = vec!["--user"];
     full_args.extend_from_slice(args);
 
@@ -573,17 +572,20 @@ fn run_systemctl(args: &[&str]) -> anyhow::Result<()> {
     let output = Command::new("systemctl").args(&full_args).output()?;
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
-        anyhow::bail!("systemctl {} failed: {stderr}", args.join(" "));
+        return Err(Error::Service(format!(
+            "systemctl {} failed: {stderr}",
+            args.join(" ")
+        )));
     }
     Ok(())
 }
 
 // ── Helpers ────────────────────────────────────────────────────────────────
 
-fn home_dir() -> anyhow::Result<PathBuf> {
+fn home_dir() -> Result<PathBuf> {
     std::env::var_os("HOME")
         .map(PathBuf::from)
-        .ok_or_else(|| anyhow::anyhow!("cannot determine home directory (HOME not set)"))
+        .ok_or_else(|| Error::Config("cannot determine home directory (HOME not set)".into()))
 }
 
 fn uid() -> u32 {

--- a/crates/qmd/Cargo.toml
+++ b/crates/qmd/Cargo.toml
@@ -11,6 +11,7 @@ moltis-agents = { workspace = true }
 moltis-memory = { workspace = true }
 serde         = { workspace = true }
 serde_json    = { workspace = true }
+thiserror     = { workspace = true }
 tokio         = { workspace = true }
 tracing       = { workspace = true }
 

--- a/crates/qmd/src/error.rs
+++ b/crates/qmd/src/error.rs
@@ -1,0 +1,19 @@
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("QMD is not available")]
+    NotAvailable,
+    #[error("QMD command timed out after {0}ms")]
+    Timeout(u64),
+    #[error("QMD {command} failed: {stderr}")]
+    CommandFailed { command: String, stderr: String },
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+    #[error(transparent)]
+    Json(#[from] serde_json::Error),
+    #[error(transparent)]
+    Utf8(#[from] std::string::FromUtf8Error),
+}
+
+pub type Result<T> = std::result::Result<T, Error>;

--- a/crates/qmd/src/lib.rs
+++ b/crates/qmd/src/lib.rs
@@ -5,10 +5,12 @@
 //!
 //! QMD must be installed separately. See: https://github.com/tobi/qmd
 
+pub mod error;
 mod manager;
 mod runtime;
 
 pub use {
+    error::Error,
     manager::{QmdCollection, QmdManager, QmdManagerConfig, QmdSearchResult, SearchMode},
     runtime::QmdMemoryRuntime,
 };

--- a/crates/qmd/src/manager.rs
+++ b/crates/qmd/src/manager.rs
@@ -10,6 +10,8 @@ use {
     tracing::{debug, info},
 };
 
+use crate::error::{Error, Result};
+
 /// Configuration for the QMD manager.
 #[derive(Debug, Clone)]
 pub struct QmdManagerConfig {
@@ -220,17 +222,17 @@ impl QmdManager {
     }
 
     /// Return the current QMD version.
-    pub async fn version(&self) -> anyhow::Result<String> {
+    pub async fn version(&self) -> Result<String> {
         let output = Command::new(&self.config.command)
             .arg("--version")
             .envs(&self.config.env_overrides)
             .output()
             .await?;
         if !output.status.success() {
-            anyhow::bail!(
-                "QMD version probe failed: {}",
-                String::from_utf8_lossy(&output.stderr).trim()
-            );
+            return Err(Error::CommandFailed {
+                command: "version".into(),
+                stderr: String::from_utf8_lossy(&output.stderr).trim().into(),
+            });
         }
         Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
     }
@@ -245,15 +247,15 @@ impl QmdManager {
         command
     }
 
-    async fn run_with_timeout(&self, mut command: Command) -> anyhow::Result<std::process::Output> {
+    async fn run_with_timeout(&self, mut command: Command) -> Result<std::process::Output> {
         let timeout_duration = Duration::from_millis(self.config.timeout_ms);
         match timeout(timeout_duration, command.output()).await {
             Ok(result) => Ok(result?),
-            Err(_) => anyhow::bail!("QMD command timed out after {}ms", self.config.timeout_ms),
+            Err(_) => Err(Error::Timeout(self.config.timeout_ms)),
         }
     }
 
-    async fn collection_exists(&self, name: &str) -> anyhow::Result<bool> {
+    async fn collection_exists(&self, name: &str) -> Result<bool> {
         let mut command = self.command_with_index();
         command
             .arg("collection")
@@ -269,13 +271,9 @@ impl QmdManager {
     /// Idempotent — if the collection already exists, this is a no-op.
     /// Useful for registering collections discovered at runtime (e.g. per-project
     /// code index directories) rather than only those pre-configured at startup.
-    pub async fn ensure_collection(
-        &self,
-        name: &str,
-        collection: &QmdCollection,
-    ) -> anyhow::Result<()> {
+    pub async fn ensure_collection(&self, name: &str, collection: &QmdCollection) -> Result<()> {
         if !self.is_available().await {
-            anyhow::bail!("QMD is not available");
+            return Err(Error::NotAvailable);
         }
 
         if self.collection_exists(name).await? {
@@ -296,11 +294,10 @@ impl QmdManager {
 
         let output = self.run_with_timeout(command).await?;
         if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            anyhow::bail!(
-                "QMD collection add failed for {name}: {}",
-                stderr.trim()
-            );
+            return Err(Error::CommandFailed {
+                command: format!("collection add {name}"),
+                stderr: String::from_utf8_lossy(&output.stderr).trim().into(),
+            });
         }
 
         Ok(())
@@ -311,7 +308,7 @@ impl QmdManager {
     /// Iterates the collections set at construction time and registers any
     /// that don't already exist. For dynamic per-call registration, use
     /// [`ensure_collection`](Self::ensure_collection) instead.
-    pub async fn ensure_collections(&self) -> anyhow::Result<()> {
+    pub async fn ensure_collections(&self) -> Result<()> {
         for (name, collection) in &self.config.collections {
             self.ensure_collection(name, collection).await?;
         }
@@ -319,7 +316,7 @@ impl QmdManager {
     }
 
     /// Refresh indexed content, and optionally embeddings, after a write or startup sync.
-    pub async fn refresh_index(&self, enable_embeddings: bool) -> anyhow::Result<()> {
+    pub async fn refresh_index(&self, enable_embeddings: bool) -> Result<()> {
         self.ensure_collections().await?;
 
         let mut update = self.command_with_index();
@@ -329,8 +326,10 @@ impl QmdManager {
             .stderr(Stdio::piped());
         let output = self.run_with_timeout(update).await?;
         if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            anyhow::bail!("QMD update failed: {}", stderr.trim());
+            return Err(Error::CommandFailed {
+                command: "update".into(),
+                stderr: String::from_utf8_lossy(&output.stderr).trim().into(),
+            });
         }
 
         if enable_embeddings {
@@ -341,8 +340,10 @@ impl QmdManager {
                 .stderr(Stdio::piped());
             let output = self.run_with_timeout(embed).await?;
             if !output.status.success() {
-                let stderr = String::from_utf8_lossy(&output.stderr);
-                anyhow::bail!("QMD embed failed: {}", stderr.trim());
+                return Err(Error::CommandFailed {
+                    command: "embed".into(),
+                    stderr: String::from_utf8_lossy(&output.stderr).trim().into(),
+                });
             }
         }
 
@@ -355,9 +356,9 @@ impl QmdManager {
         query: &str,
         mode: SearchMode,
         limit: usize,
-    ) -> anyhow::Result<Vec<QmdSearchResult>> {
+    ) -> Result<Vec<QmdSearchResult>> {
         if !self.is_available().await {
-            anyhow::bail!("QMD is not available");
+            return Err(Error::NotAvailable);
         }
 
         let mut command = self.command_with_index();
@@ -381,8 +382,10 @@ impl QmdManager {
 
         let output = self.run_with_timeout(command).await?;
         if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            anyhow::bail!("QMD search failed: {}", stderr.trim());
+            return Err(Error::CommandFailed {
+                command: mode.command_name().into(),
+                stderr: String::from_utf8_lossy(&output.stderr).trim().into(),
+            });
         }
 
         let results: Vec<QmdSearchResult> = serde_json::from_slice(&output.stdout)?;
@@ -391,20 +394,12 @@ impl QmdManager {
     }
 
     /// Fast keyword search using BM25.
-    pub async fn keyword_search(
-        &self,
-        query: &str,
-        limit: usize,
-    ) -> anyhow::Result<Vec<QmdSearchResult>> {
+    pub async fn keyword_search(&self, query: &str, limit: usize) -> Result<Vec<QmdSearchResult>> {
         self.search(query, SearchMode::Keyword, limit).await
     }
 
     /// Vector similarity search.
-    pub async fn vector_search(
-        &self,
-        query: &str,
-        limit: usize,
-    ) -> anyhow::Result<Vec<QmdSearchResult>> {
+    pub async fn vector_search(&self, query: &str, limit: usize) -> Result<Vec<QmdSearchResult>> {
         self.search(query, SearchMode::Vector, limit).await
     }
 
@@ -414,7 +409,7 @@ impl QmdManager {
         query: &str,
         limit: usize,
         rerank: bool,
-    ) -> anyhow::Result<Vec<QmdSearchResult>> {
+    ) -> Result<Vec<QmdSearchResult>> {
         self.search(query, SearchMode::Hybrid { rerank }, limit)
             .await
     }
@@ -425,9 +420,9 @@ impl QmdManager {
         target: &str,
         from_line: Option<i64>,
         max_lines: Option<usize>,
-    ) -> anyhow::Result<String> {
+    ) -> Result<String> {
         if !self.is_available().await {
-            anyhow::bail!("QMD is not available");
+            return Err(Error::NotAvailable);
         }
 
         let mut command = self.command_with_index();
@@ -446,8 +441,10 @@ impl QmdManager {
 
         let output = self.run_with_timeout(command).await?;
         if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            anyhow::bail!("QMD get failed: {}", stderr.trim());
+            return Err(Error::CommandFailed {
+                command: "get".into(),
+                stderr: String::from_utf8_lossy(&output.stderr).trim().into(),
+            });
         }
 
         Ok(String::from_utf8(output.stdout)?.trim().to_string())

--- a/crates/qmd/src/runtime.rs
+++ b/crates/qmd/src/runtime.rs
@@ -4,6 +4,7 @@ use {
     async_trait::async_trait,
     moltis_agents::memory_writer::{MemoryWriteResult, MemoryWriter},
     moltis_memory::{
+        Result as MemoryResult,
         manager::{MemoryManager, MemoryStatus, SyncReport},
         runtime::MemoryRuntime,
         schema::ChunkRow,
@@ -43,7 +44,7 @@ impl QmdMemoryRuntime {
     }
 
     async fn refresh_qmd_index(&self) -> anyhow::Result<()> {
-        self.manager.refresh_index(!self.disable_rag).await
+        Ok(self.manager.refresh_index(!self.disable_rag).await?)
     }
 
     async fn resolve_result_path(&self, result: &QmdSearchResult) -> anyhow::Result<String> {
@@ -162,41 +163,61 @@ impl MemoryRuntime for QmdMemoryRuntime {
         self.fallback.llm_reranking_enabled()
     }
 
-    async fn sync(&self) -> anyhow::Result<SyncReport> {
+    async fn sync(&self) -> MemoryResult<SyncReport> {
         let report = self.fallback.sync().await?;
-        self.refresh_qmd_index().await?;
+        self.refresh_qmd_index()
+            .await
+            .map_err(|e| moltis_memory::Error::Validation(e.to_string()))?;
         Ok(report)
     }
 
-    async fn sync_path(&self, path: &Path) -> anyhow::Result<bool> {
+    async fn sync_path(&self, path: &Path) -> MemoryResult<bool> {
         let changed = self.fallback.sync_path(path).await?;
-        self.refresh_qmd_index().await?;
+        self.refresh_qmd_index()
+            .await
+            .map_err(|e| moltis_memory::Error::Validation(e.to_string()))?;
         Ok(changed)
     }
 
-    async fn remove_path(&self, path: &Path) -> anyhow::Result<bool> {
+    async fn remove_path(&self, path: &Path) -> MemoryResult<bool> {
         let removed = self.fallback.remove_path(path).await?;
-        self.refresh_qmd_index().await?;
+        self.refresh_qmd_index()
+            .await
+            .map_err(|e| moltis_memory::Error::Validation(e.to_string()))?;
         Ok(removed)
     }
 
-    async fn search(&self, query: &str, limit: usize) -> anyhow::Result<Vec<SearchResult>> {
+    async fn search(&self, query: &str, limit: usize) -> MemoryResult<Vec<SearchResult>> {
         let qmd_results = match self.search_mode() {
-            SearchMode::Keyword => self.manager.keyword_search(query, limit).await?,
-            SearchMode::Vector => self.manager.vector_search(query, limit).await?,
-            SearchMode::Hybrid { rerank } => {
-                self.manager.hybrid_search(query, limit, rerank).await?
-            },
+            SearchMode::Keyword => self
+                .manager
+                .keyword_search(query, limit)
+                .await
+                .map_err(|e| moltis_memory::Error::Validation(e.to_string()))?,
+            SearchMode::Vector => self
+                .manager
+                .vector_search(query, limit)
+                .await
+                .map_err(|e| moltis_memory::Error::Validation(e.to_string()))?,
+            SearchMode::Hybrid { rerank } => self
+                .manager
+                .hybrid_search(query, limit, rerank)
+                .await
+                .map_err(|e| moltis_memory::Error::Validation(e.to_string()))?,
         };
 
         let mut results = Vec::with_capacity(qmd_results.len());
         for result in qmd_results {
-            results.push(self.convert_result(result).await?);
+            results.push(
+                self.convert_result(result)
+                    .await
+                    .map_err(|e| moltis_memory::Error::Validation(e.to_string()))?,
+            );
         }
         Ok(results)
     }
 
-    async fn get_chunk(&self, id: &str) -> anyhow::Result<Option<ChunkRow>> {
+    async fn get_chunk(&self, id: &str) -> MemoryResult<Option<ChunkRow>> {
         let Some((docid, start_line)) = Self::parse_chunk_id(id) else {
             return self.fallback.get_chunk(id).await;
         };
@@ -210,7 +231,8 @@ impl MemoryRuntime for QmdMemoryRuntime {
         let body = self
             .manager
             .get_document(&docid, Some(start_line), Some(DEFAULT_QMD_GET_LINES))
-            .await?;
+            .await
+            .map_err(|e| moltis_memory::Error::Validation(e.to_string()))?;
         let text = strip_qmd_context_header(&body).trim().to_string();
         let line_count = text.lines().count().max(1) as i64;
 
@@ -232,7 +254,7 @@ impl MemoryRuntime for QmdMemoryRuntime {
         }))
     }
 
-    async fn status(&self) -> anyhow::Result<MemoryStatus> {
+    async fn status(&self) -> MemoryResult<MemoryStatus> {
         let mut status = self.fallback.status().await?;
         status.embedding_model = if self.disable_rag {
             "qmd (keyword)".into()

--- a/crates/skills/Cargo.toml
+++ b/crates/skills/Cargo.toml
@@ -4,7 +4,6 @@ name              = "moltis-skills"
 version.workspace = true
 
 [dependencies]
-anyhow                = { workspace = true }
 async-trait           = { workspace = true }
 flate2                = { workspace = true }
 moltis-config         = { workspace = true }
@@ -15,6 +14,7 @@ serde                 = { workspace = true }
 serde_json            = { workspace = true }
 serde_yaml            = { workspace = true }
 tar                   = { workspace = true }
+thiserror             = { workspace = true }
 tokio                 = { workspace = true }
 tracing               = { workspace = true }
 walkdir               = { workspace = true }

--- a/crates/skills/src/discover.rs
+++ b/crates/skills/src/discover.rs
@@ -3,6 +3,7 @@ use std::path::{Path, PathBuf};
 use async_trait::async_trait;
 
 use crate::{
+    error::Result,
     formats::PluginFormat,
     manifest::ManifestStore,
     parse,
@@ -13,7 +14,7 @@ use crate::{
 #[async_trait]
 pub trait SkillDiscoverer: Send + Sync {
     /// Scan configured paths and return metadata for all discovered skills.
-    async fn discover(&self) -> anyhow::Result<Vec<SkillMetadata>>;
+    async fn discover(&self) -> Result<Vec<SkillMetadata>>;
 }
 
 /// Default filesystem-based skill discoverer.
@@ -54,7 +55,7 @@ impl FsSkillDiscoverer {
 
 #[async_trait]
 impl SkillDiscoverer for FsSkillDiscoverer {
-    async fn discover(&self) -> anyhow::Result<Vec<SkillMetadata>> {
+    async fn discover(&self) -> Result<Vec<SkillMetadata>> {
         let mut skills = Vec::new();
 
         for (base_path, source) in &self.search_paths {

--- a/crates/skills/src/error.rs
+++ b/crates/skills/src/error.rs
@@ -1,0 +1,32 @@
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+    #[error(transparent)]
+    Json(#[from] serde_json::Error),
+    #[error(transparent)]
+    Yaml(#[from] serde_yaml::Error),
+    #[error(transparent)]
+    Http(#[from] reqwest::Error),
+    #[error(transparent)]
+    Walk(#[from] walkdir::Error),
+    #[error(transparent)]
+    Join(#[from] tokio::task::JoinError),
+    #[cfg(feature = "file-watcher")]
+    #[error(transparent)]
+    Notify(#[from] notify_debouncer_full::notify::Error),
+    #[error("{0}")]
+    Parse(String),
+    #[error("{0}")]
+    Install(String),
+    #[error("{0}")]
+    NotFound(String),
+    #[error("{0}")]
+    Validation(String),
+    #[error("{0}")]
+    Bundle(String),
+}
+
+pub type Result<T> = std::result::Result<T, Error>;

--- a/crates/skills/src/formats.rs
+++ b/crates/skills/src/formats.rs
@@ -11,7 +11,10 @@ use std::{
 
 use serde::{Deserialize, Serialize};
 
-use crate::types::{SkillMetadata, SkillSource};
+use crate::{
+    error::Result,
+    types::{SkillMetadata, SkillSource},
+};
 
 // ── Plugin format enum ──────────────────────────────────────────────────────
 
@@ -65,7 +68,7 @@ pub trait FormatAdapter: Send + Sync {
     fn detect(&self, repo_dir: &Path) -> bool;
 
     /// Scan the repo and return enriched entries for each skill found.
-    fn scan_skills(&self, repo_dir: &Path) -> anyhow::Result<Vec<PluginSkillEntry>>;
+    fn scan_skills(&self, repo_dir: &Path) -> Result<Vec<PluginSkillEntry>>;
 }
 
 // ── Claude Code adapter ─────────────────────────────────────────────────────
@@ -161,7 +164,7 @@ impl ClaudeCodeAdapter {
         &self,
         repo_dir: &Path,
         seen_names: &mut HashSet<String>,
-    ) -> anyhow::Result<Vec<PluginSkillEntry>> {
+    ) -> Result<Vec<PluginSkillEntry>> {
         let marketplace_json_path = repo_dir.join(".claude-plugin/marketplace.json");
         let marketplace: ClaudeMarketplaceJson =
             serde_json::from_str(&std::fs::read_to_string(&marketplace_json_path)?)?;
@@ -270,7 +273,7 @@ impl ClaudeCodeAdapter {
         &self,
         plugin_dir: &Path,
         repo_root: &Path,
-    ) -> anyhow::Result<Vec<PluginSkillEntry>> {
+    ) -> Result<Vec<PluginSkillEntry>> {
         let plugin_json_path = plugin_dir.join(".claude-plugin/plugin.json");
         let plugin_json: ClaudePluginJson =
             serde_json::from_str(&std::fs::read_to_string(&plugin_json_path)?)?;
@@ -370,7 +373,7 @@ impl FormatAdapter for ClaudeCodeAdapter {
             || repo_dir.join(".claude-plugin/marketplace.json").is_file()
     }
 
-    fn scan_skills(&self, repo_dir: &Path) -> anyhow::Result<Vec<PluginSkillEntry>> {
+    fn scan_skills(&self, repo_dir: &Path) -> Result<Vec<PluginSkillEntry>> {
         // Single plugin case
         if repo_dir.join(".claude-plugin/plugin.json").is_file() {
             return self.scan_single_plugin(repo_dir, repo_dir);
@@ -449,7 +452,7 @@ pub fn detect_format(repo_dir: &Path) -> PluginFormat {
 pub fn scan_with_adapter(
     repo_dir: &Path,
     format: PluginFormat,
-) -> Option<anyhow::Result<Vec<PluginSkillEntry>>> {
+) -> Option<Result<Vec<PluginSkillEntry>>> {
     match format {
         PluginFormat::Skill => None, // handled by existing scan_repo_skills
         PluginFormat::ClaudeCode => Some(ClaudeCodeAdapter.scan_skills(repo_dir)),

--- a/crates/skills/src/install.rs
+++ b/crates/skills/src/install.rs
@@ -4,6 +4,7 @@ use std::path::{Component, Path, PathBuf};
 use moltis_metrics::{counter, histogram, skills as skills_metrics};
 
 use crate::{
+    error::{Error, Result},
     formats::{PluginFormat, detect_format, scan_with_adapter},
     manifest::ManifestStore,
     parse,
@@ -15,7 +16,7 @@ use crate::{
 /// Downloads the repo to `install_dir/<owner>-<repo>/`, auto-detects its format
 /// (SKILL.md, Claude Code `.claude-plugin/`, etc.), scans for skills using the
 /// appropriate adapter, and records the repo + skills in the manifest.
-pub async fn install_skill(source: &str, install_dir: &Path) -> anyhow::Result<Vec<SkillMetadata>> {
+pub async fn install_skill(source: &str, install_dir: &Path) -> Result<Vec<SkillMetadata>> {
     #[cfg(feature = "metrics")]
     let start = std::time::Instant::now();
 
@@ -33,10 +34,10 @@ pub async fn install_skill(source: &str, install_dir: &Path) -> anyhow::Result<V
         if manifest.find_repo(source).is_none() {
             tokio::fs::remove_dir_all(&target).await?;
         } else {
-            anyhow::bail!(
+            return Err(Error::Install(format!(
                 "repo directory already exists: {}. Remove it first with `skills remove`.",
                 target.display()
-            );
+            )));
         }
     }
 
@@ -72,17 +73,19 @@ pub async fn install_skill(source: &str, install_dir: &Path) -> anyhow::Result<V
             },
             None => {
                 let _ = tokio::fs::remove_dir_all(&target).await;
-                anyhow::bail!("no adapter available for format '{format}' in repo '{source}'");
+                return Err(Error::Install(format!(
+                    "no adapter available for format '{format}' in repo '{source}'"
+                )));
             },
         },
     };
 
     if skills_meta.is_empty() {
         let _ = tokio::fs::remove_dir_all(&target).await;
-        anyhow::bail!(
+        return Err(Error::Install(format!(
             "repository contains no skills (checked {})",
             target.display()
-        );
+        )));
     }
 
     // Write manifest.
@@ -116,14 +119,14 @@ pub async fn install_skill(source: &str, install_dir: &Path) -> anyhow::Result<V
 }
 
 /// Remove a repo: delete directory and manifest entry.
-pub async fn remove_repo(source: &str, install_dir: &Path) -> anyhow::Result<()> {
+pub async fn remove_repo(source: &str, install_dir: &Path) -> Result<()> {
     let manifest_path = ManifestStore::default_path()?;
     let store = ManifestStore::new(manifest_path);
     let mut manifest = store.load()?;
 
     let repo = manifest
         .find_repo(source)
-        .ok_or_else(|| anyhow::anyhow!("repo '{}' not found in manifest", source))?;
+        .ok_or_else(|| Error::NotFound(format!("repo '{}' not found in manifest", source)))?;
     let dir = install_dir.join(&repo.repo_name);
 
     if dir.exists() {
@@ -136,11 +139,7 @@ pub async fn remove_repo(source: &str, install_dir: &Path) -> anyhow::Result<()>
 }
 
 /// Install by fetching a tarball from GitHub's API.
-async fn install_via_http(
-    owner: &str,
-    repo: &str,
-    target: &Path,
-) -> anyhow::Result<Option<String>> {
+async fn install_via_http(owner: &str, repo: &str, target: &Path) -> Result<Option<String>> {
     let url = format!("https://api.github.com/repos/{owner}/{repo}/tarball");
     let client = reqwest::Client::new();
     let commit_sha = fetch_latest_commit_sha(&client, owner, repo).await;
@@ -151,7 +150,12 @@ async fn install_via_http(
         .await?;
 
     if !resp.status().is_success() {
-        anyhow::bail!("failed to fetch {}/{}: HTTP {}", owner, repo, resp.status());
+        return Err(Error::Install(format!(
+            "failed to fetch {}/{}: HTTP {}",
+            owner,
+            repo,
+            resp.status()
+        )));
     }
 
     let bytes = resp.bytes().await?;
@@ -183,14 +187,18 @@ async fn install_via_http(
                 std::fs::create_dir_all(parent)?;
                 let canonical_parent = std::fs::canonicalize(parent)?;
                 if !canonical_parent.starts_with(&canonical_target) {
-                    anyhow::bail!("archive entry escaped install directory");
+                    return Err(Error::Install(
+                        "archive entry escaped install directory".into(),
+                    ));
                 }
             }
 
             if dest.exists() {
                 let meta = std::fs::symlink_metadata(&dest)?;
                 if meta.file_type().is_symlink() {
-                    anyhow::bail!("archive entry resolves to symlink destination");
+                    return Err(Error::Install(
+                        "archive entry resolves to symlink destination".into(),
+                    ));
                 }
             }
 
@@ -201,7 +209,7 @@ async fn install_via_http(
 
             entry.unpack(&dest)?;
         }
-        Ok::<(), anyhow::Error>(())
+        Ok::<(), Error>(())
     })
     .await??;
 
@@ -234,7 +242,7 @@ async fn fetch_latest_commit_sha(
         .map(ToOwned::to_owned)
 }
 
-fn sanitize_archive_path(path: &Path) -> anyhow::Result<Option<PathBuf>> {
+fn sanitize_archive_path(path: &Path) -> Result<Option<PathBuf>> {
     let stripped: PathBuf = path.components().skip(1).collect();
     if stripped.as_os_str().is_empty() {
         return Ok(None);
@@ -245,7 +253,10 @@ fn sanitize_archive_path(path: &Path) -> anyhow::Result<Option<PathBuf>> {
             Component::Normal(_) => {},
             Component::CurDir => {},
             Component::ParentDir | Component::RootDir | Component::Prefix(_) => {
-                anyhow::bail!("archive contains unsafe path component: {}", path.display());
+                return Err(Error::Install(format!(
+                    "archive contains unsafe path component: {}",
+                    path.display()
+                )));
             },
         }
     }
@@ -259,7 +270,7 @@ fn sanitize_archive_path(path: &Path) -> anyhow::Result<Option<PathBuf>> {
 pub async fn scan_repo_skills(
     repo_dir: &Path,
     install_dir: &Path,
-) -> anyhow::Result<(Vec<SkillMetadata>, Vec<SkillState>)> {
+) -> Result<(Vec<SkillMetadata>, Vec<SkillState>)> {
     // Check root SKILL.md (single-skill repo).
     let root_skill_md = repo_dir.join("SKILL.md");
     if root_skill_md.is_file() {
@@ -337,7 +348,7 @@ pub async fn scan_repo_skills(
 
 /// Parse `owner/repo` from a source string.
 /// Accepts `owner/repo`, `https://github.com/owner/repo`, or with trailing slash/`.git`.
-fn parse_source(source: &str) -> anyhow::Result<(String, String)> {
+fn parse_source(source: &str) -> Result<(String, String)> {
     let s = source.trim().trim_end_matches('/').trim_end_matches(".git");
     let s = s
         .strip_prefix("https://github.com/")
@@ -346,16 +357,16 @@ fn parse_source(source: &str) -> anyhow::Result<(String, String)> {
         .unwrap_or(s);
     let parts: Vec<&str> = s.split('/').collect();
     if parts.len() != 2 || parts[0].is_empty() || parts[1].is_empty() {
-        anyhow::bail!(
+        return Err(Error::Parse(format!(
             "invalid skill source '{}': expected 'owner/repo' or GitHub URL",
             source
-        );
+        )));
     }
     Ok((parts[0].to_string(), parts[1].to_string()))
 }
 
 /// Get the default installation directory.
-pub fn default_install_dir() -> anyhow::Result<PathBuf> {
+pub fn default_install_dir() -> Result<PathBuf> {
     Ok(moltis_config::data_dir().join("installed-skills"))
 }
 

--- a/crates/skills/src/lib.rs
+++ b/crates/skills/src/lib.rs
@@ -4,6 +4,7 @@
 //! and markdown instructions, following the Agent Skills open standard.
 
 pub mod discover;
+pub mod error;
 pub mod formats;
 pub mod install;
 pub mod manifest;
@@ -15,6 +16,8 @@ pub mod registry;
 pub mod requirements;
 pub mod safety;
 pub mod types;
+
+pub use error::Error;
 
 /// Canonical list of sidecar subdirectories a skill directory may contain,
 /// matching the agentskills.io standard. Both the prompt generator

--- a/crates/skills/src/manifest.rs
+++ b/crates/skills/src/manifest.rs
@@ -1,6 +1,6 @@
 use std::path::{Path, PathBuf};
 
-use crate::types::SkillsManifest;
+use crate::{error::Result, types::SkillsManifest};
 
 /// Persistent manifest storage with atomic writes.
 pub struct ManifestStore {
@@ -13,12 +13,12 @@ impl ManifestStore {
     }
 
     /// Default manifest path: `~/.moltis/skills-manifest.json`.
-    pub fn default_path() -> anyhow::Result<PathBuf> {
+    pub fn default_path() -> Result<PathBuf> {
         Ok(moltis_config::data_dir().join("skills-manifest.json"))
     }
 
     /// Load manifest from disk, returning a default if missing.
-    pub fn load(&self) -> anyhow::Result<SkillsManifest> {
+    pub fn load(&self) -> Result<SkillsManifest> {
         if !self.path.exists() {
             return Ok(SkillsManifest::default());
         }
@@ -28,7 +28,7 @@ impl ManifestStore {
     }
 
     /// Save manifest atomically via temp file + rename.
-    pub fn save(&self, manifest: &SkillsManifest) -> anyhow::Result<()> {
+    pub fn save(&self, manifest: &SkillsManifest) -> Result<()> {
         if let Some(parent) = self.path.parent() {
             std::fs::create_dir_all(parent)?;
         }

--- a/crates/skills/src/migration.rs
+++ b/crates/skills/src/migration.rs
@@ -6,7 +6,7 @@
 
 use std::path::Path;
 
-use crate::manifest::ManifestStore;
+use crate::{error::Result, manifest::ManifestStore};
 
 /// Migrate plugins data into the unified skills system.
 ///
@@ -23,7 +23,7 @@ pub async fn migrate_plugins_to_skills(data_dir: &Path) {
     }
 }
 
-async fn try_migrate(data_dir: &Path) -> anyhow::Result<()> {
+async fn try_migrate(data_dir: &Path) -> Result<()> {
     let plugins_manifest_path = data_dir.join("plugins-manifest.json");
     if !plugins_manifest_path.exists() {
         return Ok(());
@@ -95,7 +95,7 @@ async fn cleanup_old_files(plugins_manifest_path: &Path, data_dir: &Path) {
     }
 }
 
-async fn copy_dir_recursive(src: &Path, dst: &Path) -> anyhow::Result<()> {
+async fn copy_dir_recursive(src: &Path, dst: &Path) -> Result<()> {
     tokio::fs::create_dir_all(dst).await?;
     let mut entries = tokio::fs::read_dir(src).await?;
     while let Some(entry) = entries.next_entry().await? {

--- a/crates/skills/src/parse.rs
+++ b/crates/skills/src/parse.rs
@@ -1,9 +1,8 @@
 use std::path::Path;
 
-use {
-    anyhow::{Context, bail},
-    serde::Deserialize,
-};
+use serde::Deserialize;
+
+use crate::error::{Error, Result};
 
 use crate::types::{InstallKind, InstallSpec, SkillContent, SkillMetadata};
 
@@ -24,7 +23,7 @@ pub fn validate_name(name: &str) -> bool {
 
 /// When `name` fails validation, try to use `slug` (from frontmatter or `_meta.json`)
 /// as the internal name, storing the original `name` as `display_name`.
-fn resolve_name_or_slug(meta: &mut SkillMetadata, skill_dir: &Path) -> anyhow::Result<()> {
+fn resolve_name_or_slug(meta: &mut SkillMetadata, skill_dir: &Path) -> Result<()> {
     if validate_name(&meta.name) {
         return Ok(());
     }
@@ -53,32 +52,30 @@ fn resolve_name_or_slug(meta: &mut SkillMetadata, skill_dir: &Path) -> anyhow::R
             } else {
                 "_meta.json"
             };
-            bail!(
+            return Err(Error::Validation(format!(
                 "skill name '{}' is invalid and slug '{}' (from {}) is also invalid: \
                  must be 1-64 lowercase alphanumeric, hyphen, or colon chars \
                  (e.g. 'my-skill' or 'ns:skill')",
-                meta.name,
-                s,
-                source
-            );
+                meta.name, s, source
+            )));
         },
         None => {
-            bail!(
+            return Err(Error::Validation(format!(
                 "skill name '{}' is invalid and no slug provided: \
                  must be 1-64 lowercase alphanumeric, hyphen, or colon chars \
                  (e.g. 'my-skill' or 'ns:skill'), \
                  or provide a valid 'slug' field",
                 meta.name
-            );
+            )));
         },
     }
 }
 
 /// Parse a SKILL.md file into metadata only (frontmatter).
-pub fn parse_metadata(content: &str, skill_dir: &Path) -> anyhow::Result<SkillMetadata> {
+pub fn parse_metadata(content: &str, skill_dir: &Path) -> Result<SkillMetadata> {
     let (frontmatter, _body) = split_frontmatter(content)?;
-    let mut meta: SkillMetadata =
-        serde_yaml::from_str(&frontmatter).context("invalid SKILL.md frontmatter")?;
+    let mut meta: SkillMetadata = serde_yaml::from_str(&frontmatter)
+        .map_err(|e| Error::Parse(format!("invalid SKILL.md frontmatter: {e}")))?;
 
     resolve_name_or_slug(&mut meta, skill_dir)?;
 
@@ -88,10 +85,10 @@ pub fn parse_metadata(content: &str, skill_dir: &Path) -> anyhow::Result<SkillMe
 }
 
 /// Parse a SKILL.md file into full content (metadata + body).
-pub fn parse_skill(content: &str, skill_dir: &Path) -> anyhow::Result<SkillContent> {
+pub fn parse_skill(content: &str, skill_dir: &Path) -> Result<SkillContent> {
     let (frontmatter, body) = split_frontmatter(content)?;
-    let mut meta: SkillMetadata =
-        serde_yaml::from_str(&frontmatter).context("invalid SKILL.md frontmatter")?;
+    let mut meta: SkillMetadata = serde_yaml::from_str(&frontmatter)
+        .map_err(|e| Error::Parse(format!("invalid SKILL.md frontmatter: {e}")))?;
 
     resolve_name_or_slug(&mut meta, skill_dir)?;
 
@@ -264,17 +261,19 @@ pub fn read_meta_json(skill_dir: &Path) -> Option<SkillMetaJson> {
 }
 
 /// Split SKILL.md content at `---` delimiters into (frontmatter, body).
-fn split_frontmatter(content: &str) -> anyhow::Result<(String, String)> {
+fn split_frontmatter(content: &str) -> Result<(String, String)> {
     let trimmed = content.trim_start();
     if !trimmed.starts_with("---") {
-        bail!("SKILL.md must start with YAML frontmatter delimited by ---");
+        return Err(Error::Parse(
+            "SKILL.md must start with YAML frontmatter delimited by ---".into(),
+        ));
     }
 
     // Skip the opening ---
     let after_open = &trimmed[3..];
     let close_pos = after_open
         .find("\n---")
-        .context("SKILL.md missing closing --- for frontmatter")?;
+        .ok_or_else(|| Error::Parse("SKILL.md missing closing --- for frontmatter".into()))?;
 
     let frontmatter = after_open[..close_pos].trim().to_string();
     let body = after_open[close_pos + 4..].trim().to_string();

--- a/crates/skills/src/portability.rs
+++ b/crates/skills/src/portability.rs
@@ -5,13 +5,13 @@ use std::{
 };
 
 use {
-    anyhow::{Context, bail},
     flate2::{Compression, read::GzDecoder, write::GzEncoder},
     tar::{Archive, Builder, Header},
     walkdir::WalkDir,
 };
 
 use crate::{
+    error::{Error, Result},
     formats::{PluginFormat, detect_format, scan_with_adapter},
     install::scan_repo_skills,
     manifest::ManifestStore,
@@ -46,7 +46,7 @@ pub struct ImportedRepoBundle {
     pub skills: Vec<SkillMetadata>,
 }
 
-pub fn default_export_dir() -> anyhow::Result<PathBuf> {
+pub fn default_export_dir() -> Result<PathBuf> {
     Ok(moltis_config::data_dir().join("skill-exports"))
 }
 
@@ -54,7 +54,7 @@ pub async fn export_repo_bundle(
     source: &str,
     install_dir: &Path,
     output_path: Option<&Path>,
-) -> anyhow::Result<ExportedRepoBundle> {
+) -> Result<ExportedRepoBundle> {
     let manifest_path = ManifestStore::default_path()?;
     let store = ManifestStore::new(manifest_path);
     export_repo_bundle_with_store(source, install_dir, output_path, &store).await
@@ -63,7 +63,7 @@ pub async fn export_repo_bundle(
 pub async fn import_repo_bundle(
     bundle_path: &Path,
     install_dir: &Path,
-) -> anyhow::Result<ImportedRepoBundle> {
+) -> Result<ImportedRepoBundle> {
     let manifest_path = ManifestStore::default_path()?;
     let store = ManifestStore::new(manifest_path);
     import_repo_bundle_with_store(bundle_path, install_dir, &store).await
@@ -74,15 +74,18 @@ pub async fn export_repo_bundle_with_store(
     install_dir: &Path,
     output_path: Option<&Path>,
     store: &ManifestStore,
-) -> anyhow::Result<ExportedRepoBundle> {
+) -> Result<ExportedRepoBundle> {
     let manifest = store.load()?;
     let repo = manifest
         .find_repo(source)
         .cloned()
-        .ok_or_else(|| anyhow::anyhow!("repo '{source}' not found"))?;
+        .ok_or_else(|| Error::NotFound(format!("repo '{source}' not found")))?;
     let repo_dir = install_dir.join(&repo.repo_name);
     if !repo_dir.is_dir() {
-        bail!("repo directory missing on disk: {}", repo_dir.display());
+        return Err(Error::NotFound(format!(
+            "repo directory missing on disk: {}",
+            repo_dir.display()
+        )));
     }
 
     let bundle_path = resolve_bundle_output_path(output_path, &repo.repo_name)?;
@@ -109,7 +112,7 @@ pub async fn import_repo_bundle_with_store(
     bundle_path: &Path,
     install_dir: &Path,
     store: &ManifestStore,
-) -> anyhow::Result<ImportedRepoBundle> {
+) -> Result<ImportedRepoBundle> {
     tokio::fs::create_dir_all(install_dir).await?;
 
     let bundle_path = bundle_path.to_path_buf();
@@ -136,10 +139,10 @@ pub async fn import_repo_bundle_with_store(
     let (format, skills_meta, skill_states) = scan_imported_repo(&repo_dir, install_dir).await?;
     if skills_meta.is_empty() {
         let _ = tokio::fs::remove_dir_all(&repo_dir).await;
-        bail!(
+        return Err(Error::Bundle(format!(
             "imported bundle '{}' contains no usable skills",
             bundle_path.display()
-        );
+        )));
     }
 
     let mut repo = manifest_bundle.repo;
@@ -179,7 +182,7 @@ pub async fn import_repo_bundle_with_store(
 async fn scan_imported_repo(
     repo_dir: &Path,
     install_dir: &Path,
-) -> anyhow::Result<(PluginFormat, Vec<SkillMetadata>, Vec<SkillState>)> {
+) -> Result<(PluginFormat, Vec<SkillMetadata>, Vec<SkillState>)> {
     let format = detect_format(repo_dir);
     let (skills_meta, skill_states) = match format {
         PluginFormat::Skill => scan_repo_skills(repo_dir, install_dir).await?,
@@ -204,17 +207,19 @@ async fn scan_imported_repo(
                     .collect();
                 (meta, states)
             },
-            None => bail!("no adapter available for imported repo format '{}'", format),
+            None => {
+                return Err(Error::Bundle(format!(
+                    "no adapter available for imported repo format '{}'",
+                    format
+                )));
+            },
         },
     };
 
     Ok((format, skills_meta, skill_states))
 }
 
-fn resolve_bundle_output_path(
-    output_path: Option<&Path>,
-    repo_name: &str,
-) -> anyhow::Result<PathBuf> {
+fn resolve_bundle_output_path(output_path: Option<&Path>, repo_name: &str) -> Result<PathBuf> {
     let default_name = format!("{repo_name}-{}.tar.gz", current_time_ms());
     let path = match output_path {
         Some(path) if path.is_dir() => path.join(default_name),
@@ -228,7 +233,7 @@ fn write_bundle_archive(
     bundle: &PortableRepoBundle,
     repo_dir: &Path,
     bundle_path: &Path,
-) -> anyhow::Result<()> {
+) -> Result<()> {
     let file = File::create(bundle_path)?;
     let encoder = GzEncoder::new(file, Compression::default());
     let mut builder = Builder::new(encoder);
@@ -250,7 +255,7 @@ fn write_bundle_archive(
 
         let relative = path
             .strip_prefix(repo_dir)
-            .with_context(|| format!("failed to relativize {}", path.display()))?;
+            .map_err(|_| Error::Bundle(format!("failed to relativize {}", path.display())))?;
         let archive_path = Path::new(BUNDLE_REPO_PREFIX).join(relative);
         if metadata.is_dir() {
             builder.append_dir(&archive_path, path)?;
@@ -265,7 +270,7 @@ fn write_bundle_archive(
     Ok(())
 }
 
-fn read_bundle_manifest(bundle_path: &Path) -> anyhow::Result<PortableRepoBundle> {
+fn read_bundle_manifest(bundle_path: &Path) -> Result<PortableRepoBundle> {
     let file = File::open(bundle_path)?;
     let decoder = GzDecoder::new(file);
     let mut archive = Archive::new(decoder);
@@ -278,24 +283,23 @@ fn read_bundle_manifest(bundle_path: &Path) -> anyhow::Result<PortableRepoBundle
             entry.read_to_string(&mut data)?;
             let bundle: PortableRepoBundle = serde_json::from_str(&data)?;
             if bundle.version != BUNDLE_VERSION {
-                bail!(
+                return Err(Error::Bundle(format!(
                     "unsupported skill bundle version {} (expected {})",
-                    bundle.version,
-                    BUNDLE_VERSION
-                );
+                    bundle.version, BUNDLE_VERSION
+                )));
             }
             return Ok(bundle);
         }
     }
 
-    bail!(
+    Err(Error::Bundle(format!(
         "bundle '{}' is missing {}",
         bundle_path.display(),
         BUNDLE_MANIFEST_PATH
-    )
+    )))
 }
 
-fn extract_bundle_archive(bundle_path: &Path, target_dir: &Path) -> anyhow::Result<()> {
+fn extract_bundle_archive(bundle_path: &Path, target_dir: &Path) -> Result<()> {
     std::fs::create_dir_all(target_dir)?;
     let canonical_target = std::fs::canonicalize(target_dir)?;
 
@@ -307,10 +311,10 @@ fn extract_bundle_archive(bundle_path: &Path, target_dir: &Path) -> anyhow::Resu
         let mut entry = entry?;
         let entry_type = entry.header().entry_type();
         if entry_type.is_symlink() || entry_type.is_hard_link() {
-            bail!(
+            return Err(Error::Bundle(format!(
                 "bundle '{}' contains unsupported link entries",
                 bundle_path.display()
-            );
+            )));
         }
 
         let path = entry.path()?.into_owned();
@@ -331,14 +335,18 @@ fn extract_bundle_archive(bundle_path: &Path, target_dir: &Path) -> anyhow::Resu
             std::fs::create_dir_all(parent)?;
             let canonical_parent = std::fs::canonicalize(parent)?;
             if !canonical_parent.starts_with(&canonical_target) {
-                bail!("bundle entry escaped import directory");
+                return Err(Error::Bundle(
+                    "bundle entry escaped import directory".into(),
+                ));
             }
         }
 
         if dest.exists() {
             let metadata = std::fs::symlink_metadata(&dest)?;
             if metadata.file_type().is_symlink() {
-                bail!("bundle entry resolves to a symlink destination");
+                return Err(Error::Bundle(
+                    "bundle entry resolves to a symlink destination".into(),
+                ));
             }
         }
 
@@ -348,10 +356,13 @@ fn extract_bundle_archive(bundle_path: &Path, target_dir: &Path) -> anyhow::Resu
     Ok(())
 }
 
-fn sanitize_bundle_repo_path(path: &Path) -> anyhow::Result<Option<PathBuf>> {
+fn sanitize_bundle_repo_path(path: &Path) -> Result<Option<PathBuf>> {
     let mut components = path.components();
     let Some(Component::Normal(prefix)) = components.next() else {
-        bail!("bundle contains invalid path '{}'", path.display());
+        return Err(Error::Bundle(format!(
+            "bundle contains invalid path '{}'",
+            path.display()
+        )));
     };
     if prefix != BUNDLE_REPO_PREFIX {
         return Ok(None);
@@ -366,7 +377,10 @@ fn sanitize_bundle_repo_path(path: &Path) -> anyhow::Result<Option<PathBuf>> {
         match component {
             Component::Normal(_) | Component::CurDir => {},
             Component::ParentDir | Component::RootDir | Component::Prefix(_) => {
-                bail!("bundle contains unsafe path '{}'", path.display());
+                return Err(Error::Bundle(format!(
+                    "bundle contains unsafe path '{}'",
+                    path.display()
+                )));
             },
         }
     }

--- a/crates/skills/src/registry.rs
+++ b/crates/skills/src/registry.rs
@@ -4,6 +4,7 @@ use async_trait::async_trait;
 
 use crate::{
     discover::SkillDiscoverer,
+    error::{Error, Result},
     parse,
     types::{SkillContent, SkillMetadata},
 };
@@ -12,16 +13,16 @@ use crate::{
 #[async_trait]
 pub trait SkillRegistry: Send + Sync {
     /// List metadata for all available skills.
-    async fn list_skills(&self) -> anyhow::Result<Vec<SkillMetadata>>;
+    async fn list_skills(&self) -> Result<Vec<SkillMetadata>>;
 
     /// Load the full content of a skill by name.
-    async fn load_skill(&self, name: &str) -> anyhow::Result<SkillContent>;
+    async fn load_skill(&self, name: &str) -> Result<SkillContent>;
 
     /// Install a skill from a source (e.g. git URL).
-    async fn install_skill(&self, source: &str) -> anyhow::Result<SkillMetadata>;
+    async fn install_skill(&self, source: &str) -> Result<SkillMetadata>;
 
     /// Remove an installed skill by name.
-    async fn remove_skill(&self, name: &str) -> anyhow::Result<()>;
+    async fn remove_skill(&self, name: &str) -> Result<()>;
 }
 
 /// In-memory registry backed by a discoverer.
@@ -38,7 +39,7 @@ impl InMemoryRegistry {
     }
 
     /// Populate the registry from a discoverer.
-    pub async fn from_discoverer(discoverer: &dyn SkillDiscoverer) -> anyhow::Result<Self> {
+    pub async fn from_discoverer(discoverer: &dyn SkillDiscoverer) -> Result<Self> {
         let discovered = discoverer.discover().await?;
         let mut skills = HashMap::new();
         for meta in discovered {
@@ -61,43 +62,47 @@ impl Default for InMemoryRegistry {
 
 #[async_trait]
 impl SkillRegistry for InMemoryRegistry {
-    async fn list_skills(&self) -> anyhow::Result<Vec<SkillMetadata>> {
+    async fn list_skills(&self) -> Result<Vec<SkillMetadata>> {
         Ok(self.skills.values().cloned().collect())
     }
 
-    async fn load_skill(&self, name: &str) -> anyhow::Result<SkillContent> {
+    async fn load_skill(&self, name: &str) -> Result<SkillContent> {
         let meta = self
             .skills
             .get(name)
-            .ok_or_else(|| anyhow::anyhow!("skill '{}' not found", name))?;
+            .ok_or_else(|| Error::NotFound(format!("skill '{}' not found", name)))?;
 
         let skill_md = meta.path.join("SKILL.md");
         let content = tokio::fs::read_to_string(&skill_md).await?;
         parse::parse_skill(&content, &meta.path)
     }
 
-    async fn install_skill(&self, _source: &str) -> anyhow::Result<SkillMetadata> {
-        anyhow::bail!("install not supported on in-memory registry; use install::install_skill")
+    async fn install_skill(&self, _source: &str) -> Result<SkillMetadata> {
+        Err(Error::Install(
+            "install not supported on in-memory registry; use install::install_skill".into(),
+        ))
     }
 
-    async fn remove_skill(&self, name: &str) -> anyhow::Result<()> {
+    async fn remove_skill(&self, name: &str) -> Result<()> {
         let meta = self
             .skills
             .get(name)
-            .ok_or_else(|| anyhow::anyhow!("skill '{}' not found", name))?;
+            .ok_or_else(|| Error::NotFound(format!("skill '{}' not found", name)))?;
 
         let path = &meta.path;
         if !path.exists() {
-            anyhow::bail!("skill directory does not exist: {}", path.display());
+            return Err(Error::NotFound(format!(
+                "skill directory does not exist: {}",
+                path.display()
+            )));
         }
 
         // Only allow removing registry-installed skills
         if meta.source != Some(crate::types::SkillSource::Registry) {
-            anyhow::bail!(
+            return Err(Error::Validation(format!(
                 "can only remove registry-installed skills, '{}' is {:?}",
-                name,
-                meta.source
-            );
+                name, meta.source
+            )));
         }
 
         tokio::fs::remove_dir_all(path).await?;
@@ -106,7 +111,7 @@ impl SkillRegistry for InMemoryRegistry {
 }
 
 /// Convenience: load a skill's full content given its path.
-pub async fn load_skill_from_path(skill_dir: &Path) -> anyhow::Result<SkillContent> {
+pub async fn load_skill_from_path(skill_dir: &Path) -> Result<SkillContent> {
     let skill_md = skill_dir.join("SKILL.md");
     let content = tokio::fs::read_to_string(&skill_md).await?;
     parse::parse_skill(&content, skill_dir)

--- a/crates/skills/src/requirements.rs
+++ b/crates/skills/src/requirements.rs
@@ -2,50 +2,53 @@
 
 use std::path::Path;
 
-use anyhow::{Context, bail};
-
-use crate::types::{InstallKind, InstallSpec, SkillEligibility, SkillMetadata};
+use crate::{
+    error::{Error, Result},
+    types::{InstallKind, InstallSpec, SkillEligibility, SkillMetadata},
+};
 
 /// Resolve install command program + args from an install spec.
-pub fn install_program_and_args(spec: &InstallSpec) -> anyhow::Result<(&'static str, Vec<&str>)> {
+pub fn install_program_and_args(spec: &InstallSpec) -> Result<(&'static str, Vec<&str>)> {
     let (program, args) = match &spec.kind {
         InstallKind::Brew => {
             let formula = spec
                 .formula
                 .as_deref()
-                .context("brew install requires 'formula'")?;
+                .ok_or_else(|| Error::Install("brew install requires 'formula'".into()))?;
             ("brew", vec!["install", formula])
         },
         InstallKind::Npm => {
             let package = spec
                 .package
                 .as_deref()
-                .context("npm install requires 'package'")?;
+                .ok_or_else(|| Error::Install("npm install requires 'package'".into()))?;
             ("npm", vec!["install", "-g", "--ignore-scripts", package])
         },
         InstallKind::Go => {
             let module = spec
                 .module
                 .as_deref()
-                .context("go install requires 'module'")?;
+                .ok_or_else(|| Error::Install("go install requires 'module'".into()))?;
             ("go", vec!["install", module])
         },
         InstallKind::Cargo => {
             let package = spec
                 .package
                 .as_deref()
-                .context("cargo install requires 'package'")?;
+                .ok_or_else(|| Error::Install("cargo install requires 'package'".into()))?;
             ("cargo", vec!["install", package])
         },
         InstallKind::Uv => {
             let package = spec
                 .package
                 .as_deref()
-                .context("uv install requires 'package'")?;
+                .ok_or_else(|| Error::Install("uv install requires 'package'".into()))?;
             ("uv", vec!["tool", "install", package])
         },
         InstallKind::Download => {
-            bail!("download install kind is not yet supported for automatic installation");
+            return Err(Error::Install(
+                "download install kind is not yet supported for automatic installation".into(),
+            ));
         },
     };
 
@@ -53,7 +56,7 @@ pub fn install_program_and_args(spec: &InstallSpec) -> anyhow::Result<(&'static 
 }
 
 /// Render an install spec to a user-visible command preview.
-pub fn install_command_preview(spec: &InstallSpec) -> anyhow::Result<String> {
+pub fn install_command_preview(spec: &InstallSpec) -> Result<String> {
     let (program, args) = install_program_and_args(spec)?;
     Ok(std::iter::once(program)
         .chain(args)
@@ -154,7 +157,7 @@ pub struct InstallResult {
 }
 
 /// Run an install spec command (e.g. `brew install <formula>`).
-pub async fn run_install(spec: &InstallSpec) -> anyhow::Result<InstallResult> {
+pub async fn run_install(spec: &InstallSpec) -> Result<InstallResult> {
     let (program, args) = install_program_and_args(spec)?;
 
     let args_owned: Vec<String> = args.iter().map(|s| s.to_string()).collect();
@@ -162,7 +165,7 @@ pub async fn run_install(spec: &InstallSpec) -> anyhow::Result<InstallResult> {
         .args(&args_owned)
         .output()
         .await
-        .with_context(|| format!("failed to run {program}"))?;
+        .map_err(|e| Error::Install(format!("failed to run {program}: {e}")))?;
 
     Ok(InstallResult {
         success: output.status.success(),

--- a/crates/skills/src/watcher.rs
+++ b/crates/skills/src/watcher.rs
@@ -9,7 +9,6 @@ use std::{
 };
 
 use {
-    anyhow::Result,
     notify_debouncer_full::{
         DebounceEventResult, Debouncer, RecommendedCache, new_debouncer, notify::RecursiveMode,
     },
@@ -19,6 +18,7 @@ use {
 
 use crate::{
     discover::FsSkillDiscoverer,
+    error::Result,
     manifest::ManifestStore,
     types::{SkillSource, SkillsManifest},
 };

--- a/crates/tools/src/skill_tools/read.rs
+++ b/crates/tools/src/skill_tools/read.rs
@@ -1159,7 +1159,9 @@ impl StaticDiscoverer {
 
 #[async_trait]
 impl SkillDiscoverer for StaticDiscoverer {
-    async fn discover(&self) -> anyhow::Result<Vec<moltis_skills::types::SkillMetadata>> {
+    async fn discover(
+        &self,
+    ) -> moltis_skills::error::Result<Vec<moltis_skills::types::SkillMetadata>> {
         Ok(self.skills.clone())
     }
 }


### PR DESCRIPTION
## Summary

- Add `thiserror`-based `Error` enums to 8 library crates that previously used only `anyhow`: **auth**, **caldav**, **httpd**, **mcp-agent-bridge**, **memory**, **node-host**, **qmd**, **skills**
- Each crate now exports a typed `Error` enum and `Result<T>` alias, following the project convention (thiserror for libraries, anyhow for CLI)
- Where external trait boundaries require `anyhow::Result` (`AgentTool`, `MemoryWriter`), implementations use typed errors internally with auto-conversion via `?`
- Updated downstream call sites in cli, gateway, chat, code-index, and tools

## Validation

### Completed
- [x] `cargo +nightly-2025-11-30 fmt --all -- --check`
- [x] `cargo check --workspace` (0 errors)
- [x] `just test` (367 tests pass)

### Remaining
- [ ] `just lint` (pre-existing clippy failure in `moltis-tools/task_list.rs` — not related to this PR)
- [ ] `./scripts/local-validate.sh`

## Manual QA
N/A — pure refactor with no behavioral changes. All existing tests pass unchanged.