### PR TITLE
fix(web): add vault-sealed banner to main app

### DIFF
--- a/crates/web/src/templates/index.html
+++ b/crates/web/src/templates/index.html
@@ -163,6 +163,12 @@
   <button id="updateDismissBtn" type="button" class="auth-disabled-setup bg-transparent border-0 p-0 cursor-pointer">Dismiss</button>
 </div>
 
+<!-- Vault sealed banner (shown when vault is locked after restart) -->
+<div id="vaultBanner" class="info-banner" style="display:none">
+  <span>Your encryption vault is locked — API keys are unavailable until unlocked.</span>
+  <a href="{{ routes.settings }}/vault" class="auth-disabled-setup">Unlock vault</a>
+</div>
+
 <!-- PWA Install Banner (shown on mobile when not installed) -->
 <div id="installBanner" class="hidden fixed bottom-0 left-0 right-0 z-50 bg-[var(--surface)] border-t border-[var(--border)] p-4 pb-[max(1rem,env(safe-area-inset-bottom))] shadow-lg flex-col gap-3 md:hidden">
   <div class="flex items-start gap-3">


### PR DESCRIPTION
## Summary

Closes #344

After a server restart, the vault is sealed but logged-in users received no visible notification or action path in the main app UI. The model list appeared empty, making the instance look broken.

## Change

Add the missing `#vaultBanner` element to `index.html`. The JS function `showVaultBanner()` in `app.tsx` already toggles this element — it was only present in `login.html`, never in the main app shell.

The banner displays:
- **Message:** "Your encryption vault is locked — API keys are unavailable until unlocked."
- **Link:** "Unlock vault" → `/settings/vault`

Reuses the existing `.info-banner` CSS class and `auth-disabled-setup` link style consistent with the update and auth-disabled banners.

## Files changed

- `crates/web/src/templates/index.html` (+6 lines)

## Test plan

- [ ] Restart moltis with vault enabled → banner appears on main app
- [ ] Click "Unlock vault" → navigates to /settings/vault
- [ ] Unlock vault → banner disappears
- [ ] Verify login page vault banner still works unchanged
