### PR TITLE
fix(tools): skip sysfs tmpfs mounts on WSL2

### DIFF
--- a/crates/tools/src/sandbox/docker.rs
+++ b/crates/tools/src/sandbox/docker.rs
@@ -2,7 +2,7 @@
 
 use {
     async_trait::async_trait,
-    std::collections::HashSet,
+    std::{collections::HashSet, sync::OnceLock},
     tokio::sync::Mutex,
     tracing::{debug, info, warn},
 };
@@ -198,7 +198,15 @@ impl DockerSandbox {
     /// `is_prebuilt` controls whether `--read-only` is applied: prebuilt images
     /// already have packages baked in so the root FS can be read-only, while
     /// non-prebuilt images need a writable root for `apt-get` provisioning.
-    pub(crate) fn hardening_args(is_prebuilt: bool, kind: BackendKind) -> Vec<String> {
+    ///
+    /// `skip_sysfs_mounts` suppresses sysfs tmpfs overlays.  This is needed on
+    /// WSL2 where the sysfs directories may not exist inside the container's
+    /// filesystem, causing Docker to fail with "mkdirat: read-only file system".
+    pub(crate) fn hardening_args(
+        is_prebuilt: bool,
+        kind: BackendKind,
+        skip_sysfs_mounts: bool,
+    ) -> Vec<String> {
         let mut args = vec![
             // --- Capability / privilege ---
             "--cap-drop".to_string(),
@@ -220,12 +228,16 @@ impl DockerSandbox {
         // (serial numbers, BIOS/UEFI data, disk models, LUKS UUIDs).
         // Empty read-only tmpfs overlays hide the underlying sysfs entries.
         //
-        // Podman is excluded: its OCI runtime performs "tmpcopyup" on sysfs
+        // Skipped for Podman: its OCI runtime performs "tmpcopyup" on sysfs
         // tmpfs mounts, copying directory contents into the tmpfs first.
         // With --cap-drop ALL some sysfs files are permission-denied even for
         // root, causing the mount (and container startup) to fail.  Podman
         // already masks /sys/firmware via its built-in OCI MaskedPaths.
-        if kind != BackendKind::Podman {
+        //
+        // Skipped on WSL2: the sysfs directories (/sys/class/dmi, etc.) may
+        // not exist inside the container's sysfs, so Docker cannot create
+        // tmpfs mountpoints on the read-only overlayfs.
+        if kind != BackendKind::Podman && !skip_sysfs_mounts {
             args.extend([
                 "--tmpfs".to_string(),
                 "/sys/firmware:ro,nosuid".to_string(),
@@ -429,7 +441,7 @@ impl Sandbox for DockerSandbox {
         }
 
         args.extend(self.resource_args());
-        args.extend(Self::hardening_args(is_prebuilt, self.kind));
+        args.extend(Self::hardening_args(is_prebuilt, self.kind, is_wsl()));
         args.extend(self.workspace_args());
         args.extend(self.home_persistence_args(id)?);
 
@@ -732,6 +744,22 @@ impl Sandbox for NoSandbox {
     async fn cleanup(&self, _id: &SandboxId) -> Result<()> {
         Ok(())
     }
+}
+
+/// Return `true` when running on Windows Subsystem for Linux (WSL).
+///
+/// WSL2 kernels identify themselves with "microsoft" or "WSL" in
+/// `/proc/version`.  The result is cached for the process lifetime.
+pub(crate) fn is_wsl() -> bool {
+    static WSL: OnceLock<bool> = OnceLock::new();
+    *WSL.get_or_init(|| {
+        std::fs::read_to_string("/proc/version")
+            .map(|v| {
+                let lower = v.to_ascii_lowercase();
+                lower.contains("microsoft") || lower.contains("wsl")
+            })
+            .unwrap_or(false)
+    })
 }
 
 /// Return `true` when the installed Podman version supports `host-gateway`

--- a/crates/tools/src/sandbox/docker.rs
+++ b/crates/tools/src/sandbox/docker.rs
@@ -753,13 +753,22 @@ impl Sandbox for NoSandbox {
 pub(crate) fn is_wsl() -> bool {
     static WSL: OnceLock<bool> = OnceLock::new();
     *WSL.get_or_init(|| {
-        std::fs::read_to_string("/proc/version")
-            .map(|v| {
-                let lower = v.to_ascii_lowercase();
-                lower.contains("microsoft") || lower.contains("wsl")
-            })
-            .unwrap_or(false)
+        let detected = detect_wsl_from_path("/proc/version");
+        if detected {
+            warn!("WSL2 detected: sysfs hardware-identifier tmpfs overlays will be skipped");
+        }
+        detected
     })
+}
+
+/// Testable inner helper: reads the given path and checks for WSL markers.
+pub(crate) fn detect_wsl_from_path(path: &str) -> bool {
+    std::fs::read_to_string(path)
+        .map(|v| {
+            let lower = v.to_ascii_lowercase();
+            lower.contains("microsoft") || lower.contains("wsl")
+        })
+        .unwrap_or(false)
 }
 
 /// Return `true` when the installed Podman version supports `host-gateway`

--- a/crates/tools/src/sandbox/tests/core.rs
+++ b/crates/tools/src/sandbox/tests/core.rs
@@ -17,7 +17,7 @@ fn test_sandbox_scope_display() {
 
 #[test]
 fn test_docker_hardening_args_prebuilt() {
-    let args = DockerSandbox::hardening_args(true, BackendKind::Docker);
+    let args = DockerSandbox::hardening_args(true, BackendKind::Docker, false);
     assert!(args.contains(&"--cap-drop".to_string()));
     assert!(args.contains(&"ALL".to_string()));
     assert!(args.contains(&"--security-opt".to_string()));
@@ -44,7 +44,7 @@ fn test_docker_hardening_args_prebuilt() {
 
 #[test]
 fn test_docker_hardening_args_not_prebuilt() {
-    let args = DockerSandbox::hardening_args(false, BackendKind::Docker);
+    let args = DockerSandbox::hardening_args(false, BackendKind::Docker, false);
     assert!(args.contains(&"--cap-drop".to_string()));
     assert!(args.contains(&"ALL".to_string()));
     assert!(args.contains(&"--security-opt".to_string()));
@@ -71,7 +71,7 @@ fn test_docker_hardening_args_not_prebuilt() {
 
 #[test]
 fn test_docker_hardening_args_podman() {
-    let args = DockerSandbox::hardening_args(true, BackendKind::Podman);
+    let args = DockerSandbox::hardening_args(true, BackendKind::Podman, false);
     // Core hardening flags must still be present
     assert!(args.contains(&"--cap-drop".to_string()));
     assert!(args.contains(&"ALL".to_string()));
@@ -95,6 +95,46 @@ fn test_docker_hardening_args_podman() {
     assert!(!args.contains(&"/sys/class/dmi:ro,nosuid".to_string()));
     assert!(!args.contains(&"/sys/devices/virtual/dmi:ro,nosuid".to_string()));
     assert!(!args.contains(&"/sys/class/block:ro,nosuid".to_string()));
+}
+
+#[test]
+fn test_docker_hardening_args_skips_sysfs_on_wsl() {
+    // On WSL2 the sysfs directories (/sys/class/dmi, /sys/devices/virtual/dmi,
+    // etc.) may not exist inside the container's sysfs, so Docker cannot create
+    // tmpfs mountpoints on the read-only overlayfs.  hardening_args must skip
+    // sysfs masks when `skip_sysfs_mounts` is true.
+    let args = DockerSandbox::hardening_args(true, BackendKind::Docker, true);
+
+    // Core hardening flags must still be present
+    assert!(args.contains(&"--cap-drop".to_string()));
+    assert!(args.contains(&"ALL".to_string()));
+    assert!(args.contains(&"--security-opt".to_string()));
+    assert!(args.contains(&"no-new-privileges".to_string()));
+    assert!(args.contains(&"--read-only".to_string()));
+    // Basic tmpfs mounts (writable /tmp and /run) must still be present
+    assert!(args.contains(&"/tmp:rw,nosuid,size=256m".to_string()));
+    assert!(args.contains(&"/run:rw,nosuid,size=64m".to_string()));
+    // Hostname isolation still present
+    let hostname_pos = args
+        .iter()
+        .position(|a| a == "--hostname")
+        .expect("--hostname flag missing");
+    assert_eq!(
+        args[hostname_pos + 1],
+        "sandbox",
+        "--hostname value should be 'sandbox'"
+    );
+    // Sysfs tmpfs overlays must NOT be present (WSL2 compat)
+    assert!(!args.contains(&"/sys/firmware:ro,nosuid".to_string()));
+    assert!(!args.contains(&"/sys/class/dmi:ro,nosuid".to_string()));
+    assert!(!args.contains(&"/sys/devices/virtual/dmi:ro,nosuid".to_string()));
+    assert!(!args.contains(&"/sys/class/block:ro,nosuid".to_string()));
+}
+
+#[test]
+fn test_is_wsl_returns_false_on_non_wsl() {
+    // On macOS and standard Linux CI, is_wsl() must return false.
+    assert!(!is_wsl());
 }
 
 #[test]

--- a/crates/tools/src/sandbox/tests/core.rs
+++ b/crates/tools/src/sandbox/tests/core.rs
@@ -134,7 +134,30 @@ fn test_docker_hardening_args_skips_sysfs_on_wsl() {
 #[test]
 fn test_is_wsl_returns_false_on_non_wsl() {
     // On macOS and standard Linux CI, is_wsl() must return false.
+    // Note: uses the OnceLock-cached value — this test assumes it does not
+    // run on an actual WSL2 host.
     assert!(!is_wsl());
+}
+
+#[test]
+fn test_detect_wsl_from_path_positive() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("proc_version");
+    std::fs::write(&path, "Linux version 5.15.167.4-microsoft-standard-WSL2").unwrap();
+    assert!(detect_wsl_from_path(path.to_str().unwrap()));
+}
+
+#[test]
+fn test_detect_wsl_from_path_negative() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("proc_version");
+    std::fs::write(&path, "Linux version 6.8.0-45-generic (buildd@lcy02-amd64)").unwrap();
+    assert!(!detect_wsl_from_path(path.to_str().unwrap()));
+}
+
+#[test]
+fn test_detect_wsl_from_path_missing_file() {
+    assert!(!detect_wsl_from_path("/nonexistent/path/proc/version"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Detect WSL2 at runtime via `/proc/version` (cached with `OnceLock`) and skip sysfs tmpfs overlay mounts (`/sys/class/dmi`, `/sys/firmware`, `/sys/devices/virtual/dmi`, `/sys/class/block`) that fail on WSL2 where these directories don't exist in the container's sysfs
- All other Docker hardening flags (cap-drop ALL, no-new-privileges, hostname isolation, writable tmpfs for /tmp and /run, read-only root FS) remain active

Closes #828

## Validation

### Completed
- [x] `cargo +nightly-2025-11-30 fmt --all -- --check` passes
- [x] `just lint` passes (clippy clean)
- [x] `cargo test -p moltis-tools --lib sandbox` — 230 tests pass
- [x] New test `test_docker_hardening_args_skips_sysfs_on_wsl` verifies sysfs mounts are excluded when `skip_sysfs_mounts=true`
- [x] New test `test_is_wsl_returns_false_on_non_wsl` verifies detection returns false on macOS/standard Linux
- [x] Existing hardening tests updated and pass with new parameter

### Remaining
- [ ] `./scripts/local-validate.sh` (full CI suite)
- [ ] Manual QA on WSL2 host

## Manual QA

1. On a WSL2 host with Docker, run `moltis` and execute `/sh ls` — should succeed without "mkdirat: read-only file system" error
2. On a non-WSL Linux host, verify sysfs tmpfs overlays are still applied (check `docker inspect` on the sandbox container)
3. On macOS, verify no behavioral change (sysfs mounts still applied)