### PR TITLE
fix(chat): correct push notification click-through URL

### DIFF
--- a/crates/chat/src/channels.rs
+++ b/crates/chat/src/channels.rs
@@ -14,6 +14,14 @@ use crate::{
     agent_loop::ChannelReplyTargetKey, compaction_run, error, runtime::ChatRuntime, types::*,
 };
 
+/// Build the SPA URL for a push notification click-through.
+///
+/// Must match the frontend `sessionPath()` in `router.ts`:
+/// `/chats/${key.replace(/:/g, "/")}`.
+pub(crate) fn push_notification_url(session_key: &str) -> String {
+    format!("/chats/{}", session_key.replace(':', "/"))
+}
+
 #[cfg(feature = "push-notifications")]
 pub(crate) async fn send_chat_push_notification(
     state: &Arc<dyn ChatRuntime>,
@@ -28,7 +36,7 @@ pub(crate) async fn send_chat_push_notification(
     };
 
     let title = "Message received";
-    let url = format!("/chat/{session_key}");
+    let url = push_notification_url(session_key);
 
     match state
         .send_push_notification(title, &summary, Some(&url), Some(session_key))
@@ -1302,5 +1310,29 @@ pub(crate) async fn send_location_to_channels(
         if let Err(e) = task.await {
             warn!(error = %e, "channel location task join failed");
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn push_notification_url_uses_chats_prefix_and_replaces_colons() {
+        // Must match frontend sessionPath(): `/chats/${key.replace(/:/g, "/")}`
+        assert_eq!(push_notification_url("session:42"), "/chats/session/42");
+    }
+
+    #[test]
+    fn push_notification_url_handles_nested_session_keys() {
+        assert_eq!(
+            push_notification_url("telegram:bot123:chat456"),
+            "/chats/telegram/bot123/chat456"
+        );
+    }
+
+    #[test]
+    fn push_notification_url_handles_key_without_colons() {
+        assert_eq!(push_notification_url("main"), "/chats/main");
     }
 }

--- a/crates/chat/src/channels.rs
+++ b/crates/chat/src/channels.rs
@@ -18,6 +18,7 @@ use crate::{
 ///
 /// Must match the frontend `sessionPath()` in `router.ts`:
 /// `/chats/${key.replace(/:/g, "/")}`.
+#[cfg(any(feature = "push-notifications", test))]
 pub(crate) fn push_notification_url(session_key: &str) -> String {
     format!("/chats/{}", session_key.replace(':', "/"))
 }


### PR DESCRIPTION
## Summary

- Push notification "View" CTA was navigating to `/chat/session:42` which doesn't match any SPA route, causing a 404
- Fixed URL construction to produce `/chats/session/42`, matching the frontend `sessionPath()` in `router.ts`
- Extracted `push_notification_url()` helper with unit tests

Closes #773

## Validation

### Completed
- [x] `cargo +nightly-2025-11-30 fmt --all -- --check` passes
- [x] `cargo test -p moltis-chat push_notification_url` — 3 tests pass
- [x] No other callers construct push URLs with the old `/chat/` prefix

### Remaining
- [ ] `just lint`
- [ ] `just test`
- [ ] Manual QA: enable push notifications, trigger a heartbeat, tap the notification CTA

## Manual QA

1. Enable push notifications in Settings > Notifications
2. Add a heartbeat cron job
3. Wait for the heartbeat to fire
4. Tap "View" on the push notification
5. Verify it navigates to the correct chat session (no 404)