### PR TITLE
fix(providers): strip null from enum arrays for Fireworks AI

### DIFF
--- a/crates/providers/src/openai/provider/completion.rs
+++ b/crates/providers/src/openai/provider/completion.rs
@@ -7,8 +7,7 @@ use crate::{
     ollama::normalize_ollama_api_base_url,
     openai_compat::{
         parse_openai_compat_usage_from_payload, parse_tool_calls,
-        split_responses_instructions_and_input, strip_think_tags, to_openai_tools,
-        to_responses_api_tools,
+        split_responses_instructions_and_input, strip_think_tags, to_responses_api_tools,
     },
     raw_model_id,
 };
@@ -225,15 +224,8 @@ impl OpenAiProvider {
         self.apply_system_prompt_rewrite(&mut body);
 
         if !tools.is_empty() {
-            let mut converted = to_openai_tools(tools, self.needs_strict_tools());
-            if self.rejects_null_in_enums() {
-                for tool in &mut converted {
-                    if let Some(params) = tool.pointer_mut("/function/parameters") {
-                        crate::openai_compat::strip_null_from_typed_enums(params);
-                    }
-                }
-            }
-            body["tools"] = serde_json::Value::Array(converted);
+            body["tools"] =
+                serde_json::Value::Array(self.prepare_chat_tools(tools));
         }
 
         self.apply_reasoning_effort_chat(&mut body);

--- a/crates/providers/src/openai/provider/completion.rs
+++ b/crates/providers/src/openai/provider/completion.rs
@@ -225,8 +225,15 @@ impl OpenAiProvider {
         self.apply_system_prompt_rewrite(&mut body);
 
         if !tools.is_empty() {
-            body["tools"] =
-                serde_json::Value::Array(to_openai_tools(tools, self.needs_strict_tools()));
+            let mut converted = to_openai_tools(tools, self.needs_strict_tools());
+            if self.rejects_null_in_enums() {
+                for tool in &mut converted {
+                    if let Some(params) = tool.pointer_mut("/function/parameters") {
+                        crate::openai_compat::strip_null_from_typed_enums(params);
+                    }
+                }
+            }
+            body["tools"] = serde_json::Value::Array(converted);
         }
 
         self.apply_reasoning_effort_chat(&mut body);

--- a/crates/providers/src/openai/provider/request.rs
+++ b/crates/providers/src/openai/provider/request.rs
@@ -134,9 +134,33 @@ impl OpenAiProvider {
     /// providers, `strip_null_from_typed_enums` is applied after strict-mode
     /// patching so type-level nullability (`["string", "null"]`) remains
     /// but the redundant null is removed from enum arrays (issue #848).
-    pub(super) fn rejects_null_in_enums(&self) -> bool {
+    fn rejects_null_in_enums(&self) -> bool {
         self.provider_name.eq_ignore_ascii_case("fireworks")
             || self.base_url.contains("fireworks.ai")
+    }
+
+    /// Convert raw tool schemas into the provider-compatible Chat
+    /// Completions format, applying all provider-specific post-processing.
+    ///
+    /// Centralises strict-mode patching, null-enum stripping, and any
+    /// future provider quirks so callers (streaming, completion) don't
+    /// duplicate the logic.
+    pub(super) fn prepare_chat_tools(
+        &self,
+        tools: &[serde_json::Value],
+    ) -> Vec<serde_json::Value> {
+        let mut converted =
+            crate::openai_compat::to_openai_tools(tools, self.needs_strict_tools());
+
+        if self.rejects_null_in_enums() {
+            for tool in &mut converted {
+                if let Some(params) = tool.pointer_mut("/function/parameters") {
+                    crate::openai_compat::strip_null_from_typed_enums(params);
+                }
+            }
+        }
+
+        converted
     }
 
     fn is_custom_openai_compatible_provider(&self) -> bool {

--- a/crates/providers/src/openai/provider/request.rs
+++ b/crates/providers/src/openai/provider/request.rs
@@ -127,6 +127,18 @@ impl OpenAiProvider {
             || self.base_url.to_ascii_lowercase().contains("minimax")
     }
 
+    /// Whether this provider rejects `null` in JSON Schema `enum` arrays.
+    ///
+    /// Fireworks AI returns 400 "could not translate the enum None" when
+    /// any tool schema contains `null` in an `enum` array. For these
+    /// providers, `strip_null_from_typed_enums` is applied after strict-mode
+    /// patching so type-level nullability (`["string", "null"]`) remains
+    /// but the redundant null is removed from enum arrays (issue #848).
+    pub(super) fn rejects_null_in_enums(&self) -> bool {
+        self.provider_name.eq_ignore_ascii_case("fireworks")
+            || self.base_url.contains("fireworks.ai")
+    }
+
     fn is_custom_openai_compatible_provider(&self) -> bool {
         self.provider_name.starts_with("custom-")
     }
@@ -611,6 +623,41 @@ mod tests {
         assert!(
             p.needs_strict_tools(),
             "Native Fireworks models should use strict tools by default"
+        );
+    }
+
+    #[test]
+    fn fireworks_rejects_null_in_enums() {
+        let p = provider(
+            "accounts/fireworks/models/deepseek-v3p2",
+            "fireworks",
+            "https://api.fireworks.ai/inference/v1",
+        );
+        assert!(
+            p.rejects_null_in_enums(),
+            "Fireworks should reject null in enums (issue #848)"
+        );
+    }
+
+    #[test]
+    fn custom_fireworks_rejects_null_in_enums_via_base_url() {
+        let p = provider(
+            "accounts/fireworks/routers/kimi-k2p5-turbo",
+            "custom-fireworks-ai",
+            "https://api.fireworks.ai/inference/v1",
+        );
+        assert!(
+            p.rejects_null_in_enums(),
+            "Custom Fireworks provider should be detected via base URL (issue #848)"
+        );
+    }
+
+    #[test]
+    fn openai_allows_null_in_enums() {
+        let p = provider("gpt-4o", "openai", "https://api.openai.com/v1");
+        assert!(
+            !p.rejects_null_in_enums(),
+            "OpenAI should allow null in enums (issue #712)"
         );
     }
 

--- a/crates/providers/src/openai/provider/request.rs
+++ b/crates/providers/src/openai/provider/request.rs
@@ -136,7 +136,7 @@ impl OpenAiProvider {
     /// but the redundant null is removed from enum arrays (issue #848).
     fn rejects_null_in_enums(&self) -> bool {
         self.provider_name.eq_ignore_ascii_case("fireworks")
-            || self.base_url.contains("fireworks.ai")
+            || self.base_url.to_ascii_lowercase().contains("fireworks.ai")
     }
 
     /// Convert raw tool schemas into the provider-compatible Chat

--- a/crates/providers/src/openai/provider/streaming.rs
+++ b/crates/providers/src/openai/provider/streaming.rs
@@ -9,7 +9,7 @@ use crate::{
     openai_compat::{
         ResponsesStreamState, SseLineResult, StreamingToolState, finalize_responses_stream,
         finalize_stream, process_openai_sse_line, process_responses_sse_line,
-        split_responses_instructions_and_input, to_openai_tools, to_responses_api_tools,
+        split_responses_instructions_and_input, to_responses_api_tools,
     },
 };
 
@@ -173,15 +173,8 @@ impl OpenAiProvider {
             self.apply_system_prompt_rewrite(&mut body);
 
             if !tools.is_empty() {
-                let mut converted = to_openai_tools(&tools, self.needs_strict_tools());
-                if self.rejects_null_in_enums() {
-                    for tool in &mut converted {
-                        if let Some(params) = tool.pointer_mut("/function/parameters") {
-                            crate::openai_compat::strip_null_from_typed_enums(params);
-                        }
-                    }
-                }
-                body["tools"] = serde_json::Value::Array(converted);
+                body["tools"] =
+                    serde_json::Value::Array(self.prepare_chat_tools(&tools));
             }
 
             self.apply_reasoning_effort_chat(&mut body);

--- a/crates/providers/src/openai/provider/streaming.rs
+++ b/crates/providers/src/openai/provider/streaming.rs
@@ -173,8 +173,15 @@ impl OpenAiProvider {
             self.apply_system_prompt_rewrite(&mut body);
 
             if !tools.is_empty() {
-                body["tools"] =
-                    serde_json::Value::Array(to_openai_tools(&tools, self.needs_strict_tools()));
+                let mut converted = to_openai_tools(&tools, self.needs_strict_tools());
+                if self.rejects_null_in_enums() {
+                    for tool in &mut converted {
+                        if let Some(params) = tool.pointer_mut("/function/parameters") {
+                            crate::openai_compat::strip_null_from_typed_enums(params);
+                        }
+                    }
+                }
+                body["tools"] = serde_json::Value::Array(converted);
             }
 
             self.apply_reasoning_effort_chat(&mut body);

--- a/crates/providers/src/openai_compat/mod.rs
+++ b/crates/providers/src/openai_compat/mod.rs
@@ -19,6 +19,7 @@ pub use {
         process_responses_sse_line, responses_output_index, split_responses_instructions_and_input,
         strip_think_tags, to_openai_tools, to_responses_api_tools, to_responses_input,
     },
+    schema_normalization::strip_null_from_typed_enums,
     strict_mode::patch_schema_for_strict_mode,
 };
 

--- a/crates/providers/src/openai_compat/schema_normalization.rs
+++ b/crates/providers/src/openai_compat/schema_normalization.rs
@@ -704,10 +704,13 @@ pub fn strip_null_from_typed_enums(schema: &mut serde_json::Value) {
     };
 
     // Only strip null from enum when type already communicates nullability.
-    let type_includes_null = obj
-        .get("type")
-        .and_then(|ty| ty.as_array())
-        .is_some_and(|arr| arr.iter().any(|v| v.as_str() == Some("null")));
+    let type_includes_null = match obj.get("type") {
+        Some(serde_json::Value::Array(arr)) => {
+            arr.iter().any(|v| v.as_str() == Some("null"))
+        },
+        Some(serde_json::Value::String(s)) => s == "null",
+        _ => false,
+    };
 
     if type_includes_null
         && let Some(enum_values) = obj.get_mut("enum").and_then(|v| v.as_array_mut())

--- a/crates/providers/src/openai_compat/schema_normalization.rs
+++ b/crates/providers/src/openai_compat/schema_normalization.rs
@@ -686,6 +686,58 @@ pub(crate) fn sanitize_schema_for_openai_compat(schema: &mut serde_json::Value) 
     *schema = transformed.to_value();
 }
 
+/// Recursively remove `null` from `enum` arrays in schemas that already
+/// communicate nullability via `type` (e.g. `["string", "null"]`).
+///
+/// Strict mode's `make_nullable` adds `null` to both `type` and `enum`
+/// (issue #712, needed for OpenAI so LLMs send JSON null instead of the
+/// string "null"). However, providers like Fireworks AI reject `null` in
+/// enum arrays with "could not translate the enum None" (issue #848).
+///
+/// This function strips the redundant `null` from enum arrays when the
+/// `type` already includes `"null"`, making the schema compatible with
+/// providers that reject null enum values while preserving the type-level
+/// nullability signal.
+pub fn strip_null_from_typed_enums(schema: &mut serde_json::Value) {
+    let Some(obj) = schema.as_object_mut() else {
+        return;
+    };
+
+    // Only strip null from enum when type already communicates nullability.
+    let type_includes_null = obj
+        .get("type")
+        .and_then(|ty| ty.as_array())
+        .is_some_and(|arr| arr.iter().any(|v| v.as_str() == Some("null")));
+
+    if type_includes_null
+        && let Some(enum_values) = obj.get_mut("enum").and_then(|v| v.as_array_mut())
+    {
+        enum_values.retain(|v| !v.is_null());
+    }
+
+    // Recurse into sub-schemas.
+    if let Some(props) = obj.get_mut("properties").and_then(|v| v.as_object_mut()) {
+        for prop_schema in props.values_mut() {
+            strip_null_from_typed_enums(prop_schema);
+        }
+    }
+    if let Some(items) = obj.get_mut("items") {
+        strip_null_from_typed_enums(items);
+    }
+    for keyword in ["anyOf", "oneOf", "allOf"] {
+        if let Some(variants) = obj.get_mut(keyword).and_then(|v| v.as_array_mut()) {
+            for variant in variants {
+                strip_null_from_typed_enums(variant);
+            }
+        }
+    }
+    if let Some(ap) = obj.get_mut("additionalProperties")
+        && ap.is_object()
+    {
+        strip_null_from_typed_enums(ap);
+    }
+}
+
 /// Collapse union constructs that OpenRouter's non-strict Google path cannot
 /// safely translate into Gemini function declarations.
 pub(crate) fn collapse_schema_unions_for_non_strict_tools(schema: &mut serde_json::Value) {

--- a/crates/providers/src/openai_compat/schema_normalization.rs
+++ b/crates/providers/src/openai_compat/schema_normalization.rs
@@ -717,6 +717,14 @@ pub fn strip_null_from_typed_enums(schema: &mut serde_json::Value) {
     {
         enum_values.retain(|v| !v.is_null());
     }
+    // An empty enum means "no value is valid" — remove it entirely.
+    if obj
+        .get("enum")
+        .and_then(|v| v.as_array())
+        .is_some_and(|a| a.is_empty())
+    {
+        obj.remove("enum");
+    }
 
     // Recurse into sub-schemas.
     if let Some(props) = obj.get_mut("properties").and_then(|v| v.as_object_mut()) {

--- a/crates/providers/src/openai_compat/strict_mode.rs
+++ b/crates/providers/src/openai_compat/strict_mode.rs
@@ -38,6 +38,10 @@ fn make_nullable(schema: &mut serde_json::Value) {
         // too. Without this the type says "nullable" but the enum doesn't
         // include null, causing LLMs to send the literal string "null"
         // instead of JSON null (issue #712).
+        //
+        // Providers that reject null in enums (Fireworks AI, issue #848)
+        // must apply `strip_null_from_typed_enums` as a post-processing
+        // step after strict-mode patching.
         add_null_to_enum(obj);
         return;
     }

--- a/crates/providers/src/openai_compat/tests/schema_normalization.rs
+++ b/crates/providers/src/openai_compat/tests/schema_normalization.rs
@@ -3,7 +3,9 @@ use {
     crate::openai_compat::{
         SseLineResult, StreamingToolState, parse_tool_calls, process_openai_sse_line,
         sanitize_schema_for_openai_compat,
-        schema_normalization::collapse_schema_unions_for_non_strict_tools,
+        schema_normalization::{
+            collapse_schema_unions_for_non_strict_tools, strip_null_from_typed_enums,
+        },
         strict_mode::patch_schema_for_strict_mode, to_openai_tools, to_responses_api_tools,
     },
     moltis_agents::model::StreamEvent,
@@ -626,6 +628,113 @@ fn strict_mode_boolean_property_no_null_in_enum() {
             "{prop_name} should have a type field: {}",
             serde_json::to_string_pretty(prop).unwrap_or_default()
         );
+    }
+}
+
+/// Issue #848: `add_null_to_enum` (PR #724) adds `null` to enum arrays
+/// for nullable optional properties in strict mode. Fireworks AI rejects
+/// `null` in ANY enum, not just boolean enums. Optional string enum
+/// properties like `{ "type": "string", "enum": ["fast", "slow"] }` get
+/// `null` appended → `["fast", "slow", null]`, triggering
+/// "could not translate the enum None."
+///
+/// The fix: providers that reject null in enums (Fireworks) apply
+/// `strip_null_from_typed_enums` after strict-mode patching. This removes
+/// `null` from enum arrays when the `type` already communicates
+/// nullability (e.g. `["string", "null"]`).
+#[test]
+fn strict_mode_fireworks_string_enum_no_null_after_strip() {
+    let tools = vec![serde_json::json!({
+        "name": "cron_tool",
+        "description": "Schedule tasks",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "action": {
+                    "type": "string",
+                    "enum": ["add", "remove", "list"],
+                    "description": "The action to perform"
+                },
+                "job": {
+                    "type": "object",
+                    "properties": {
+                        "name": { "type": "string" },
+                        "session_target": {
+                            "type": "string",
+                            "enum": ["main", "isolated"]
+                        },
+                        "enabled": { "type": "boolean" },
+                        "priority": {
+                            "type": "integer",
+                            "enum": [0, 1, 2, 3]
+                        }
+                    },
+                    "required": ["name"]
+                }
+            },
+            "required": ["action"]
+        }
+    })];
+
+    // strict=true then strip nulls (Fireworks provider path)
+    let mut converted = to_openai_tools(&tools, true);
+    for tool in &mut converted {
+        if let Some(params) = tool.pointer_mut("/function/parameters") {
+            strip_null_from_typed_enums(params);
+        }
+    }
+    let params = &converted[0]["function"]["parameters"];
+
+    // After stripping, no enum array should contain null.
+    assert_no_null_in_enums(params, "parameters");
+
+    // But type-level nullability should be preserved for optional props.
+    let job = &params["properties"]["job"];
+    let job_props = &job["properties"];
+    for prop_name in ["session_target", "enabled", "priority"] {
+        let prop = &job_props[prop_name];
+        let ty = prop.get("type").and_then(|v| v.as_array());
+        assert!(
+            ty.is_some_and(|arr| arr.iter().any(|v| v.as_str() == Some("null"))),
+            "{prop_name} type should still include null for nullability: {}",
+            serde_json::to_string_pretty(prop).unwrap_or_default()
+        );
+    }
+}
+
+/// Recursively assert no `null` value appears in any `enum` array.
+/// Fireworks AI rejects schemas where any enum variant is JSON null.
+fn assert_no_null_in_enums(schema: &serde_json::Value, path: &str) {
+    let Some(obj) = schema.as_object() else {
+        return;
+    };
+
+    if let Some(enum_arr) = obj.get("enum").and_then(|v| v.as_array()) {
+        assert!(
+            !enum_arr.iter().any(|v| v.is_null()),
+            "null in enum at {path}: {enum_arr:?}"
+        );
+    }
+
+    if let Some(props) = obj.get("properties").and_then(|v| v.as_object()) {
+        for (key, value) in props {
+            assert_no_null_in_enums(value, &format!("{path}.properties.{key}"));
+        }
+    }
+    if let Some(items) = obj.get("items") {
+        assert_no_null_in_enums(items, &format!("{path}.items"));
+    }
+    for keyword in ["anyOf", "oneOf", "allOf"] {
+        if let Some(variants) = obj.get(keyword).and_then(|v| v.as_array()) {
+            for (i, variant) in variants.iter().enumerate() {
+                assert_no_null_in_enums(variant, &format!("{path}.{keyword}[{i}]"));
+            }
+        }
+    }
+    if let Some(ap) = obj.get("additionalProperties")
+        && ap.is_object()
+    {
+        assert_no_null_in_enums(ap, &format!("{path}.additionalProperties"));
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes #848 — Fireworks AI rejects `null` in JSON Schema enum arrays with "could not translate the enum None" (HTTP 400).

- **Root cause**: `make_nullable()` in strict mode adds `null` to both `type` and `enum` arrays (needed for OpenAI per #712). Fireworks rejects null in enum arrays.
- **Fix**: Provider-aware post-processing that strips `null` from enum arrays when `type` already communicates nullability (e.g. `["string", "null"]`), following openclaw's pattern of provider-specific schema transforms.
- Preserves #712 behavior for OpenAI (null stays in enums so LLMs send JSON null, not the string "null")

### Changes

| File | Change |
|------|--------|
| `schema_normalization.rs` | New `strip_null_from_typed_enums()` — recursively removes null from enum arrays when type includes "null" |
| `request.rs` | New `rejects_null_in_enums()` — detects Fireworks by provider name or base URL |
| `streaming.rs` + `completion.rs` | Apply strip after `to_openai_tools` for Fireworks providers |
| `strict_mode.rs` | Comment noting providers must apply strip as post-processing |
| `tests/schema_normalization.rs` | New test with nested string/integer/boolean enum properties + recursive null assertion helper |
| `request.rs` tests | 3 new tests: Fireworks detection (native + custom), OpenAI non-detection |

## Validation

### Completed
- [x] `cargo +nightly-2025-11-30 fmt --all -- --check` (providers crate clean)
- [x] `cargo clippy -p moltis-providers --all-targets -- -D warnings`
- [x] `cargo test -p moltis-providers` (160 tests pass)
- [x] `cargo test --workspace` (all pass, 0 failures)
- [x] #712 tests still pass (null in enums for OpenAI)
- [x] #848 boolean enum test still passes
- [x] #849 deep-merge and allOf collapse tests still pass

### Remaining
- [ ] `./scripts/local-validate.sh 860`
- [ ] Manual QA: Fireworks with Kimi K2.5 Turbo (no "could not translate the enum None")
- [ ] Manual QA: OpenAI with MCP tools with optional enum params (LLM sends JSON null, not string "null")

## Manual QA

1. Configure Fireworks with Kimi K2.5 Turbo (or any Fireworks model), send a message with tools enabled — verify no schema validation errors
2. Configure OpenAI, add an MCP tool with optional enum parameters (e.g. Tavily), send a query that doesn't need the optional enum — verify LLM sends JSON null (not string "null")