### PR TITLE
fix(gateway): downgrade broadcast log from debug to trace

### DIFF
--- a/crates/gateway/src/broadcast.rs
+++ b/crates/gateway/src/broadcast.rs
@@ -2,7 +2,7 @@ use std::{collections::HashMap, sync::Arc};
 
 use {
     moltis_protocol::{EventFrame, StateVersion, scopes},
-    tracing::{debug, warn},
+    tracing::{trace, warn},
 };
 
 use crate::state::GatewayState;
@@ -121,7 +121,7 @@ pub async fn broadcast(
     let required_scopes = guards.get(event);
 
     let inner = state.inner.read().await;
-    debug!(
+    trace!(
         event,
         seq,
         clients = inner.clients.len(),


### PR DESCRIPTION
## Summary

- Downgrade the per-event `debug!` log in `broadcast()` to `trace!` to break a feedback loop where each `logs.entry` broadcast generates another debug line, which is itself broadcast — filling disk rapidly at debug level.

Closes #823

## Validation

### Completed
- [x] `cargo check -p moltis-gateway` passes
- [x] Change is a single-line log level swap (`debug!` → `trace!`), no behavioral change

### Remaining
- [ ] `just lint`
- [ ] `just test`

## Manual QA

1. Run `RUST_LOG=moltis_gateway=debug moltis`
2. Confirm no flood of "broadcasting event" messages
3. Run `RUST_LOG=moltis_gateway=trace moltis` and confirm the messages still appear at trace level