### PR TITLE
Add Kimi K2.6 model to Moonshot and Kimi Code providers

### DIFF
--- a/crates/providers/src/kimi_code.rs
+++ b/crates/providers/src/kimi_code.rs
@@ -181,6 +181,7 @@ pub fn has_stored_tokens() -> bool {
 pub const KIMI_CODE_MODELS: &[(&str, &str)] = &[
     ("kimi-for-coding", "Kimi For Coding"),
     ("kimi-k2.5", "Kimi K2.5"),
+    ("kimi-k2.6", "Kimi K2.6"),
 ];
 
 // ── LlmProvider impl ────────────────────────────────────────────────────────

--- a/crates/providers/src/model_catalogs.rs
+++ b/crates/providers/src/model_catalogs.rs
@@ -108,7 +108,10 @@ pub(crate) const DEEPSEEK_MODELS: &[(&str, &str)] = &[
 ];
 
 /// Known Moonshot models.
-pub(crate) const MOONSHOT_MODELS: &[(&str, &str)] = &[("kimi-k2.5", "Kimi K2.5")];
+pub(crate) const MOONSHOT_MODELS: &[(&str, &str)] = &[
+    ("kimi-k2.5", "Kimi K2.5"),
+    ("kimi-k2.6", "Kimi K2.6"),
+];
 
 /// Known Google Gemini models.
 /// See: <https://ai.google.dev/gemini-api/docs/models>

--- a/crates/providers/tests/kimi_code_integration.rs
+++ b/crates/providers/tests/kimi_code_integration.rs
@@ -19,7 +19,7 @@ use {
 const BASE_URL: &str = "https://api.kimi.com/coding/v1";
 const TEST_MODEL: &str = "kimi-k2.5";
 
-const KNOWN_MODELS: &[&str] = &["kimi-for-coding", "kimi-k2.5"];
+const KNOWN_MODELS: &[&str] = &["kimi-for-coding", "kimi-k2.5", "kimi-k2.6"];
 
 fn api_key() -> Secret<String> {
     Secret::new(

--- a/crates/providers/tests/moonshot_integration.rs
+++ b/crates/providers/tests/moonshot_integration.rs
@@ -22,7 +22,7 @@ const TEST_MODEL: &str = "kimi-k2.5";
 
 /// Known Moonshot models we catalog. Keep in sync with `MOONSHOT_MODELS` in
 /// `crates/providers/src/lib.rs`.
-const KNOWN_MODELS: &[&str] = &["kimi-k2.5"];
+const KNOWN_MODELS: &[&str] = &["kimi-k2.5", "kimi-k2.6"];
 
 fn api_key() -> Secret<String> {
     let key = std::env::var("MOONSHOT_API_KEY")


### PR DESCRIPTION
## Summary

- Add `kimi-k2.6` to the Moonshot OpenAI-compatible model catalog and Kimi Code provider
- Update integration test `KNOWN_MODELS` for both providers

Kimi K2.6 just launched with strong coding benchmarks (SWE-Bench Pro 58.6, HLE 54.0, SWE-bench Multilingual 76.7). Available via both the Moonshot API (`api.moonshot.ai`) and Kimi Code API (`api.kimi.com`).

## Validation

### Completed
- [x] `cargo check -p moltis-providers` passes
- [x] `model_lists_have_unique_ids` test passes
- [x] `model_lists_not_empty` test passes

### Remaining
- [ ] `cargo +nightly-2025-11-30 fmt --all -- --check`
- [ ] `just lint`
- [ ] `just test`
- [ ] Integration tests with `MOONSHOT_API_KEY` / `KIMI_API_KEY`

## Manual QA

1. Set `MOONSHOT_API_KEY` and verify `kimi-k2.6` appears in model list
2. Set `KIMI_API_KEY` and verify `kimi-k2.6` appears in Kimi Code model list
3. Send a test message to `kimi-k2.6` via either provider