### PR TITLE
fix(providers): deep-merge properties in schema union collapse, strip redundant boolean enum

### DIFF
--- a/crates/providers/src/openai_compat/schema_normalization.rs
+++ b/crates/providers/src/openai_compat/schema_normalization.rs
@@ -430,12 +430,38 @@ impl Transform for RestoreEnumTypeTransform {
         // Only restore when all non-null values share a single type.
         if types.len() == 1 {
             let inferred_type = types.into_iter().next().unwrap_or_default();
+
+            // Check for redundant boolean enum BEFORE mutating obj.
+            // `json_schema_ast` converts `"type": "boolean"` →
+            // `"enum": [false, true]` which adds no constraint beyond the
+            // restored type. Leaving this redundant enum causes
+            // `make_nullable` in strict mode to append `null` to the enum
+            // array, which Fireworks AI rejects with "could not translate
+            // the enum None" (#848).
+            let strip_redundant_enum =
+                inferred_type == "boolean" && is_complete_boolean_enum(values);
+
             obj.insert(
                 "type".to_string(),
                 serde_json::Value::String(inferred_type.to_string()),
             );
+
+            if strip_redundant_enum {
+                obj.remove("enum");
+            }
         }
     }
+}
+
+/// Whether an enum array is exactly `[false, true]` (in any order, ignoring
+/// nulls). This is the complete boolean domain produced by `json_schema_ast`'s
+/// `lower_boolean_and_null_types` canonicalization and adds no constraint when
+/// the type is already `"boolean"`.
+fn is_complete_boolean_enum(values: &[serde_json::Value]) -> bool {
+    let non_null: Vec<_> = values.iter().filter(|v| !v.is_null()).collect();
+    non_null.len() == 2
+        && non_null.iter().any(|v| v.as_bool() == Some(false))
+        && non_null.iter().any(|v| v.as_bool() == Some(true))
 }
 
 /// Remove empty `{}` (the JSON Schema "true" schema) from `anyOf`/`oneOf`

--- a/crates/providers/src/openai_compat/schema_normalization.rs
+++ b/crates/providers/src/openai_compat/schema_normalization.rs
@@ -149,12 +149,50 @@ fn merge_schema_object(
     obj: &mut serde_json::Map<String, serde_json::Value>,
     variant: serde_json::Value,
 ) {
-    if let serde_json::Value::Object(inner) = variant {
-        for (key, value) in inner {
-            // Parent-key wins: if a key is already present (e.g. `description`
-            // from the surrounding schema), keep it and use the selected
-            // variant only for missing structural keys.
-            obj.entry(key).or_insert(value);
+    let serde_json::Value::Object(inner) = variant else {
+        return;
+    };
+    for (key, value) in inner {
+        match key.as_str() {
+            // Deep-merge `properties`: variant properties that are absent in
+            // the parent are added rather than silently dropped. Without this,
+            // a shallow `or_insert` on the `properties` key discards the
+            // entire variant property map when the parent already has one,
+            // creating orphaned `required` entries (#849).
+            "properties" => {
+                if let (Some(parent_props), Some(variant_props)) = (
+                    obj.get_mut("properties").and_then(|v| v.as_object_mut()),
+                    value.as_object(),
+                ) {
+                    for (prop_key, prop_value) in variant_props {
+                        parent_props.entry(prop_key).or_insert(prop_value.clone());
+                    }
+                } else {
+                    obj.entry(key).or_insert(value);
+                }
+            },
+            // Union `required` arrays: concatenate and deduplicate instead of
+            // discarding the variant's array when the parent already has one.
+            "required" => {
+                if let (Some(parent_req), Some(variant_req)) = (
+                    obj.get_mut("required").and_then(|v| v.as_array_mut()),
+                    value.as_array(),
+                ) {
+                    for entry in variant_req {
+                        if !parent_req.contains(entry) {
+                            parent_req.push(entry.clone());
+                        }
+                    }
+                } else {
+                    obj.entry(key).or_insert(value);
+                }
+            },
+            // Everything else: parent-key wins. If a key is already present
+            // (e.g. `description`), keep it and use the variant only for
+            // missing structural keys.
+            _ => {
+                obj.entry(key).or_insert(value);
+            },
         }
     }
 }
@@ -212,8 +250,17 @@ fn preferred_union_variant_index(variants: &[serde_json::Value]) -> Option<usize
         .or_else(|| (!variants.is_empty()).then_some(0))
 }
 
-/// Collapse `anyOf`/`oneOf` unions to a single schema for providers that
-/// cannot represent JSON Schema unions in tool parameters.
+/// Collapse `anyOf`/`oneOf`/`allOf` unions to a single schema for providers
+/// that cannot represent JSON Schema unions in tool parameters.
+///
+/// `anyOf` / `oneOf` — picks the best variant (prefers object > array >
+/// first non-null) and merges it into the parent.
+///
+/// `allOf` — merges ALL variants into the parent because `allOf` semantics
+/// require satisfying every variant simultaneously. Without this,
+/// multi-variant `allOf` (produced by `json_schema_ast` when a type array
+/// coexists with an existing `anyOf`) survives all transforms and
+/// OpenRouter's Gemini translation can mis-convert it (#849).
 #[derive(Debug, Clone, Default)]
 struct CollapseCompositeUnionTransform;
 
@@ -238,6 +285,20 @@ impl Transform for CollapseCompositeUnionTransform {
                 let selected = variants.remove(index);
                 obj.remove(keyword);
                 merge_schema_object(obj, selected);
+            }
+        }
+
+        // allOf: merge ALL variants (intersection semantics).
+        if let Some(variants) = obj.get_mut("allOf").and_then(|v| v.as_array_mut()) {
+            variants.retain(|v| !v.as_object().is_some_and(|o| o.is_empty()));
+            if variants.is_empty() {
+                obj.remove("allOf");
+            } else {
+                let taken = std::mem::take(variants);
+                obj.remove("allOf");
+                for variant in taken {
+                    merge_schema_object(obj, variant);
+                }
             }
         }
     }

--- a/crates/providers/src/openai_compat/schema_normalization.rs
+++ b/crates/providers/src/openai_compat/schema_normalization.rs
@@ -294,6 +294,23 @@ impl Transform for CollapseCompositeUnionTransform {
             if variants.is_empty() {
                 obj.remove("allOf");
             } else {
+                // Warn when variants carry conflicting `type` values — the
+                // first-wins merge silently drops later types, which can
+                // produce semantically impossible schemas (e.g. type:"string"
+                // with properties). True allOf with conflicting types is
+                // itself invalid JSON Schema, but logging helps debug
+                // provider rejections.
+                let types: Vec<&str> = variants
+                    .iter()
+                    .filter_map(|v| v.get("type").and_then(|t| t.as_str()))
+                    .collect();
+                if types.len() > 1 && types.windows(2).any(|w| w[0] != w[1]) {
+                    debug!(
+                        ?types,
+                        "allOf variants have conflicting types; first-wins merge may produce an inconsistent schema"
+                    );
+                }
+
                 let taken = std::mem::take(variants);
                 obj.remove("allOf");
                 for variant in taken {

--- a/crates/providers/src/openai_compat/tests.rs
+++ b/crates/providers/src/openai_compat/tests.rs
@@ -1031,14 +1031,13 @@ fn sanitize_draft07_nested_definitions_schema_canonicalized() {
     // `name` property type preserved.
     assert_eq!(schema["properties"]["name"]["type"], "string");
 
-    // Canonicalization lowers `type: "boolean"` → `enum: [false, true]`.
-    // If this enum is present, canonicalization ran (not the fallback path
-    // that would emit a WARN log).
-    let verbose_enum = schema["properties"]["verbose"]["enum"].as_array();
-    assert!(
-        verbose_enum.is_some(),
-        "boolean property should have enum after canonicalization (proves no WARN fallback), got: {}",
-        schema["properties"]["verbose"]
+    // Canonicalization lowers `type: "boolean"` → `enum: [false, true]`,
+    // then `RestoreEnumTypeTransform` restores `type: "boolean"` and strips
+    // the redundant enum (#848). The `$schema` stripping above already
+    // proves canonicalization ran; verify the type is correctly preserved.
+    assert_eq!(
+        schema["properties"]["verbose"]["type"], "boolean",
+        "boolean type must be restored after canonicalization"
     );
 }
 
@@ -1060,24 +1059,24 @@ fn sanitize_draft07_schema_uses_canonicalization_not_fallback() {
 
     sanitize_schema_for_openai_compat(&mut schema);
 
+    // `$schema` is stripped during canonicalization — its absence proves
+    // we used the real canonicalization path, not the raw-input fallback.
+    assert!(
+        schema.get("$schema").is_none(),
+        "$schema should be stripped (proves canonicalization ran)"
+    );
     // Canonicalization lowers `type: "boolean"` → `enum: [false, true]`,
-    // then `RestoreEnumTypeTransform` re-adds `type: "boolean"`. The
-    // presence of `enum` proves canonicalization ran (the fallback path
-    // would leave `type: "boolean"` unchanged without an `enum`).
+    // then `RestoreEnumTypeTransform` re-adds `type: "boolean"` and strips
+    // the redundant enum (#848). The type should be preserved.
     assert_eq!(
         schema["properties"]["verbose"]["type"], "boolean",
         "type must be restored after canonicalization"
     );
-    let Some(verbose_enum) = schema["properties"]["verbose"]["enum"].as_array() else {
-        panic!(
-            "boolean property should have enum after canonicalization (proves non-fallback path), got: {}",
-            schema["properties"]["verbose"]
-        );
-    };
-    assert_eq!(
-        verbose_enum.len(),
-        2,
-        "boolean enum should have [false, true]"
+    // The redundant `[false, true]` enum is stripped to prevent Fireworks
+    // from receiving `null` in enum arrays during strict-mode nullability.
+    assert!(
+        schema["properties"]["verbose"].get("enum").is_none(),
+        "redundant boolean enum should be stripped (#848)"
     );
 }
 
@@ -1497,4 +1496,99 @@ fn non_strict_allof_collapsed_and_merged() {
     );
 
     assert_no_orphaned_required(&schema, "root");
+}
+
+/// Issue #848: `json_schema_ast` canonicalization converts `"type": "boolean"`
+/// to `"enum": [false, true]`. `RestoreEnumTypeTransform` restores
+/// `"type": "boolean"` but leaves the redundant `enum`. Then strict mode's
+/// `make_nullable` appends `null` to the enum: `[false, true, null]`.
+/// Fireworks AI rejects this with "could not translate the enum None."
+///
+/// The fix: `RestoreEnumTypeTransform` strips redundant `[false, true]` enum
+/// arrays when `type: "boolean"` is restored, preventing `null` from being
+/// added to a boolean enum.
+#[test]
+fn strict_mode_boolean_property_no_null_in_enum() {
+    let tools = vec![serde_json::json!({
+        "name": "test_tool",
+        "description": "Test",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "query": { "type": "string" },
+                "verbose": { "type": "boolean" },
+                "dry_run": { "type": "boolean", "default": false }
+            },
+            "required": ["query"]
+        }
+    })];
+
+    // strict=true (Fireworks path)
+    let converted = to_openai_tools(&tools, true);
+    let params = &converted[0]["function"]["parameters"];
+    let serialized = params.to_string();
+
+    // Boolean properties should NOT have enum arrays containing null.
+    // They should use type-nullability only: "type": ["boolean", "null"]
+    for prop_name in ["verbose", "dry_run"] {
+        let prop = &params["properties"][prop_name];
+
+        // Should NOT have an enum with null
+        if let Some(enum_arr) = prop.get("enum").and_then(|v| v.as_array()) {
+            assert!(
+                !enum_arr.iter().any(|v| v.is_null()),
+                "{prop_name} should not have null in enum: {enum_arr:?} \
+                 (full schema: {serialized})"
+            );
+        }
+
+        // Should be nullable via type
+        let ty = prop.get("type");
+        assert!(
+            ty.is_some(),
+            "{prop_name} should have a type field: {}",
+            serde_json::to_string_pretty(prop).unwrap_or_default()
+        );
+    }
+}
+
+/// Issue #848: enum-only schemas with only `null` values (from
+/// `json_schema_ast`'s `lower_boolean_and_null_types` converting
+/// `"type": "null"` → `"enum": [null]`) should not reach Fireworks.
+/// After `RestoreEnumTypeTransform`, such schemas keep `"enum": [null]`
+/// without a type — verify they don't appear in strict-mode output.
+#[test]
+fn sanitize_strips_redundant_boolean_enum() {
+    let mut schema = serde_json::json!({
+        "type": "object",
+        "properties": {
+            "flag": { "type": "boolean" },
+            "mode": { "type": "string", "enum": ["fast", "slow"] }
+        },
+        "required": ["flag"]
+    });
+
+    sanitize_schema_for_openai_compat(&mut schema);
+
+    // After canonicalization + restore, `flag` should have type: "boolean"
+    // WITHOUT a redundant enum: [false, true].
+    let flag = &schema["properties"]["flag"];
+    assert_eq!(
+        flag.get("type").and_then(|v| v.as_str()),
+        Some("boolean"),
+        "flag should have type boolean"
+    );
+    assert!(
+        flag.get("enum").is_none(),
+        "flag should not have redundant boolean enum, got: {}",
+        serde_json::to_string_pretty(flag).unwrap_or_default()
+    );
+
+    // `mode` should keep its enum (it's a real constraint, not a
+    // canonicalization artifact).
+    let mode = &schema["properties"]["mode"];
+    assert!(
+        mode.get("enum").is_some(),
+        "mode should keep its string enum"
+    );
 }

--- a/crates/providers/src/openai_compat/tests.rs
+++ b/crates/providers/src/openai_compat/tests.rs
@@ -14,6 +14,10 @@ fn assert_no_orphaned_required(schema: &serde_json::Value, path: &str) {
         return;
     };
 
+    // Only check entries that are verifiably absent from the properties map.
+    // `required` without `properties` is valid JSON Schema (e.g. with
+    // `additionalProperties` or `patternProperties`), so skip the check
+    // when no `properties` map exists.
     if let (Some(required), Some(props)) = (
         obj.get("required").and_then(|v| v.as_array()),
         obj.get("properties").and_then(|v| v.as_object()),
@@ -27,10 +31,6 @@ fn assert_no_orphaned_required(schema: &serde_json::Value, path: &str) {
                 );
             }
         }
-    } else if let Some(required) = obj.get("required").and_then(|v| v.as_array())
-        && !required.is_empty()
-    {
-        panic!("required array at {path} has entries {required:?} but no properties object");
     }
 
     // Recurse into properties

--- a/crates/providers/src/openai_compat/tests.rs
+++ b/crates/providers/src/openai_compat/tests.rs
@@ -3,8 +3,67 @@ use moltis_agents::model::StreamEvent;
 use super::{
     SseLineResult, StreamingToolState, parse_responses_completion, parse_tool_calls,
     process_openai_sse_line, sanitize_schema_for_openai_compat,
+    schema_normalization::collapse_schema_unions_for_non_strict_tools,
     strict_mode::patch_schema_for_strict_mode, to_openai_tools, to_responses_api_tools,
 };
+
+/// Recursively assert that every `required` entry has a corresponding key in
+/// `properties`. Panics with `path` context on the first orphaned entry.
+fn assert_no_orphaned_required(schema: &serde_json::Value, path: &str) {
+    let Some(obj) = schema.as_object() else {
+        return;
+    };
+
+    if let (Some(required), Some(props)) = (
+        obj.get("required").and_then(|v| v.as_array()),
+        obj.get("properties").and_then(|v| v.as_object()),
+    ) {
+        for entry in required {
+            if let Some(name) = entry.as_str() {
+                assert!(
+                    props.contains_key(name),
+                    "orphaned required entry \"{name}\" at {path} — not in properties {:?}",
+                    props.keys().collect::<Vec<_>>()
+                );
+            }
+        }
+    } else if let Some(required) = obj.get("required").and_then(|v| v.as_array())
+        && !required.is_empty()
+    {
+        panic!("required array at {path} has entries {required:?} but no properties object");
+    }
+
+    // Recurse into properties
+    if let Some(props) = obj.get("properties").and_then(|v| v.as_object()) {
+        for (key, value) in props {
+            assert_no_orphaned_required(value, &format!("{path}.properties.{key}"));
+        }
+    }
+    // Recurse into items
+    if let Some(items) = obj.get("items") {
+        if items.is_object() {
+            assert_no_orphaned_required(items, &format!("{path}.items"));
+        } else if let Some(arr) = items.as_array() {
+            for (i, item) in arr.iter().enumerate() {
+                assert_no_orphaned_required(item, &format!("{path}.items[{i}]"));
+            }
+        }
+    }
+    // Recurse into anyOf/oneOf/allOf
+    for keyword in ["anyOf", "oneOf", "allOf"] {
+        if let Some(variants) = obj.get(keyword).and_then(|v| v.as_array()) {
+            for (i, variant) in variants.iter().enumerate() {
+                assert_no_orphaned_required(variant, &format!("{path}.{keyword}[{i}]"));
+            }
+        }
+    }
+    // Recurse into additionalProperties
+    if let Some(ap) = obj.get("additionalProperties")
+        && ap.is_object()
+    {
+        assert_no_orphaned_required(ap, &format!("{path}.additionalProperties"));
+    }
+}
 
 #[test]
 fn parse_tool_calls_preserves_native_falsy_types() {
@@ -1192,4 +1251,250 @@ fn strict_mode_nullable_enum_only_schema_includes_null() {
         time_enum.iter().any(|v| v.is_null()),
         "enum-only schema should include null, got: {time_enum:?}"
     );
+}
+
+/// Issue #849: cron-style schemas with union type arrays (`["object",
+/// "string", "integer"]`) trigger `lower_type_array_to_any_of` in
+/// `json_schema_ast`, which copies ALL context keys (including `properties`
+/// and `required`) to every branch. After `CollapseCompositeUnionTransform`
+/// picks the object variant, the shallow `merge_schema_object` may drop
+/// variant `properties` when the parent already has a `properties` key,
+/// leaving orphaned `required` entries that Gemini rejects with "property is
+/// not defined".
+#[test]
+fn non_strict_cron_tool_schema_no_orphaned_required() {
+    let time_field = |description: &str| {
+        serde_json::json!({
+            "type": ["integer", "string"],
+            "description": description
+        })
+    };
+    let tools = vec![serde_json::json!({
+        "name": "cron",
+        "description": "Manage scheduled tasks",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "action": {
+                    "type": "string",
+                    "enum": ["status", "list", "add", "update", "remove", "run", "runs"],
+                    "description": "The action to perform"
+                },
+                "job": {
+                    "type": "object",
+                    "description": "Job specification",
+                    "properties": {
+                        "name": { "type": "string" },
+                        "schedule": {
+                            "type": ["object", "string", "integer"],
+                            "description": "Schedule specification",
+                            "properties": {
+                                "kind": { "type": "string", "enum": ["at", "every", "cron"] },
+                                "delay_ms": time_field("Milliseconds from now"),
+                                "at_ms": time_field("Absolute epoch milliseconds"),
+                                "every_ms": time_field("Recurring interval"),
+                                "anchor_ms": time_field("Optional anchor"),
+                                "expr": { "type": "string", "description": "Cron expression" },
+                                "tz": { "type": "string", "description": "Timezone" }
+                            },
+                            "required": ["kind"]
+                        },
+                        "payload": {
+                            "type": ["object", "string"],
+                            "description": "What to do",
+                            "properties": {
+                                "kind": { "type": "string", "enum": ["systemEvent", "agentTurn"] },
+                                "text": { "type": "string" },
+                                "message": { "type": "string" },
+                                "model": { "type": "string" },
+                                "timeout_secs": { "type": ["integer", "string"] },
+                                "deliver": { "type": "boolean" },
+                                "channel": { "type": "string" },
+                                "to": { "type": "string" }
+                            },
+                            "required": ["kind"]
+                        },
+                        "sessionTarget": { "type": "string", "enum": ["main", "isolated"] },
+                        "deleteAfterRun": { "type": "boolean" },
+                        "enabled": { "type": "boolean" }
+                    },
+                    "required": ["name", "schedule", "payload"]
+                },
+                "id": { "type": "string" },
+                "force": { "type": "boolean" },
+                "limit": { "type": "integer" }
+            },
+            "required": ["action"]
+        }
+    })];
+
+    let converted = to_openai_tools(&tools, false);
+    assert_eq!(converted.len(), 1, "should have 1 tool");
+    let params = &converted[0]["function"]["parameters"];
+
+    // No array-form types should survive
+    let serialized = params.to_string();
+    assert!(
+        !serialized.contains("[\"integer\""),
+        "no array-form types should remain: {serialized}"
+    );
+    assert!(
+        !serialized.contains("[\"object\""),
+        "no array-form types should remain: {serialized}"
+    );
+    assert!(
+        !serialized.contains("[\"string\""),
+        "no array-form types should remain: {serialized}"
+    );
+
+    // Recursively validate: no required entry references a missing property
+    assert_no_orphaned_required(params, "parameters");
+}
+
+/// Issue #849: MultiEdit tool has nested required inside array `items`.
+/// Verify the nested required entries survive sanitization correctly.
+#[test]
+fn non_strict_multi_edit_schema_no_orphaned_required() {
+    let tools = vec![serde_json::json!({
+        "name": "MultiEdit",
+        "description": "Apply multiple sequential edits",
+        "parameters": {
+            "type": "object",
+            "required": ["file_path", "edits"],
+            "properties": {
+                "file_path": {
+                    "type": "string",
+                    "description": "Absolute path to the file"
+                },
+                "edits": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "type": "object",
+                        "required": ["old_string", "new_string"],
+                        "properties": {
+                            "old_string": { "type": "string" },
+                            "new_string": { "type": "string" },
+                            "replace_all": { "type": "boolean", "default": false }
+                        }
+                    }
+                }
+            }
+        }
+    })];
+
+    let converted = to_openai_tools(&tools, false);
+    let params = &converted[0]["function"]["parameters"];
+
+    // Recursively validate
+    assert_no_orphaned_required(params, "parameters");
+
+    // Items-level required should be intact
+    let items_required = params["properties"]["edits"]["items"]["required"]
+        .as_array()
+        .unwrap_or_else(|| panic!("items.required should exist"));
+    let names: Vec<&str> = items_required.iter().filter_map(|v| v.as_str()).collect();
+    assert!(names.contains(&"old_string"));
+    assert!(names.contains(&"new_string"));
+}
+
+/// Issue #849: after `CollapseCompositeUnionTransform` merges a selected
+/// `anyOf` variant into a parent that already has `properties`, the shallow
+/// `merge_schema_object` drops the variant's `properties` (parent-key-wins).
+/// If the variant's `required` is merged (parent had none), it references
+/// the variant's dropped properties — creating orphaned entries.
+/// `PruneOrphanedRequiredTransform` must clean these up.
+#[test]
+fn non_strict_anyof_merge_deep_merges_variant_properties() {
+    // Parent has `properties: {mode}`, variant has `properties: {target, count}`
+    // and `required: [target, count]`. Deep merge should preserve ALL properties:
+    // parent's `mode` AND variant's `target` + `count`.
+    let mut schema = serde_json::json!({
+        "type": "object",
+        "description": "A tool with union parameters",
+        "properties": {
+            "mode": { "type": "string" }
+        },
+        "anyOf": [
+            {
+                "type": "object",
+                "properties": {
+                    "target": { "type": "string" },
+                    "count": { "type": "integer" }
+                },
+                "required": ["target", "count"]
+            },
+            {
+                "type": "string"
+            }
+        ]
+    });
+
+    sanitize_schema_for_openai_compat(&mut schema);
+    collapse_schema_unions_for_non_strict_tools(&mut schema);
+
+    assert_no_orphaned_required(&schema, "root");
+
+    // Deep merge should have preserved ALL properties from both parent and variant
+    let props = schema["properties"]
+        .as_object()
+        .unwrap_or_else(|| panic!("should have properties"));
+    assert!(props.contains_key("mode"), "parent property should survive");
+    assert!(
+        props.contains_key("target"),
+        "variant property 'target' should be deep-merged"
+    );
+    assert!(
+        props.contains_key("count"),
+        "variant property 'count' should be deep-merged"
+    );
+
+    // Variant's required entries should also be present (since their
+    // properties were deep-merged and now exist)
+    let required = schema["required"]
+        .as_array()
+        .unwrap_or_else(|| panic!("should have required"));
+    let names: Vec<&str> = required.iter().filter_map(|v| v.as_str()).collect();
+    assert!(names.contains(&"target"), "target should be in required");
+    assert!(names.contains(&"count"), "count should be in required");
+}
+
+/// Issue #849: `allOf` produced by `json_schema_ast` when a type array
+/// coexists with an existing `anyOf` should be collapsed. Multi-variant
+/// `allOf` that survives transforms is mis-converted by OpenRouter's Gemini
+/// translation.
+#[test]
+fn non_strict_allof_collapsed_and_merged() {
+    let mut schema = serde_json::json!({
+        "allOf": [
+            {
+                "properties": {
+                    "kind": { "type": "string", "enum": ["at", "every"] }
+                },
+                "required": ["kind"],
+                "anyOf": [
+                    { "properties": { "delay_ms": { "type": "integer" } } },
+                    { "properties": { "every_ms": { "type": "integer" } } }
+                ]
+            },
+            {
+                "anyOf": [
+                    { "type": "object", "properties": { "kind": { "type": "string" } }, "required": ["kind"] },
+                    { "type": "string" }
+                ]
+            }
+        ]
+    });
+
+    sanitize_schema_for_openai_compat(&mut schema);
+    collapse_schema_unions_for_non_strict_tools(&mut schema);
+
+    // allOf should be fully collapsed
+    assert!(
+        schema.get("allOf").is_none(),
+        "allOf should be collapsed, got: {}",
+        serde_json::to_string_pretty(&schema).unwrap_or_default()
+    );
+
+    assert_no_orphaned_required(&schema, "root");
 }

--- a/crates/providers/tests/openai_compat_type_arrays.rs
+++ b/crates/providers/tests/openai_compat_type_arrays.rs
@@ -230,7 +230,7 @@ fn to_openai_tools_collapses_union_types_without_strict_mode() {
 }
 
 #[test]
-fn to_openai_tools_prunes_orphans_after_non_strict_composite_collapse() {
+fn to_openai_tools_deep_merges_variant_properties_after_non_strict_composite_collapse() {
     let tools = vec![serde_json::json!({
         "name": "composite",
         "description": "Composite schema edge case",
@@ -266,11 +266,26 @@ fn to_openai_tools_prunes_orphans_after_non_strict_composite_collapse() {
     let mut orphans = Vec::new();
     find_required_orphans(params, "root", &mut orphans);
     assert!(orphans.is_empty(), "found required orphans: {orphans:?}");
+
+    // Deep merge: parent's `y` + variant's `x` are both preserved (#849).
+    let config_props = config["properties"]
+        .as_object()
+        .unwrap_or_else(|| panic!("config should have properties"));
     assert!(
-        config.get("required").is_none(),
-        "orphaned composite variant required entries should be pruned"
+        config_props.contains_key("y"),
+        "parent property y should survive"
     );
-    assert!(config["properties"].get("y").is_some());
+    assert!(
+        config_props.contains_key("x"),
+        "variant property x should be deep-merged"
+    );
+
+    // Since `x` is now in properties, required: ["x"] is no longer orphaned.
+    let config_required = config["required"]
+        .as_array()
+        .unwrap_or_else(|| panic!("config should have required since x was deep-merged"));
+    let names: Vec<&str> = config_required.iter().filter_map(|v| v.as_str()).collect();
+    assert!(names.contains(&"x"), "x should be in config.required");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Fixes #849 and #848 — two related schema normalization issues affecting Gemini (via OpenRouter) and Fireworks AI.

### #849: deep-merge properties in schema union collapse
When collapsing `anyOf`/`oneOf` unions for non-strict (Gemini) tool schemas, `merge_schema_object` used shallow `or_insert` which dropped the entire variant `properties` map when the parent already had one. This silently lost variant property definitions, creating orphaned `required` entries that Gemini rejects with "property is not defined".

- **Deep-merge `properties`**: variant properties absent in the parent are now added (parent-key still wins for conflicts)
- **Union `required` arrays**: concatenated and deduplicated instead of discarding the variant's array
- **Collapse `allOf`**: `json_schema_ast` produces multi-variant `allOf` when a type array coexists with an existing `anyOf`; now merged with intersection semantics

### #848: strip redundant boolean enum
`json_schema_ast` converts `{ "type": "boolean" }` → `{ "enum": [false, true] }`. `RestoreEnumTypeTransform` restores `"type": "boolean"` but left the redundant enum. Strict mode's `make_nullable` then appended `null` to the enum: `[false, true, null]`. Fireworks AI rejects this with "could not translate the enum None."

Fix: strip the redundant `[false, true]` enum when restoring `type: "boolean"`, since it adds no constraint.

## Validation

### Completed
- [x] `cargo +nightly-2025-11-30 fmt --all -- --check`
- [x] `cargo clippy -p moltis-providers --all-targets -- -D warnings`
- [x] `cargo test -p moltis-providers` (171 tests pass, 0 failures)

### Remaining
- [ ] `./scripts/local-validate.sh 856`
- [ ] Manual QA with Gemini via OpenRouter (no "property is not defined")
- [ ] Manual QA with Fireworks AI (no "could not translate the enum None")

## Manual QA

1. **#849**: Configure OpenRouter with a Gemini model, start a chat with tools enabled, verify no "property is not defined" errors
2. **#848**: Configure Fireworks with Kimi K2.5 Turbo, send a message, verify no "could not translate the enum None" errors
3. Test the cron tool (`add` action) which has complex union type schemas

🤖 Generated with [Claude Code](https://claude.com/claude-code)