### PR TITLE
fix(slack): strip leading slash from commands before gateway dispatch

### DIFF
--- a/crates/gateway/src/channel_events/commands/dispatch.rs
+++ b/crates/gateway/src/channel_events/commands/dispatch.rs
@@ -177,27 +177,4 @@ mod tests {
             );
         }
     }
-
-    /// Regression test for https://github.com/moltis-org/moltis/issues/798
-    ///
-    /// Slack sends commands with a leading slash (`/new`, `/clear`). The
-    /// dispatch function must strip it before matching, otherwise the match
-    /// falls through to the unknown-command arm producing `//new`.
-    #[test]
-    fn leading_slash_is_stripped_before_matching() {
-        // Simulates the slash-stripping logic in dispatch_command.
-        let inputs = ["/new", "/clear", "/model gpt-4o", "new", "clear"];
-        for input in inputs {
-            let stripped = input.strip_prefix('/').unwrap_or(input);
-            let cmd = stripped.split_whitespace().next().unwrap_or("");
-            assert!(
-                !cmd.starts_with('/'),
-                "command `{input}` should not produce a slash-prefixed cmd, got `{cmd}`"
-            );
-            assert!(
-                !cmd.is_empty(),
-                "command `{input}` should produce a non-empty cmd"
-            );
-        }
-    }
 }

--- a/crates/gateway/src/channel_events/commands/dispatch.rs
+++ b/crates/gateway/src/channel_events/commands/dispatch.rs
@@ -50,6 +50,10 @@ pub(in crate::channel_events) async fn dispatch_command(
         .ok_or_else(|| ChannelError::unavailable("session metadata not available"))?;
     let session_key = resolve_channel_session(&reply_to, session_metadata).await;
 
+    // Strip leading slash — some channels (e.g. Slack) include it in the
+    // command field, others (Telegram, Discord) strip it before calling.
+    let command = command.strip_prefix('/').unwrap_or(command);
+
     // Extract the command name (first word) and args (rest).
     let cmd = command.split_whitespace().next().unwrap_or("");
     let args = command[cmd.len()..].trim();
@@ -170,6 +174,29 @@ mod tests {
                 registry_names.contains(name),
                 "dispatch arm `/{name}` exists but is not in the centralized command registry. \
                  Add it to moltis_channels::commands::all_commands().",
+            );
+        }
+    }
+
+    /// Regression test for https://github.com/moltis-org/moltis/issues/798
+    ///
+    /// Slack sends commands with a leading slash (`/new`, `/clear`). The
+    /// dispatch function must strip it before matching, otherwise the match
+    /// falls through to the unknown-command arm producing `//new`.
+    #[test]
+    fn leading_slash_is_stripped_before_matching() {
+        // Simulates the slash-stripping logic in dispatch_command.
+        let inputs = ["/new", "/clear", "/model gpt-4o", "new", "clear"];
+        for input in inputs {
+            let stripped = input.strip_prefix('/').unwrap_or(input);
+            let cmd = stripped.split_whitespace().next().unwrap_or("");
+            assert!(
+                !cmd.starts_with('/'),
+                "command `{input}` should not produce a slash-prefixed cmd, got `{cmd}`"
+            );
+            assert!(
+                !cmd.is_empty(),
+                "command `{input}` should produce a non-empty cmd"
             );
         }
     }

--- a/crates/slack/src/webhook.rs
+++ b/crates/slack/src/webhook.rs
@@ -550,6 +550,54 @@ fn url_decode(input: &str) -> Option<String> {
 mod tests {
     use super::*;
 
+    use std::sync::Mutex;
+
+    use moltis_channels::{ChannelEvent, ChannelMessageMeta, Result as ChannelResult};
+
+    /// Mock sink that records the command string passed to `dispatch_command`.
+    struct RecordingSink {
+        commands: Mutex<Vec<String>>,
+    }
+
+    impl RecordingSink {
+        fn new() -> Self {
+            Self {
+                commands: Mutex::new(Vec::new()),
+            }
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl ChannelEventSink for RecordingSink {
+        async fn emit(&self, _event: ChannelEvent) {}
+
+        async fn dispatch_to_chat(
+            &self,
+            _text: &str,
+            _reply_to: ChannelReplyTarget,
+            _meta: ChannelMessageMeta,
+        ) {
+        }
+
+        async fn dispatch_command(
+            &self,
+            command: &str,
+            _reply_to: ChannelReplyTarget,
+            _sender_id: Option<&str>,
+        ) -> ChannelResult<String> {
+            self.commands.lock().unwrap().push(command.to_string());
+            Ok("ok".to_string())
+        }
+
+        async fn request_disable_account(
+            &self,
+            _channel_type: &str,
+            _account_id: &str,
+            _reason: &str,
+        ) {
+        }
+    }
+
     #[test]
     fn verify_valid_signature() {
         let secret = "8f742231b10e8888abcd99yez67543";
@@ -686,5 +734,72 @@ mod tests {
         let result = handle_verified_command_webhook("acct1", body, &accounts).await;
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), "Channel not configured");
+    }
+
+    /// Regression test for https://github.com/moltis-org/moltis/issues/798
+    ///
+    /// Slack sends command fields like `/new`, `/clear` (with leading slash).
+    /// The full_command passed to dispatch_command must strip the slash so the
+    /// gateway doesn't produce "unknown command: //new".
+    #[tokio::test]
+    async fn slash_command_strips_leading_slash() {
+        let sink = Arc::new(RecordingSink::new());
+        let accounts: AccountStateMap =
+            Arc::new(std::sync::RwLock::new(std::collections::HashMap::new()));
+        {
+            let mut accts = accounts.write().unwrap();
+            accts.insert("acct1".to_string(), AccountState {
+                account_id: "acct1".to_string(),
+                config: SlackAccountConfig::default(),
+                message_log: None,
+                event_sink: Some(sink.clone()),
+                cancel: tokio_util::sync::CancellationToken::new(),
+                bot_user_id: Some("B123".to_string()),
+                pending_threads: std::collections::HashMap::new(),
+            });
+        }
+
+        // Slack sends `/new` URL-encoded as %2Fnew
+        let body = b"command=%2Fnew&text=&user_id=U123&channel_id=C456";
+        let result = handle_verified_command_webhook("acct1", body, &accounts).await;
+        assert!(result.is_ok(), "dispatch failed: {:?}", result);
+
+        let dispatched = sink.commands.lock().unwrap();
+        assert_eq!(dispatched.len(), 1);
+        assert_eq!(
+            dispatched[0], "/new",
+            "webhook should pass the raw command (slash-stripping is gateway's job)"
+        );
+    }
+
+    /// Regression test for https://github.com/moltis-org/moltis/issues/798
+    ///
+    /// Verify that commands with arguments also work correctly.
+    #[tokio::test]
+    async fn slash_command_with_args_preserves_text() {
+        let sink = Arc::new(RecordingSink::new());
+        let accounts: AccountStateMap =
+            Arc::new(std::sync::RwLock::new(std::collections::HashMap::new()));
+        {
+            let mut accts = accounts.write().unwrap();
+            accts.insert("acct1".to_string(), AccountState {
+                account_id: "acct1".to_string(),
+                config: SlackAccountConfig::default(),
+                message_log: None,
+                event_sink: Some(sink.clone()),
+                cancel: tokio_util::sync::CancellationToken::new(),
+                bot_user_id: Some("B123".to_string()),
+                pending_threads: std::collections::HashMap::new(),
+            });
+        }
+
+        // Slack sends `/model` with text "gpt-4o"
+        let body = b"command=%2Fmodel&text=gpt-4o&user_id=U123&channel_id=C456";
+        let result = handle_verified_command_webhook("acct1", body, &accounts).await;
+        assert!(result.is_ok(), "dispatch failed: {:?}", result);
+
+        let dispatched = sink.commands.lock().unwrap();
+        assert_eq!(dispatched.len(), 1);
+        assert_eq!(dispatched[0], "/model gpt-4o");
     }
 }


### PR DESCRIPTION
## Summary

- Slack sends command fields with a leading `/` (`/new`, `/clear`), unlike Telegram/Discord which strip it before calling `dispatch_command`
- The gateway match never matched these, falling through to the unknown-command arm producing `"unknown command: //new"` (double slash)
- Fix: strip leading `/` defensively in `dispatch_command` so all channels work regardless of whether they pre-strip

Closes #798

## Validation

### Completed
- [x] `cargo +nightly-2025-11-30 fmt --all -- --check`
- [x] `cargo clippy -p moltis-gateway -p moltis-slack -- -D warnings`
- [x] `cargo test -p moltis-gateway channel_events::commands::dispatch`
- [x] `cargo test -p moltis-slack webhook`

### Remaining
- [ ] `./scripts/local-validate.sh`

## Manual QA

1. Configure Slack channel integration
2. Send `/new` in a Slack conversation — should start a new session
3. Send `/clear` — should clear context
4. Send `/model gpt-4o` — should switch model