### PR TITLE
fix(telegram): infer MIME from filename when Telegram sends octet-stream

### DIFF
--- a/crates/telegram/src/handlers/media.rs
+++ b/crates/telegram/src/handlers/media.rs
@@ -134,7 +134,8 @@ pub(super) fn extract_document_file(msg: &Message) -> Option<DocumentFileInfo> {
                 // Telegram often sends application/octet-stream for file types
                 // it doesn't recognise (e.g. .md, .toml, .yaml). Fall back to
                 // extension-based detection so these documents aren't silently
-                // dropped.
+                // dropped. Only the last extension segment is consulted
+                // (e.g. "archive.tar.gz" → "gz"), which is intentional.
                 let media_type = if normalized == "application/octet-stream" {
                     d.document
                         .file_name
@@ -265,6 +266,9 @@ pub(super) fn should_inline_document_text(media_type: &str) -> bool {
             | "text/x-yaml"
             | "application/json"
             | "application/xml"
+            // mime_guess returns text/x-toml and text/x-yaml for the inference
+            // path; the application/* variants cover cases where Telegram (or
+            // another source) sends these MIME types directly.
             | "application/toml"
             | "application/yaml"
             | "application/x-yaml"

--- a/crates/telegram/src/handlers/media.rs
+++ b/crates/telegram/src/handlers/media.rs
@@ -130,9 +130,25 @@ pub(super) fn extract_document_file(msg: &Message) -> Option<DocumentFileInfo> {
                     .as_ref()
                     .map(ToString::to_string)
                     .unwrap_or_else(|| "application/octet-stream".to_string());
+                let normalized = normalize_media_type(&raw);
+                // Telegram often sends application/octet-stream for file types
+                // it doesn't recognise (e.g. .md, .toml, .yaml). Fall back to
+                // extension-based detection so these documents aren't silently
+                // dropped.
+                let media_type = if normalized == "application/octet-stream" {
+                    d.document
+                        .file_name
+                        .as_deref()
+                        .and_then(|name| name.rsplit('.').next())
+                        .and_then(moltis_media::mime::mime_from_extension)
+                        .map(str::to_string)
+                        .unwrap_or(normalized)
+                } else {
+                    normalized
+                };
                 Some(DocumentFileInfo {
                     file_id: d.document.file.id.clone(),
-                    media_type: normalize_media_type(&raw),
+                    media_type,
                     file_name: d.document.file_name.clone(),
                 })
             },
@@ -244,8 +260,14 @@ pub(super) fn should_inline_document_text(media_type: &str) -> bool {
             | "text/markdown"
             | "text/x-markdown"
             | "text/xml"
+            | "text/csv"
+            | "text/x-toml"
+            | "text/x-yaml"
             | "application/json"
             | "application/xml"
+            | "application/toml"
+            | "application/yaml"
+            | "application/x-yaml"
     ) || media_type.ends_with("+json")
         || media_type.ends_with("+xml")
 }

--- a/crates/telegram/src/handlers/tests/media.rs
+++ b/crates/telegram/src/handlers/tests/media.rs
@@ -83,6 +83,100 @@ fn extract_document_file_defaults_media_type_when_missing() {
 }
 
 #[test]
+fn extract_document_file_infers_mime_from_extension_for_octet_stream() {
+    // Telegram sends application/octet-stream for .md files — we should
+    // derive text/markdown from the filename extension.
+    let msg: Message = serde_json::from_value(json!({
+        "message_id": 4,
+        "date": 1,
+        "chat": { "id": 42, "type": "private", "first_name": "Alice" },
+        "from": {
+            "id": 1001,
+            "is_bot": false,
+            "first_name": "Alice",
+            "username": "alice"
+        },
+        "document": {
+            "file_id": "doc-md-file-id",
+            "file_unique_id": "doc-md-unique-id",
+            "file_name": "notes.md",
+            "mime_type": "application/octet-stream",
+            "file_size": 256
+        }
+    }))
+    .expect("deserialize document message");
+
+    let document = extract_document_file(&msg).expect("document should be extracted");
+    assert_eq!(document.media_type, "text/markdown");
+    assert!(is_supported_document_type(&document.media_type));
+}
+
+#[test]
+fn extract_document_file_infers_mime_for_other_text_extensions() {
+    for (file_name, expected_mime) in [
+        ("config.toml", "text/x-toml"),
+        ("data.yaml", "text/x-yaml"),
+        ("data.yml", "text/x-yaml"),
+        ("readme.txt", "text/plain"),
+        ("schema.json", "application/json"),
+    ] {
+        let msg: Message = serde_json::from_value(json!({
+            "message_id": 5,
+            "date": 1,
+            "chat": { "id": 42, "type": "private", "first_name": "Alice" },
+            "from": {
+                "id": 1001,
+                "is_bot": false,
+                "first_name": "Alice",
+                "username": "alice"
+            },
+            "document": {
+                "file_id": "doc-file-id",
+                "file_unique_id": "doc-unique-id",
+                "file_name": file_name,
+                "mime_type": "application/octet-stream",
+                "file_size": 128
+            }
+        }))
+        .expect("deserialize document message");
+
+        let document = extract_document_file(&msg).expect("document should be extracted");
+        assert_eq!(
+            document.media_type, expected_mime,
+            "expected {expected_mime} for {file_name}, got {}",
+            document.media_type
+        );
+    }
+}
+
+#[test]
+fn extract_document_file_keeps_explicit_mime_when_not_octet_stream() {
+    // When Telegram provides a real MIME type, don't override it.
+    let msg: Message = serde_json::from_value(json!({
+        "message_id": 6,
+        "date": 1,
+        "chat": { "id": 42, "type": "private", "first_name": "Alice" },
+        "from": {
+            "id": 1001,
+            "is_bot": false,
+            "first_name": "Alice",
+            "username": "alice"
+        },
+        "document": {
+            "file_id": "doc-file-id",
+            "file_unique_id": "doc-unique-id",
+            "file_name": "photo.jpg",
+            "mime_type": "image/jpeg",
+            "file_size": 512
+        }
+    }))
+    .expect("deserialize document message");
+
+    let document = extract_document_file(&msg).expect("document should be extracted");
+    assert_eq!(document.media_type, "image/jpeg");
+}
+
+#[test]
 fn should_inline_markdown_document_types() {
     assert!(should_inline_document_text("text/markdown"));
     assert!(should_inline_document_text("text/x-markdown"));


### PR DESCRIPTION
## Summary

- Telegram sends `application/octet-stream` for file types it doesn't recognise (`.md`, `.toml`, `.yaml`, etc.), causing documents to be silently dropped
- Fall back to extension-based MIME detection via `moltis_media::mime::mime_from_extension` in `extract_document_file()` when the resolved type is `application/octet-stream`
- Expand `should_inline_document_text()` to cover `text/x-toml`, `text/x-yaml`, `text/csv`, and their `application/*` variants

Closes #813

## Validation

### Completed
- [x] `cargo +nightly-2025-11-30 fmt --all -- --check` — clean
- [x] `just lint` — clean
- [x] `cargo test -p moltis-telegram` — 112 tests pass

### Remaining
- [ ] `./scripts/local-validate.sh`
- [ ] Full `just test`

## Manual QA

1. Configure a Telegram channel
2. Send a `.md` file as a document attachment — agent should now see file contents
3. Send a `.toml` / `.yaml` file — same behavior
4. Send a `.txt` file with explicit MIME from Telegram — should still work (no regression)
5. Send a `.bin` file with no known extension — should remain `application/octet-stream` (graceful fallback)