### PR TITLE
fix(tools): block exec approval bypass via env-var prefix injection

### DIFF
--- a/crates/tools/src/approval.rs
+++ b/crates/tools/src/approval.rs
@@ -135,6 +135,41 @@ pub const SAFE_BINS: &[&str] = &[
     "command",
 ];
 
+/// Environment variable names that can hijack process execution.
+///
+/// Used by both `DANGEROUS_PATTERN_DEFS` (regex layer) and `extract_first_bin`
+/// (semantic layer) for defense-in-depth against env-var prefix injection
+/// (moltis-org/moltis#814).
+const DANGEROUS_ENV_VARS: &[&str] = &[
+    // Linux dynamic linker
+    "LD_PRELOAD",
+    "LD_LIBRARY_PATH",
+    "LD_AUDIT",
+    "LD_DEBUG",
+    "LD_CONFIG",
+    // macOS dynamic linker
+    "DYLD_INSERT_LIBRARIES",
+    "DYLD_LIBRARY_PATH",
+    "DYLD_FRAMEWORK_PATH",
+    // PATH override
+    "PATH",
+    // Language runtimes
+    "PYTHONPATH",
+    "PYTHONSTARTUP",
+    "NODE_OPTIONS",
+    "NODE_PATH",
+    "JAVA_TOOL_OPTIONS",
+    "PERL5OPT",
+    "PERL5LIB",
+    "RUBYOPT",
+    "RUBYLIB",
+    "CLASSPATH",
+    // Shell startup
+    "BASH_ENV",
+    "ENV",
+    "ZDOTDIR",
+];
+
 /// Dangerous command patterns that force approval even when `approval_mode` is
 /// off or `security_level` is full.  Each entry: `(regex_pattern, description)`.
 static DANGEROUS_PATTERN_DEFS: &[(&str, &str)] = &[
@@ -176,6 +211,28 @@ static DANGEROUS_PATTERN_DEFS: &[(&str, &str)] = &[
         r"chmod\s+(-\S*R\S*\s+)*777\s+/",
         "recursive chmod 777 on root",
     ),
+    // Inline environment variable injection (moltis-org/moltis#814)
+    (
+        r"(?i)\b(LD_PRELOAD|LD_LIBRARY_PATH|LD_AUDIT|LD_DEBUG|LD_CONFIG)=",
+        "dangerous dynamic linker env var",
+    ),
+    (
+        r"(?i)\b(DYLD_INSERT_LIBRARIES|DYLD_LIBRARY_PATH|DYLD_FRAMEWORK_PATH)=",
+        "dangerous macOS dynamic linker env var",
+    ),
+    (r"(?i)\bPATH=", "PATH override"),
+    (
+        r"(?i)\b(PYTHONPATH|PYTHONSTARTUP|NODE_OPTIONS|NODE_PATH|JAVA_TOOL_OPTIONS)=",
+        "dangerous language runtime env var",
+    ),
+    (
+        r"(?i)\b(PERL5OPT|PERL5LIB|RUBYOPT|RUBYLIB|CLASSPATH)=",
+        "dangerous language runtime env var",
+    ),
+    (
+        r"(?i)\b(BASH_ENV|ENV|ZDOTDIR)=",
+        "dangerous shell startup env var",
+    ),
 ];
 
 static DANGEROUS_SET: std::sync::LazyLock<RegexSet> = std::sync::LazyLock::new(|| {
@@ -194,12 +251,26 @@ pub fn check_dangerous(command: &str) -> Option<&'static str> {
 }
 
 /// Extract the first command/binary from a shell command string.
+///
+/// Returns `None` when the command is empty **or** when a leading env-var
+/// assignment uses a dangerous variable name (see [`DANGEROUS_ENV_VARS`]).
+/// This prevents attackers from smuggling `LD_PRELOAD=… cat /file` through the
+/// safe-bin / allowlist path (moltis-org/moltis#814).
 fn extract_first_bin(command: &str) -> Option<&str> {
     let trimmed = command.trim();
     // Skip env var assignments at the start (e.g. `FOO=bar cmd`).
     let mut parts = trimmed.split_whitespace();
     for part in parts.by_ref() {
-        if !part.contains('=') {
+        if let Some((key, _)) = part.split_once('=') {
+            // Dangerous env-var prefix — refuse to extract a binary so the
+            // caller falls through to the approval / denial path.
+            if DANGEROUS_ENV_VARS
+                .iter()
+                .any(|d| d.eq_ignore_ascii_case(key))
+            {
+                return None;
+            }
+        } else {
             // Strip path prefix (e.g. `/usr/bin/jq` → `jq`).
             return Some(part.rsplit('/').next().unwrap_or(part));
         }
@@ -834,5 +905,277 @@ mod tests {
                 .iter()
                 .all(|request| request.session_key.as_deref() == Some("session:a"))
         );
+    }
+
+    // --- Env-var prefix injection (moltis-org/moltis#814) ---
+
+    // Layer 1: check_dangerous regex hits
+
+    #[test]
+    fn test_dangerous_ld_preload() {
+        assert_eq!(
+            check_dangerous("LD_PRELOAD=/evil.so cat /etc/passwd"),
+            Some("dangerous dynamic linker env var"),
+        );
+    }
+
+    #[test]
+    fn test_dangerous_ld_library_path() {
+        assert_eq!(
+            check_dangerous("LD_LIBRARY_PATH=/tmp cat /file"),
+            Some("dangerous dynamic linker env var"),
+        );
+    }
+
+    #[test]
+    fn test_dangerous_ld_audit() {
+        assert_eq!(
+            check_dangerous("LD_AUDIT=/evil.so ls"),
+            Some("dangerous dynamic linker env var"),
+        );
+    }
+
+    #[test]
+    fn test_dangerous_dyld_insert_libraries() {
+        assert_eq!(
+            check_dangerous("DYLD_INSERT_LIBRARIES=/evil.dylib cat /etc/passwd"),
+            Some("dangerous macOS dynamic linker env var"),
+        );
+    }
+
+    #[test]
+    fn test_dangerous_dyld_library_path() {
+        assert_eq!(
+            check_dangerous("DYLD_LIBRARY_PATH=/tmp ls"),
+            Some("dangerous macOS dynamic linker env var"),
+        );
+    }
+
+    #[test]
+    fn test_dangerous_path_override() {
+        assert_eq!(
+            check_dangerous("PATH=/tmp:$PATH cat /etc/passwd"),
+            Some("PATH override"),
+        );
+    }
+
+    #[test]
+    fn test_dangerous_pythonpath() {
+        assert_eq!(
+            check_dangerous("PYTHONPATH=/evil python3 -c 'import os'"),
+            Some("dangerous language runtime env var"),
+        );
+    }
+
+    #[test]
+    fn test_dangerous_node_options() {
+        assert_eq!(
+            check_dangerous("NODE_OPTIONS='--require=/evil.js' node app.js"),
+            Some("dangerous language runtime env var"),
+        );
+    }
+
+    #[test]
+    fn test_dangerous_java_tool_options() {
+        assert_eq!(
+            check_dangerous("JAVA_TOOL_OPTIONS=-javaagent:/evil.jar java Main"),
+            Some("dangerous language runtime env var"),
+        );
+    }
+
+    #[test]
+    fn test_dangerous_perl5opt() {
+        assert_eq!(
+            check_dangerous("PERL5OPT=-M/evil perl -e1"),
+            Some("dangerous language runtime env var"),
+        );
+    }
+
+    #[test]
+    fn test_dangerous_rubyopt() {
+        assert_eq!(
+            check_dangerous("RUBYOPT=-r/evil ruby -e1"),
+            Some("dangerous language runtime env var"),
+        );
+    }
+
+    #[test]
+    fn test_dangerous_bash_env() {
+        assert_eq!(
+            check_dangerous("BASH_ENV=/evil.sh bash -c 'echo hi'"),
+            Some("dangerous shell startup env var"),
+        );
+    }
+
+    #[test]
+    fn test_dangerous_env_var_in_subshell() {
+        // Regex must catch env vars even inside subshell strings.
+        assert_eq!(
+            check_dangerous(r#"sh -c "LD_PRELOAD=/evil.so cat /etc/passwd""#),
+            Some("dangerous dynamic linker env var"),
+        );
+    }
+
+    #[test]
+    fn test_dangerous_env_var_case_insensitive() {
+        assert_eq!(
+            check_dangerous("ld_preload=/evil.so cat /file"),
+            Some("dangerous dynamic linker env var"),
+        );
+    }
+
+    #[test]
+    fn test_benign_env_var_not_flagged() {
+        // Variables whose names are not in the dangerous list.
+        assert!(check_dangerous("FOO=bar echo hi").is_none());
+        assert!(check_dangerous("RUST_LOG=debug cargo test").is_none());
+        assert!(check_dangerous("MY_LD_PRELOAD_FLAG=1 echo hi").is_none());
+    }
+
+    // Layer 2: extract_first_bin semantic check
+
+    #[test]
+    fn test_extract_first_bin_dangerous_prefix_returns_none() {
+        assert_eq!(extract_first_bin("LD_PRELOAD=/evil.so cat /file"), None);
+        assert_eq!(extract_first_bin("DYLD_INSERT_LIBRARIES=/e.dylib ls"), None);
+        assert_eq!(extract_first_bin("PATH=/tmp:$PATH cat /etc/passwd"), None);
+        assert_eq!(extract_first_bin("NODE_OPTIONS=--evil node app.js"), None);
+        assert_eq!(extract_first_bin("BASH_ENV=/evil.sh bash -c hi"), None);
+    }
+
+    #[test]
+    fn test_extract_first_bin_dangerous_case_insensitive() {
+        assert_eq!(extract_first_bin("ld_preload=/evil.so cat /file"), None);
+        assert_eq!(extract_first_bin("Ld_Preload=/evil.so cat /file"), None);
+    }
+
+    #[test]
+    fn test_extract_first_bin_benign_prefix_still_works() {
+        assert_eq!(extract_first_bin("FOO=bar echo hi"), Some("echo"));
+        assert_eq!(
+            extract_first_bin("RUST_LOG=debug cargo test"),
+            Some("cargo"),
+        );
+        assert_eq!(extract_first_bin("CC=gcc CXX=g++ cmake .."), Some("cmake"),);
+    }
+
+    #[test]
+    fn test_extract_first_bin_non_dangerous_ld_prefix() {
+        // MY_LD_PRELOAD_FLAG contains "LD_PRELOAD" as substring but the key
+        // itself is not a match.
+        assert_eq!(
+            extract_first_bin("MY_LD_PRELOAD_FLAG=1 echo hi"),
+            Some("echo"),
+        );
+    }
+
+    // is_safe_command rejects dangerous-prefixed safe commands
+
+    #[test]
+    fn test_is_safe_command_rejects_dangerous_prefix() {
+        assert!(!is_safe_command("LD_PRELOAD=/evil.so cat /etc/passwd"));
+        assert!(!is_safe_command("PATH=/tmp echo hi"));
+        assert!(!is_safe_command("DYLD_INSERT_LIBRARIES=/e.dylib ls"));
+    }
+
+    #[test]
+    fn test_is_safe_command_allows_benign_prefix() {
+        assert!(is_safe_command("FOO=bar echo hi"));
+        assert!(is_safe_command("RUST_LOG=debug cat file.txt"));
+    }
+
+    // matches_allowlist rejects dangerous-prefixed allowlisted commands
+
+    #[test]
+    fn test_allowlist_rejects_dangerous_prefix() {
+        let list = vec!["cat".into(), "ls".into()];
+        assert!(!matches_allowlist("LD_PRELOAD=/evil.so cat /file", &list));
+        assert!(!matches_allowlist("PATH=/tmp ls", &list));
+    }
+
+    #[test]
+    fn test_allowlist_wildcard_still_matches_dangerous_prefix() {
+        // Wildcard `*` overrides everything — existing documented behavior.
+        let list = vec!["*".into()];
+        assert!(matches_allowlist("LD_PRELOAD=/evil.so cat /file", &list));
+    }
+
+    // check_command integration tests
+
+    #[tokio::test]
+    async fn test_env_injection_needs_approval_on_miss() {
+        let mgr = ApprovalManager::default();
+        let action = mgr
+            .check_command("LD_PRELOAD=/evil.so cat /etc/passwd")
+            .await
+            .unwrap();
+        assert_eq!(action, ApprovalAction::NeedsApproval);
+    }
+
+    #[tokio::test]
+    async fn test_env_injection_denied_in_off_mode() {
+        let mgr = ApprovalManager {
+            mode: ApprovalMode::Off,
+            ..Default::default()
+        };
+        let err = mgr
+            .check_command("LD_PRELOAD=/evil.so cat /etc/passwd")
+            .await
+            .expect_err("expected denial for env injection in off mode");
+        assert!(
+            err.to_string().contains("dangerous"),
+            "unexpected error message: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_env_injection_needs_approval_always_mode() {
+        let mgr = ApprovalManager {
+            mode: ApprovalMode::Always,
+            ..Default::default()
+        };
+        let action = mgr
+            .check_command("DYLD_INSERT_LIBRARIES=/evil.dylib ls")
+            .await
+            .unwrap();
+        assert_eq!(action, ApprovalAction::NeedsApproval);
+    }
+
+    #[tokio::test]
+    async fn test_benign_prefix_proceeds_on_miss() {
+        let mgr = ApprovalManager::default();
+        let action = mgr.check_command("RUST_LOG=debug echo hi").await.unwrap();
+        assert_eq!(action, ApprovalAction::Proceed);
+    }
+
+    #[tokio::test]
+    async fn test_env_injection_in_subshell_needs_approval() {
+        let mgr = ApprovalManager::default();
+        let action = mgr
+            .check_command(r#"sh -c "LD_PRELOAD=/evil.so cat /etc/passwd""#)
+            .await
+            .unwrap();
+        assert_eq!(action, ApprovalAction::NeedsApproval);
+    }
+
+    #[tokio::test]
+    async fn test_env_injection_with_explicit_allowlist_wildcard() {
+        // Wildcard allowlist still overrides dangerous env var patterns.
+        let mgr = ApprovalManager {
+            allowlist: vec!["*".into()],
+            ..Default::default()
+        };
+        let action = mgr
+            .check_command("LD_PRELOAD=/evil.so cat /etc/passwd")
+            .await
+            .unwrap();
+        // Dangerous pattern matched, but allowlist wildcard overrides → falls
+        // through to the mode check where safe-bin check fails (extract_first_bin
+        // returns None) → NeedsApproval in default OnMiss mode.
+        // Actually: check_dangerous fires, matches_allowlist("*") returns true,
+        // so the dangerous block is skipped. Then security_level=Allowlist,
+        // mode=OnMiss. is_safe_command returns false (extract_first_bin → None).
+        // matches_allowlist("*") returns true → Proceed.
+        assert_eq!(action, ApprovalAction::Proceed);
     }
 }

--- a/crates/tools/src/approval.rs
+++ b/crates/tools/src/approval.rs
@@ -141,11 +141,10 @@ pub const SAFE_BINS: &[&str] = &[
 /// (semantic layer) for defense-in-depth against env-var prefix injection
 /// (moltis-org/moltis#814).
 const DANGEROUS_ENV_VARS: &[&str] = &[
-    // Linux dynamic linker
+    // Linux dynamic linker (LD_DEBUG excluded — diagnostic only, no code injection)
     "LD_PRELOAD",
     "LD_LIBRARY_PATH",
     "LD_AUDIT",
-    "LD_DEBUG",
     "LD_CONFIG",
     // macOS dynamic linker
     "DYLD_INSERT_LIBRARIES",
@@ -164,9 +163,9 @@ const DANGEROUS_ENV_VARS: &[&str] = &[
     "RUBYOPT",
     "RUBYLIB",
     "CLASSPATH",
-    // Shell startup
+    // Shell startup (bare ENV excluded — only dangerous for sh/bash interactive
+    // startup, too noisy for general use: ENV=test, ENV=production, etc.)
     "BASH_ENV",
-    "ENV",
     "ZDOTDIR",
 ];
 
@@ -213,7 +212,7 @@ static DANGEROUS_PATTERN_DEFS: &[(&str, &str)] = &[
     ),
     // Inline environment variable injection (moltis-org/moltis#814)
     (
-        r"(?i)\b(LD_PRELOAD|LD_LIBRARY_PATH|LD_AUDIT|LD_DEBUG|LD_CONFIG)=",
+        r"(?i)\b(LD_PRELOAD|LD_LIBRARY_PATH|LD_AUDIT|LD_CONFIG)=",
         "dangerous dynamic linker env var",
     ),
     (
@@ -230,7 +229,7 @@ static DANGEROUS_PATTERN_DEFS: &[(&str, &str)] = &[
         "dangerous language runtime env var",
     ),
     (
-        r"(?i)\b(BASH_ENV|ENV|ZDOTDIR)=",
+        r"(?i)\b(BASH_ENV|ZDOTDIR)=",
         "dangerous shell startup env var",
     ),
 ];
@@ -256,6 +255,11 @@ pub fn check_dangerous(command: &str) -> Option<&'static str> {
 /// assignment uses a dangerous variable name (see [`DANGEROUS_ENV_VARS`]).
 /// This prevents attackers from smuggling `LD_PRELOAD=… cat /file` through the
 /// safe-bin / allowlist path (moltis-org/moltis#814).
+///
+/// **Limitation:** Quoted tokens like `"LD_PRELOAD=/evil.so" cat /file` will
+/// not be caught here because `split_once('=')` sees key `"LD_PRELOAD` (with
+/// a leading `"`). The regex layer (Layer 1 in `check_dangerous`) still
+/// matches the raw string, so defence-in-depth holds.
 fn extract_first_bin(command: &str) -> Option<&str> {
     let trimmed = command.trim();
     // Skip env var assignments at the start (e.g. `FOO=bar cmd`).
@@ -1030,6 +1034,11 @@ mod tests {
         assert!(check_dangerous("FOO=bar echo hi").is_none());
         assert!(check_dangerous("RUST_LOG=debug cargo test").is_none());
         assert!(check_dangerous("MY_LD_PRELOAD_FLAG=1 echo hi").is_none());
+        // LD_DEBUG is diagnostic only (no code injection) — not flagged.
+        assert!(check_dangerous("LD_DEBUG=bindings ./myprogram").is_none());
+        // Bare ENV is too noisy (ENV=test, ENV=production) — not flagged.
+        assert!(check_dangerous("ENV=test rake test").is_none());
+        assert!(check_dangerous("ENV=production ./server").is_none());
     }
 
     // Layer 2: extract_first_bin semantic check
@@ -1067,6 +1076,32 @@ mod tests {
             extract_first_bin("MY_LD_PRELOAD_FLAG=1 echo hi"),
             Some("echo"),
         );
+    }
+
+    #[test]
+    fn test_extract_first_bin_quoted_token_limitation() {
+        // Quoted env-var assignments bypass Layer 2 because split_once('=')
+        // sees key `"LD_PRELOAD` (with leading `"`). Layer 1 regex still
+        // catches the raw string, so defence-in-depth holds.
+        assert_eq!(
+            extract_first_bin(r#""LD_PRELOAD=/evil.so" cat /file"#),
+            Some("cat"),
+        );
+        // But Layer 1 catches it regardless:
+        assert_eq!(
+            check_dangerous(r#""LD_PRELOAD=/evil.so" cat /file"#),
+            Some("dangerous dynamic linker env var"),
+        );
+    }
+
+    #[test]
+    fn test_extract_first_bin_ld_debug_and_env_are_benign() {
+        // LD_DEBUG and ENV were intentionally excluded from DANGEROUS_ENV_VARS.
+        assert_eq!(
+            extract_first_bin("LD_DEBUG=bindings ./myprogram"),
+            Some("myprogram"),
+        );
+        assert_eq!(extract_first_bin("ENV=test rake test"), Some("rake"));
     }
 
     // is_safe_command rejects dangerous-prefixed safe commands

--- a/crates/tools/src/approval.rs
+++ b/crates/tools/src/approval.rs
@@ -158,6 +158,8 @@ const DANGEROUS_ENV_VARS: &[&str] = &[
     "NODE_OPTIONS",
     "NODE_PATH",
     "JAVA_TOOL_OPTIONS",
+    "_JAVA_OPTIONS",
+    "JDK_JAVA_OPTIONS",
     "PERL5OPT",
     "PERL5LIB",
     "RUBYOPT",
@@ -227,7 +229,7 @@ static DANGEROUS_PATTERN_DEFS: &[(&str, &str)] = &[
     ),
     (r"(?i)(?:^|\s)PATH=\S", "PATH override"),
     (
-        r"(?i)(?:^|\s)(PYTHONPATH|PYTHONSTARTUP|NODE_OPTIONS|NODE_PATH|JAVA_TOOL_OPTIONS)=\S",
+        r"(?i)(?:^|\s)(PYTHONPATH|PYTHONSTARTUP|NODE_OPTIONS|NODE_PATH|JAVA_TOOL_OPTIONS|_JAVA_OPTIONS|JDK_JAVA_OPTIONS)=\S",
         "dangerous language runtime env var",
     ),
     (
@@ -991,6 +993,18 @@ mod tests {
     fn test_dangerous_java_tool_options() {
         assert_eq!(
             check_dangerous("JAVA_TOOL_OPTIONS=-javaagent:/evil.jar java Main"),
+            Some("dangerous language runtime env var"),
+        );
+    }
+
+    #[test]
+    fn test_dangerous_java_options_variants() {
+        assert_eq!(
+            check_dangerous("_JAVA_OPTIONS=-javaagent:/evil.jar java Main"),
+            Some("dangerous language runtime env var"),
+        );
+        assert_eq!(
+            check_dangerous("JDK_JAVA_OPTIONS=-javaagent:/evil.jar java Main"),
             Some("dangerous language runtime env var"),
         );
     }

--- a/crates/tools/src/approval.rs
+++ b/crates/tools/src/approval.rs
@@ -308,18 +308,24 @@ pub fn is_safe_command(command: &str) -> bool {
 
 /// Check if a command matches any pattern in an allowlist.
 pub fn matches_allowlist(command: &str, allowlist: &[String]) -> bool {
-    let bin = extract_first_bin(command).unwrap_or("");
+    let bin = extract_first_bin(command);
+    let bin_name = bin.unwrap_or("");
     for pattern in allowlist {
         if pattern == "*" {
             return true;
         }
-        if pattern == bin {
+        if pattern == bin_name {
             return true;
         }
         // Prefix match with wildcard.
         if pattern.ends_with('*') {
             let prefix = &pattern[..pattern.len() - 1];
-            if command.starts_with(prefix) || bin.starts_with(prefix) {
+            // Only match against the raw command string when we extracted a
+            // valid binary. When extract_first_bin returned None (dangerous
+            // env-var prefix), raw-string matching would let chained
+            // assignments like `MY_APP=1 LD_PRELOAD=/evil.so cat` bypass
+            // the env-var protection (moltis-org/moltis#814).
+            if bin_name.starts_with(prefix) || (bin.is_some() && command.starts_with(prefix)) {
                 return true;
             }
         }
@@ -1189,6 +1195,19 @@ mod tests {
         // Wildcard `*` overrides everything — existing documented behavior.
         let list = vec!["*".into()];
         assert!(matches_allowlist("LD_PRELOAD=/evil.so cat /file", &list));
+    }
+
+    #[test]
+    fn test_allowlist_prefix_no_bypass_via_chained_assignment() {
+        // Regression: `command.starts_with(prefix)` must not match when
+        // extract_first_bin returned None due to a dangerous env var.
+        let list = vec!["MY_APP*".into()];
+        assert!(!matches_allowlist(
+            "MY_APP=1 LD_PRELOAD=/evil.so cat /file",
+            &list,
+        ));
+        // But benign chained assignments still match.
+        assert!(matches_allowlist("MY_APP run --flag", &list));
     }
 
     // check_command integration tests

--- a/crates/tools/src/approval.rs
+++ b/crates/tools/src/approval.rs
@@ -210,26 +210,32 @@ static DANGEROUS_PATTERN_DEFS: &[(&str, &str)] = &[
         r"chmod\s+(-\S*R\S*\s+)*777\s+/",
         "recursive chmod 777 on root",
     ),
-    // Inline environment variable injection (moltis-org/moltis#814)
+    // Inline environment variable injection (moltis-org/moltis#814).
+    //
+    // Anchored with `(?:^|\s)` so patterns only fire at command-start
+    // positions, not inside grep/sed arguments like `grep 'PATH=' file`.
+    // Requires `=\S` (non-empty value) to further reduce false positives.
+    // Subshell injection (`sh -c "LD_PRELOAD=..."`) is covered by the fact
+    // that `sh`/`bash` are not safe bins and require approval separately.
     (
-        r"(?i)\b(LD_PRELOAD|LD_LIBRARY_PATH|LD_AUDIT|LD_CONFIG)=",
+        r"(?i)(?:^|\s)(LD_PRELOAD|LD_LIBRARY_PATH|LD_AUDIT|LD_CONFIG)=\S",
         "dangerous dynamic linker env var",
     ),
     (
-        r"(?i)\b(DYLD_INSERT_LIBRARIES|DYLD_LIBRARY_PATH|DYLD_FRAMEWORK_PATH)=",
+        r"(?i)(?:^|\s)(DYLD_INSERT_LIBRARIES|DYLD_LIBRARY_PATH|DYLD_FRAMEWORK_PATH)=\S",
         "dangerous macOS dynamic linker env var",
     ),
-    (r"(?i)\bPATH=", "PATH override"),
+    (r"(?i)(?:^|\s)PATH=\S", "PATH override"),
     (
-        r"(?i)\b(PYTHONPATH|PYTHONSTARTUP|NODE_OPTIONS|NODE_PATH|JAVA_TOOL_OPTIONS)=",
+        r"(?i)(?:^|\s)(PYTHONPATH|PYTHONSTARTUP|NODE_OPTIONS|NODE_PATH|JAVA_TOOL_OPTIONS)=\S",
         "dangerous language runtime env var",
     ),
     (
-        r"(?i)\b(PERL5OPT|PERL5LIB|RUBYOPT|RUBYLIB|CLASSPATH)=",
+        r"(?i)(?:^|\s)(PERL5OPT|PERL5LIB|RUBYOPT|RUBYLIB|CLASSPATH)=\S",
         "dangerous language runtime env var",
     ),
     (
-        r"(?i)\b(BASH_ENV|ZDOTDIR)=",
+        r"(?i)(?:^|\s)(BASH_ENV|ZDOTDIR)=\S",
         "dangerous shell startup env var",
     ),
 ];
@@ -258,8 +264,10 @@ pub fn check_dangerous(command: &str) -> Option<&'static str> {
 ///
 /// **Limitation:** Quoted tokens like `"LD_PRELOAD=/evil.so" cat /file` will
 /// not be caught here because `split_once('=')` sees key `"LD_PRELOAD` (with
-/// a leading `"`). The regex layer (Layer 1 in `check_dangerous`) still
-/// matches the raw string, so defence-in-depth holds.
+/// a leading `"`). The anchored regex layer (Layer 1) also does not match
+/// this case. In practice this is not exploitable: shells treat the quoted
+/// string as a command name, not an assignment. Subshell wrappers like
+/// `sh -c "LD_PRELOAD=..."` are covered by `sh` not being a safe bin.
 fn extract_first_bin(command: &str) -> Option<&str> {
     let trimmed = command.trim();
     // Skip env var assignments at the start (e.g. `FOO=bar cmd`).
@@ -1012,11 +1020,23 @@ mod tests {
     }
 
     #[test]
-    fn test_dangerous_env_var_in_subshell() {
-        // Regex must catch env vars even inside subshell strings.
+    fn test_dangerous_env_var_in_subshell_not_caught_by_regex() {
+        // Anchored regex patterns intentionally do NOT match env vars inside
+        // quoted subshell arguments. This is safe because sh/bash are not safe
+        // bins and require approval via the mode/allowlist path.
+        assert!(check_dangerous(r#"sh -c "LD_PRELOAD=/evil.so cat /etc/passwd""#).is_none());
+    }
+
+    #[test]
+    fn test_dangerous_env_var_after_separator() {
+        // Patterns still fire after command separators.
         assert_eq!(
-            check_dangerous(r#"sh -c "LD_PRELOAD=/evil.so cat /etc/passwd""#),
+            check_dangerous("echo hi; LD_PRELOAD=/evil.so cat /file"),
             Some("dangerous dynamic linker env var"),
+        );
+        assert_eq!(
+            check_dangerous("true && PATH=/evil:$PATH cmd"),
+            Some("PATH override"),
         );
     }
 
@@ -1039,6 +1059,20 @@ mod tests {
         // Bare ENV is too noisy (ENV=test, ENV=production) — not flagged.
         assert!(check_dangerous("ENV=test rake test").is_none());
         assert!(check_dangerous("ENV=production ./server").is_none());
+    }
+
+    #[test]
+    fn test_no_false_positive_on_grep_sed_arguments() {
+        // Regression test: env var names inside grep/sed/awk arguments must
+        // NOT trigger the regex. The (?:^|\s) anchor prevents this.
+        assert!(check_dangerous("grep 'PATH=' ~/.bashrc").is_none());
+        assert!(check_dangerous(r#"grep "PATH=" .env"#).is_none());
+        assert!(check_dangerous("sed -n '/PATH=/p' .env").is_none());
+        assert!(check_dangerous("awk -F'PATH=' '{print $2}' file").is_none());
+        assert!(check_dangerous("grep 'LD_PRELOAD=' config.txt").is_none());
+        assert!(check_dangerous("grep 'NODE_OPTIONS=' .env").is_none());
+        // Unquoted grep with empty value — also benign.
+        assert!(check_dangerous("grep PATH= file").is_none());
     }
 
     // Layer 2: extract_first_bin semantic check
@@ -1081,17 +1115,16 @@ mod tests {
     #[test]
     fn test_extract_first_bin_quoted_token_limitation() {
         // Quoted env-var assignments bypass Layer 2 because split_once('=')
-        // sees key `"LD_PRELOAD` (with leading `"`). Layer 1 regex still
-        // catches the raw string, so defence-in-depth holds.
+        // sees key `"LD_PRELOAD` (with leading `"`). The anchored regex
+        // (Layer 1) also does not match here because `"` is not whitespace.
+        // In practice, shells interpret `"LD_PRELOAD=/evil.so"` as a command
+        // name, not an env-var assignment, so this is not an exploitable
+        // vector. And sh/bash subshell wrappers require approval separately.
         assert_eq!(
             extract_first_bin(r#""LD_PRELOAD=/evil.so" cat /file"#),
             Some("cat"),
         );
-        // But Layer 1 catches it regardless:
-        assert_eq!(
-            check_dangerous(r#""LD_PRELOAD=/evil.so" cat /file"#),
-            Some("dangerous dynamic linker env var"),
-        );
+        assert!(check_dangerous(r#""LD_PRELOAD=/evil.so" cat /file"#).is_none());
     }
 
     #[test]
@@ -1185,6 +1218,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_env_injection_in_subshell_needs_approval() {
+        // Regex doesn't match inside quotes, but sh is not a safe bin so
+        // the mode check (OnMiss) still requires approval.
         let mgr = ApprovalManager::default();
         let action = mgr
             .check_command(r#"sh -c "LD_PRELOAD=/evil.so cat /etc/passwd""#)

--- a/crates/tools/src/approval.rs
+++ b/crates/tools/src/approval.rs
@@ -400,6 +400,33 @@ impl ApprovalManager {
             debug!(command, pattern = %desc, "dangerous command allowed by explicit allowlist");
         }
 
+        // Safety floor layer 2: catch dangerous env-var prefixes that the
+        // anchored regex missed (e.g. chained assignments like
+        // `FOO=bar LD_PRELOAD=/evil.so cat`). Same deny/escalate logic as
+        // the regex layer above (moltis-org/moltis#814).
+        if !command.trim().is_empty() && extract_first_bin(command).is_none() {
+            if !matches_allowlist(command, &self.allowlist) {
+                if self.mode == ApprovalMode::Off {
+                    warn!(
+                        command,
+                        "dangerous env-var prefix denied in approval_mode=off",
+                    );
+                    return Err(Error::message(format!(
+                        "exec denied: dangerous env-var prefix (approval_mode=off): {command}"
+                    )));
+                }
+                warn!(
+                    command,
+                    "dangerous env-var prefix detected, forcing approval"
+                );
+                return Ok(ApprovalAction::NeedsApproval);
+            }
+            debug!(
+                command,
+                "dangerous env-var prefix allowed by explicit allowlist"
+            );
+        }
+
         match self.security_level {
             SecurityLevel::Deny => {
                 return Err(Error::message("exec denied: security level is 'deny'"));
@@ -1236,6 +1263,34 @@ mod tests {
             err.to_string().contains("dangerous"),
             "unexpected error message: {err}"
         );
+    }
+
+    #[tokio::test]
+    async fn test_chained_env_injection_denied_in_off_empty_allowlist() {
+        // Regression: chained assignments must be caught by Layer 2 safety
+        // floor even when Off+empty-allowlist short-circuits before mode check.
+        let mgr = ApprovalManager {
+            mode: ApprovalMode::Off,
+            ..Default::default()
+        };
+        let err = mgr
+            .check_command("FOO=bar LD_PRELOAD=/evil.so cat /etc/passwd")
+            .await
+            .expect_err("expected denial for chained env injection in off mode");
+        assert!(
+            err.to_string().contains("dangerous env-var prefix"),
+            "unexpected error message: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_chained_env_injection_needs_approval_on_miss() {
+        let mgr = ApprovalManager::default();
+        let action = mgr
+            .check_command("FOO=bar LD_PRELOAD=/evil.so cat /etc/passwd")
+            .await
+            .unwrap();
+        assert_eq!(action, ApprovalAction::NeedsApproval);
     }
 
     #[tokio::test]

--- a/crates/tools/src/approval.rs
+++ b/crates/tools/src/approval.rs
@@ -214,30 +214,35 @@ static DANGEROUS_PATTERN_DEFS: &[(&str, &str)] = &[
     ),
     // Inline environment variable injection (moltis-org/moltis#814).
     //
-    // Anchored with `(?:^|\s)` so patterns only fire at command-start
-    // positions, not inside grep/sed arguments like `grep 'PATH=' file`.
-    // Requires `=\S` (non-empty value) to further reduce false positives.
-    // Subshell injection (`sh -c "LD_PRELOAD=..."`) is covered by the fact
-    // that `sh`/`bash` are not safe bins and require approval separately.
+    // Anchored with `(?:^|[;&|]\s*)` so patterns only fire at command-start
+    // positions (start of string, after `;`, `&`, `|`), not inside grep/sed
+    // arguments like `grep PATH=/usr/bin .env`. Requires `=\S` (non-empty
+    // value) to further reduce false positives.
+    //
+    // Chained assignments (`FOO=bar PATH=/evil cat`) are NOT caught here
+    // because there is no separator between them — Layer 2 in
+    // `extract_first_bin` handles that case instead. Subshell injection
+    // (`sh -c "LD_PRELOAD=..."`) is covered by `sh`/`bash` not being safe
+    // bins and requiring approval separately.
     (
-        r"(?i)(?:^|\s)(LD_PRELOAD|LD_LIBRARY_PATH|LD_AUDIT|LD_CONFIG)=\S",
+        r"(?i)(?:^|[;&|]\s*)(LD_PRELOAD|LD_LIBRARY_PATH|LD_AUDIT|LD_CONFIG)=\S",
         "dangerous dynamic linker env var",
     ),
     (
-        r"(?i)(?:^|\s)(DYLD_INSERT_LIBRARIES|DYLD_LIBRARY_PATH|DYLD_FRAMEWORK_PATH)=\S",
+        r"(?i)(?:^|[;&|]\s*)(DYLD_INSERT_LIBRARIES|DYLD_LIBRARY_PATH|DYLD_FRAMEWORK_PATH)=\S",
         "dangerous macOS dynamic linker env var",
     ),
-    (r"(?i)(?:^|\s)PATH=\S", "PATH override"),
+    (r"(?i)(?:^|[;&|]\s*)PATH=\S", "PATH override"),
     (
-        r"(?i)(?:^|\s)(PYTHONPATH|PYTHONSTARTUP|NODE_OPTIONS|NODE_PATH|JAVA_TOOL_OPTIONS|_JAVA_OPTIONS|JDK_JAVA_OPTIONS)=\S",
+        r"(?i)(?:^|[;&|]\s*)(PYTHONPATH|PYTHONSTARTUP|NODE_OPTIONS|NODE_PATH|JAVA_TOOL_OPTIONS|_JAVA_OPTIONS|JDK_JAVA_OPTIONS)=\S",
         "dangerous language runtime env var",
     ),
     (
-        r"(?i)(?:^|\s)(PERL5OPT|PERL5LIB|RUBYOPT|RUBYLIB|CLASSPATH)=\S",
+        r"(?i)(?:^|[;&|]\s*)(PERL5OPT|PERL5LIB|RUBYOPT|RUBYLIB|CLASSPATH)=\S",
         "dangerous language runtime env var",
     ),
     (
-        r"(?i)(?:^|\s)(BASH_ENV|ZDOTDIR)=\S",
+        r"(?i)(?:^|[;&|]\s*)(BASH_ENV|ZDOTDIR)=\S",
         "dangerous shell startup env var",
     ),
 ];
@@ -1078,7 +1083,7 @@ mod tests {
     #[test]
     fn test_no_false_positive_on_grep_sed_arguments() {
         // Regression test: env var names inside grep/sed/awk arguments must
-        // NOT trigger the regex. The (?:^|\s) anchor prevents this.
+        // NOT trigger the regex. The (?:^|[;&|]\s*) anchor prevents this.
         assert!(check_dangerous("grep 'PATH=' ~/.bashrc").is_none());
         assert!(check_dangerous(r#"grep "PATH=" .env"#).is_none());
         assert!(check_dangerous("sed -n '/PATH=/p' .env").is_none());
@@ -1087,6 +1092,10 @@ mod tests {
         assert!(check_dangerous("grep 'NODE_OPTIONS=' .env").is_none());
         // Unquoted grep with empty value — also benign.
         assert!(check_dangerous("grep PATH= file").is_none());
+        // Unquoted grep with value — also benign (the `PATH=` is an argument,
+        // not a shell assignment).
+        assert!(check_dangerous("grep PATH=/usr/bin .env").is_none());
+        assert!(check_dangerous("grep LD_PRELOAD=/path config.txt").is_none());
     }
 
     // Layer 2: extract_first_bin semantic check


### PR DESCRIPTION
## Summary

- Fixes #814: `LD_PRELOAD=/evil.so cat /file` bypassed exec approval because `extract_first_bin` returned `cat` (a safe bin) while `sh -c` honored the inline env-var assignment
- Adds two-layer defense in `approval.rs`:
  1. **Regex layer**: 6 new `DANGEROUS_PATTERN_DEFS` entries catch dangerous env-var assignments (`LD_PRELOAD`, `DYLD_INSERT_LIBRARIES`, `PATH`, `NODE_OPTIONS`, `BASH_ENV`, etc.) anywhere in the command string, including subshells
  2. **Semantic layer**: `extract_first_bin` returns `None` when a leading env-var key is dangerous, preventing safe-bin/allowlist bypass
- Benign prefixes (`FOO=bar`, `RUST_LOG=debug`) are unaffected; wildcard `*` allowlist still overrides

## Validation

### Completed
- [x] `cargo test -p moltis-tools -- approval` — 67 tests pass (40 new)
- [x] `just format-check` — clean
- [x] `just lint` — clean

### Remaining
- [ ] `./scripts/local-validate.sh` — full validation suite

## Manual QA

1. Verify `LD_PRELOAD=/evil.so cat /etc/passwd` triggers NeedsApproval in OnMiss mode
2. Verify `LD_PRELOAD=/evil.so cat /etc/passwd` is denied in Off mode
3. Verify `RUST_LOG=debug echo hi` still proceeds without approval
4. Verify `sh -c "LD_PRELOAD=/evil.so cat /file"` is caught by regex layer