### PR TITLE
fix(browser): add diagnostic logging for container readiness failures

### DIFF
--- a/crates/browser/src/container.rs
+++ b/crates/browser/src/container.rs
@@ -120,28 +120,31 @@ fn stop_container_by_id(backend: ContainerBackend, container_id: &str) {
         },
     }
 
-    // Apple Container requires explicit deletion after stop.
-    #[cfg(target_os = "macos")]
-    if backend == ContainerBackend::AppleContainer {
-        match Command::new("container")
-            .args(["rm", container_id])
-            .output()
-        {
-            Ok(output) if output.status.success() => {
-                debug!(container_id, "browser container removed");
-            },
-            Ok(output) => {
-                let stderr = String::from_utf8_lossy(&output.stderr);
-                warn!(
-                    container_id,
-                    error = %stderr.trim(),
-                    "failed to remove browser container"
-                );
-            },
-            Err(e) => {
-                warn!(container_id, error = %e, "failed to run container rm");
-            },
-        }
+    // Containers are started without --rm so that logs and status remain
+    // available for diagnostics after a crash.  Explicitly remove the
+    // container after stopping it.
+    match Command::new(cli).args(["rm", container_id]).output() {
+        Ok(output) if output.status.success() => {
+            debug!(container_id, backend = cli, "browser container removed");
+        },
+        Ok(output) => {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            warn!(
+                container_id,
+                backend = cli,
+                error = %stderr.trim(),
+                "failed to remove browser container"
+            );
+        },
+        Err(e) => {
+            warn!(
+                container_id,
+                backend = cli,
+                error = %e,
+                "failed to run {} rm",
+                cli
+            );
+        },
     }
 }
 
@@ -283,20 +286,11 @@ impl BrowserContainer {
             }
 
             if let Some(ref logs) = container_logs {
-                // Truncate to last 50 lines to keep output manageable
-                let tail: String = logs
-                    .lines()
-                    .rev()
-                    .take(50)
-                    .collect::<Vec<_>>()
-                    .into_iter()
-                    .rev()
-                    .collect::<Vec<_>>()
-                    .join("\n");
+                // Already limited to 50 lines by --tail 50 in fetch_container_logs
                 warn!(
                     container_id,
-                    logs = tail,
-                    "browser container logs (last 50 lines)"
+                    logs = %logs,
+                    "browser container logs"
                 );
             } else {
                 warn!(container_id, "no container logs available");
@@ -479,7 +473,6 @@ fn start_oci_container(
     let mut run_args = vec![
         "run".to_string(),
         "-d".to_string(),
-        "--rm".to_string(),
         "--name".to_string(),
         container_name.clone(),
         "-p".to_string(),
@@ -675,11 +668,21 @@ fn find_available_port() -> Result<u16> {
 
 /// Fetch the last logs from a container for diagnostic purposes.
 fn fetch_container_logs(backend: ContainerBackend, container_id: &str) -> Option<String> {
+    // Apple Container CLI may not support `logs --tail`
+    #[cfg(target_os = "macos")]
+    if backend == ContainerBackend::AppleContainer {
+        return None;
+    }
+
     let cli = backend.cli();
     let output = Command::new(cli)
         .args(["logs", "--tail", "50", container_id])
         .output()
         .ok()?;
+
+    if !output.status.success() {
+        return None;
+    }
 
     let stdout = String::from_utf8_lossy(&output.stdout);
     let stderr = String::from_utf8_lossy(&output.stderr);

--- a/crates/browser/src/container.rs
+++ b/crates/browser/src/container.rs
@@ -220,6 +220,7 @@ impl BrowserContainer {
             image,
             host_port,
             backend = backend.cli(),
+            container_host,
             "starting browser container"
         );
 
@@ -259,13 +260,57 @@ impl BrowserContainer {
 
         // Wait for the container to be ready
         if let Err(error) = wait_for_ready(container_host, host_port) {
+            // Fetch container logs before cleanup to help diagnose why Chrome
+            // didn't start (e.g. crash, missing libs, permission errors).
+            let container_logs = fetch_container_logs(backend, &container_id);
+            let container_status = inspect_container_status(backend, &container_id);
+
             warn!(
                 container_id,
                 host_port,
+                container_host,
                 backend = backend.cli(),
                 error = %error,
                 "browser container failed readiness check, cleaning up"
             );
+
+            if let Some(ref status) = container_status {
+                warn!(
+                    container_id,
+                    container_status = status,
+                    "browser container status at time of failure"
+                );
+            }
+
+            if let Some(ref logs) = container_logs {
+                // Truncate to last 50 lines to keep output manageable
+                let tail: String = logs
+                    .lines()
+                    .rev()
+                    .take(50)
+                    .collect::<Vec<_>>()
+                    .into_iter()
+                    .rev()
+                    .collect::<Vec<_>>()
+                    .join("\n");
+                warn!(
+                    container_id,
+                    logs = tail,
+                    "browser container logs (last 50 lines)"
+                );
+            } else {
+                warn!(container_id, "no container logs available");
+            }
+
+            if is_running_in_container() {
+                warn!(
+                    container_host,
+                    "moltis appears to be running inside a container — if the browser \
+                     container is a sibling (not nested), set browser.container_host to \
+                     the Docker host IP or \"host.docker.internal\" in moltis.toml"
+                );
+            }
+
             stop_container_by_id(backend, &container_id);
             return Err(error);
         }
@@ -461,6 +506,12 @@ fn start_oci_container(
 
     run_args.push(image.to_string());
 
+    info!(
+        backend = cli,
+        args = %run_args.join(" "),
+        "browser container run command"
+    );
+
     let output = Command::new(cli)
         .args(&run_args)
         .output()
@@ -620,6 +671,87 @@ fn find_available_port() -> Result<u16> {
 
     drop(listener);
     Ok(port)
+}
+
+/// Fetch the last logs from a container for diagnostic purposes.
+fn fetch_container_logs(backend: ContainerBackend, container_id: &str) -> Option<String> {
+    let cli = backend.cli();
+    let output = Command::new(cli)
+        .args(["logs", "--tail", "50", container_id])
+        .output()
+        .ok()?;
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    // Browserless/Chrome may log to either stdout or stderr
+    let combined = format!("{stdout}{stderr}");
+    let trimmed = combined.trim().to_string();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed)
+    }
+}
+
+/// Inspect a container's status (running, exited, etc.) for diagnostics.
+fn inspect_container_status(backend: ContainerBackend, container_id: &str) -> Option<String> {
+    let cli = backend.cli();
+
+    #[cfg(target_os = "macos")]
+    if backend == ContainerBackend::AppleContainer {
+        // Apple Container doesn't support `inspect --format`
+        return None;
+    }
+
+    let output = Command::new(cli)
+        .args([
+            "inspect",
+            "--format",
+            "{{.State.Status}} (ExitCode={{.State.ExitCode}}, OOMKilled={{.State.OOMKilled}})",
+            container_id,
+        ])
+        .output()
+        .ok()?;
+
+    if output.status.success() {
+        let status = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        if status.is_empty() {
+            None
+        } else {
+            Some(status)
+        }
+    } else {
+        None
+    }
+}
+
+/// Detect whether we are running inside a container (Docker/Podman/etc.).
+///
+/// Checks for `/.dockerenv` (Docker) and cgroup markers (various runtimes).
+fn is_running_in_container() -> bool {
+    use std::path::Path;
+
+    // Docker creates this file inside its containers
+    if Path::new("/.dockerenv").exists() {
+        return true;
+    }
+
+    // Podman/other runtimes may set container env vars
+    if std::env::var_os("container").is_some() {
+        return true;
+    }
+
+    // Check cgroup for container markers
+    if let Ok(cgroup) = std::fs::read_to_string("/proc/1/cgroup")
+        && (cgroup.contains("docker")
+            || cgroup.contains("kubepods")
+            || cgroup.contains("containerd"))
+    {
+        return true;
+    }
+
+    false
 }
 
 /// Wait for the container to be ready by probing the Chrome DevTools endpoint.

--- a/crates/browser/src/pool.rs
+++ b/crates/browser/src/pool.rs
@@ -391,6 +391,15 @@ impl BrowserPool {
         let profile_dir = sandbox_profile_dir(self.config.resolved_profile_dir(), session_id);
         let container_host = self.config.container_host.clone();
 
+        info!(
+            session_id,
+            image = %image,
+            container_host = %container_host,
+            profile_dir = ?profile_dir,
+            session_timeout_ms,
+            "launching sandboxed browser container"
+        );
+
         let container = tokio::task::spawn_blocking(move || {
             // Check container runtime availability (Docker, Podman, or Apple Container)
             if !container::is_container_available() {


### PR DESCRIPTION
## Summary

- When a browser container fails readiness checks, logs now include: container status (running/exited/OOM-killed), Chrome's own logs from inside the container, the full `docker run` command, and the `container_host` being probed
- Detects when Moltis is running inside a container and warns the user to set `browser.container_host` to `host.docker.internal` — the exact fix for the Docker-in-Docker networking issue in #786
- Adds `container_host` to existing startup and failure log lines for visibility

Closes #786

## Validation

### Completed
- [x] `cargo check -p moltis-browser`
- [x] `cargo test -p moltis-browser` — 86 tests pass
- [x] `cargo clippy -p moltis-browser -- -D warnings`
- [x] `cargo +nightly-2025-11-30 fmt --all -- --check`

### Remaining
- [ ] `./scripts/local-validate.sh`

## Manual QA

1. Run Moltis inside Docker with a mounted Docker socket (the reporter's setup)
2. Ask the agent to use the browser tool
3. When the container fails readiness, verify the logs now show:
   - `container_host="127.0.0.1"` in the startup log
   - Container status and Chrome logs after timeout
   - Warning: "moltis appears to be running inside a container — set browser.container_host to host.docker.internal"
4. Set `browser.container_host = "host.docker.internal"` in moltis.toml and verify browser works

🤖 Generated with [Claude Code](https://claude.com/claude-code)