### PR TITLE
fix(mcp): show re-auth button when OAuth server needs re-authentication

### DIFF
--- a/crates/web/src/assets/dist/chunks/skills2.js
+++ b/crates/web/src/assets/dist/chunks/skills2.js
@@ -89,6 +89,9 @@ const skills = {
   securitySandbox: "With sandbox mode enabled (Docker, Apple Container, or cgroup), command execution is isolated and the damage a malicious skill can do is significantly limited.",
   dismiss: "Dismiss",
   disableAllThirdParty: "Disable all third-party skills",
+  // ── Bundled categories ──────────────────────────────────
+  bundledTitle: "Catégories de compétences intégrées",
+  bundledDescription: "Activez ou désactivez les catégories de compétences intégrées. Les catégories désactivées sont exclues du contexte de l'agent.",
   // ── Featured skill descriptions ─────────────────────────
   featuredOpenClaw: "Community skills from ClawdHub",
   featuredAnthropic: "Official Anthropic agent skills",

--- a/crates/web/src/assets/dist/chunks/skills3.js
+++ b/crates/web/src/assets/dist/chunks/skills3.js
@@ -89,6 +89,9 @@ const skills = {
   securitySandbox: "启用沙盒模式（Docker、Apple Container 或 cgroup）后，命令执行将被隔离，恶意技能造成的损害将大大减少。",
   dismiss: "忽略",
   disableAllThirdParty: "禁用所有第三方技能",
+  // ── Bundled categories ──────────────────────────────────
+  bundledTitle: "内置技能类别",
+  bundledDescription: "切换内置技能类别。已禁用的类别将从代理上下文中排除。",
   // ── Featured skill descriptions ─────────────────────────
   featuredOpenClaw: "来自 ClawdHub 的社区技能",
   featuredAnthropic: "Anthropic 官方代理技能",

--- a/crates/web/src/assets/dist/main.js
+++ b/crates/web/src/assets/dist/main.js
@@ -22859,6 +22859,7 @@ function ServerCard({ server }) {
   const expanded = useSignal(false);
   const tools = useSignal(null);
   const toggling = useSignal(false);
+  const authing = useSignal(false);
   const editing = useSignal(false);
   const editTransport = useSignal("stdio");
   const editCmd = useSignal("");
@@ -22902,6 +22903,7 @@ function ServerCard({ server }) {
   async function reauth(e) {
     var _a2;
     e.stopPropagation();
+    authing.value = true;
     const res = await sendRpc("mcp.reauth", { name: server.name, redirectUri: oauthCallbackUrl() });
     if (res == null ? void 0 : res.ok) {
       const p = res.payload;
@@ -22909,6 +22911,7 @@ function ServerCard({ server }) {
       if (p == null ? void 0 : p.authUrl) window.open(p.authUrl, "_blank", "noopener,noreferrer");
     } else showToast$1(`Re-auth failed: ${((_a2 = res == null ? void 0 : res.error) == null ? void 0 : _a2.message) || "unknown"}`, "error");
     await refreshServers();
+    authing.value = false;
   }
   function startEdit(e) {
     e.stopPropagation();
@@ -23012,7 +23015,7 @@ function ServerCard({ server }) {
         needsReauth && /* @__PURE__ */ u("span", { className: "text-[0.62rem] px-1.5 py-px rounded-full bg-[var(--error)] text-white font-medium", children: server.auth_state === "failed" ? "Auth failed" : "OAuth required" })
       ] }),
       /* @__PURE__ */ u("div", { className: "flex items-center gap-1.5", children: [
-        needsReauth && /* @__PURE__ */ u("button", { onClick: reauth, className: "provider-btn provider-btn-sm", children: "Re-auth" }),
+        needsReauth && /* @__PURE__ */ u("button", { onClick: reauth, disabled: authing.value, className: "provider-btn provider-btn-sm", children: authing.value ? "…" : "Re-auth" }),
         /* @__PURE__ */ u("button", { onClick: startEdit, className: "provider-btn provider-btn-secondary provider-btn-sm", children: "Edit" }),
         /* @__PURE__ */ u(
           "button",

--- a/crates/web/src/assets/dist/main.js
+++ b/crates/web/src/assets/dist/main.js
@@ -22899,6 +22899,17 @@ function ServerCard({ server }) {
     showToast$1(`Restarted "${server.name}"`, "success");
     await refreshServers();
   }
+  async function reauth(e) {
+    var _a2;
+    e.stopPropagation();
+    const res = await sendRpc("mcp.reauth", { name: server.name, redirectUri: oauthCallbackUrl() });
+    if (res == null ? void 0 : res.ok) {
+      const p = res.payload;
+      showToast$1(`OAuth started for "${server.name}"`, "success");
+      if (p == null ? void 0 : p.authUrl) window.open(p.authUrl, "_blank", "noopener,noreferrer");
+    } else showToast$1(`Re-auth failed: ${((_a2 = res == null ? void 0 : res.error) == null ? void 0 : _a2.message) || "unknown"}`, "error");
+    await refreshServers();
+  }
   function startEdit(e) {
     e.stopPropagation();
     editTransport.value = server.transport || "stdio";
@@ -22973,6 +22984,7 @@ function ServerCard({ server }) {
       });
     });
   }
+  const needsReauth = server.auth_state === "awaiting_browser" || server.auth_state === "failed";
   const displayName = server.display_name || server.name;
   const showTechnical = server.display_name && server.display_name !== server.name;
   const currentSafeUrl = typeof server.url === "string" ? server.url.trim() : "";
@@ -22996,9 +23008,11 @@ function ServerCard({ server }) {
           server.tool_count,
           " tool",
           server.tool_count !== 1 ? "s" : ""
-        ] })
+        ] }),
+        needsReauth && /* @__PURE__ */ u("span", { className: "text-[0.62rem] px-1.5 py-px rounded-full bg-[var(--error)] text-white font-medium", children: server.auth_state === "failed" ? "Auth failed" : "OAuth required" })
       ] }),
       /* @__PURE__ */ u("div", { className: "flex items-center gap-1.5", children: [
+        needsReauth && /* @__PURE__ */ u("button", { onClick: reauth, className: "provider-btn provider-btn-sm", children: "Re-auth" }),
         /* @__PURE__ */ u("button", { onClick: startEdit, className: "provider-btn provider-btn-secondary provider-btn-sm", children: "Edit" }),
         /* @__PURE__ */ u(
           "button",

--- a/crates/web/ui/e2e/specs/mcp.spec.js
+++ b/crates/web/ui/e2e/specs/mcp.spec.js
@@ -150,6 +150,89 @@ test.describe("MCP page", () => {
 		expect(pageErrors).toEqual([]);
 	});
 
+	// Issue #851: MCP OAuth re-auth button missing from UI
+	// When a server has auth_state "awaiting_browser" or "failed", the UI
+	// should display a "Re-auth" button so users can trigger OAuth again.
+	test("re-auth button shown when server auth_state is awaiting_browser", async ({ page }) => {
+		const pageErrors = watchPageErrors(page);
+		await page.route("**/api/mcp", async (route) => {
+			await route.fulfill({
+				status: 200,
+				contentType: "application/json",
+				body: JSON.stringify([
+					{
+						name: "hubspot",
+						state: "stopped",
+						enabled: true,
+						tool_count: 0,
+						transport: "sse",
+						url: "https://mcp.hubspot.com",
+						auth_state: "awaiting_browser",
+					},
+				]),
+			});
+		});
+
+		await navigateAndWait(page, "/settings/mcp");
+		await expect(page.getByText("hubspot", { exact: true })).toBeVisible();
+		await expect(page.getByRole("button", { name: "Re-auth", exact: true })).toBeVisible();
+		await expect(page.getByText("OAuth required", { exact: false })).toBeVisible();
+		expect(pageErrors).toEqual([]);
+	});
+
+	test("re-auth button shown when server auth_state is failed", async ({ page }) => {
+		const pageErrors = watchPageErrors(page);
+		await page.route("**/api/mcp", async (route) => {
+			await route.fulfill({
+				status: 200,
+				contentType: "application/json",
+				body: JSON.stringify([
+					{
+						name: "hubspot-fail",
+						state: "dead",
+						enabled: true,
+						tool_count: 0,
+						transport: "sse",
+						url: "https://mcp.hubspot.com",
+						auth_state: "failed",
+					},
+				]),
+			});
+		});
+
+		await navigateAndWait(page, "/settings/mcp");
+		await expect(page.getByText("hubspot-fail", { exact: true })).toBeVisible();
+		await expect(page.getByRole("button", { name: "Re-auth", exact: true })).toBeVisible();
+		await expect(page.getByText("Auth failed", { exact: false })).toBeVisible();
+		expect(pageErrors).toEqual([]);
+	});
+
+	test("no re-auth button when server auth_state is authenticated", async ({ page }) => {
+		const pageErrors = watchPageErrors(page);
+		await page.route("**/api/mcp", async (route) => {
+			await route.fulfill({
+				status: 200,
+				contentType: "application/json",
+				body: JSON.stringify([
+					{
+						name: "hubspot-ok",
+						state: "running",
+						enabled: true,
+						tool_count: 3,
+						transport: "sse",
+						url: "https://mcp.hubspot.com",
+						auth_state: "authenticated",
+					},
+				]),
+			});
+		});
+
+		await navigateAndWait(page, "/settings/mcp");
+		await expect(page.getByText("hubspot-ok", { exact: true })).toBeVisible();
+		await expect(page.getByRole("button", { name: "Re-auth", exact: true })).toHaveCount(0);
+		expect(pageErrors).toEqual([]);
+	});
+
 	test("page has no JS errors", async ({ page }) => {
 		const pageErrors = watchPageErrors(page);
 		await navigateAndWait(page, "/settings/mcp");

--- a/crates/web/ui/src/pages/McpPage.tsx
+++ b/crates/web/ui/src/pages/McpPage.tsx
@@ -651,6 +651,7 @@ function ServerCard({ server }: { server: McpServer }): VNode {
 	const expanded = useSignal(false);
 	const tools = useSignal<McpTool[] | null>(null);
 	const toggling = useSignal(false);
+	const authing = useSignal(false);
 	const editing = useSignal(false);
 	const editTransport = useSignal("stdio");
 	const editCmd = useSignal("");
@@ -693,6 +694,7 @@ function ServerCard({ server }: { server: McpServer }): VNode {
 	}
 	async function reauth(e: Event): Promise<void> {
 		e.stopPropagation();
+		authing.value = true;
 		const res = await sendRpc("mcp.reauth", { name: server.name, redirectUri: oauthCallbackUrl() });
 		if (res?.ok) {
 			const p = res.payload as Record<string, unknown>;
@@ -700,6 +702,7 @@ function ServerCard({ server }: { server: McpServer }): VNode {
 			if (p?.authUrl) window.open(p.authUrl as string, "_blank", "noopener,noreferrer");
 		} else showToast(`Re-auth failed: ${res?.error?.message || "unknown"}`, "error");
 		await refreshServers();
+		authing.value = false;
 	}
 	function startEdit(e: Event): void {
 		e.stopPropagation();
@@ -816,8 +819,8 @@ function ServerCard({ server }: { server: McpServer }): VNode {
 				</div>
 				<div className="flex items-center gap-1.5">
 					{needsReauth && (
-						<button onClick={reauth} className="provider-btn provider-btn-sm">
-							Re-auth
+						<button onClick={reauth} disabled={authing.value} className="provider-btn provider-btn-sm">
+							{authing.value ? "\u2026" : "Re-auth"}
 						</button>
 					)}
 					<button onClick={startEdit} className="provider-btn provider-btn-secondary provider-btn-sm">

--- a/crates/web/ui/src/pages/McpPage.tsx
+++ b/crates/web/ui/src/pages/McpPage.tsx
@@ -691,6 +691,16 @@ function ServerCard({ server }: { server: McpServer }): VNode {
 		showToast(`Restarted "${server.name}"`, "success");
 		await refreshServers();
 	}
+	async function reauth(e: Event): Promise<void> {
+		e.stopPropagation();
+		const res = await sendRpc("mcp.reauth", { name: server.name, redirectUri: oauthCallbackUrl() });
+		if (res?.ok) {
+			const p = res.payload as Record<string, unknown>;
+			showToast(`OAuth started for "${server.name}"`, "success");
+			if (p?.authUrl) window.open(p.authUrl as string, "_blank", "noopener,noreferrer");
+		} else showToast(`Re-auth failed: ${res?.error?.message || "unknown"}`, "error");
+		await refreshServers();
+	}
 	function startEdit(e: Event): void {
 		e.stopPropagation();
 		editTransport.value = server.transport || "stdio";
@@ -767,6 +777,7 @@ function ServerCard({ server }: { server: McpServer }): VNode {
 		});
 	}
 
+	const needsReauth = server.auth_state === "awaiting_browser" || server.auth_state === "failed";
 	const displayName = server.display_name || server.name;
 	const showTechnical = server.display_name && server.display_name !== server.name;
 	const currentSafeUrl = typeof server.url === "string" ? server.url.trim() : "";
@@ -797,8 +808,18 @@ function ServerCard({ server }: { server: McpServer }): VNode {
 					<span className="text-xs text-[var(--muted)]">
 						{server.tool_count} tool{server.tool_count !== 1 ? "s" : ""}
 					</span>
+					{needsReauth && (
+						<span className="text-[0.62rem] px-1.5 py-px rounded-full bg-[var(--error)] text-white font-medium">
+							{server.auth_state === "failed" ? "Auth failed" : "OAuth required"}
+						</span>
+					)}
 				</div>
 				<div className="flex items-center gap-1.5">
+					{needsReauth && (
+						<button onClick={reauth} className="provider-btn provider-btn-sm">
+							Re-auth
+						</button>
+					)}
 					<button onClick={startEdit} className="provider-btn provider-btn-secondary provider-btn-sm">
 						Edit
 					</button>


### PR DESCRIPTION
## Summary

Fixes #851.

- Add a **Re-auth** button and auth status badge to `ServerCard` when `auth_state` is `awaiting_browser` or `failed`
- The button calls the existing `mcp.reauth` RPC and opens the OAuth URL in a new browser tab
- Badge shows "OAuth required" (awaiting) or "Auth failed" (failed); hidden when authenticated or absent

## Validation

### Completed

- [x] `npx tsc --noEmit` — zero errors
- [x] `biome check --write` on changed files
- [x] `npm run build` — Vite bundle rebuilt and committed
- [x] E2E tests: 12/12 pass (`npx playwright test e2e/specs/mcp.spec.js --project=default`)
- [x] Verified tests fail without the fix (needsReauth = false), pass with it

### Remaining

- [ ] `just lint` (Rust unchanged, but full CI will confirm)
- [ ] `just test` (Rust unchanged)

## Manual QA

1. Configure an MCP server with OAuth (e.g. HubSpot at `https://mcp.hubspot.com`)
2. Let the token expire or remove stored tokens
3. Navigate to Settings → MCP
4. Verify a red "OAuth required" or "Auth failed" badge appears next to the server
5. Verify a "Re-auth" button appears — clicking it should open the OAuth flow in a new tab
6. After completing OAuth, verify the badge and button disappear


🤖 Generated with [Claude Code](https://claude.com/claude-code)