### PR TITLE
fix(sandbox): skip sysfs tmpfs mounts for missing paths (ARM/Raspberry Pi)

### DIFF
--- a/crates/tools/src/sandbox/docker.rs
+++ b/crates/tools/src/sandbox/docker.rs
@@ -763,17 +763,23 @@ pub(crate) fn sysfs_paths_to_mask() -> Vec<&'static str> {
 }
 
 /// Testable inner helper: probes each `SYSFS_MASK_PATHS` entry and returns
-/// only those that exist.  If `sysfs_root` itself doesn't exist (macOS),
-/// all paths are returned — Docker Desktop's VM will have them.
+/// only those that exist under `sysfs_root`.  If `sysfs_root` itself doesn't
+/// exist (macOS), all paths are returned — Docker Desktop's VM will have them.
 pub(crate) fn sysfs_paths_to_mask_from(sysfs_root: &str) -> Vec<&'static str> {
-    if !std::path::Path::new(sysfs_root).exists() {
+    let root = std::path::Path::new(sysfs_root);
+    if !root.exists() {
         // Non-Linux host (macOS): Docker runs in a VM with full sysfs.
         return SYSFS_MASK_PATHS.to_vec();
     }
     SYSFS_MASK_PATHS
         .iter()
         .copied()
-        .filter(|p| std::path::Path::new(p).exists())
+        .filter(|p| {
+            // Strip the canonical "/sys/" prefix so the path is relative,
+            // then probe under the supplied root (real or test tempdir).
+            let rel = p.strip_prefix("/sys/").unwrap_or(p);
+            root.join(rel).exists()
+        })
         .collect()
 }
 

--- a/crates/tools/src/sandbox/docker.rs
+++ b/crates/tools/src/sandbox/docker.rs
@@ -198,15 +198,7 @@ impl DockerSandbox {
     /// `is_prebuilt` controls whether `--read-only` is applied: prebuilt images
     /// already have packages baked in so the root FS can be read-only, while
     /// non-prebuilt images need a writable root for `apt-get` provisioning.
-    ///
-    /// `skip_sysfs_mounts` suppresses sysfs tmpfs overlays.  This is needed on
-    /// WSL2 where the sysfs directories may not exist inside the container's
-    /// filesystem, causing Docker to fail with "mkdirat: read-only file system".
-    pub(crate) fn hardening_args(
-        is_prebuilt: bool,
-        kind: BackendKind,
-        skip_sysfs_mounts: bool,
-    ) -> Vec<String> {
+    pub(crate) fn hardening_args(is_prebuilt: bool, kind: BackendKind) -> Vec<String> {
         let mut args = vec![
             // --- Capability / privilege ---
             "--cap-drop".to_string(),
@@ -233,21 +225,10 @@ impl DockerSandbox {
         // With --cap-drop ALL some sysfs files are permission-denied even for
         // root, causing the mount (and container startup) to fail.  Podman
         // already masks /sys/firmware via its built-in OCI MaskedPaths.
-        //
-        // Skipped on WSL2: the sysfs directories (/sys/class/dmi, etc.) may
-        // not exist inside the container's sysfs, so Docker cannot create
-        // tmpfs mountpoints on the read-only overlayfs.
-        if kind != BackendKind::Podman && !skip_sysfs_mounts {
-            args.extend([
-                "--tmpfs".to_string(),
-                "/sys/firmware:ro,nosuid".to_string(),
-                "--tmpfs".to_string(),
-                "/sys/class/dmi:ro,nosuid".to_string(),
-                "--tmpfs".to_string(),
-                "/sys/devices/virtual/dmi:ro,nosuid".to_string(),
-                "--tmpfs".to_string(),
-                "/sys/class/block:ro,nosuid".to_string(),
-            ]);
+        if kind != BackendKind::Podman {
+            for path in sysfs_paths_to_mask() {
+                args.extend(["--tmpfs".to_string(), format!("{path}:ro,nosuid")]);
+            }
         }
         if is_prebuilt {
             args.push("--read-only".to_string());
@@ -441,7 +422,7 @@ impl Sandbox for DockerSandbox {
         }
 
         args.extend(self.resource_args());
-        args.extend(Self::hardening_args(is_prebuilt, self.kind, is_wsl()));
+        args.extend(Self::hardening_args(is_prebuilt, self.kind));
         args.extend(self.workspace_args());
         args.extend(self.home_persistence_args(id)?);
 
@@ -746,29 +727,54 @@ impl Sandbox for NoSandbox {
     }
 }
 
-/// Return `true` when running on Windows Subsystem for Linux (WSL).
+/// Sysfs paths to mask with empty read-only tmpfs overlays.
 ///
-/// WSL2 kernels identify themselves with "microsoft" or "WSL" in
-/// `/proc/version`.  The result is cached for the process lifetime.
-pub(crate) fn is_wsl() -> bool {
-    static WSL: OnceLock<bool> = OnceLock::new();
-    *WSL.get_or_init(|| {
-        let detected = detect_wsl_from_path("/proc/version");
-        if detected {
-            warn!("WSL2 detected: sysfs hardware-identifier tmpfs overlays will be skipped");
-        }
-        detected
-    })
+/// On Linux, Docker shares the host kernel's sysfs.  Paths that don't exist
+/// on the host (ARM devices without DMI, WSL2, etc.) would cause Docker to
+/// fail with "mkdirat: read-only file system" when it tries to create
+/// mountpoints on the read-only sysfs.  We probe each path and only mount
+/// the ones that actually exist.
+///
+/// On non-Linux hosts (macOS), Docker Desktop runs in a Linux VM with full
+/// sysfs, so all paths are included unconditionally — the host `/sys` layout
+/// is irrelevant.
+pub(crate) const SYSFS_MASK_PATHS: &[&str] = &[
+    "/sys/firmware",
+    "/sys/class/dmi",
+    "/sys/devices/virtual/dmi",
+    "/sys/class/block",
+];
+
+pub(crate) fn sysfs_paths_to_mask() -> Vec<&'static str> {
+    static PATHS: OnceLock<Vec<&'static str>> = OnceLock::new();
+    PATHS
+        .get_or_init(|| {
+            let paths = sysfs_paths_to_mask_from("/sys");
+            let skipped = SYSFS_MASK_PATHS.len() - paths.len();
+            if skipped > 0 {
+                warn!(
+                    skipped,
+                    "some sysfs mask paths do not exist on this host and will be skipped"
+                );
+            }
+            paths
+        })
+        .clone()
 }
 
-/// Testable inner helper: reads the given path and checks for WSL markers.
-pub(crate) fn detect_wsl_from_path(path: &str) -> bool {
-    std::fs::read_to_string(path)
-        .map(|v| {
-            let lower = v.to_ascii_lowercase();
-            lower.contains("microsoft") || lower.contains("wsl")
-        })
-        .unwrap_or(false)
+/// Testable inner helper: probes each `SYSFS_MASK_PATHS` entry and returns
+/// only those that exist.  If `sysfs_root` itself doesn't exist (macOS),
+/// all paths are returned — Docker Desktop's VM will have them.
+pub(crate) fn sysfs_paths_to_mask_from(sysfs_root: &str) -> Vec<&'static str> {
+    if !std::path::Path::new(sysfs_root).exists() {
+        // Non-Linux host (macOS): Docker runs in a VM with full sysfs.
+        return SYSFS_MASK_PATHS.to_vec();
+    }
+    SYSFS_MASK_PATHS
+        .iter()
+        .copied()
+        .filter(|p| std::path::Path::new(p).exists())
+        .collect()
 }
 
 /// Return `true` when the installed Podman version supports `host-gateway`

--- a/crates/tools/src/sandbox/tests/core.rs
+++ b/crates/tools/src/sandbox/tests/core.rs
@@ -17,7 +17,7 @@ fn test_sandbox_scope_display() {
 
 #[test]
 fn test_docker_hardening_args_prebuilt() {
-    let args = DockerSandbox::hardening_args(true, BackendKind::Docker, false);
+    let args = DockerSandbox::hardening_args(true, BackendKind::Docker);
     assert!(args.contains(&"--cap-drop".to_string()));
     assert!(args.contains(&"ALL".to_string()));
     assert!(args.contains(&"--security-opt".to_string()));
@@ -36,15 +36,21 @@ fn test_docker_hardening_args_prebuilt() {
         "sandbox",
         "--hostname value should be 'sandbox'"
     );
-    assert!(args.contains(&"/sys/firmware:ro,nosuid".to_string()));
-    assert!(args.contains(&"/sys/class/dmi:ro,nosuid".to_string()));
-    assert!(args.contains(&"/sys/devices/virtual/dmi:ro,nosuid".to_string()));
-    assert!(args.contains(&"/sys/class/block:ro,nosuid".to_string()));
+    // Sysfs masks are present (actual set depends on host — macOS includes
+    // all because /sys doesn't exist; Linux includes only existing paths).
+    // On macOS CI all four are present.
+    #[cfg(not(target_os = "linux"))]
+    {
+        assert!(args.contains(&"/sys/firmware:ro,nosuid".to_string()));
+        assert!(args.contains(&"/sys/class/dmi:ro,nosuid".to_string()));
+        assert!(args.contains(&"/sys/devices/virtual/dmi:ro,nosuid".to_string()));
+        assert!(args.contains(&"/sys/class/block:ro,nosuid".to_string()));
+    }
 }
 
 #[test]
 fn test_docker_hardening_args_not_prebuilt() {
-    let args = DockerSandbox::hardening_args(false, BackendKind::Docker, false);
+    let args = DockerSandbox::hardening_args(false, BackendKind::Docker);
     assert!(args.contains(&"--cap-drop".to_string()));
     assert!(args.contains(&"ALL".to_string()));
     assert!(args.contains(&"--security-opt".to_string()));
@@ -53,7 +59,7 @@ fn test_docker_hardening_args_not_prebuilt() {
     assert!(!args.contains(&"--read-only".to_string()));
     // tmpfs mounts still present
     assert!(args.contains(&"/tmp:rw,nosuid,size=256m".to_string()));
-    // Host metadata isolation still present — all 4 sysfs masks + hostname
+    // Host metadata isolation still present — hostname
     let hostname_pos = args
         .iter()
         .position(|a| a == "--hostname")
@@ -63,15 +69,18 @@ fn test_docker_hardening_args_not_prebuilt() {
         "sandbox",
         "--hostname value should be 'sandbox'"
     );
-    assert!(args.contains(&"/sys/firmware:ro,nosuid".to_string()));
-    assert!(args.contains(&"/sys/class/dmi:ro,nosuid".to_string()));
-    assert!(args.contains(&"/sys/devices/virtual/dmi:ro,nosuid".to_string()));
-    assert!(args.contains(&"/sys/class/block:ro,nosuid".to_string()));
+    #[cfg(not(target_os = "linux"))]
+    {
+        assert!(args.contains(&"/sys/firmware:ro,nosuid".to_string()));
+        assert!(args.contains(&"/sys/class/dmi:ro,nosuid".to_string()));
+        assert!(args.contains(&"/sys/devices/virtual/dmi:ro,nosuid".to_string()));
+        assert!(args.contains(&"/sys/class/block:ro,nosuid".to_string()));
+    }
 }
 
 #[test]
 fn test_docker_hardening_args_podman() {
-    let args = DockerSandbox::hardening_args(true, BackendKind::Podman, false);
+    let args = DockerSandbox::hardening_args(true, BackendKind::Podman);
     // Core hardening flags must still be present
     assert!(args.contains(&"--cap-drop".to_string()));
     assert!(args.contains(&"ALL".to_string()));
@@ -98,66 +107,49 @@ fn test_docker_hardening_args_podman() {
 }
 
 #[test]
-fn test_docker_hardening_args_skips_sysfs_on_wsl() {
-    // On WSL2 the sysfs directories (/sys/class/dmi, /sys/devices/virtual/dmi,
-    // etc.) may not exist inside the container's sysfs, so Docker cannot create
-    // tmpfs mountpoints on the read-only overlayfs.  hardening_args must skip
-    // sysfs masks when `skip_sysfs_mounts` is true.
-    let args = DockerSandbox::hardening_args(true, BackendKind::Docker, true);
+fn test_sysfs_paths_to_mask_no_sysfs_root_returns_all() {
+    // When /sys doesn't exist (macOS), all paths should be returned because
+    // Docker Desktop runs in a Linux VM with full sysfs.
+    let paths = sysfs_paths_to_mask_from("/nonexistent/sysfs/root");
+    assert_eq!(paths, vec![
+        "/sys/firmware",
+        "/sys/class/dmi",
+        "/sys/devices/virtual/dmi",
+        "/sys/class/block",
+    ]);
+}
 
-    // Core hardening flags must still be present
-    assert!(args.contains(&"--cap-drop".to_string()));
-    assert!(args.contains(&"ALL".to_string()));
-    assert!(args.contains(&"--security-opt".to_string()));
-    assert!(args.contains(&"no-new-privileges".to_string()));
-    assert!(args.contains(&"--read-only".to_string()));
-    // Basic tmpfs mounts (writable /tmp and /run) must still be present
-    assert!(args.contains(&"/tmp:rw,nosuid,size=256m".to_string()));
-    assert!(args.contains(&"/run:rw,nosuid,size=64m".to_string()));
-    // Hostname isolation still present
-    let hostname_pos = args
-        .iter()
-        .position(|a| a == "--hostname")
-        .expect("--hostname flag missing");
-    assert_eq!(
-        args[hostname_pos + 1],
-        "sandbox",
-        "--hostname value should be 'sandbox'"
+#[test]
+fn test_sysfs_paths_to_mask_filters_missing_paths() {
+    // Simulate a Linux host where the sysfs root exists but specific
+    // subtrees are missing (e.g. ARM without DMI, or WSL2).
+    let dir = tempfile::tempdir().unwrap();
+    let sysfs_root = dir.path().join("sys");
+    // Create only /sys/firmware and /sys/class/block, skip DMI paths
+    // (simulates Raspberry Pi / ARM which lacks DMI).
+    std::fs::create_dir_all(sysfs_root.join("firmware")).unwrap();
+    std::fs::create_dir_all(sysfs_root.join("class/block")).unwrap();
+
+    let paths = sysfs_paths_to_mask_from(sysfs_root.to_str().unwrap());
+    // Only the paths that exist under the real /sys are returned.
+    // Since we're checking absolute paths (/sys/firmware etc.) against the
+    // real filesystem, and tempdir isn't at /sys, none will match — this
+    // tests that the function correctly filters based on path existence.
+    // On a real system, the function checks /sys/firmware etc. directly.
+    assert!(
+        paths.is_empty(),
+        "paths under tempdir cannot match absolute /sys/* paths"
     );
-    // Sysfs tmpfs overlays must NOT be present (WSL2 compat)
-    assert!(!args.contains(&"/sys/firmware:ro,nosuid".to_string()));
-    assert!(!args.contains(&"/sys/class/dmi:ro,nosuid".to_string()));
-    assert!(!args.contains(&"/sys/devices/virtual/dmi:ro,nosuid".to_string()));
-    assert!(!args.contains(&"/sys/class/block:ro,nosuid".to_string()));
 }
 
 #[test]
-fn test_is_wsl_returns_false_on_non_wsl() {
-    // On macOS and standard Linux CI, is_wsl() must return false.
-    // Note: uses the OnceLock-cached value — this test assumes it does not
-    // run on an actual WSL2 host.
-    assert!(!is_wsl());
-}
-
-#[test]
-fn test_detect_wsl_from_path_positive() {
-    let dir = tempfile::tempdir().unwrap();
-    let path = dir.path().join("proc_version");
-    std::fs::write(&path, "Linux version 5.15.167.4-microsoft-standard-WSL2").unwrap();
-    assert!(detect_wsl_from_path(path.to_str().unwrap()));
-}
-
-#[test]
-fn test_detect_wsl_from_path_negative() {
-    let dir = tempfile::tempdir().unwrap();
-    let path = dir.path().join("proc_version");
-    std::fs::write(&path, "Linux version 6.8.0-45-generic (buildd@lcy02-amd64)").unwrap();
-    assert!(!detect_wsl_from_path(path.to_str().unwrap()));
-}
-
-#[test]
-fn test_detect_wsl_from_path_missing_file() {
-    assert!(!detect_wsl_from_path("/nonexistent/path/proc/version"));
+fn test_sysfs_mask_paths_constant_contains_expected_entries() {
+    // Guard against accidentally removing paths from the constant.
+    assert!(SYSFS_MASK_PATHS.contains(&"/sys/firmware"));
+    assert!(SYSFS_MASK_PATHS.contains(&"/sys/class/dmi"));
+    assert!(SYSFS_MASK_PATHS.contains(&"/sys/devices/virtual/dmi"));
+    assert!(SYSFS_MASK_PATHS.contains(&"/sys/class/block"));
+    assert_eq!(SYSFS_MASK_PATHS.len(), 4);
 }
 
 #[test]

--- a/crates/tools/src/sandbox/tests/core.rs
+++ b/crates/tools/src/sandbox/tests/core.rs
@@ -131,15 +131,8 @@ fn test_sysfs_paths_to_mask_filters_missing_paths() {
     std::fs::create_dir_all(sysfs_root.join("class/block")).unwrap();
 
     let paths = sysfs_paths_to_mask_from(sysfs_root.to_str().unwrap());
-    // Only the paths that exist under the real /sys are returned.
-    // Since we're checking absolute paths (/sys/firmware etc.) against the
-    // real filesystem, and tempdir isn't at /sys, none will match — this
-    // tests that the function correctly filters based on path existence.
-    // On a real system, the function checks /sys/firmware etc. directly.
-    assert!(
-        paths.is_empty(),
-        "paths under tempdir cannot match absolute /sys/* paths"
-    );
+    // Only the two paths that exist under the tempdir sysfs root are returned.
+    assert_eq!(paths, vec!["/sys/firmware", "/sys/class/block"]);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Fixes Docker sandbox failing on Raspberry Pi (ARM) and WSL2 with "mkdirat: read-only file system" when mounting tmpfs on sysfs paths like `/sys/class/dmi` that don't exist on the host
- Replaces WSL2-only detection (`is_wsl()`) with per-path host existence checking — on Linux, only mount sysfs tmpfs overlays for paths that actually exist; on macOS, include all (Docker Desktop VM has full sysfs)
- ARM devices lack DMI (a BIOS/UEFI concept), so `/sys/class/dmi` and `/sys/devices/virtual/dmi` are absent

Closes #828

## Validation

### Completed
- [x] `cargo check -p moltis-tools` — compiles clean
- [x] `cargo +nightly-2025-11-30 fmt --all -- --check` — formatted
- [x] `just lint` — clippy clean
- [x] `cargo nextest run -p moltis-tools` — 943 tests pass
- [x] New tests cover: missing sysfs root returns all paths, existing root filters missing paths, constant guard test

### Remaining
- [ ] `./scripts/local-validate.sh` — full validation

## Manual QA

1. On a Raspberry Pi (or ARM device) with Docker, run `moltis` and execute a sandboxed command — should no longer fail with "mkdirat: read-only file system"
2. On macOS with Docker Desktop, sandboxed commands should continue to work (all sysfs mounts still applied)
3. On WSL2, sandboxed commands should work (missing sysfs paths auto-skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)