### PR TITLE
fix(providers): normalize non-strict tool schema unions

### DIFF
--- a/crates/providers/src/openai_compat/provider.rs
+++ b/crates/providers/src/openai_compat/provider.rs
@@ -15,7 +15,9 @@ use {
 };
 
 use super::{
-    schema_normalization::sanitize_schema_for_openai_compat,
+    schema_normalization::{
+        collapse_schema_unions_for_non_strict_tools, sanitize_schema_for_openai_compat,
+    },
     strict_mode::patch_schema_for_strict_mode,
 };
 
@@ -91,6 +93,8 @@ pub fn to_openai_tools(tools: &[serde_json::Value], strict: bool) -> Vec<serde_j
             sanitize_schema_for_openai_compat(&mut params);
             if strict {
                 patch_schema_for_strict_mode(&mut params);
+            } else {
+                collapse_schema_unions_for_non_strict_tools(&mut params);
             }
 
             let name = t["name"].as_str()?.to_string();

--- a/crates/providers/src/openai_compat/schema_normalization.rs
+++ b/crates/providers/src/openai_compat/schema_normalization.rs
@@ -89,6 +89,160 @@ impl Transform for EnsurePropertyTypeTransform {
     }
 }
 
+/// Collapse JSON Schema `type` arrays to a single provider-compatible type.
+///
+/// Some OpenAI-compatible providers, especially Google AI Studio through
+/// OpenRouter, reject or mis-convert array-form types. When an object union
+/// like `["object", "string"]` has `properties`/`required`, OpenRouter's
+/// Google translation can drop the properties but keep `required`, causing
+/// "property is not defined" at request time (#793).
+#[derive(Debug, Clone, Default)]
+struct CollapseTypeArrayTransform;
+
+impl Transform for CollapseTypeArrayTransform {
+    fn transform(&mut self, schema: &mut Schema) {
+        let Some(obj) = schema.as_object_mut() else {
+            return;
+        };
+
+        let Some(types) = obj.get("type").and_then(|value| value.as_array()) else {
+            return;
+        };
+
+        let has_type = |name: &str| {
+            types
+                .iter()
+                .any(|value| value.as_str().is_some_and(|kind| kind == name))
+        };
+
+        let collapsed = if has_type("object")
+            && (obj.contains_key("properties")
+                || obj.contains_key("required")
+                || obj.contains_key("additionalProperties"))
+        {
+            Some("object")
+        } else if has_type("array")
+            && (obj.contains_key("items")
+                || obj.contains_key("minItems")
+                || obj.contains_key("maxItems")
+                || obj.contains_key("uniqueItems"))
+        {
+            Some("array")
+        } else {
+            types
+                .iter()
+                .filter_map(serde_json::Value::as_str)
+                .find(|kind| *kind != "null")
+                .or_else(|| types.iter().filter_map(serde_json::Value::as_str).next())
+        };
+
+        if let Some(kind) = collapsed {
+            obj.insert(
+                "type".to_string(),
+                serde_json::Value::String(kind.to_string()),
+            );
+        }
+    }
+}
+
+fn merge_schema_object(
+    obj: &mut serde_json::Map<String, serde_json::Value>,
+    variant: serde_json::Value,
+) {
+    if let serde_json::Value::Object(inner) = variant {
+        for (key, value) in inner {
+            // Parent-key wins: if a key is already present (e.g. `description`
+            // from the surrounding schema), keep it and use the selected
+            // variant only for missing structural keys.
+            obj.entry(key).or_insert(value);
+        }
+    }
+}
+
+fn schema_type(value: &serde_json::Value) -> Option<&str> {
+    value
+        .as_object()
+        .and_then(|obj| obj.get("type"))
+        .and_then(serde_json::Value::as_str)
+}
+
+fn has_object_shape(value: &serde_json::Value) -> bool {
+    value.as_object().is_some_and(|obj| {
+        obj.contains_key("properties")
+            || obj.contains_key("required")
+            || obj.contains_key("additionalProperties")
+    })
+}
+
+fn has_array_shape(value: &serde_json::Value) -> bool {
+    value.as_object().is_some_and(|obj| {
+        obj.contains_key("items")
+            || obj.contains_key("minItems")
+            || obj.contains_key("maxItems")
+            || obj.contains_key("uniqueItems")
+    })
+}
+
+fn preferred_union_variant_index(variants: &[serde_json::Value]) -> Option<usize> {
+    variants
+        .iter()
+        .position(|variant| schema_type(variant) == Some("object") && has_object_shape(variant))
+        .or_else(|| variants.iter().position(has_object_shape))
+        .or_else(|| {
+            variants.iter().position(|variant| {
+                schema_type(variant) == Some("array") && has_array_shape(variant)
+            })
+        })
+        .or_else(|| variants.iter().position(has_array_shape))
+        .or_else(|| {
+            variants
+                .iter()
+                .position(|variant| schema_type(variant) == Some("object"))
+        })
+        .or_else(|| {
+            variants
+                .iter()
+                .position(|variant| schema_type(variant) == Some("array"))
+        })
+        .or_else(|| {
+            variants
+                .iter()
+                .position(|variant| schema_type(variant).is_some_and(|kind| kind != "null"))
+        })
+        .or_else(|| (!variants.is_empty()).then_some(0))
+}
+
+/// Collapse `anyOf`/`oneOf` unions to a single schema for providers that
+/// cannot represent JSON Schema unions in tool parameters.
+#[derive(Debug, Clone, Default)]
+struct CollapseCompositeUnionTransform;
+
+impl Transform for CollapseCompositeUnionTransform {
+    fn transform(&mut self, schema: &mut Schema) {
+        let Some(obj) = schema.as_object_mut() else {
+            return;
+        };
+
+        for keyword in ["anyOf", "oneOf"] {
+            let Some(variants) = obj.get_mut(keyword).and_then(|v| v.as_array_mut()) else {
+                continue;
+            };
+
+            variants.retain(|v| !v.as_object().is_some_and(|o| o.is_empty()));
+            if variants.is_empty() {
+                obj.remove(keyword);
+                continue;
+            }
+
+            if let Some(index) = preferred_union_variant_index(variants) {
+                let selected = variants.remove(index);
+                obj.remove(keyword);
+                merge_schema_object(obj, selected);
+            }
+        }
+    }
+}
+
 /// Prune `required` entries that reference properties not defined in `properties`.
 ///
 /// MCP tools (e.g. Home Assistant with 80+ tools) may declare `required`
@@ -252,13 +406,7 @@ impl Transform for SimplifyCompositeTransform {
                 let single = variants.remove(0);
                 obj.remove(keyword);
                 if let serde_json::Value::Object(inner) = single {
-                    for (k, v) in inner {
-                        // Parent-key wins: if a key is already present (e.g. `type`
-                        // from a surrounding object schema), we keep the parent value
-                        // and discard the variant's. This is safe for the `not`→`{}`
-                        // canonicalization pattern this transform targets.
-                        obj.entry(k).or_insert(v);
-                    }
+                    merge_schema_object(obj, serde_json::Value::Object(inner));
                 }
             } else if variants.is_empty() {
                 obj.remove(keyword);
@@ -400,6 +548,12 @@ pub(crate) fn sanitize_schema_for_openai_compat(schema: &mut serde_json::Value) 
     let mut subset_transform = RecursiveTransform(OpenAiSchemaSubsetTransform);
     subset_transform.transform(&mut transformed);
 
+    // Collapse array-form types before pruning. Otherwise OpenRouter's Google
+    // converter can discard union-typed object properties while keeping their
+    // nested `required` arrays (#793).
+    let mut collapse_type_arrays = RecursiveTransform(CollapseTypeArrayTransform);
+    collapse_type_arrays.transform(&mut transformed);
+
     // Strip empty `{}` schemas from anyOf/oneOf (left behind by
     // canonicalization of `not` and other negation keywords) and collapse
     // single-variant composites inline (issue #743).
@@ -424,6 +578,22 @@ pub(crate) fn sanitize_schema_for_openai_compat(schema: &mut serde_json::Value) 
     // annotations even when enum values unambiguously imply the type.
     let mut restore_enum_type = RecursiveTransform(RestoreEnumTypeTransform);
     restore_enum_type.transform(&mut transformed);
+
+    *schema = transformed.to_value();
+}
+
+/// Collapse union constructs that OpenRouter's non-strict Google path cannot
+/// safely translate into Gemini function declarations.
+pub(crate) fn collapse_schema_unions_for_non_strict_tools(schema: &mut serde_json::Value) {
+    let Ok(mut transformed) = Schema::try_from(schema.clone()) else {
+        return;
+    };
+
+    let mut collapse_type_arrays = RecursiveTransform(CollapseTypeArrayTransform);
+    collapse_type_arrays.transform(&mut transformed);
+
+    let mut collapse_composite_unions = RecursiveTransform(CollapseCompositeUnionTransform);
+    collapse_composite_unions.transform(&mut transformed);
 
     *schema = transformed.to_value();
 }

--- a/crates/providers/src/openai_compat/schema_normalization.rs
+++ b/crates/providers/src/openai_compat/schema_normalization.rs
@@ -589,11 +589,11 @@ pub(crate) fn collapse_schema_unions_for_non_strict_tools(schema: &mut serde_jso
         return;
     };
 
-    let mut collapse_type_arrays = RecursiveTransform(CollapseTypeArrayTransform);
-    collapse_type_arrays.transform(&mut transformed);
-
     let mut collapse_composite_unions = RecursiveTransform(CollapseCompositeUnionTransform);
     collapse_composite_unions.transform(&mut transformed);
+
+    let mut prune_orphaned_required = RecursiveTransform(PruneOrphanedRequiredTransform);
+    prune_orphaned_required.transform(&mut transformed);
 
     *schema = transformed.to_value();
 }

--- a/crates/providers/tests/openai_compat_type_arrays.rs
+++ b/crates/providers/tests/openai_compat_type_arrays.rs
@@ -230,6 +230,50 @@ fn to_openai_tools_collapses_union_types_without_strict_mode() {
 }
 
 #[test]
+fn to_openai_tools_prunes_orphans_after_non_strict_composite_collapse() {
+    let tools = vec![serde_json::json!({
+        "name": "composite",
+        "description": "Composite schema edge case",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "config": {
+                    "type": "object",
+                    "properties": {
+                        "y": { "type": "string" }
+                    },
+                    "anyOf": [
+                        {
+                            "type": "object",
+                            "properties": {
+                                "x": { "type": "string" }
+                            },
+                            "required": ["x"]
+                        },
+                        { "type": "string" }
+                    ]
+                }
+            },
+            "required": ["config"]
+        }
+    })];
+
+    let converted = to_openai_tools(&tools, false);
+    assert_eq!(converted.len(), 1);
+
+    let params = &converted[0]["function"]["parameters"];
+    let config = &params["properties"]["config"];
+    let mut orphans = Vec::new();
+    find_required_orphans(params, "root", &mut orphans);
+    assert!(orphans.is_empty(), "found required orphans: {orphans:?}");
+    assert!(
+        config.get("required").is_none(),
+        "orphaned composite variant required entries should be pruned"
+    );
+    assert!(config["properties"].get("y").is_some());
+}
+
+#[test]
 fn to_openai_tools_preserves_nested_array_item_required_properties() {
     let tools = vec![serde_json::json!({
         "name": "MultiEdit",

--- a/crates/providers/tests/openai_compat_type_arrays.rs
+++ b/crates/providers/tests/openai_compat_type_arrays.rs
@@ -180,6 +180,108 @@ fn to_openai_tools_collapses_union_types_end_to_end() {
 }
 
 #[test]
+fn to_openai_tools_collapses_union_types_without_strict_mode() {
+    let tools = vec![serde_json::json!({
+        "name": "cron",
+        "description": "Manage cron jobs",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "action": { "type": "string" },
+                "job": {
+                    "type": ["object", "string"],
+                    "properties": {
+                        "name": { "type": "string" },
+                        "schedule": {
+                            "type": ["object", "string", "integer"],
+                            "properties": {
+                                "kind": { "type": "string" }
+                            },
+                            "required": ["kind"]
+                        }
+                    },
+                    "required": ["name", "schedule"]
+                }
+            },
+            "required": ["action", "job"]
+        }
+    })];
+
+    let converted = to_openai_tools(&tools, false);
+    assert_eq!(converted.len(), 1);
+
+    let params = &converted[0]["function"]["parameters"];
+    assert_eq!(params["properties"]["job"]["type"], "object");
+    assert_eq!(
+        params["properties"]["job"]["properties"]["schedule"]["type"],
+        "object"
+    );
+
+    let mut type_arrays = Vec::new();
+    find_type_arrays(params, "root", &mut type_arrays);
+    assert!(
+        type_arrays.is_empty(),
+        "found type arrays after non-strict pipeline: {type_arrays:?}"
+    );
+
+    let mut orphans = Vec::new();
+    find_required_orphans(params, "root", &mut orphans);
+    assert!(orphans.is_empty(), "found required orphans: {orphans:?}");
+}
+
+#[test]
+fn to_openai_tools_preserves_nested_array_item_required_properties() {
+    let tools = vec![serde_json::json!({
+        "name": "MultiEdit",
+        "description": "Apply multiple sequential edits to a single file.",
+        "parameters": {
+            "type": "object",
+            "required": ["file_path", "edits"],
+            "properties": {
+                "file_path": {
+                    "type": "string",
+                    "description": "Absolute path to the file to edit."
+                },
+                "edits": {
+                    "type": "array",
+                    "minItems": 1,
+                    "description": "Ordered list of edits to apply atomically.",
+                    "items": {
+                        "type": "object",
+                        "required": ["old_string", "new_string"],
+                        "properties": {
+                            "old_string": { "type": "string" },
+                            "new_string": { "type": "string" },
+                            "replace_all": { "type": "boolean", "default": false }
+                        }
+                    }
+                }
+            }
+        }
+    })];
+
+    let converted = to_openai_tools(&tools, false);
+    assert_eq!(converted.len(), 1);
+
+    let params = &converted[0]["function"]["parameters"];
+    let mut orphans = Vec::new();
+    find_required_orphans(params, "root", &mut orphans);
+    assert!(orphans.is_empty(), "found required orphans: {orphans:?}");
+
+    let edits_items = &params["properties"]["edits"]["items"];
+    let item_required: Vec<&str> = array_value(&edits_items["required"], "edits.items.required")
+        .iter()
+        .map(|value| str_value(value, "required entry"))
+        .collect();
+    let item_properties = object_value(&edits_items["properties"], "edits.items.properties");
+    assert_eq!(item_required.len(), 2);
+    assert!(item_required.contains(&"old_string"));
+    assert!(item_required.contains(&"new_string"));
+    assert!(item_properties.contains_key("old_string"));
+    assert!(item_properties.contains_key("new_string"));
+}
+
+#[test]
 fn collapse_inside_any_of_variants() {
     let mut schema = serde_json::json!({
         "type": "object",

--- a/crates/providers/tests/openrouter_integration.rs
+++ b/crates/providers/tests/openrouter_integration.rs
@@ -11,7 +11,7 @@
 use {
     futures::StreamExt,
     moltis_agents::model::{ChatMessage, LlmProvider, StreamEvent, ToolCall},
-    moltis_providers::openai::OpenAiProvider,
+    moltis_providers::{openai::OpenAiProvider, openai_compat::to_openai_tools},
     secrecy::{ExposeSecret, Secret},
 };
 
@@ -189,6 +189,64 @@ async fn multi_turn_tool_use() {
         .await
         .expect("second turn");
     assert!(r2.text.is_some(), "should have text after tool result");
+}
+
+#[tokio::test]
+#[ignore]
+async fn google_ai_studio_accepts_non_strict_union_typed_tool_schema() {
+    let key = api_key();
+    let client = reqwest::Client::new();
+    let tools = to_openai_tools(
+        &[serde_json::json!({
+            "name": "cron",
+            "description": "Manage cron jobs.",
+            "parameters": {
+                "type": "object",
+                "required": ["action", "job"],
+                "properties": {
+                    "action": { "type": "string" },
+                    "job": {
+                        "type": ["object", "string"],
+                        "properties": {
+                            "name": { "type": "string" },
+                            "schedule": {
+                                "type": ["object", "string", "integer"],
+                                "properties": {
+                                    "kind": { "type": "string" }
+                                },
+                                "required": ["kind"]
+                            }
+                        },
+                        "required": ["name", "schedule"]
+                    }
+                }
+            }
+        })],
+        false,
+    );
+    let body = serde_json::json!({
+        "model": "google/gemini-3-flash-preview",
+        "messages": [{ "role": "user", "content": "hi" }],
+        "stream": false,
+        "provider": {
+            "ignore": ["google-vertex"]
+        },
+        "tools": tools
+    });
+
+    let resp = client
+        .post(format!("{BASE_URL}/chat/completions"))
+        .header("Authorization", format!("Bearer {}", key.expose_secret()))
+        .json(&body)
+        .send()
+        .await
+        .expect("HTTP request should complete");
+    let status = resp.status();
+    let text = resp.text().await.expect("response body should be readable");
+    assert!(
+        status.is_success(),
+        "OpenRouter Google AI Studio should accept normalized union-typed tool schema, got {status}: {text}"
+    );
 }
 
 // ── Probe & streaming ────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes the OpenRouter + Google AI Studio tool-schema regression from #793 by normalizing non-strict OpenAI-compatible tool schemas before they are sent upstream.

Root cause: OpenRouter runs this provider path with `strict=false`, so the previous strict-mode-only union collapse did not apply. Google AI Studio's OpenRouter translation can drop union-typed object properties like `type: ["object", "string"]` while preserving their nested `required` arrays, producing `property is not defined` validation errors.

This PR:
- collapses array-form `type` unions and composite `anyOf`/`oneOf` unions for non-strict tool schemas
- keeps strict-mode behavior intact
- adds regression coverage for non-strict union schemas and nested array item `required` entries
- adds an ignored live OpenRouter regression test that forces Google AI Studio routing

## Validation

### Completed

- [x] `cargo test -p moltis-providers --test openai_compat_type_arrays -- --nocapture`
- [x] `cargo test -p moltis-providers --test openrouter_integration google_ai_studio_accepts_non_strict_union_typed_tool_schema -- --ignored --nocapture`
- [x] `cargo +nightly-2025-11-30 fmt --all`
- [x] `cargo +nightly-2025-11-30 clippy -p moltis-providers --all-targets -- -D warnings`
- [x] `git diff --check`

### Remaining

- [ ] Full workspace `just lint` / `just test` if desired before merge.

## Manual QA

Reproduced the failure class with a direct OpenRouter request routed to `Google AI Studio` by ignoring `google-vertex`; the unnormalized union-typed schema returned HTTP 400 with `property is not defined`. After the fix, the ignored live regression test sends the schema through `to_openai_tools(..., false)` and receives a successful response from Google AI Studio.