### PR TITLE
fix(sandbox): verify image in Podman store after BuildKit build

### DIFF
--- a/crates/tools/src/sandbox/docker.rs
+++ b/crates/tools/src/sandbox/docker.rs
@@ -51,7 +51,7 @@ pub(crate) enum BackendKind {
 /// behaviour branching without string comparisons.
 pub struct DockerSandbox {
     pub config: SandboxConfig,
-    kind: BackendKind,
+    pub(crate) kind: BackendKind,
     cli: &'static str,
     backend_label: &'static str,
     /// Container names that have already been provisioned in this process.
@@ -98,7 +98,7 @@ impl DockerSandbox {
         format!("{}-{}", self.container_prefix(), id.key)
     }
 
-    fn image_repo(&self) -> &str {
+    pub(crate) fn image_repo(&self) -> &str {
         self.container_prefix()
     }
 
@@ -306,6 +306,99 @@ impl DockerSandbox {
         };
         Ok(result.tag)
     }
+
+    /// Export an image from BuildKit's cache into the Podman store.
+    ///
+    /// When Podman delegates `podman build` to a BuildKit daemon the image may
+    /// land only in BuildKit's internal cache.  This method re-runs the build
+    /// with `--output type=docker,dest=<file>` (a BuildKit cache-hit, so
+    /// essentially free) and pipes the tarball into `podman load`.
+    async fn export_buildkit_image_to_store(
+        &self,
+        tag: &str,
+        dockerfile_path: &std::path::Path,
+        context_dir: &std::path::Path,
+    ) -> Result<()> {
+        let tar_path = std::env::temp_dir().join(format!(
+            "moltis-sandbox-export-{}.tar",
+            uuid::Uuid::new_v4()
+        ));
+
+        // Re-build with docker-archive output.  BuildKit's layer cache makes
+        // this a near-instant cache hit for the same Dockerfile.
+        let export_output = tokio::process::Command::new(self.cli)
+            .args([
+                "build",
+                "--output",
+                &format!("type=docker,dest={}", tar_path.display()),
+                "-f",
+            ])
+            .arg(dockerfile_path)
+            .arg(context_dir)
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .output()
+            .await?;
+
+        if !export_output.status.success() {
+            let _ = std::fs::remove_file(&tar_path);
+            let stderr = String::from_utf8_lossy(&export_output.stderr);
+            return Err(Error::message(format!(
+                "podman build --output failed for {tag}: {}",
+                stderr.trim()
+            )));
+        }
+
+        // Load the tarball into the Podman store.
+        let load_output = tokio::process::Command::new(self.cli)
+            .args(["load", "-i"])
+            .arg(&tar_path)
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .output()
+            .await?;
+
+        let _ = std::fs::remove_file(&tar_path);
+
+        if !load_output.status.success() {
+            let stderr = String::from_utf8_lossy(&load_output.stderr);
+            return Err(Error::message(format!(
+                "podman load failed for {tag}: {}",
+                stderr.trim()
+            )));
+        }
+
+        // The loaded image may have a different name — re-tag it.
+        let retag_output = tokio::process::Command::new(self.cli)
+            .args(["tag"])
+            .arg(tag)
+            .arg(tag)
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::piped())
+            .output()
+            .await;
+
+        // Ignore tag errors — the load may have already applied the right name.
+        if let Ok(ref o) = retag_output
+            && !o.status.success()
+        {
+            debug!(
+                tag,
+                stderr = %String::from_utf8_lossy(&o.stderr).trim(),
+                "podman tag after load failed (non-fatal)"
+            );
+        }
+
+        // Final verification.
+        if !sandbox_image_exists(self.cli, tag).await {
+            return Err(Error::message(format!(
+                "image {tag} still missing from podman store after BuildKit export"
+            )));
+        }
+
+        info!(tag, "successfully exported BuildKit image to podman store");
+        Ok(())
+    }
 }
 
 #[async_trait]
@@ -443,11 +536,9 @@ impl Sandbox for DockerSandbox {
             .output()
             .await;
 
-        // Clean up temp dir regardless of result.
-        let _ = std::fs::remove_dir_all(&tmp_dir);
-
         let output = output?;
         if !output.status.success() {
+            let _ = std::fs::remove_dir_all(&tmp_dir);
             let stdout = String::from_utf8_lossy(&output.stdout);
             let stderr = String::from_utf8_lossy(&output.stderr);
             warn!(
@@ -466,6 +557,23 @@ impl Sandbox for DockerSandbox {
 
         let stdout = String::from_utf8_lossy(&output.stdout);
         debug!(tag, output = %tail_lines(&stdout, 20), "docker build output");
+
+        // Podman with BuildKit: the build may succeed (exit 0) but leave the
+        // image in BuildKit's internal cache instead of the Podman store.
+        // Verify the image is actually present and recover if not.
+        if self.kind == BackendKind::Podman && !sandbox_image_exists(self.cli, &tag).await {
+            warn!(
+                tag,
+                "podman build succeeded but image missing from store \
+                 (likely BuildKit delegation), exporting via tarball"
+            );
+            self.export_buildkit_image_to_store(&tag, &dockerfile_path, &tmp_dir)
+                .await?;
+        }
+
+        // Clean up temp dir after post-build verification.
+        let _ = std::fs::remove_dir_all(&tmp_dir);
+
         info!(tag, "pre-built sandbox image ready");
         Ok(Some(BuildImageResult { tag, built: true }))
     }

--- a/crates/tools/src/sandbox/docker.rs
+++ b/crates/tools/src/sandbox/docker.rs
@@ -324,13 +324,17 @@ impl DockerSandbox {
             uuid::Uuid::new_v4()
         ));
 
-        // Re-build with docker-archive output.  BuildKit's layer cache makes
-        // this a near-instant cache hit for the same Dockerfile.
+        // Re-build with docker-archive output.  The `-t` flag embeds the
+        // correct tag in the archive so `podman load` names it correctly.
+        // BuildKit's layer cache makes this a near-instant cache hit for the
+        // same Dockerfile.
         let export_output = tokio::process::Command::new(self.cli)
             .args([
                 "build",
                 "--output",
                 &format!("type=docker,dest={}", tar_path.display()),
+                "-t",
+                tag,
                 "-f",
             ])
             .arg(dockerfile_path)
@@ -366,27 +370,6 @@ impl DockerSandbox {
                 "podman load failed for {tag}: {}",
                 stderr.trim()
             )));
-        }
-
-        // The loaded image may have a different name — re-tag it.
-        let retag_output = tokio::process::Command::new(self.cli)
-            .args(["tag"])
-            .arg(tag)
-            .arg(tag)
-            .stdout(std::process::Stdio::null())
-            .stderr(std::process::Stdio::piped())
-            .output()
-            .await;
-
-        // Ignore tag errors — the load may have already applied the right name.
-        if let Ok(ref o) = retag_output
-            && !o.status.success()
-        {
-            debug!(
-                tag,
-                stderr = %String::from_utf8_lossy(&o.stderr).trim(),
-                "podman tag after load failed (non-fatal)"
-            );
         }
 
         // Final verification.
@@ -567,12 +550,15 @@ impl Sandbox for DockerSandbox {
                 "podman build succeeded but image missing from store \
                  (likely BuildKit delegation), exporting via tarball"
             );
-            self.export_buildkit_image_to_store(&tag, &dockerfile_path, &tmp_dir)
-                .await?;
+            let export_result = self
+                .export_buildkit_image_to_store(&tag, &dockerfile_path, &tmp_dir)
+                .await;
+            // Clean up temp dir regardless of export result.
+            let _ = std::fs::remove_dir_all(&tmp_dir);
+            export_result?;
+        } else {
+            let _ = std::fs::remove_dir_all(&tmp_dir);
         }
-
-        // Clean up temp dir after post-build verification.
-        let _ = std::fs::remove_dir_all(&tmp_dir);
 
         info!(tag, "pre-built sandbox image ready");
         Ok(Some(BuildImageResult { tag, built: true }))

--- a/crates/tools/src/sandbox/tests/core.rs
+++ b/crates/tools/src/sandbox/tests/core.rs
@@ -602,6 +602,20 @@ async fn test_provisioning_guard_independent_containers() {
 }
 
 #[test]
+fn test_podman_build_verifies_image_in_store() {
+    // The Podman constructor must set `kind = BackendKind::Podman` so the
+    // post-build verification branch in `build_image` activates.
+    let sandbox = DockerSandbox::podman(SandboxConfig::default());
+    assert_eq!(sandbox.kind, BackendKind::Podman);
+    assert_eq!(sandbox.backend_name(), "podman");
+
+    // Docker constructor must NOT be Podman.
+    let docker = DockerSandbox::new(SandboxConfig::default());
+    assert_eq!(docker.kind, BackendKind::Docker);
+    assert_ne!(docker.kind, BackendKind::Podman);
+}
+
+#[test]
 fn test_tail_lines_fewer_than_n() {
     let text = "line1\nline2\nline3";
     assert_eq!(tail_lines(text, 5), text);

--- a/crates/tools/src/sandbox/tests/docker_router.rs
+++ b/crates/tools/src/sandbox/tests/docker_router.rs
@@ -1,4 +1,6 @@
 #![allow(clippy::unwrap_used, clippy::expect_used)]
+use std::env;
+
 use super::*;
 
 #[test]
@@ -653,4 +655,49 @@ async fn test_sandbox_router_global_image_override() {
     router.remove_image_override("main").await;
     let img = router.default_image().await;
     assert_eq!(img, DEFAULT_SANDBOX_IMAGE);
+}
+
+/// E2E regression test for #796: Podman+BuildKit may leave images in
+/// BuildKit's cache instead of the Podman store.  Gated behind
+/// `MOLTIS_SANDBOX_RUNTIME_E2E=1` and requires Podman to be installed.
+#[tokio::test]
+async fn test_podman_build_image_exists_in_store() {
+    let enabled = env::var("MOLTIS_SANDBOX_RUNTIME_E2E")
+        .map(|v| matches!(v.trim().to_ascii_lowercase().as_str(), "1" | "true" | "yes"))
+        .unwrap_or(false);
+    if !enabled || !is_cli_available("podman") {
+        eprintln!(
+            "skipping test_podman_build_image_exists_in_store (set MOLTIS_SANDBOX_RUNTIME_E2E=1 and install podman)"
+        );
+        return;
+    }
+
+    let sandbox = DockerSandbox::podman(SandboxConfig::default());
+    let packages = vec!["curl".into()];
+    let tag = sandbox_image_tag(sandbox.image_repo(), "ubuntu:25.10", &packages);
+
+    // Remove any pre-existing image so we exercise the full build path.
+    let _ = tokio::process::Command::new("podman")
+        .args(["rmi", "-f", &tag])
+        .output()
+        .await;
+
+    let result = sandbox
+        .build_image("ubuntu:25.10", &packages)
+        .await
+        .expect("build_image should succeed");
+    let result = result.expect("build_image should return Some for non-empty packages");
+    assert_eq!(result.tag, tag);
+
+    // The critical assertion: the image must be in the Podman store.
+    assert!(
+        sandbox_image_exists("podman", &tag).await,
+        "image {tag} must exist in podman store after build_image"
+    );
+
+    // Cleanup.
+    let _ = tokio::process::Command::new("podman")
+        .args(["rmi", "-f", &tag])
+        .output()
+        .await;
 }


### PR DESCRIPTION
## Summary

- After `podman build` succeeds, verify the image is actually in the Podman store via `sandbox_image_exists()`
- If missing (BuildKit delegation scenario), export via `--output type=docker,dest=<tmpfile>` + `podman load` to force the image into the store
- Normal Podman+buildah and Docker flows are unaffected — the verify check passes immediately

Fixes #796

## Validation

### Completed
- [x] `cargo +nightly-2025-11-30 fmt --all -- --check` — clean
- [x] `just lint` — passes
- [x] `just test` — 5024 tests pass
- [x] `cargo test -p moltis-tools test_podman_build` — 2 new tests pass

### Remaining
- [ ] `MOLTIS_SANDBOX_RUNTIME_E2E=1 cargo test -p moltis-tools test_podman_build_image_exists` on a Linux host with Podman + BuildKit to reproduce the original bug

## Manual QA

1. On Debian/Podman 5.4.2 with BuildKit enabled (`buildx_buildkit_default` container running):
   - Run `moltis sandbox build` — image should appear in `podman images`
   - Run `moltis sandbox list` — built image should be listed
   - Start a sandbox session — container should launch without "image not found"
2. On Docker Desktop (macOS/Linux): verify no behavior change — build still works as before