### PR TITLE
fix(skills): materialize bundled skill scripts to disk for execution

### DIFF
--- a/crates/skills/src/bundled.rs
+++ b/crates/skills/src/bundled.rs
@@ -160,6 +160,8 @@ impl BundledSkillStore {
                     std::fs::set_permissions(&target, std::fs::Permissions::from_mode(0o755))
                 {
                     tracing::warn!(skill = %name, path = %rel_path, %e, "failed to set executable permission");
+                    failed.push(rel_path.clone());
+                    continue;
                 }
             }
         }

--- a/crates/skills/src/bundled.rs
+++ b/crates/skills/src/bundled.rs
@@ -57,11 +57,21 @@ impl BundledSkillStore {
     }
 
     /// Create a store with a custom materialization directory (for tests).
+    ///
+    /// Avoids calling [`data_dir()`](moltis_config::data_dir) so tests
+    /// do not trigger side effects from the global config.
     #[must_use]
     pub fn with_materialize_dir(materialize_dir: PathBuf) -> Self {
-        let mut store = Self::new();
-        store.materialize_dir = materialize_dir;
-        store
+        let cargo_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src/assets");
+        let source = if cargo_dir.is_dir() {
+            AssetSource::Filesystem(cargo_dir)
+        } else {
+            AssetSource::Embedded
+        };
+        Self {
+            source,
+            materialize_dir,
+        }
     }
 
     /// Discover metadata for all bundled skills.
@@ -113,7 +123,8 @@ impl BundledSkillStore {
 
     /// Materialize sidecar files for a skill to an explicit target directory.
     ///
-    /// Returns `Some(target_dir/<name>)` if files were written.
+    /// Returns `Some(target_dir/<name>)` if at least one file was written,
+    /// `None` if the skill has no sidecars or every write failed.
     pub fn materialize_sidecars_to(&self, name: &str, target_dir: &Path) -> Option<PathBuf> {
         let sidecars = self.list_sidecars(name);
         if sidecars.is_empty() {
@@ -121,17 +132,21 @@ impl BundledSkillStore {
         }
 
         let skill_dir = target_dir.join(name);
+        let mut written = 0usize;
         for (rel_path, _) in &sidecars {
             let Some((bytes, _)) = self.read_sidecar(name, rel_path) else {
+                tracing::warn!(skill = %name, path = %rel_path, "failed to read bundled sidecar");
                 continue;
             };
             let target = skill_dir.join(rel_path);
             if let Some(parent) = target.parent()
-                && std::fs::create_dir_all(parent).is_err()
+                && let Err(e) = std::fs::create_dir_all(parent)
             {
+                tracing::warn!(skill = %name, path = %rel_path, %e, "failed to create sidecar directory");
                 continue;
             }
-            if std::fs::write(&target, &bytes).is_err() {
+            if let Err(e) = std::fs::write(&target, &bytes) {
+                tracing::warn!(skill = %name, path = %rel_path, %e, "failed to write sidecar file");
                 continue;
             }
             #[cfg(unix)]
@@ -139,9 +154,15 @@ impl BundledSkillStore {
                 use std::os::unix::fs::PermissionsExt;
                 let _ = std::fs::set_permissions(&target, std::fs::Permissions::from_mode(0o755));
             }
+            written += 1;
         }
 
-        Some(skill_dir)
+        if written > 0 {
+            Some(skill_dir)
+        } else {
+            tracing::warn!(skill = %name, "no sidecar files could be materialized");
+            None
+        }
     }
 }
 

--- a/crates/skills/src/bundled.rs
+++ b/crates/skills/src/bundled.rs
@@ -32,6 +32,9 @@ enum AssetSource {
 /// discoverer and the `ReadSkillTool`.
 pub struct BundledSkillStore {
     source: AssetSource,
+    /// Directory where bundled sidecar files (scripts, templates, etc.)
+    /// are materialized on disk so they can be executed by the agent.
+    materialize_dir: PathBuf,
 }
 
 impl BundledSkillStore {
@@ -39,6 +42,7 @@ impl BundledSkillStore {
     #[must_use]
     pub fn new() -> Self {
         let cargo_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src/assets");
+        let materialize_dir = moltis_config::data_dir().join("bundled-skills");
         let source = if cargo_dir.is_dir() {
             tracing::debug!(path = %cargo_dir.display(), "bundled skills: using filesystem (dev mode)");
             AssetSource::Filesystem(cargo_dir)
@@ -46,7 +50,18 @@ impl BundledSkillStore {
             tracing::debug!("bundled skills: using embedded assets");
             AssetSource::Embedded
         };
-        Self { source }
+        Self {
+            source,
+            materialize_dir,
+        }
+    }
+
+    /// Create a store with a custom materialization directory (for tests).
+    #[must_use]
+    pub fn with_materialize_dir(materialize_dir: PathBuf) -> Self {
+        let mut store = Self::new();
+        store.materialize_dir = materialize_dir;
+        store
     }
 
     /// Discover metadata for all bundled skills.
@@ -84,6 +99,49 @@ impl BundledSkillStore {
             AssetSource::Filesystem(dir) => list_sidecars_fs(dir, name),
             AssetSource::Embedded => list_sidecars_embedded(name),
         }
+    }
+
+    /// Materialize sidecar files for a skill to the configured directory.
+    ///
+    /// Returns `Some(skill_dir)` if files were written, `None` if the skill
+    /// has no sidecars. The returned path is the skill-level directory
+    /// (e.g. `<materialize_dir>/<name>/`), so `scripts/maps_client.py`
+    /// becomes `<skill_dir>/scripts/maps_client.py`.
+    pub fn materialize_sidecars(&self, name: &str) -> Option<PathBuf> {
+        self.materialize_sidecars_to(name, &self.materialize_dir)
+    }
+
+    /// Materialize sidecar files for a skill to an explicit target directory.
+    ///
+    /// Returns `Some(target_dir/<name>)` if files were written.
+    pub fn materialize_sidecars_to(&self, name: &str, target_dir: &Path) -> Option<PathBuf> {
+        let sidecars = self.list_sidecars(name);
+        if sidecars.is_empty() {
+            return None;
+        }
+
+        let skill_dir = target_dir.join(name);
+        for (rel_path, _) in &sidecars {
+            let Some((bytes, _)) = self.read_sidecar(name, rel_path) else {
+                continue;
+            };
+            let target = skill_dir.join(rel_path);
+            if let Some(parent) = target.parent()
+                && std::fs::create_dir_all(parent).is_err()
+            {
+                continue;
+            }
+            if std::fs::write(&target, &bytes).is_err() {
+                continue;
+            }
+            #[cfg(unix)]
+            if rel_path.starts_with("scripts/") {
+                use std::os::unix::fs::PermissionsExt;
+                let _ = std::fs::set_permissions(&target, std::fs::Permissions::from_mode(0o755));
+            }
+        }
+
+        Some(skill_dir)
     }
 }
 
@@ -543,6 +601,74 @@ mod tests {
     #[test]
     fn missing_sidecar_returns_none() {
         assert!(store().read_sidecar("arxiv", "nonexistent.md").is_none());
+    }
+
+    // ── Materialization ────────────────────────────────────────────
+
+    #[test]
+    fn materialize_sidecars_writes_scripts_to_disk() {
+        let s = store();
+        let tmp = tempfile::tempdir().unwrap();
+
+        // The "maps" skill has scripts/maps_client.py as a sidecar.
+        let skill_dir = s
+            .materialize_sidecars_to("maps", tmp.path())
+            .expect("maps skill should have sidecars to materialize");
+
+        let script = skill_dir.join("scripts/maps_client.py");
+        assert!(
+            script.exists(),
+            "maps_client.py must be materialized at {}",
+            script.display()
+        );
+
+        // Script content must be non-empty.
+        let content = std::fs::read_to_string(&script).unwrap();
+        assert!(!content.is_empty(), "materialized script must not be empty");
+
+        // On unix, scripts/ files must be executable.
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mode = std::fs::metadata(&script).unwrap().permissions().mode();
+            assert!(
+                mode & 0o111 != 0,
+                "scripts must be executable, got mode {mode:#o}"
+            );
+        }
+    }
+
+    #[test]
+    fn materialize_sidecars_returns_none_for_skill_without_sidecars() {
+        let s = store();
+        let tmp = tempfile::tempdir().unwrap();
+
+        // Find a skill that has no sidecars (e.g. ascii-art).
+        let sidecars = s.list_sidecars("ascii-art");
+        if sidecars.is_empty() {
+            let result = s.materialize_sidecars_to("ascii-art", tmp.path());
+            assert!(
+                result.is_none(),
+                "skill without sidecars should return None"
+            );
+        }
+    }
+
+    #[test]
+    fn materialize_sidecars_is_idempotent() {
+        let s = store();
+        let tmp = tempfile::tempdir().unwrap();
+
+        let dir1 = s.materialize_sidecars_to("maps", tmp.path());
+        let dir2 = s.materialize_sidecars_to("maps", tmp.path());
+        assert_eq!(
+            dir1, dir2,
+            "repeated materialization must return the same path"
+        );
+
+        // File must still be valid after second write.
+        let script = dir2.unwrap().join("scripts/maps_client.py");
+        assert!(script.exists());
     }
 
     // ── Specific skills smoke tests ─────────────────────────────────────

--- a/crates/skills/src/bundled.rs
+++ b/crates/skills/src/bundled.rs
@@ -123,8 +123,8 @@ impl BundledSkillStore {
 
     /// Materialize sidecar files for a skill to an explicit target directory.
     ///
-    /// Returns `Some(target_dir/<name>)` if at least one file was written,
-    /// `None` if the skill has no sidecars or every write failed.
+    /// Returns `Some(target_dir/<name>)` if **all** files were written
+    /// successfully, `None` if the skill has no sidecars or any write failed.
     pub fn materialize_sidecars_to(&self, name: &str, target_dir: &Path) -> Option<PathBuf> {
         let sidecars = self.list_sidecars(name);
         if sidecars.is_empty() {
@@ -132,10 +132,12 @@ impl BundledSkillStore {
         }
 
         let skill_dir = target_dir.join(name);
-        let mut written = 0usize;
+        let total = sidecars.len();
+        let mut failed = Vec::new();
         for (rel_path, _) in &sidecars {
             let Some((bytes, _)) = self.read_sidecar(name, rel_path) else {
                 tracing::warn!(skill = %name, path = %rel_path, "failed to read bundled sidecar");
+                failed.push(rel_path.clone());
                 continue;
             };
             let target = skill_dir.join(rel_path);
@@ -143,24 +145,34 @@ impl BundledSkillStore {
                 && let Err(e) = std::fs::create_dir_all(parent)
             {
                 tracing::warn!(skill = %name, path = %rel_path, %e, "failed to create sidecar directory");
+                failed.push(rel_path.clone());
                 continue;
             }
             if let Err(e) = std::fs::write(&target, &bytes) {
                 tracing::warn!(skill = %name, path = %rel_path, %e, "failed to write sidecar file");
+                failed.push(rel_path.clone());
                 continue;
             }
             #[cfg(unix)]
             if rel_path.starts_with("scripts/") {
                 use std::os::unix::fs::PermissionsExt;
-                let _ = std::fs::set_permissions(&target, std::fs::Permissions::from_mode(0o755));
+                if let Err(e) =
+                    std::fs::set_permissions(&target, std::fs::Permissions::from_mode(0o755))
+                {
+                    tracing::warn!(skill = %name, path = %rel_path, %e, "failed to set executable permission");
+                }
             }
-            written += 1;
         }
 
-        if written > 0 {
+        if failed.is_empty() {
             Some(skill_dir)
         } else {
-            tracing::warn!(skill = %name, "no sidecar files could be materialized");
+            tracing::warn!(
+                skill = %name,
+                failed = failed.len(),
+                total,
+                "some sidecar files could not be materialized"
+            );
             None
         }
     }

--- a/crates/tools/src/skill_tools/read.rs
+++ b/crates/tools/src/skill_tools/read.rs
@@ -1147,6 +1147,69 @@ async fn test_read_skill_sidecar_rejects_symlinked_skill_directory() {
     );
 }
 
+// ── Bundled skill materialization ────────────────────────────────────
+
+#[cfg(feature = "bundled-skills")]
+#[tokio::test]
+async fn test_read_bundled_skill_with_scripts_includes_skill_dir() {
+    use moltis_skills::bundled::BundledSkillStore;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let store = Arc::new(BundledSkillStore::with_materialize_dir(
+        tmp.path().to_path_buf(),
+    ));
+    let skills = store.discover();
+    let maps = skills
+        .iter()
+        .find(|s| s.name == "maps")
+        .expect("maps should be a bundled skill")
+        .clone();
+
+    let discoverer: Arc<dyn SkillDiscoverer> = Arc::new(StaticDiscoverer::new(vec![maps]));
+    let tool = ReadSkillTool::with_bundled(discoverer, store);
+
+    let result = tool.execute(json!({ "name": "maps" })).await.unwrap();
+
+    // A bundled skill with script sidecars must include `skill_dir`
+    // so the agent can resolve script paths referenced in the body.
+    let skill_dir = result["skill_dir"]
+        .as_str()
+        .expect("bundled skill with scripts must include skill_dir in response");
+    assert!(
+        Path::new(skill_dir).join("scripts/maps_client.py").exists(),
+        "scripts/maps_client.py must be materialized at {skill_dir}"
+    );
+}
+
+#[cfg(feature = "bundled-skills")]
+#[tokio::test]
+async fn test_read_bundled_skill_without_scripts_omits_skill_dir() {
+    use moltis_skills::bundled::BundledSkillStore;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let store = Arc::new(BundledSkillStore::with_materialize_dir(
+        tmp.path().to_path_buf(),
+    ));
+    let skills = store.discover();
+
+    // Find a skill without sidecars.
+    let no_sidecars = skills
+        .iter()
+        .find(|s| store.list_sidecars(&s.name).is_empty())
+        .expect("should have at least one skill without sidecars")
+        .clone();
+    let name = no_sidecars.name.clone();
+
+    let discoverer: Arc<dyn SkillDiscoverer> = Arc::new(StaticDiscoverer::new(vec![no_sidecars]));
+    let tool = ReadSkillTool::with_bundled(discoverer, store);
+
+    let result = tool.execute(json!({ "name": name })).await.unwrap();
+    assert!(
+        result.get("skill_dir").is_none(),
+        "bundled skill without sidecars should not include skill_dir: {result}"
+    );
+}
+
 /// Test-only `SkillDiscoverer` that returns a fixed snapshot. Lets the
 /// plugin/symlink tests construct scenarios that don't match the
 /// `FsSkillDiscoverer`'s directory-walking assumptions.

--- a/crates/tools/src/skill_tools/read_ops.rs
+++ b/crates/tools/src/skill_tools/read_ops.rs
@@ -610,7 +610,13 @@ fn read_bundled(
         response.insert("allowed_tools".into(), json!(meta.allowed_tools));
     }
     if !linked.is_empty() {
-        let hint = if skill_dir.is_some() {
+        let has_scripts = skill_dir.is_some()
+            && linked.iter().any(|v| {
+                v.get("path")
+                    .and_then(|p| p.as_str())
+                    .is_some_and(|p| p.starts_with("scripts/"))
+            });
+        let hint = if has_scripts {
             "This skill includes executable scripts. Use the `skill_dir` path \
              to resolve script references in the body. To view a linked file, \
              call read_skill again with file_path set to one of the paths in \

--- a/crates/tools/src/skill_tools/read_ops.rs
+++ b/crates/tools/src/skill_tools/read_ops.rs
@@ -578,6 +578,9 @@ fn read_bundled(
         .map(|(path, bytes)| json!({"path": path, "bytes": bytes}))
         .collect();
 
+    // Materialize sidecar files to disk so scripts can be executed.
+    let skill_dir = store.materialize_sidecars(name);
+
     let mut response = serde_json::Map::new();
     response.insert("name".into(), json!(name));
     response.insert("description".into(), json!(meta.description));
@@ -587,6 +590,9 @@ fn read_bundled(
     }
     response.insert("body".into(), json!(body));
     response.insert("bytes".into(), json!(body.len()));
+    if let Some(ref dir) = skill_dir {
+        response.insert("skill_dir".into(), json!(dir.display().to_string()));
+    }
 
     if let Some(display_name) = &meta.display_name {
         response.insert("display_name".into(), json!(display_name));
@@ -604,13 +610,16 @@ fn read_bundled(
         response.insert("allowed_tools".into(), json!(meta.allowed_tools));
     }
     if !linked.is_empty() {
-        response.insert(
-            "usage_hint".into(),
-            json!(
-                "To view a linked file, call read_skill again with file_path \
-                 set to one of the paths in linked_files."
-            ),
-        );
+        let hint = if skill_dir.is_some() {
+            "This skill includes executable scripts. Use the `skill_dir` path \
+             to resolve script references in the body. To view a linked file, \
+             call read_skill again with file_path set to one of the paths in \
+             linked_files."
+        } else {
+            "To view a linked file, call read_skill again with file_path \
+             set to one of the paths in linked_files."
+        };
+        response.insert("usage_hint".into(), json!(hint));
     }
     response.insert("linked_files".into(), json!(linked));
 


### PR DESCRIPTION
## Summary

- Bundled skills with scripts (like `maps`) reference filesystem paths in their body but those files only exist embedded in the binary — when the agent tries to execute them, they fail
- Add `materialize_sidecars()` to `BundledSkillStore` that writes sidecar files from the embedded store to `data_dir()/bundled-skills/<name>/` with `+x` on scripts
- `read_bundled()` response now includes `skill_dir` pointing to the materialized directory so the agent can resolve script paths
- Fixes the issue reported in https://github.com/moltis-org/moltis/pull/797#issuecomment-4309586590

## Validation

### Completed
- [x] `cargo +nightly-2025-11-30 fmt --all -- --check` — clean
- [x] `cargo clippy -p moltis-skills --features bundled-skills -- -D warnings` — clean
- [x] `cargo clippy -p moltis-tools --features bundled-skills -- -D warnings` — clean
- [x] `cargo test -p moltis-skills --features bundled-skills` — 138 tests pass (3 new)
- [x] `cargo test -p moltis-tools --features bundled-skills -- skill_tools` — 86 tests pass (2 new)

### Remaining
- [ ] `just lint` (full clippy)
- [ ] `just test` (full workspace tests)
- [ ] `./scripts/local-validate.sh`

## Manual QA

1. `cargo run` → ask agent about nearby cafes
2. Agent calls `read_skill(name="maps")` → response includes `skill_dir`
3. Verify `~/.moltis/bundled-skills/maps/scripts/maps_client.py` exists and is executable
4. Agent uses `skill_dir` path to run `python3 <skill_dir>/scripts/maps_client.py nearby ...` → succeeds