### PR TITLE
test(voice): add ElevenLabs TTS tests for custom voice support

### DIFF
--- a/crates/voice/src/tts/elevenlabs.rs
+++ b/crates/voice/src/tts/elevenlabs.rs
@@ -31,6 +31,7 @@ pub struct ElevenLabsTts {
     api_key: Option<Secret<String>>,
     default_voice_id: String,
     default_model: String,
+    base_url: String,
 }
 
 impl std::fmt::Debug for ElevenLabsTts {
@@ -58,6 +59,7 @@ impl ElevenLabsTts {
             api_key,
             default_voice_id: DEFAULT_VOICE_ID.into(),
             default_model: DEFAULT_MODEL.into(),
+            base_url: API_BASE.into(),
         }
     }
 
@@ -73,7 +75,16 @@ impl ElevenLabsTts {
             api_key,
             default_voice_id: voice_id.unwrap_or_else(|| DEFAULT_VOICE_ID.into()),
             default_model: model.unwrap_or_else(|| DEFAULT_MODEL.into()),
+            base_url: API_BASE.into(),
         }
+    }
+
+    /// Override the base URL (for testing with wiremock).
+    #[cfg(test)]
+    #[must_use]
+    pub fn with_base_url(mut self, base_url: impl Into<String>) -> Self {
+        self.base_url = base_url.into();
+        self
     }
 
     /// Get the API key, returning an error if not configured.
@@ -118,7 +129,7 @@ impl TtsProvider for ElevenLabsTts {
 
         let response = self
             .client
-            .get(format!("{API_BASE}/voices"))
+            .get(format!("{}/voices", self.base_url))
             .header("xi-api-key", api_key.expose_secret())
             .send()
             .await
@@ -183,7 +194,8 @@ impl TtsProvider for ElevenLabsTts {
 
         let output_format = Self::output_format_param(request.output_format);
         let url = format!(
-            "{API_BASE}/text-to-speech/{voice_id}?output_format={output_format}&optimize_streaming_latency=2"
+            "{}/text-to-speech/{voice_id}?output_format={output_format}&optimize_streaming_latency=2",
+            self.base_url
         );
 
         debug!(url = %url, "ElevenLabs TTS API call");
@@ -280,7 +292,7 @@ mod tests {
         super::*,
         wiremock::{
             Mock, MockServer, ResponseTemplate,
-            matchers::{header, method, path_regex},
+            matchers::{header, method, path, path_regex},
         },
     };
 
@@ -317,36 +329,173 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_voices_request() {
+    async fn test_voices_returns_premade_and_custom() {
         let mock_server = MockServer::start().await;
 
         Mock::given(method("GET"))
-            .and(path_regex("/v1/voices"))
+            .and(path("/voices"))
             .and(header("xi-api-key", "test-key"))
             .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
                 "voices": [
                     {
-                        "voice_id": "voice1",
-                        "name": "Test Voice",
-                        "description": "A test voice",
-                        "preview_url": "https://example.com/preview.mp3"
+                        "voice_id": "21m00Tcm4TlvDq8ikWAM",
+                        "name": "Rachel",
+                        "category": "premade",
+                        "description": "A premade voice"
+                    },
+                    {
+                        "voice_id": "abcdef1234567890custom",
+                        "name": "My Custom Voice",
+                        "category": "cloned",
+                        "description": "A user-cloned voice"
+                    },
+                    {
+                        "voice_id": "generated9876543210ab",
+                        "name": "My Generated Voice",
+                        "category": "generated",
+                        "description": null,
+                        "preview_url": null
                     }
                 ]
             })))
+            .expect(1)
             .mount(&mock_server)
             .await;
 
-        // Create provider with mocked URL
-        let provider = ElevenLabsTts {
-            client: Client::new(),
-            api_key: Some(Secret::new("test-key".into())),
-            default_voice_id: DEFAULT_VOICE_ID.into(),
-            default_model: DEFAULT_MODEL.into(),
+        let provider = ElevenLabsTts::new(Some(Secret::new("test-key".into())))
+            .with_base_url(mock_server.uri());
+
+        let voices = provider.voices().await.unwrap();
+
+        assert_eq!(voices.len(), 3);
+        assert_eq!(voices[0].id, "21m00Tcm4TlvDq8ikWAM");
+        assert_eq!(voices[0].name, "Rachel");
+        assert_eq!(voices[1].id, "abcdef1234567890custom");
+        assert_eq!(voices[1].name, "My Custom Voice");
+        assert_eq!(voices[2].id, "generated9876543210ab");
+        assert_eq!(voices[2].name, "My Generated Voice");
+    }
+
+    #[tokio::test]
+    async fn test_synthesize_with_custom_voice_id() {
+        let mock_server = MockServer::start().await;
+        let custom_voice_id = "abcdef1234567890custom";
+
+        Mock::given(method("POST"))
+            .and(path(format!("/text-to-speech/{custom_voice_id}")))
+            .and(header("xi-api-key", "test-key"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(b"fake-audio-data".to_vec()))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let provider = ElevenLabsTts::new(Some(Secret::new("test-key".into())))
+            .with_base_url(mock_server.uri());
+
+        let request = SynthesizeRequest {
+            text: "Hello from a custom voice".into(),
+            voice_id: Some(custom_voice_id.into()),
+            ..Default::default()
         };
 
-        // Note: This test would need the API_BASE to be configurable for full testing
-        // For now, we just verify the provider is properly structured
-        assert!(provider.is_configured());
+        let result = provider.synthesize(request).await.unwrap();
+        assert_eq!(result.data.as_ref(), b"fake-audio-data");
+    }
+
+    #[tokio::test]
+    async fn test_synthesize_uses_default_voice_when_none_specified() {
+        let mock_server = MockServer::start().await;
+        let custom_default = "my-custom-default-voice";
+
+        Mock::given(method("POST"))
+            .and(path(format!("/text-to-speech/{custom_default}")))
+            .and(header("xi-api-key", "test-key"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(b"audio-data".to_vec()))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        // Provider configured with a custom default voice
+        let provider = ElevenLabsTts::with_defaults(
+            Some(Secret::new("test-key".into())),
+            Some(custom_default.into()),
+            None,
+        )
+        .with_base_url(mock_server.uri());
+
+        let request = SynthesizeRequest {
+            text: "Hello".into(),
+            voice_id: None, // No voice_id in request — should use default
+            ..Default::default()
+        };
+
+        let result = provider.synthesize(request).await.unwrap();
+        assert_eq!(result.data.as_ref(), b"audio-data");
+    }
+
+    #[tokio::test]
+    async fn test_synthesize_request_voice_id_overrides_default() {
+        let mock_server = MockServer::start().await;
+        let override_voice = "override-voice-id";
+
+        // Only match the override voice in the URL — the default must NOT be used.
+        Mock::given(method("POST"))
+            .and(path(format!("/text-to-speech/{override_voice}")))
+            .and(header("xi-api-key", "test-key"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(b"override-audio".to_vec()))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let provider = ElevenLabsTts::with_defaults(
+            Some(Secret::new("test-key".into())),
+            Some("should-not-be-used".into()),
+            None,
+        )
+        .with_base_url(mock_server.uri());
+
+        let request = SynthesizeRequest {
+            text: "Test override".into(),
+            voice_id: Some(override_voice.into()),
+            ..Default::default()
+        };
+
+        let result = provider.synthesize(request).await.unwrap();
+        assert_eq!(result.data.as_ref(), b"override-audio");
+    }
+
+    #[tokio::test]
+    async fn test_synthesize_api_error_propagated() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path_regex("/text-to-speech/.*"))
+            .respond_with(ResponseTemplate::new(400).set_body_json(serde_json::json!({
+                "detail": {
+                    "status": "invalid_voice",
+                    "message": "Voice not found or not authorized"
+                }
+            })))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let provider = ElevenLabsTts::new(Some(Secret::new("test-key".into())))
+            .with_base_url(mock_server.uri());
+
+        let request = SynthesizeRequest {
+            text: "Hello".into(),
+            voice_id: Some("nonexistent-voice".into()),
+            ..Default::default()
+        };
+
+        let result = provider.synthesize(request).await;
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("400"),
+            "error should contain status code: {err}"
+        );
     }
 
     #[tokio::test]

--- a/crates/voice/src/tts/elevenlabs.rs
+++ b/crates/voice/src/tts/elevenlabs.rs
@@ -31,6 +31,7 @@ pub struct ElevenLabsTts {
     api_key: Option<Secret<String>>,
     default_voice_id: String,
     default_model: String,
+    #[cfg(test)]
     base_url: String,
 }
 
@@ -59,6 +60,7 @@ impl ElevenLabsTts {
             api_key,
             default_voice_id: DEFAULT_VOICE_ID.into(),
             default_model: DEFAULT_MODEL.into(),
+            #[cfg(test)]
             base_url: API_BASE.into(),
         }
     }
@@ -75,6 +77,7 @@ impl ElevenLabsTts {
             api_key,
             default_voice_id: voice_id.unwrap_or_else(|| DEFAULT_VOICE_ID.into()),
             default_model: model.unwrap_or_else(|| DEFAULT_MODEL.into()),
+            #[cfg(test)]
             base_url: API_BASE.into(),
         }
     }
@@ -85,6 +88,19 @@ impl ElevenLabsTts {
     pub fn with_base_url(mut self, base_url: impl Into<String>) -> Self {
         self.base_url = base_url.into();
         self
+    }
+
+    /// The API base URL. In production this is the constant `API_BASE`;
+    /// in tests the field can be overridden via [`Self::with_base_url`].
+    fn api_base(&self) -> &str {
+        #[cfg(test)]
+        {
+            &self.base_url
+        }
+        #[cfg(not(test))]
+        {
+            API_BASE
+        }
     }
 
     /// Get the API key, returning an error if not configured.
@@ -129,7 +145,7 @@ impl TtsProvider for ElevenLabsTts {
 
         let response = self
             .client
-            .get(format!("{}/voices", self.base_url))
+            .get(format!("{}/voices", self.api_base()))
             .header("xi-api-key", api_key.expose_secret())
             .send()
             .await
@@ -195,7 +211,7 @@ impl TtsProvider for ElevenLabsTts {
         let output_format = Self::output_format_param(request.output_format);
         let url = format!(
             "{}/text-to-speech/{voice_id}?output_format={output_format}&optimize_streaming_latency=2",
-            self.base_url
+            self.api_base()
         );
 
         debug!(url = %url, "ElevenLabs TTS API call");

--- a/crates/voice/tests/elevenlabs_integration.rs
+++ b/crates/voice/tests/elevenlabs_integration.rs
@@ -120,15 +120,14 @@ async fn synthesize_custom_voice_from_catalog() {
 
 #[tokio::test]
 #[ignore]
-async fn synthesize_with_default_voice_from_config() {
-    // Simulates the path taken when the user saves a custom voice in the
-    // settings UI and then clicks "Test". The test button calls tts.convert
-    // without a voiceId, so the provider falls back to its default_voice_id.
-    let custom_voice_id = "21m00Tcm4TlvDq8ikWAM"; // Rachel for now
+async fn synthesize_falls_back_to_configured_default_voice() {
+    // Verifies the voice_id: None → default_voice_id fallback path used by
+    // the UI "Test" button (tts.convert is called without a voiceId param).
+    let configured_voice_id = "21m00Tcm4TlvDq8ikWAM"; // Rachel (premade)
 
     let provider = ElevenLabsTts::with_defaults(
         Some(api_key()),
-        Some(custom_voice_id.into()),
+        Some(configured_voice_id.into()),
         Some("eleven_flash_v2_5".into()),
     );
 

--- a/crates/voice/tests/elevenlabs_integration.rs
+++ b/crates/voice/tests/elevenlabs_integration.rs
@@ -1,0 +1,231 @@
+//! Live integration tests for the ElevenLabs TTS provider.
+//!
+//! These tests hit the real ElevenLabs API and require `ELEVENLABS_API_KEY` in
+//! the environment. They are `#[ignore]`d by default so `cargo test` skips them.
+//!
+//! Run with:
+//!   cargo test -p moltis-voice --test elevenlabs_integration -- --ignored
+//!
+//! Covers regressions for:
+//! - #735: custom ElevenLabs voices don't work
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use {
+    moltis_voice::tts::{AudioFormat, ElevenLabsTts, SynthesizeRequest, TtsProvider},
+    secrecy::Secret,
+};
+
+fn api_key() -> Secret<String> {
+    let key = std::env::var("ELEVENLABS_API_KEY")
+        .expect("ELEVENLABS_API_KEY must be set for integration tests");
+    Secret::new(key)
+}
+
+fn make_provider() -> ElevenLabsTts {
+    ElevenLabsTts::new(Some(api_key()))
+}
+
+// ── Basic TTS synthesis ──────────────────────────────────────────────────
+
+#[tokio::test]
+#[ignore]
+async fn synthesize_premade_voice() {
+    let provider = make_provider();
+
+    let request = SynthesizeRequest {
+        text: "Hello, this is a test.".into(),
+        voice_id: Some("21m00Tcm4TlvDq8ikWAM".into()), // Rachel (premade)
+        model: Some("eleven_flash_v2_5".into()),
+        output_format: AudioFormat::Mp3,
+        ..Default::default()
+    };
+
+    let output = provider
+        .synthesize(request)
+        .await
+        .expect("premade voice synthesis should succeed");
+
+    assert!(
+        output.data.len() > 100,
+        "audio data should be non-trivial: {} bytes",
+        output.data.len()
+    );
+    assert_eq!(output.format, AudioFormat::Mp3);
+}
+
+#[tokio::test]
+#[ignore]
+async fn synthesize_custom_voice_from_catalog() {
+    let provider = make_provider();
+
+    // List voices from the account to find custom (non-premade) voices.
+    let voices = match provider.voices().await {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!(
+                "Skipping custom voice test: cannot list voices (API key may lack voices_read): {e}"
+            );
+            return;
+        },
+    };
+
+    eprintln!("Account has {} voice(s):", voices.len());
+    for v in &voices {
+        eprintln!("  {} — {}", v.id, v.name);
+    }
+
+    if voices.is_empty() {
+        eprintln!("Skipping: no voices available on account");
+        return;
+    }
+
+    // Try every voice — the bug is that custom voices fail while premade ones work.
+    for voice in &voices {
+        let request = SynthesizeRequest {
+            text: "Testing this voice.".into(),
+            voice_id: Some(voice.id.clone()),
+            model: Some("eleven_flash_v2_5".into()),
+            output_format: AudioFormat::Mp3,
+            ..Default::default()
+        };
+
+        let result = provider.synthesize(request).await;
+        match &result {
+            Ok(output) => {
+                assert!(
+                    output.data.len() > 100,
+                    "voice {} ({}) returned too few bytes: {}",
+                    voice.id,
+                    voice.name,
+                    output.data.len()
+                );
+                eprintln!(
+                    "  ✓ {} ({}) — {} bytes",
+                    voice.id,
+                    voice.name,
+                    output.data.len()
+                );
+            },
+            Err(e) => {
+                panic!(
+                    "Voice {} ({}) failed to synthesize: {e}\n\
+                     This confirms the bug: custom voices fail while premade ones work.",
+                    voice.id, voice.name
+                );
+            },
+        }
+    }
+}
+
+#[tokio::test]
+#[ignore]
+async fn synthesize_with_default_voice_from_config() {
+    // Simulates the path taken when the user saves a custom voice in the
+    // settings UI and then clicks "Test". The test button calls tts.convert
+    // without a voiceId, so the provider falls back to its default_voice_id.
+    let custom_voice_id = "21m00Tcm4TlvDq8ikWAM"; // Rachel for now
+
+    let provider = ElevenLabsTts::with_defaults(
+        Some(api_key()),
+        Some(custom_voice_id.into()),
+        Some("eleven_flash_v2_5".into()),
+    );
+
+    // No voice_id in request — mirrors how testTts() works in the UI.
+    let request = SynthesizeRequest {
+        text: "Testing default voice from config.".into(),
+        voice_id: None,
+        model: None,
+        output_format: AudioFormat::Mp3,
+        ..Default::default()
+    };
+
+    let output = provider
+        .synthesize(request)
+        .await
+        .expect("synthesis with default voice from config should succeed");
+
+    assert!(
+        output.data.len() > 100,
+        "audio should be non-trivial: {} bytes",
+        output.data.len()
+    );
+}
+
+// ── Voice listing ────────────────────────────────────────────────────────
+
+#[tokio::test]
+#[ignore]
+async fn list_voices_returns_non_empty() {
+    let provider = make_provider();
+
+    match provider.voices().await {
+        Ok(voices) => {
+            eprintln!("Listed {} voice(s)", voices.len());
+            for v in &voices {
+                eprintln!("  {} — {} (desc: {:?})", v.id, v.name, v.description);
+            }
+            // If the key has voices_read permission, should return voices.
+            assert!(!voices.is_empty(), "voices list should not be empty");
+        },
+        Err(e) => {
+            let msg = e.to_string();
+            if msg.contains("401") || msg.contains("missing_permissions") {
+                eprintln!("Skipping: API key lacks voices_read permission: {msg}");
+            } else {
+                panic!("Unexpected error listing voices: {e}");
+            }
+        },
+    }
+}
+
+// ── Error handling ───────────────────────────────────────────────────────
+
+#[tokio::test]
+#[ignore]
+async fn synthesize_invalid_voice_returns_error() {
+    let provider = make_provider();
+
+    let request = SynthesizeRequest {
+        text: "This should fail.".into(),
+        voice_id: Some("nonexistent_voice_id_00000".into()),
+        output_format: AudioFormat::Mp3,
+        ..Default::default()
+    };
+
+    let result = provider.synthesize(request).await;
+    assert!(
+        result.is_err(),
+        "synthesis with nonexistent voice_id should fail"
+    );
+    let err = result.unwrap_err().to_string();
+    eprintln!("Expected error for invalid voice: {err}");
+}
+
+// ── Model compatibility ──────────────────────────────────────────────────
+
+#[tokio::test]
+#[ignore]
+async fn synthesize_with_multilingual_model() {
+    let provider = make_provider();
+
+    let request = SynthesizeRequest {
+        text: "Bonjour, comment allez-vous?".into(),
+        voice_id: Some("21m00Tcm4TlvDq8ikWAM".into()),
+        model: Some("eleven_multilingual_v2".into()),
+        output_format: AudioFormat::Mp3,
+        ..Default::default()
+    };
+
+    let output = provider
+        .synthesize(request)
+        .await
+        .expect("multilingual model synthesis should succeed");
+
+    assert!(
+        output.data.len() > 100,
+        "audio should be non-trivial: {} bytes",
+        output.data.len()
+    );
+}


### PR DESCRIPTION
## Summary

- Add wiremock unit tests verifying custom (cloned/generated) ElevenLabs voices are handled identically to premade voices — voice_id flows correctly through the TTS API URL
- Add live integration tests (`#[ignore]`d) that hit the real ElevenLabs API to validate synthesis with premade voices, custom voices from the catalog, and error handling
- Make `ElevenLabsTts.base_url` configurable (`#[cfg(test)]` only) to enable wiremock testing of the full `synthesize()`/`voices()` flow

## Validation

### Completed
- [x] `cargo test -p moltis-voice` — 137 unit tests pass
- [x] `cargo test -p moltis-voice --test elevenlabs_integration -- --ignored` — 6 live tests pass
- [x] `cargo clippy -p moltis-voice --all-targets -- -D warnings` — clean
- [x] `cargo +nightly-2025-11-30 fmt --all -- --check` — clean

### Remaining
- [ ] `./scripts/local-validate.sh` (full CI validation)

## Manual QA

Run the live integration tests on an account with custom ElevenLabs voices:
```bash
ELEVENLABS_API_KEY=<key-with-custom-voices> cargo test -p moltis-voice --test elevenlabs_integration -- --ignored --nocapture
```

The `synthesize_custom_voice_from_catalog` test will list all voices and try TTS on each — any custom voice failure will panic with a clear message.

Closes #735