### PR TITLE
fix(chat): preserve Gemini tool call metadata

### DIFF
--- a/crates/agents/src/model.rs
+++ b/crates/agents/src/model.rs
@@ -9,6 +9,12 @@ use crate::multimodal::parse_data_uri;
 /// Re-export from config so downstream crates can use `moltis_agents::model::ReasoningEffort`.
 pub use moltis_config::schema::ReasoningEffort;
 
+mod types;
+pub use types::{
+    CompletionResponse, MAX_CAPTURED_PROVIDER_RAW_EVENTS, ModelMetadata, TOOL_CALL_METADATA_KEYS,
+    ToolCall, Usage, push_capped_provider_raw_event,
+};
+
 fn document_absolute_path_from_media_ref(media_ref: &str) -> String {
     if Path::new(media_ref).is_absolute() {
         return media_ref.to_string();
@@ -631,73 +637,6 @@ pub trait LlmProvider: Send + Sync {
             context_length: self.context_window(),
         })
     }
-}
-
-/// Response from an LLM completion call.
-#[derive(Debug)]
-pub struct CompletionResponse {
-    pub text: Option<String>,
-    pub tool_calls: Vec<ToolCall>,
-    pub usage: Usage,
-}
-
-pub const MAX_CAPTURED_PROVIDER_RAW_EVENTS: usize = 256;
-
-#[derive(Debug, Clone)]
-pub struct ToolCall {
-    pub id: String,
-    pub name: String,
-    pub arguments: serde_json::Value,
-    /// Provider-specific opaque metadata to round-trip (e.g. Gemini `thought_signature`).
-    /// Only allowlisted keys are extracted; see [`TOOL_CALL_METADATA_KEYS`].
-    pub metadata: Option<serde_json::Map<String, serde_json::Value>>,
-}
-
-/// Keys extracted from provider tool-call JSON into [`ToolCall::metadata`].
-pub const TOOL_CALL_METADATA_KEYS: &[&str] = &["thought_signature"];
-
-#[derive(Debug, Clone, Default)]
-pub struct Usage {
-    pub input_tokens: u32,
-    pub output_tokens: u32,
-    pub cache_read_tokens: u32,
-    pub cache_write_tokens: u32,
-}
-
-impl Usage {
-    #[must_use]
-    pub fn saturating_add(&self, other: &Self) -> Self {
-        Self {
-            input_tokens: self.input_tokens.saturating_add(other.input_tokens),
-            output_tokens: self.output_tokens.saturating_add(other.output_tokens),
-            cache_read_tokens: self
-                .cache_read_tokens
-                .saturating_add(other.cache_read_tokens),
-            cache_write_tokens: self
-                .cache_write_tokens
-                .saturating_add(other.cache_write_tokens),
-        }
-    }
-
-    pub fn saturating_add_assign(&mut self, other: &Self) {
-        *self = self.saturating_add(other);
-    }
-}
-
-pub fn push_capped_provider_raw_event(
-    raw_events: &mut Vec<serde_json::Value>,
-    raw_event: serde_json::Value,
-) {
-    if raw_events.len() < MAX_CAPTURED_PROVIDER_RAW_EVENTS {
-        raw_events.push(raw_event);
-    }
-}
-
-/// Runtime model metadata fetched from provider APIs.
-#[derive(Debug, Clone)]
-pub struct ModelMetadata {
-    pub id: String,
-    pub context_length: u32,
 }
 
 #[allow(clippy::unwrap_used, clippy::expect_used)]

--- a/crates/agents/src/model.rs
+++ b/crates/agents/src/model.rs
@@ -251,9 +251,14 @@ pub fn extract_tool_call_metadata(
     tc: &serde_json::Value,
 ) -> Option<serde_json::Map<String, serde_json::Value>> {
     let obj = tc.as_object()?;
+    let nested = obj.get("metadata").and_then(serde_json::Value::as_object);
     let meta: serde_json::Map<_, _> = TOOL_CALL_METADATA_KEYS
         .iter()
-        .filter_map(|&k| obj.get(k).map(|v| (k.to_string(), v.clone())))
+        .filter_map(|&k| {
+            obj.get(k)
+                .or_else(|| nested.and_then(|metadata| metadata.get(k)))
+                .map(|v| (k.to_string(), v.clone()))
+        })
         .collect();
     if meta.is_empty() {
         None
@@ -1449,6 +1454,19 @@ mod tests {
             ChatMessage::Assistant { tool_calls, .. } => {
                 let meta = tool_calls[0].metadata.as_ref().expect("metadata present");
                 assert_eq!(meta["thought_signature"], "sig_abc");
+            },
+            other => panic!("expected Assistant, got {other:?}"),
+        }
+        // Persisted sessions store provider fields under tool_calls[].metadata.
+        let persisted = vec![serde_json::json!({
+            "role": "assistant", "content": null,
+            "tool_calls": [{"id": "c1", "metadata": {"thought_signature": "sig_persisted"},
+                            "function": {"name": "exec", "arguments": "{}"}}]
+        })];
+        match &values_to_chat_messages(&persisted)[0] {
+            ChatMessage::Assistant { tool_calls, .. } => {
+                let meta = tool_calls[0].metadata.as_ref().expect("metadata present");
+                assert_eq!(meta["thought_signature"], "sig_persisted");
             },
             other => panic!("expected Assistant, got {other:?}"),
         }

--- a/crates/agents/src/model/types.rs
+++ b/crates/agents/src/model/types.rs
@@ -1,0 +1,66 @@
+/// Response from an LLM completion call.
+#[derive(Debug)]
+pub struct CompletionResponse {
+    pub text: Option<String>,
+    pub tool_calls: Vec<ToolCall>,
+    pub usage: Usage,
+}
+
+pub const MAX_CAPTURED_PROVIDER_RAW_EVENTS: usize = 256;
+
+#[derive(Debug, Clone)]
+pub struct ToolCall {
+    pub id: String,
+    pub name: String,
+    pub arguments: serde_json::Value,
+    /// Provider-specific opaque metadata to round-trip (e.g. Gemini `thought_signature`).
+    /// Only allowlisted keys are extracted; see [`TOOL_CALL_METADATA_KEYS`].
+    pub metadata: Option<serde_json::Map<String, serde_json::Value>>,
+}
+
+/// Keys extracted from provider tool-call JSON into [`ToolCall::metadata`].
+pub const TOOL_CALL_METADATA_KEYS: &[&str] = &["thought_signature"];
+
+#[derive(Debug, Clone, Default)]
+pub struct Usage {
+    pub input_tokens: u32,
+    pub output_tokens: u32,
+    pub cache_read_tokens: u32,
+    pub cache_write_tokens: u32,
+}
+
+impl Usage {
+    #[must_use]
+    pub fn saturating_add(&self, other: &Self) -> Self {
+        Self {
+            input_tokens: self.input_tokens.saturating_add(other.input_tokens),
+            output_tokens: self.output_tokens.saturating_add(other.output_tokens),
+            cache_read_tokens: self
+                .cache_read_tokens
+                .saturating_add(other.cache_read_tokens),
+            cache_write_tokens: self
+                .cache_write_tokens
+                .saturating_add(other.cache_write_tokens),
+        }
+    }
+
+    pub fn saturating_add_assign(&mut self, other: &Self) {
+        *self = self.saturating_add(other);
+    }
+}
+
+pub fn push_capped_provider_raw_event(
+    raw_events: &mut Vec<serde_json::Value>,
+    raw_event: serde_json::Value,
+) {
+    if raw_events.len() < MAX_CAPTURED_PROVIDER_RAW_EVENTS {
+        raw_events.push(raw_event);
+    }
+}
+
+/// Runtime model metadata fetched from provider APIs.
+#[derive(Debug, Clone)]
+pub struct ModelMetadata {
+    pub id: String,
+    pub context_length: u32,
+}

--- a/crates/agents/src/runner/helpers.rs
+++ b/crates/agents/src/runner/helpers.rs
@@ -102,6 +102,7 @@ pub enum RunnerEvent {
         id: String,
         name: String,
         arguments: serde_json::Value,
+        metadata: Option<serde_json::Map<String, serde_json::Value>>,
     },
     ToolCallEnd {
         id: String,

--- a/crates/agents/src/runner/non_streaming.rs
+++ b/crates/agents/src/runner/non_streaming.rs
@@ -523,6 +523,7 @@ pub async fn run_agent_loop_with_context(
                             id: tc.id.clone(),
                             name: tc.name.clone(),
                             arguments: args.clone(),
+                            metadata: tc.metadata.clone(),
                         });
                     }
                     info!(tool = %tc_name, id = %tc.id, args = %args, "executing tool");

--- a/crates/agents/src/runner/streaming.rs
+++ b/crates/agents/src/runner/streaming.rs
@@ -646,6 +646,7 @@ pub async fn run_agent_loop_streaming(
                             id: tc.id.clone(),
                             name: tc.name.clone(),
                             arguments: args.clone(),
+                            metadata: tc.metadata.clone(),
                         });
                     }
                     info!(tool = %tc_name, id = %tc.id, args = %args, "executing tool");

--- a/crates/agents/src/runner/tests_legacy/core.rs
+++ b/crates/agents/src/runner/tests_legacy/core.rs
@@ -473,6 +473,7 @@ pub enum RunnerEvent {
         id: String,
         name: String,
         arguments: serde_json::Value,
+        metadata: Option<serde_json::Map<String, serde_json::Value>>,
     },
     ToolCallEnd {
         id: String,

--- a/crates/agents/src/runner/tests_legacy/runner.rs
+++ b/crates/agents/src/runner/tests_legacy/runner.rs
@@ -525,6 +525,7 @@ pub async fn run_agent_loop_with_context(
                             id: tc.id.clone(),
                             name: tc.name.clone(),
                             arguments: args.clone(),
+                            metadata: tc.metadata.clone(),
                         });
                     }
                     info!(tool = %tc_name, id = %tc.id, args = %args, "executing tool");

--- a/crates/agents/src/runner/tests_legacy/streaming.rs
+++ b/crates/agents/src/runner/tests_legacy/streaming.rs
@@ -628,6 +628,7 @@ pub async fn run_agent_loop_streaming(
                             id: tc.id.clone(),
                             name: tc.name.clone(),
                             arguments: args.clone(),
+                            metadata: tc.metadata.clone(),
                         });
                     }
                     info!(tool = %tc_name, id = %tc.id, args = %args, "executing tool");

--- a/crates/chat/src/run_with_tools.rs
+++ b/crates/chat/src/run_with_tools.rs
@@ -249,6 +249,7 @@ pub(crate) async fn run_with_tools(
     let event_forwarder = tokio::spawn(async move {
         // Track tool call arguments from ToolCallStart so they can be persisted in ToolCallEnd.
         let mut tool_args_map: HashMap<String, Value> = HashMap::new();
+        let mut tool_metadata_map: HashMap<String, serde_json::Map<String, Value>> = HashMap::new();
         // Track reasoning text that should be persisted with the first tool call after thinking.
         let mut tool_reasoning_map: HashMap<String, String> = HashMap::new();
         let mut latest_reasoning = String::new();
@@ -275,8 +276,12 @@ pub(crate) async fn run_with_tools(
                     id,
                     name,
                     arguments,
+                    metadata,
                 } => {
                     tool_args_map.insert(id.clone(), arguments.clone());
+                    if let Some(metadata) = metadata {
+                        tool_metadata_map.insert(id.clone(), metadata);
+                    }
 
                     // Track active tool call for chat.peek.
                     if let Some(ref map) = active_tool_calls {
@@ -616,11 +621,12 @@ pub(crate) async fn run_with_tools(
                             r
                         });
                         let tracked_reasoning = tool_reasoning_map.remove(&id);
+                        let tracked_metadata = tool_metadata_map.remove(&id);
                         let assistant_tool_call_msg = build_tool_call_assistant_message(
                             id.clone(),
                             name.clone(),
                             tracked_args.clone(),
-                            None,
+                            tracked_metadata,
                             seq,
                             Some(run_id.as_str()),
                         );

--- a/crates/web/ui/e2e/README.md
+++ b/crates/web/ui/e2e/README.md
@@ -66,6 +66,7 @@ project for local Ollama/Qwen validation:
 | `settings-nav.spec.js` | 17 | Settings subsection routing and rendering |
 | `theme.spec.js` | 3 | Theme toggle, dark mode, localStorage persistence |
 | `providers.spec.js` | 5 | Provider page load, add/detect buttons, guidance |
+| `gemini-tool-signature.spec.js` | 1 | Mock Gemini-compatible provider verifies tool-call `thought_signature` survives a web chat tool round trip |
 | `cron.spec.js` | 4 | Cron jobs page, heartbeat tab, create button |
 | `skills.spec.js` | 4 | Skills page, install input, featured repos |
 | `projects.spec.js` | 4 | Projects page, add input, auto-detect |

--- a/crates/web/ui/e2e/specs/gemini-tool-signature.spec.js
+++ b/crates/web/ui/e2e/specs/gemini-tool-signature.spec.js
@@ -1,0 +1,298 @@
+const http = require("node:http");
+
+const { expect, test } = require("../base-test");
+const { navigateAndWait, waitForWsConnected, watchPageErrors } = require("../helpers");
+
+const MODEL_ID = "gemini-e2e-tool-signature";
+const SIGNATURE = "sig_e2e_issue_375";
+const SENTINEL = "GEMINI_E2E_TOOL_SIGNATURE_OK";
+const MISSING_SIGNATURE_ERROR =
+	"Function call is missing a thought_signature in functionCall parts. This is required for tools to work correctly, and missing thought_signature may lead to degraded model performance.";
+
+function isRetryableRpcError(message) {
+	if (typeof message !== "string") return false;
+	return message.includes("WebSocket not connected") || message.includes("WebSocket disconnected");
+}
+
+async function sendRpcFromPage(page, method, params) {
+	let lastResponse = null;
+	for (let attempt = 0; attempt < 30; attempt++) {
+		if (attempt > 0) {
+			await waitForWsConnected(page, 5_000).catch(() => "ignored");
+		}
+		lastResponse = await page
+			.evaluate(
+				async ({ methodName, methodParams }) => {
+					var appScript = document.querySelector('script[type="module"][src*="js/app.js"]');
+					if (!appScript) throw new Error("app module script not found");
+					var appUrl = new URL(appScript.src, window.location.origin);
+					var prefix = appUrl.href.slice(0, appUrl.href.length - "js/app.js".length);
+					var helpers = await import(`${prefix}js/helpers.js`);
+					return helpers.sendRpc(methodName, methodParams);
+				},
+				{
+					methodName: method,
+					methodParams: params,
+				},
+			)
+			.catch((error) => ({ ok: false, error: { message: error?.message || String(error) } }));
+
+		if (lastResponse?.ok) return lastResponse;
+		if (!isRetryableRpcError(lastResponse?.error?.message)) return lastResponse;
+	}
+	return lastResponse;
+}
+
+async function expectRpcOk(page, method, params) {
+	const response = await sendRpcFromPage(page, method, params);
+	expect(response?.ok, `RPC ${method} failed: ${response?.error?.message || "unknown error"}`).toBeTruthy();
+	return response;
+}
+
+function readRequestJson(req) {
+	return new Promise((resolve, reject) => {
+		let raw = "";
+		req.setEncoding("utf8");
+		req.on("data", (chunk) => {
+			raw += chunk;
+		});
+		req.on("end", () => {
+			try {
+				resolve(raw ? JSON.parse(raw) : {});
+			} catch (error) {
+				reject(error);
+			}
+		});
+		req.on("error", reject);
+	});
+}
+
+function writeJson(res, status, body) {
+	res.writeHead(status, { "content-type": "application/json" });
+	res.end(JSON.stringify(body));
+}
+
+function writeSse(res, events) {
+	res.writeHead(200, {
+		"cache-control": "no-cache",
+		connection: "keep-alive",
+		"content-type": "text/event-stream",
+	});
+	for (const event of events) {
+		res.write(`data: ${typeof event === "string" ? event : JSON.stringify(event)}\n\n`);
+	}
+	res.end();
+}
+
+function toolCallStartEvent() {
+	return {
+		choices: [
+			{
+				delta: {
+					tool_calls: [
+						{
+							index: 0,
+							id: "gemini_call_1",
+							thought_signature: SIGNATURE,
+							function: {
+								name: "exec",
+								arguments: "",
+							},
+						},
+					],
+				},
+				finish_reason: null,
+			},
+		],
+	};
+}
+
+function toolCallArgumentsEvent() {
+	return {
+		choices: [
+			{
+				delta: {
+					tool_calls: [
+						{
+							index: 0,
+							function: {
+								arguments: JSON.stringify({ command: `printf ${SENTINEL}` }),
+							},
+						},
+					],
+				},
+				finish_reason: "tool_calls",
+			},
+		],
+	};
+}
+
+function finalTextEvent() {
+	return {
+		choices: [
+			{
+				delta: {
+					content: SENTINEL,
+				},
+				finish_reason: null,
+			},
+		],
+	};
+}
+
+function doneEvent() {
+	return {
+		choices: [
+			{
+				delta: {},
+				finish_reason: "stop",
+			},
+		],
+		usage: {
+			prompt_tokens: 12,
+			completion_tokens: 4,
+			total_tokens: 16,
+		},
+	};
+}
+
+function requestIncludesThoughtSignature(body) {
+	const messages = Array.isArray(body?.messages) ? body.messages : [];
+	return messages.some((message) => {
+		const toolCalls = Array.isArray(message?.tool_calls) ? message.tool_calls : [];
+		return toolCalls.some((toolCall) => toolCall?.thought_signature === SIGNATURE);
+	});
+}
+
+async function startGeminiMockServer() {
+	const completionRequests = [];
+	let completionCount = 0;
+	const server = http.createServer(async (req, res) => {
+		try {
+			if (req.method === "GET" && req.url === "/v1/models") {
+				writeJson(res, 200, {
+					object: "list",
+					data: [{ id: MODEL_ID, object: "model", created: 1, owned_by: "e2e" }],
+				});
+				return;
+			}
+
+			if (req.method !== "POST" || req.url !== "/v1/chat/completions") {
+				writeJson(res, 404, { error: { message: "not found" } });
+				return;
+			}
+
+			const body = await readRequestJson(req);
+			completionCount += 1;
+			completionRequests.push(body);
+
+			if (completionCount === 1) {
+				writeSse(res, [toolCallStartEvent(), toolCallArgumentsEvent(), "[DONE]"]);
+				return;
+			}
+
+			if (!requestIncludesThoughtSignature(body)) {
+				writeJson(res, 400, {
+					error: {
+						code: 400,
+						message: MISSING_SIGNATURE_ERROR,
+						status: "INVALID_ARGUMENT",
+					},
+				});
+				return;
+			}
+
+			writeSse(res, [finalTextEvent(), doneEvent(), "[DONE]"]);
+		} catch (error) {
+			writeJson(res, 500, { error: { message: error?.message || String(error) } });
+		}
+	});
+
+	await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+	const address = server.address();
+	if (!address || typeof address === "string") {
+		throw new Error("mock server did not bind to a TCP port");
+	}
+
+	return {
+		baseUrl: `http://127.0.0.1:${address.port}/v1`,
+		completionRequests,
+		close: () => new Promise((resolve, reject) => server.close((error) => (error ? reject(error) : resolve()))),
+	};
+}
+
+test.describe("Gemini tool-call thought signatures", () => {
+	test("web chat round-trips tool call metadata into the follow-up provider request", async ({ page }) => {
+		test.setTimeout(120_000);
+		const mock = await startGeminiMockServer();
+		const pageErrors = watchPageErrors(page);
+		let providerName = "";
+
+		try {
+			await navigateAndWait(page, "/");
+			await waitForWsConnected(page);
+
+			const customResponse = await expectRpcOk(page, "providers.add_custom", {
+				baseUrl: mock.baseUrl,
+				apiKey: "e2e-key",
+				model: MODEL_ID,
+			});
+			providerName = String(customResponse.payload?.providerName || "");
+			expect(providerName).toMatch(/^custom-/);
+
+			const modelsResponse = await expectRpcOk(page, "models.list", {});
+			const model = (modelsResponse.payload || []).find((entry) => entry?.id === `${providerName}::${MODEL_ID}`);
+			expect(model, "expected the custom Gemini mock model to be registered").toBeTruthy();
+
+			await expectRpcOk(page, "chat.clear", { sessionKey: "main" });
+			const sendResponse = await expectRpcOk(page, "chat.send", {
+				sessionKey: "main",
+				model: model.id,
+				text: "Use the exec tool to print the sentinel.",
+			});
+			expect(String(sendResponse.payload?.runId || "")).not.toBe("");
+
+			await expect
+				.poll(
+					async () => {
+						const historyResponse = await sendRpcFromPage(page, "chat.history", { sessionKey: "main" });
+						if (!historyResponse?.ok) {
+							return `history-rpc-error:${historyResponse?.error?.message || "unknown error"}`;
+						}
+
+						const errorCards = page.locator(".error-card, .msg.error");
+						const errorCount = await errorCards.count();
+						if (errorCount > 0) {
+							const text = await errorCards
+								.nth(errorCount - 1)
+								.textContent()
+								.catch(() => "");
+							if (text) return `page-error:${text.trim()}`;
+						}
+
+						const assistantMessages = (historyResponse.payload || []).filter((message) => message.role === "assistant");
+						return String(assistantMessages.at(-1)?.content || "");
+					},
+					{ timeout: 120_000 },
+				)
+				.toContain(SENTINEL);
+
+			expect(mock.completionRequests.length).toBeGreaterThanOrEqual(2);
+			expect(requestIncludesThoughtSignature(mock.completionRequests[1])).toBe(true);
+
+			const historyResponse = await expectRpcOk(page, "chat.history", { sessionKey: "main" });
+			const persistedToolCall = (historyResponse.payload || [])
+				.flatMap((message) => (Array.isArray(message?.tool_calls) ? message.tool_calls : []))
+				.find((toolCall) => toolCall?.id === "gemini_call_1");
+			expect(persistedToolCall?.metadata?.thought_signature).toBe(SIGNATURE);
+
+			await expect(page.locator(".error-card, .msg.error")).toHaveCount(0);
+			expect(pageErrors).toEqual([]);
+		} finally {
+			if (providerName) {
+				await sendRpcFromPage(page, "providers.remove_key", { provider: providerName }).catch(() => null);
+			}
+			await mock.close();
+		}
+	});
+});

--- a/crates/web/ui/e2e/specs/gemini-tool-signature.spec.js
+++ b/crates/web/ui/e2e/specs/gemini-tool-signature.spec.js
@@ -59,8 +59,8 @@ function readRequestJson(req) {
 		req.on("end", () => {
 			try {
 				resolve(raw ? JSON.parse(raw) : {});
-			} catch (error) {
-				reject(error);
+			} catch (_error) {
+				reject(new Error("invalid request json"));
 			}
 		});
 		req.on("error", reject);
@@ -203,8 +203,8 @@ async function startGeminiMockServer() {
 			}
 
 			writeSse(res, [finalTextEvent(), doneEvent(), "[DONE]"]);
-		} catch (error) {
-			writeJson(res, 500, { error: { message: error?.message || String(error) } });
+		} catch (_error) {
+			writeJson(res, 500, { error: { message: "mock server internal error" } });
 		}
 	});
 


### PR DESCRIPTION
## Summary
- Preserve Gemini/OpenAI-compatible tool-call metadata through runner events and chat history persistence.
- Restore persisted `tool_calls[].metadata.thought_signature` into provider request messages on later turns.
- Add a mocked web e2e regression for issue #375's Gemini tool-call failure.
- Split `crates/agents/src/model.rs` model types into a sibling module to satisfy the 1,500-line file-size gate.

## Validation

### Completed
- [x] `cargo +nightly-2025-11-30 fmt --all -- --check`
- [x] `./scripts/check-file-size.sh`
- [x] `cargo +nightly-2025-11-30 test -p moltis-agents values_to_chat_messages_metadata_extraction --lib`
- [x] `cargo +nightly-2025-11-30 check -p moltis-agents`
- [x] `cargo +nightly-2025-11-30 check -p moltis-chat`
- [x] `cd crates/web/ui && npx biome check --write e2e/specs/gemini-tool-signature.spec.js`
- [x] `node --check crates/web/ui/e2e/specs/gemini-tool-signature.spec.js`
- [x] `git diff --check`

### Remaining
- [ ] `cd crates/web/ui && npx playwright test e2e/specs/gemini-tool-signature.spec.js` (attempted; Playwright webServer timed out after 300s compiling the gateway before browser tests started)
- [ ] `just lint`
- [ ] `just test`
- [ ] `just release-preflight`
- [ ] `./scripts/local-validate.sh 836`

## Manual QA
- Not run manually. The new e2e mock is intended to cover the browser/API path once the gateway binary build completes within the Playwright webServer timeout.
