### PR TITLE
fix(prompt): move datetime from system message to user content for KV cache stability

### DIFF
--- a/crates/agents/src/prompt.rs
+++ b/crates/agents/src/prompt.rs
@@ -8,7 +8,8 @@ pub use {
     builder::{
         build_system_prompt, build_system_prompt_minimal_runtime,
         build_system_prompt_minimal_runtime_details, build_system_prompt_with_session_runtime,
-        build_system_prompt_with_session_runtime_details, runtime_datetime_message,
+        build_system_prompt_with_session_runtime_details, prepend_datetime_to_user_content,
+        runtime_datetime_message,
     },
     types::{
         DEFAULT_WORKSPACE_FILE_MAX_CHARS, ModelFamily, PromptBuildLimits, PromptBuildMetadata,

--- a/crates/agents/src/prompt/builder.rs
+++ b/crates/agents/src/prompt/builder.rs
@@ -1,5 +1,6 @@
 use {
     crate::{
+        model::{ContentPart, UserContent},
         prompt::{
             formatting::{
                 append_truncated_text_block, format_compact_tool_schema, format_host_runtime_line,
@@ -216,6 +217,25 @@ pub fn build_system_prompt_minimal_runtime_details(
         limits,
         guidelines_text,
     )
+}
+
+/// Prepend datetime context to user content so it lives in the final
+/// (always-changing) user message rather than a separate system message
+/// that would shift position and break KV cache prefix matching.
+#[must_use]
+pub fn prepend_datetime_to_user_content(
+    user_content: &UserContent,
+    runtime_context: Option<&PromptRuntimeContext>,
+) -> Option<UserContent> {
+    let datetime_text = runtime_datetime_message(runtime_context)?;
+    Some(match user_content {
+        UserContent::Text(text) => UserContent::Text(format!("[{datetime_text}]\n\n{text}")),
+        UserContent::Multimodal(parts) => {
+            let mut new_parts = vec![ContentPart::Text(format!("[{datetime_text}]"))];
+            new_parts.extend(parts.iter().cloned());
+            UserContent::Multimodal(new_parts)
+        },
+    })
 }
 
 /// Build a short datetime string suitable for injection as a trailing system message.

--- a/crates/agents/src/prompt/tests.rs
+++ b/crates/agents/src/prompt/tests.rs
@@ -1320,6 +1320,13 @@ fn test_prepend_datetime_to_multimodal_content() {
                 ContentPart::Text(t) => assert_eq!(t, "Describe this image"),
                 _ => panic!("expected original Text part second"),
             }
+            match &parts[2] {
+                ContentPart::Image { media_type, data } => {
+                    assert_eq!(media_type, "image/png");
+                    assert_eq!(data, "base64data");
+                },
+                _ => panic!("expected Image part third"),
+            }
         },
         UserContent::Text(_) => panic!("expected Multimodal variant"),
     }

--- a/crates/agents/src/prompt/tests.rs
+++ b/crates/agents/src/prompt/tests.rs
@@ -2,13 +2,14 @@
 
 use {
     crate::{
+        model::{ContentPart, UserContent},
         prompt::{
             ModelFamily, PromptBuildLimits, PromptHostRuntimeContext, PromptRuntimeContext,
             PromptSandboxRuntimeContext, build_system_prompt, build_system_prompt_minimal_runtime,
             build_system_prompt_with_session_runtime,
             build_system_prompt_with_session_runtime_details,
             formatting::{format_compact_tool_schema, tool_call_guidance},
-            runtime_datetime_message,
+            prepend_datetime_to_user_content, runtime_datetime_message,
         },
         tool_registry::ToolRegistry,
     },
@@ -1260,4 +1261,104 @@ fn test_skill_self_improvement_omitted_when_disabled() {
     );
     // Skills block itself should still be present.
     assert!(output.prompt.contains("<available_skills>"));
+}
+
+// ── prepend_datetime_to_user_content tests ──────────────────────────
+
+#[test]
+fn test_prepend_datetime_to_text_content() {
+    let runtime = PromptRuntimeContext {
+        host: PromptHostRuntimeContext {
+            time: Some("2026-04-23 10:30:00 CET".into()),
+            ..Default::default()
+        },
+        sandbox: None,
+        nodes: None,
+    };
+    let content = UserContent::Text("Hello, what time is it?".into());
+    let result = prepend_datetime_to_user_content(&content, Some(&runtime));
+    assert!(result.is_some());
+    match result.unwrap() {
+        UserContent::Text(text) => {
+            assert!(text.starts_with("[The current user datetime is 2026-04-23 10:30:00 CET.]"));
+            assert!(text.ends_with("Hello, what time is it?"));
+            assert!(text.contains("\n\n"));
+        },
+        UserContent::Multimodal(_) => panic!("expected Text variant"),
+    }
+}
+
+#[test]
+fn test_prepend_datetime_to_multimodal_content() {
+    let runtime = PromptRuntimeContext {
+        host: PromptHostRuntimeContext {
+            time: Some("2026-04-23 10:30:00 CET".into()),
+            ..Default::default()
+        },
+        sandbox: None,
+        nodes: None,
+    };
+    let content = UserContent::Multimodal(vec![
+        ContentPart::Text("Describe this image".into()),
+        ContentPart::Image {
+            media_type: "image/png".into(),
+            data: "base64data".into(),
+        },
+    ]);
+    let result = prepend_datetime_to_user_content(&content, Some(&runtime));
+    assert!(result.is_some());
+    match result.unwrap() {
+        UserContent::Multimodal(parts) => {
+            assert_eq!(parts.len(), 3);
+            match &parts[0] {
+                ContentPart::Text(t) => {
+                    assert!(t.contains("The current user datetime is 2026-04-23 10:30:00 CET."));
+                },
+                _ => panic!("expected Text part first"),
+            }
+            match &parts[1] {
+                ContentPart::Text(t) => assert_eq!(t, "Describe this image"),
+                _ => panic!("expected original Text part second"),
+            }
+        },
+        UserContent::Text(_) => panic!("expected Multimodal variant"),
+    }
+}
+
+#[test]
+fn test_prepend_datetime_returns_none_without_runtime() {
+    let content = UserContent::Text("Hello".into());
+    assert!(prepend_datetime_to_user_content(&content, None).is_none());
+}
+
+#[test]
+fn test_prepend_datetime_returns_none_without_time_or_date() {
+    let runtime = PromptRuntimeContext {
+        host: PromptHostRuntimeContext::default(),
+        sandbox: None,
+        nodes: None,
+    };
+    let content = UserContent::Text("Hello".into());
+    assert!(prepend_datetime_to_user_content(&content, Some(&runtime)).is_none());
+}
+
+#[test]
+fn test_prepend_datetime_falls_back_to_today() {
+    let runtime = PromptRuntimeContext {
+        host: PromptHostRuntimeContext {
+            today: Some("2026-04-23".into()),
+            ..Default::default()
+        },
+        sandbox: None,
+        nodes: None,
+    };
+    let content = UserContent::Text("What day is it?".into());
+    let result = prepend_datetime_to_user_content(&content, Some(&runtime));
+    assert!(result.is_some());
+    match result.unwrap() {
+        UserContent::Text(text) => {
+            assert!(text.starts_with("[The current user date is 2026-04-23.]"));
+        },
+        _ => panic!("expected Text variant"),
+    }
 }

--- a/crates/chat/src/run_with_tools.rs
+++ b/crates/chat/src/run_with_tools.rs
@@ -14,7 +14,7 @@ use {
 
 use {
     moltis_agents::{
-        AgentRunError, ChatMessage, UserContent,
+        AgentRunError, UserContent,
         model::values_to_chat_messages,
         prompt::{
             PromptRuntimeContext, build_system_prompt_minimal_runtime_details,
@@ -822,20 +822,21 @@ pub(crate) async fn run_with_tools(
         .insert(session_key.to_string(), event_forwarder);
 
     // Convert persisted JSON history to typed ChatMessages for the LLM provider.
-    let mut chat_history = values_to_chat_messages(history_raw);
-
-    // Inject the datetime as a trailing system message so the main system
-    // prompt stays byte-identical between turns, enabling KV cache hits for
-    // local LLMs (Ollama, LM Studio) and prompt-cache hits for cloud providers.
-    if let Some(datetime_msg) = moltis_agents::prompt::runtime_datetime_message(runtime_context) {
-        chat_history.push(ChatMessage::system(&datetime_msg));
-    }
+    let chat_history = values_to_chat_messages(history_raw);
 
     let hist = if chat_history.is_empty() {
         None
     } else {
         Some(chat_history)
     };
+
+    // Fold datetime into the user message content so the message array before
+    // it stays positionally stable, preserving KV cache prefix matching for
+    // local LLMs (llama.cpp, Ollama, LM Studio) and prompt-cache hits for
+    // cloud providers.
+    let effective_user_content =
+        moltis_agents::prompt::prepend_datetime_to_user_content(user_content, runtime_context)
+            .unwrap_or_else(|| user_content.clone());
 
     // Inject session key and accept-language into tool call params so tools can
     // resolve per-session state and forward the user's locale to web requests.
@@ -851,7 +852,7 @@ pub(crate) async fn run_with_tools(
         provider,
         &filtered_registry,
         &system_prompt,
-        user_content,
+        &effective_user_content,
         Some(&on_event),
         hist,
         Some(tool_context.clone()),
@@ -937,24 +938,19 @@ pub(crate) async fn run_with_tools(
 
                     // Reload compacted history and retry.
                     let compacted_history_raw = store.read(session_key).await.unwrap_or_default();
-                    let mut compacted_chat = values_to_chat_messages(&compacted_history_raw);
-                    // Re-inject datetime so the retry has current time context.
-                    if let Some(datetime_msg) =
-                        moltis_agents::prompt::runtime_datetime_message(runtime_context)
-                    {
-                        compacted_chat.push(ChatMessage::system(&datetime_msg));
-                    }
+                    let compacted_chat = values_to_chat_messages(&compacted_history_raw);
                     let retry_hist = if compacted_chat.is_empty() {
                         None
                     } else {
                         Some(compacted_chat)
                     };
 
+                    // effective_user_content already carries datetime context.
                     run_agent_loop_streaming(
                         provider_ref.clone(),
                         &filtered_registry,
                         &system_prompt,
-                        user_content,
+                        &effective_user_content,
                         Some(&on_event),
                         retry_hist,
                         Some(tool_context),

--- a/crates/chat/src/streaming.rs
+++ b/crates/chat/src/streaming.rs
@@ -199,17 +199,20 @@ pub(crate) async fn run_streaming(
     // Layer 1: instruct the LLM to write speech-friendly output when voice is active.
     let system_prompt = apply_voice_reply_suffix(system_prompt, desired_reply_medium);
 
+    // Fold datetime into the user message content so the message array before
+    // it stays positionally stable, preserving KV cache prefix matching for
+    // local LLMs (llama.cpp, Ollama, LM Studio) and prompt-cache hits for
+    // cloud providers.
+    let effective_user_content =
+        moltis_agents::prompt::prepend_datetime_to_user_content(user_content, runtime_context)
+            .unwrap_or_else(|| user_content.clone());
+
     let mut messages: Vec<ChatMessage> = Vec::new();
     messages.push(ChatMessage::system(system_prompt));
     // Convert persisted JSON history to typed ChatMessages for the LLM provider.
     messages.extend(values_to_chat_messages(history_raw));
-    // Inject datetime as a trailing system message so the main system prompt
-    // stays byte-identical between turns (KV cache / prompt cache locality).
-    if let Some(datetime_msg) = moltis_agents::prompt::runtime_datetime_message(runtime_context) {
-        messages.push(ChatMessage::system(&datetime_msg));
-    }
     messages.push(ChatMessage::User {
-        content: user_content.clone(),
+        content: effective_user_content,
         name: sender_name,
     });
 


### PR DESCRIPTION
## Summary

- Move datetime injection from a trailing `ChatMessage::System` to the user message content via new `prepend_datetime_to_user_content()` helper
- Fixes KV cache prefix invalidation for local LLMs (llama.cpp, Ollama, LM Studio) where the shifting position of the datetime system message caused full history reprocessing every turn
- Also improves prompt-cache hit rates for cloud providers (Anthropic, OpenAI) since the system messages array is now fully stable

Closes #176

## Validation

### Completed

- [x] `cargo test -p moltis-agents -- runtime_datetime prepend_datetime` (8 passed)
- [x] `cargo test -p moltis-chat` (110 passed)
- [x] `cargo +nightly-2025-11-30 fmt --all -- --check` (clean)
- [x] `just lint` (clean)

### Remaining

- [ ] `./scripts/local-validate.sh`

## Manual QA

- [ ] Start a session with a local LLM (Ollama/LM Studio), verify datetime appears in user message content (not as separate system message)
- [ ] Confirm multi-turn conversations maintain KV cache hits (check llama.cpp logs for prefix match length)
- [ ] Verify datetime is visible in multimodal (image) messages