### PR TITLE
fix(providers): disable strict tools for Fireworks Kimi router

### DIFF
--- a/crates/providers/src/model_catalogs.rs
+++ b/crates/providers/src/model_catalogs.rs
@@ -58,6 +58,15 @@ pub(crate) const ZAI_MODELS: &[(&str, &str)] = &[
     ("glm-4-32b-0414-128k", "GLM-4 32B 128K"),
 ];
 
+/// Whether a model is a Fireworks Fire Pass router for Kimi/Moonshot.
+///
+/// These models proxy through Fireworks to Moonshot's Kimi API, which has
+/// different schema and message requirements (no strict tools, needs
+/// `reasoning_content`). Issue #810.
+pub(crate) fn is_fireworks_kimi_router(def: &OpenAiCompatDef, model_id: &str) -> bool {
+    def.config_name == "fireworks" && model_id.contains("/routers/") && model_id.contains("kimi")
+}
+
 /// Known Fireworks models.
 pub(crate) const FIREWORKS_MODELS: &[(&str, &str)] = &[
     (
@@ -434,5 +443,45 @@ mod tests {
             "expected 'localhost' in Ollama default_base_url, got: {}",
             ollama.default_base_url,
         );
+    }
+
+    #[test]
+    fn is_fireworks_kimi_router_detects_router_model() {
+        let fireworks = OPENAI_COMPAT_PROVIDERS
+            .iter()
+            .find(|d| d.config_name == "fireworks")
+            .expect("fireworks entry must exist");
+        assert!(is_fireworks_kimi_router(
+            fireworks,
+            "accounts/fireworks/routers/kimi-k2p5-turbo"
+        ));
+    }
+
+    #[test]
+    fn is_fireworks_kimi_router_rejects_native_model() {
+        let fireworks = OPENAI_COMPAT_PROVIDERS
+            .iter()
+            .find(|d| d.config_name == "fireworks")
+            .expect("fireworks entry must exist");
+        assert!(!is_fireworks_kimi_router(
+            fireworks,
+            "accounts/fireworks/models/deepseek-v3p2"
+        ));
+        assert!(!is_fireworks_kimi_router(
+            fireworks,
+            "accounts/fireworks/models/kimi-k2-instruct-0905"
+        ));
+    }
+
+    #[test]
+    fn is_fireworks_kimi_router_rejects_other_providers() {
+        let deepseek = OPENAI_COMPAT_PROVIDERS
+            .iter()
+            .find(|d| d.config_name == "deepseek")
+            .expect("deepseek entry must exist");
+        assert!(!is_fireworks_kimi_router(
+            deepseek,
+            "accounts/fireworks/routers/kimi-k2p5-turbo"
+        ));
     }
 }

--- a/crates/providers/src/openai/mod.rs
+++ b/crates/providers/src/openai/mod.rs
@@ -27,6 +27,8 @@ pub struct OpenAiProvider {
     cache_retention: moltis_config::CacheRetention,
     /// Explicit override for strict tool schema mode. `None` = auto-detect.
     strict_tools_override: Option<bool>,
+    /// Explicit override for reasoning_content requirement. `None` = auto-detect.
+    reasoning_content_override: Option<bool>,
     /// Global per-model context window overrides from `[models.<id>]` config.
     context_window_global: std::collections::HashMap<String, u32>,
     /// Provider-scoped per-model context window overrides from

--- a/crates/providers/src/openai/provider/core.rs
+++ b/crates/providers/src/openai/provider/core.rs
@@ -34,6 +34,7 @@ impl OpenAiProvider {
             reasoning_effort: None,
             cache_retention: moltis_config::CacheRetention::Short,
             strict_tools_override: None,
+            reasoning_content_override: None,
             context_window_global: std::collections::HashMap::new(),
             context_window_provider: std::collections::HashMap::new(),
         }
@@ -58,6 +59,7 @@ impl OpenAiProvider {
             reasoning_effort: None,
             cache_retention: moltis_config::CacheRetention::Short,
             strict_tools_override: None,
+            reasoning_content_override: None,
             context_window_global: std::collections::HashMap::new(),
             context_window_provider: std::collections::HashMap::new(),
         }
@@ -90,6 +92,12 @@ impl OpenAiProvider {
     #[must_use]
     pub fn with_strict_tools(mut self, strict: bool) -> Self {
         self.strict_tools_override = Some(strict);
+        self
+    }
+
+    #[must_use]
+    pub fn with_reasoning_content(mut self, required: bool) -> Self {
+        self.reasoning_content_override = Some(required);
         self
     }
 
@@ -190,6 +198,7 @@ impl LlmProvider for OpenAiProvider {
             context_window_global: self.context_window_global.clone(),
             context_window_provider: self.context_window_provider.clone(),
             strict_tools_override: self.strict_tools_override,
+            reasoning_content_override: self.reasoning_content_override,
         }))
     }
 

--- a/crates/providers/src/openai/provider/request.rs
+++ b/crates/providers/src/openai/provider/request.rs
@@ -105,6 +105,12 @@ impl OpenAiProvider {
         {
             return false;
         }
+        // Fireworks Fire Pass router models for Kimi route to Moonshot,
+        // which rejects strict-mode schemas (type arrays, forced
+        // additionalProperties). Issue #810.
+        if self.is_fireworks_kimi_router() {
+            return false;
+        }
         true
     }
 
@@ -113,6 +119,20 @@ impl OpenAiProvider {
             || self.base_url.contains("moonshot.ai")
             || self.base_url.contains("moonshot.cn")
             || self.model.starts_with("kimi-")
+            // Fireworks Fire Pass routes kimi-k2p5-turbo to Moonshot,
+            // which requires reasoning_content on tool-call messages.
+            || self.is_fireworks_kimi_router()
+    }
+
+    /// Detect Fireworks Fire Pass router models that route to Moonshot/Kimi.
+    ///
+    /// These models use Fireworks as a proxy but the backend is Moonshot's Kimi
+    /// API, which has different schema and message requirements than Fireworks'
+    /// native models. Pattern: `accounts/fireworks/routers/kimi-*`.
+    fn is_fireworks_kimi_router(&self) -> bool {
+        self.base_url.contains("fireworks.ai")
+            && self.model.contains("/routers/")
+            && self.model.contains("kimi")
     }
 
     /// Some providers (e.g. MiniMax) reject `role: "system"` in the messages
@@ -564,5 +584,65 @@ mod tests {
         assert_eq!(messages[0]["role"], "system");
         assert_eq!(messages[0]["content"], "sys1\n\nsys2");
         assert_eq!(messages[1]["role"], "user");
+    }
+
+    // ── Fireworks Kimi router detection (issue #810) ─────────────────
+
+    #[test]
+    fn fireworks_kimi_router_disables_strict_tools() {
+        let p = provider(
+            "accounts/fireworks/routers/kimi-k2p5-turbo",
+            "fireworks",
+            "https://api.fireworks.ai/inference/v1",
+        );
+        assert!(
+            !p.needs_strict_tools(),
+            "Fireworks Kimi router must not use strict tools (issue #810)"
+        );
+    }
+
+    #[test]
+    fn fireworks_kimi_router_requires_reasoning_content() {
+        let p = provider(
+            "accounts/fireworks/routers/kimi-k2p5-turbo",
+            "fireworks",
+            "https://api.fireworks.ai/inference/v1",
+        );
+        assert!(
+            p.requires_reasoning_content_on_tool_messages(),
+            "Fireworks Kimi router must add reasoning_content (issue #810)"
+        );
+    }
+
+    #[test]
+    fn fireworks_native_model_still_uses_strict_tools() {
+        let p = provider(
+            "accounts/fireworks/models/deepseek-v3p2",
+            "fireworks",
+            "https://api.fireworks.ai/inference/v1",
+        );
+        assert!(
+            p.needs_strict_tools(),
+            "Native Fireworks models should use strict tools"
+        );
+    }
+
+    #[test]
+    fn fireworks_native_model_no_reasoning_content() {
+        let p = provider(
+            "accounts/fireworks/models/deepseek-v3p2",
+            "fireworks",
+            "https://api.fireworks.ai/inference/v1",
+        );
+        assert!(
+            !p.requires_reasoning_content_on_tool_messages(),
+            "Native Fireworks models should not add reasoning_content"
+        );
+    }
+
+    #[test]
+    fn moonshot_direct_still_requires_reasoning_content() {
+        let p = provider("kimi-k2.5", "moonshot", "https://api.moonshot.ai/v1");
+        assert!(p.requires_reasoning_content_on_tool_messages());
     }
 }

--- a/crates/providers/src/openai/provider/request.rs
+++ b/crates/providers/src/openai/provider/request.rs
@@ -105,34 +105,17 @@ impl OpenAiProvider {
         {
             return false;
         }
-        // Fireworks Fire Pass router models for Kimi route to Moonshot,
-        // which rejects strict-mode schemas (type arrays, forced
-        // additionalProperties). Issue #810.
-        if self.is_fireworks_kimi_router() {
-            return false;
-        }
         true
     }
 
     fn requires_reasoning_content_on_tool_messages(&self) -> bool {
+        if let Some(explicit) = self.reasoning_content_override {
+            return explicit;
+        }
         self.provider_name.eq_ignore_ascii_case("moonshot")
             || self.base_url.contains("moonshot.ai")
             || self.base_url.contains("moonshot.cn")
             || self.model.starts_with("kimi-")
-            // Fireworks Fire Pass routes kimi-k2p5-turbo to Moonshot,
-            // which requires reasoning_content on tool-call messages.
-            || self.is_fireworks_kimi_router()
-    }
-
-    /// Detect Fireworks Fire Pass router models that route to Moonshot/Kimi.
-    ///
-    /// These models use Fireworks as a proxy but the backend is Moonshot's Kimi
-    /// API, which has different schema and message requirements than Fireworks'
-    /// native models. Pattern: `accounts/fireworks/routers/kimi-*`.
-    fn is_fireworks_kimi_router(&self) -> bool {
-        self.base_url.contains("fireworks.ai")
-            && self.model.contains("/routers/")
-            && self.model.contains("kimi")
     }
 
     /// Some providers (e.g. MiniMax) reject `role: "system"` in the messages
@@ -586,36 +569,40 @@ mod tests {
         assert_eq!(messages[1]["role"], "user");
     }
 
-    // ── Fireworks Kimi router detection (issue #810) ─────────────────
+    // ── strict_tools and reasoning_content overrides (issue #810) ───
 
     #[test]
-    fn fireworks_kimi_router_disables_strict_tools() {
-        let p = provider(
-            "accounts/fireworks/routers/kimi-k2p5-turbo",
-            "fireworks",
-            "https://api.fireworks.ai/inference/v1",
-        );
+    fn strict_tools_override_false_disables_strict() {
+        let p = OpenAiProvider::new_with_name(
+            generated_api_key(),
+            "accounts/fireworks/routers/kimi-k2p5-turbo".into(),
+            "https://api.fireworks.ai/inference/v1".into(),
+            "fireworks".into(),
+        )
+        .with_strict_tools(false);
         assert!(
             !p.needs_strict_tools(),
-            "Fireworks Kimi router must not use strict tools (issue #810)"
+            "strict_tools_override=false must disable strict tools (issue #810)"
         );
     }
 
     #[test]
-    fn fireworks_kimi_router_requires_reasoning_content() {
-        let p = provider(
-            "accounts/fireworks/routers/kimi-k2p5-turbo",
-            "fireworks",
-            "https://api.fireworks.ai/inference/v1",
-        );
+    fn reasoning_content_override_true_enables_reasoning() {
+        let p = OpenAiProvider::new_with_name(
+            generated_api_key(),
+            "accounts/fireworks/routers/kimi-k2p5-turbo".into(),
+            "https://api.fireworks.ai/inference/v1".into(),
+            "fireworks".into(),
+        )
+        .with_reasoning_content(true);
         assert!(
             p.requires_reasoning_content_on_tool_messages(),
-            "Fireworks Kimi router must add reasoning_content (issue #810)"
+            "reasoning_content_override=true must enable reasoning_content (issue #810)"
         );
     }
 
     #[test]
-    fn fireworks_native_model_still_uses_strict_tools() {
+    fn fireworks_native_model_defaults_to_strict_tools() {
         let p = provider(
             "accounts/fireworks/models/deepseek-v3p2",
             "fireworks",
@@ -623,7 +610,7 @@ mod tests {
         );
         assert!(
             p.needs_strict_tools(),
-            "Native Fireworks models should use strict tools"
+            "Native Fireworks models should use strict tools by default"
         );
     }
 
@@ -641,7 +628,7 @@ mod tests {
     }
 
     #[test]
-    fn moonshot_direct_still_requires_reasoning_content() {
+    fn moonshot_direct_auto_detects_reasoning_content() {
         let p = provider("kimi-k2.5", "moonshot", "https://api.moonshot.ai/v1");
         assert!(p.requires_reasoning_content_on_tool_messages());
     }

--- a/crates/providers/src/registry/registration.rs
+++ b/crates/providers/src/registry/registration.rs
@@ -948,6 +948,20 @@ impl ProviderRegistry {
                     oai = oai.with_strict_tools(strict);
                 }
 
+                // Fireworks Fire Pass router models for Kimi route to
+                // Moonshot, which rejects strict-mode schemas and requires
+                // reasoning_content on tool-call messages (issue #810).
+                if is_fireworks_kimi_router(def, &model_id) {
+                    if config
+                        .get(def.config_name)
+                        .and_then(|e| e.strict_tools)
+                        .is_none()
+                    {
+                        oai = oai.with_strict_tools(false);
+                    }
+                    oai = oai.with_reasoning_content(true);
+                }
+
                 let provider = Arc::new(oai);
                 self.register(
                     ModelInfo {

--- a/crates/providers/tests/fireworks_integration.rs
+++ b/crates/providers/tests/fireworks_integration.rs
@@ -328,6 +328,99 @@ async fn catalog_models_are_live() {
     );
 }
 
+// ── Fire Pass router: Kimi K2.5 Turbo (issue #810) ──────────────────────────
+
+const KIMI_ROUTER_MODEL: &str = "accounts/fireworks/routers/kimi-k2p5-turbo";
+
+/// Basic completion via Fireworks Fire Pass router to Kimi K2.5 must succeed.
+/// Regression test for issue #810 where strict mode schemas caused 400 errors.
+#[tokio::test]
+#[ignore]
+async fn kimi_router_basic_completion() {
+    let p = make_provider(KIMI_ROUTER_MODEL);
+    let messages = vec![ChatMessage::user(
+        "What is 2+2? Answer with just the number.",
+    )];
+
+    let response = p
+        .complete(&messages, &[])
+        .await
+        .expect("Kimi K2.5 via Fire Pass should succeed (issue #810)");
+
+    let text = response.text.expect("should have text response");
+    assert!(text.contains('4'), "expected '4' in response: {text:?}");
+}
+
+/// Tool calling via Fireworks Fire Pass Kimi K2.5 must not return 400.
+/// This was the primary regression in issue #810: strict tool schemas were
+/// sent to a backend that doesn't support them.
+#[tokio::test]
+#[ignore]
+async fn kimi_router_tool_call_no_400() {
+    let p = make_provider(KIMI_ROUTER_MODEL);
+    let tools = vec![weather_tool()];
+    let messages = vec![ChatMessage::user(
+        "What's the weather in Berlin? You must use the get_weather tool.",
+    )];
+
+    let response = p
+        .complete(&messages, &tools)
+        .await
+        .expect("Kimi K2.5 via Fire Pass tool call should not 400 (issue #810)");
+
+    assert!(
+        !response.tool_calls.is_empty(),
+        "Kimi router should call tools, got text: {:?}",
+        response.text
+    );
+    assert_eq!(response.tool_calls[0].name, "get_weather");
+}
+
+/// Multi-turn tool use with Kimi via Fire Pass: exercises reasoning_content
+/// serialization that Moonshot requires on assistant tool-call messages.
+#[tokio::test]
+#[ignore]
+async fn kimi_router_multi_turn_tool_use() {
+    let p = make_provider(KIMI_ROUTER_MODEL);
+    let tools = vec![weather_tool()];
+
+    // Step 1: trigger tool call
+    let messages = vec![ChatMessage::user(
+        "What's the weather in Tokyo? You must use the get_weather tool.",
+    )];
+    let response = p
+        .complete(&messages, &tools)
+        .await
+        .expect("first turn should succeed");
+
+    assert!(
+        !response.tool_calls.is_empty(),
+        "should call get_weather, got text: {:?}",
+        response.text
+    );
+    let tc = &response.tool_calls[0];
+
+    // Step 2: provide result
+    let messages = vec![
+        ChatMessage::user("What's the weather in Tokyo? You must use the get_weather tool."),
+        ChatMessage::assistant_with_tools(response.text.clone(), vec![ToolCall {
+            id: tc.id.clone(),
+            name: tc.name.clone(),
+            arguments: tc.arguments.clone(),
+            metadata: tc.metadata.clone(),
+        }]),
+        ChatMessage::tool(&tc.id, r#"{"temperature": 28, "condition": "sunny"}"#),
+    ];
+
+    let final_response = p
+        .complete(&messages, &tools)
+        .await
+        .expect("second turn with tool result should succeed (issue #810)");
+
+    let text = final_response.text.expect("should have text response");
+    assert!(!text.is_empty(), "final response should not be empty");
+}
+
 /// Discover new models via the Fireworks /models endpoint and compare with
 /// our static catalog.
 #[tokio::test]


### PR DESCRIPTION
## Summary

- Fixes 400 error when using Kimi K2.5 Turbo via Fireworks Fire Pass (`accounts/fireworks/routers/kimi-k2p5-turbo`)
- Disables strict tool schemas for Fireworks Kimi router models (Moonshot backend rejects type arrays and forced `additionalProperties`)
- Enables `reasoning_content` on assistant tool-call messages for these models (required by Moonshot for multi-turn tool use)

Closes #810

## Validation

### Completed
- [x] `cargo +nightly-2025-11-30 fmt --all -- --check`
- [x] `just lint` (clippy clean)
- [x] `just test` (5030 tests pass)
- [x] Unit tests: 5 new tests covering detection logic for router vs native Fireworks models
- [x] Integration tests: 3 new live API tests for Kimi router (basic completion, tool call, multi-turn)

### Remaining
- [ ] `cargo test --test fireworks_integration -- --ignored` (requires `FIREWORKS_API_KEY`)

## Manual QA

1. Set model to `accounts/fireworks/routers/kimi-k2p5-turbo` via Fireworks
2. Send a message — should get a response without 400
3. Trigger tool use (e.g. "what's the weather?") — should call tools and respond


🤖 Generated with [Claude Code](https://claude.com/claude-code)