### PR TITLE
feat(sandbox): install Node.js 22 LTS via NodeSource

### DIFF
--- a/crates/config/src/schema/tools.rs
+++ b/crates/config/src/schema/tools.rs
@@ -720,8 +720,7 @@ fn default_sandbox_packages() -> Vec<String> {
         "python3-pip",
         "python3-venv",
         "python-is-python3",
-        "nodejs",
-        "npm",
+        "nodejs", // installed via NodeSource 22.x (npm bundled)
         "ruby",
         "ruby-dev",
         "golang-go",

--- a/crates/config/src/template.rs
+++ b/crates/config/src/template.rs
@@ -475,8 +475,7 @@ packages = [
     "python3-pip",
     "python3-venv",
     "python-is-python3",
-    "nodejs",
-    "npm",
+    "nodejs",  # installed via NodeSource 22.x (npm bundled)
     "ruby",
     "ruby-dev",
     "golang-go",

--- a/crates/tools/src/sandbox/containers.rs
+++ b/crates/tools/src/sandbox/containers.rs
@@ -17,8 +17,8 @@ use {
     crate::error::{Error, Result},
 };
 
-/// Packages that are installed via dedicated setup steps rather than plain apt-get.
-/// These are filtered from the apt package list to avoid version conflicts.
+/// Packages superseded by NodeSource's `nodejs` (which bundles npm).
+/// Only filtered when `nodejs` is in the package list.
 const NODESOURCE_SUPERSEDED_PACKAGES: &[&str] = &["npm"];
 
 pub(crate) fn sandbox_image_dockerfile(base: &str, packages: &[String]) -> String {
@@ -27,18 +27,21 @@ pub(crate) fn sandbox_image_dockerfile(base: &str, packages: &[String]) -> Strin
     let pkg_list: Vec<&str> = canonical
         .iter()
         .map(String::as_str)
-        .filter(|p| !NODESOURCE_SUPERSEDED_PACKAGES.contains(p))
+        .filter(|p| !has_nodejs || !NODESOURCE_SUPERSEDED_PACKAGES.contains(p))
         .collect();
     let pkg_str = pkg_list.join(" ");
 
-    // If nodejs is requested, set up NodeSource 22.x repo before apt-get so
-    // `apt-get install nodejs` pulls Node 22 LTS (which bundles npm).
+    // If nodejs is requested, bootstrap curl+gnupg, add the NodeSource 22.x
+    // repo, then let the main apt-get install pick up nodejs v22 (bundles npm).
     let nodesource_setup = if has_nodejs {
-        "RUN install -m 0755 -d /etc/apt/keyrings && \\\n    \
-             curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key \
-| gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg && \\\n    \
-             echo \"deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main\" \
-> /etc/apt/sources.list.d/nodesource.list\n"
+        "RUN apt-get update -qq \
+&& apt-get install -y -qq curl gnupg \
+&& install -m 0755 -d /etc/apt/keyrings \
+&& curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key \
+   | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
+&& echo \"deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main\" \
+   > /etc/apt/sources.list.d/nodesource.list \
+&& rm -rf /var/lib/apt/lists/*\n"
     } else {
         ""
     };

--- a/crates/tools/src/sandbox/containers.rs
+++ b/crates/tools/src/sandbox/containers.rs
@@ -17,11 +17,36 @@ use {
     crate::error::{Error, Result},
 };
 
+/// Packages that are installed via dedicated setup steps rather than plain apt-get.
+/// These are filtered from the apt package list to avoid version conflicts.
+const NODESOURCE_SUPERSEDED_PACKAGES: &[&str] = &["npm"];
+
 pub(crate) fn sandbox_image_dockerfile(base: &str, packages: &[String]) -> String {
-    let pkg_list = canonical_sandbox_packages(packages).join(" ");
+    let canonical = canonical_sandbox_packages(packages);
+    let has_nodejs = canonical.iter().any(|p| p == "nodejs");
+    let pkg_list: Vec<&str> = canonical
+        .iter()
+        .map(String::as_str)
+        .filter(|p| !NODESOURCE_SUPERSEDED_PACKAGES.contains(p))
+        .collect();
+    let pkg_str = pkg_list.join(" ");
+
+    // If nodejs is requested, set up NodeSource 22.x repo before apt-get so
+    // `apt-get install nodejs` pulls Node 22 LTS (which bundles npm).
+    let nodesource_setup = if has_nodejs {
+        "RUN install -m 0755 -d /etc/apt/keyrings && \\\n    \
+             curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key \
+| gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg && \\\n    \
+             echo \"deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main\" \
+> /etc/apt/sources.list.d/nodesource.list\n"
+    } else {
+        ""
+    };
+
     format!(
         "FROM {base}\n\
-RUN apt-get update -qq && apt-get install -y -qq {pkg_list} \
+{nodesource_setup}\
+RUN apt-get update -qq && apt-get install -y -qq {pkg_str} \
     && mkdir -p {SANDBOX_HOME_DIR}\n\
 RUN if command -v corepack >/dev/null 2>&1; then corepack enable; fi\n\
 RUN if command -v go >/dev/null 2>&1; then \

--- a/crates/tools/src/sandbox/tests/docker_router.rs
+++ b/crates/tools/src/sandbox/tests/docker_router.rs
@@ -529,6 +529,28 @@ fn test_sandbox_image_dockerfile_installs_gogcli() {
 }
 
 #[test]
+fn test_sandbox_image_dockerfile_adds_nodesource_for_nodejs() {
+    let dockerfile = sandbox_image_dockerfile("ubuntu:25.10", &["curl".into(), "nodejs".into()]);
+    assert!(dockerfile.contains("nodesource.gpg"));
+    assert!(dockerfile.contains("node_22.x"));
+    // nodejs should remain in the apt-get install line
+    assert!(dockerfile.contains("nodejs"));
+    // npm is superseded by NodeSource nodejs and should be filtered out
+    let dockerfile_with_npm = sandbox_image_dockerfile("ubuntu:25.10", &[
+        "curl".into(),
+        "nodejs".into(),
+        "npm".into(),
+    ]);
+    assert!(!dockerfile_with_npm.contains(" npm"));
+}
+
+#[test]
+fn test_sandbox_image_dockerfile_no_nodesource_without_nodejs() {
+    let dockerfile = sandbox_image_dockerfile("ubuntu:25.10", &["curl".into(), "git".into()]);
+    assert!(!dockerfile.contains("nodesource"));
+}
+
+#[test]
 fn test_docker_image_tag_changes_with_base() {
     let packages = vec!["curl".into()];
     let t1 = sandbox_image_tag("moltis-main-sandbox", "ubuntu:25.10", &packages);

--- a/crates/tools/src/sandbox/tests/docker_router.rs
+++ b/crates/tools/src/sandbox/tests/docker_router.rs
@@ -533,7 +533,9 @@ fn test_sandbox_image_dockerfile_adds_nodesource_for_nodejs() {
     let dockerfile = sandbox_image_dockerfile("ubuntu:25.10", &["curl".into(), "nodejs".into()]);
     assert!(dockerfile.contains("nodesource.gpg"));
     assert!(dockerfile.contains("node_22.x"));
-    // nodejs should remain in the apt-get install line
+    // Bootstraps curl+gnupg before using them
+    assert!(dockerfile.contains("apt-get install -y -qq curl gnupg"));
+    // nodejs should remain in the main apt-get install line
     assert!(dockerfile.contains("nodejs"));
     // npm is superseded by NodeSource nodejs and should be filtered out
     let dockerfile_with_npm = sandbox_image_dockerfile("ubuntu:25.10", &[
@@ -541,12 +543,20 @@ fn test_sandbox_image_dockerfile_adds_nodesource_for_nodejs() {
         "nodejs".into(),
         "npm".into(),
     ]);
-    assert!(!dockerfile_with_npm.contains(" npm"));
+    assert!(!dockerfile_with_npm.contains(" npm "));
 }
 
 #[test]
 fn test_sandbox_image_dockerfile_no_nodesource_without_nodejs() {
     let dockerfile = sandbox_image_dockerfile("ubuntu:25.10", &["curl".into(), "git".into()]);
+    assert!(!dockerfile.contains("nodesource"));
+}
+
+#[test]
+fn test_sandbox_image_dockerfile_npm_without_nodejs_kept() {
+    // npm without nodejs is a valid config — should not be filtered
+    let dockerfile = sandbox_image_dockerfile("ubuntu:25.10", &["npm".into(), "curl".into()]);
+    assert!(dockerfile.contains("npm"));
     assert!(!dockerfile.contains("nodesource"));
 }
 

--- a/crates/tools/src/sandbox_packages.rs
+++ b/crates/tools/src/sandbox_packages.rs
@@ -49,8 +49,7 @@ const CATEGORY_MAP: &[(&str, &[&str])] = &[
         "python3-pip",
         "python3-venv",
         "python-is-python3",
-        "nodejs",
-        "npm",
+        "nodejs", // NodeSource 22.x (npm bundled)
         "ruby",
         "golang-go",
     ]),


### PR DESCRIPTION
## Summary

- Sandbox containers now install Node.js 22 LTS via NodeSource instead of Node.js 20 from Ubuntu apt repos
- Removes separate `npm` package from defaults since NodeSource's `nodejs` bundles it
- Mirrors the approach already used in the main Moltis Dockerfile

## Validation

### Completed
- [x] `cargo +nightly-2025-11-30 fmt --all -- --check`
- [x] `cargo clippy -p moltis-tools -p moltis-config -- -D warnings`
- [x] `cargo test -p moltis-tools sandbox` (225 tests pass)
- [x] `cargo test -p moltis-config` (247 tests pass)

### Remaining
- [ ] `./scripts/local-validate.sh`
- [ ] Rebuild sandbox image and verify `node -v` reports v22

## Manual QA

1. Run `moltis sandbox build` to rebuild the sandbox image
2. Exec into sandbox: `moltis sandbox exec -- node -v` → should show v22.x
3. Verify npm is available: `moltis sandbox exec -- npm -v`