### PR TITLE
feat(discord): channel name pattern filtering and per-pattern overrides

### DIFF
--- a/crates/discord/src/access.rs
+++ b/crates/discord/src/access.rs
@@ -77,6 +77,30 @@ fn check_guild_access(
     }
 }
 
+/// Check whether a guild channel passes the channel-name / category filter.
+///
+/// Returns `true` when the channel is allowed. When both
+/// `channel_name_patterns` and `category_allowlist` are empty the filter is
+/// inactive and every channel is allowed. When either (or both) lists are
+/// non-empty, the channel must match at least one entry in either list (OR).
+pub fn channel_matches_filter(
+    config: &DiscordAccountConfig,
+    channel_name: Option<&str>,
+    category_id: Option<&str>,
+) -> bool {
+    if config.channel_name_patterns.is_empty() && config.category_allowlist.is_empty() {
+        return true;
+    }
+
+    let name_match = !config.channel_name_patterns.is_empty()
+        && channel_name.is_some_and(|n| gating::is_allowed(n, &config.channel_name_patterns));
+
+    let cat_match = !config.category_allowlist.is_empty()
+        && category_id.is_some_and(|c| gating::is_allowed(c, &config.category_allowlist));
+
+    name_match || cat_match
+}
+
 /// Reason an inbound message was denied.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum AccessDenied {
@@ -86,6 +110,7 @@ pub enum AccessDenied {
     GuildNotOnAllowlist,
     MentionModeNone,
     NotMentioned,
+    ChannelNotAllowed,
 }
 
 impl std::fmt::Display for AccessDenied {
@@ -97,6 +122,7 @@ impl std::fmt::Display for AccessDenied {
             Self::GuildNotOnAllowlist => write!(f, "guild not on allowlist"),
             Self::MentionModeNone => write!(f, "bot does not respond in guilds"),
             Self::NotMentioned => write!(f, "bot was not mentioned"),
+            Self::ChannelNotAllowed => write!(f, "channel not in name/category filter"),
         }
     }
 }
@@ -271,6 +297,51 @@ mod tests {
             check_access(&c, &ChatType::Group, "user", None, Some("grp1"), true),
             Err(AccessDenied::GuildNotOnAllowlist)
         );
+    }
+
+    // ── Channel name / category filter tests ──────────────────
+
+    #[test]
+    fn channel_filter_inactive_allows_all() {
+        let c = cfg();
+        assert!(channel_matches_filter(&c, Some("anything"), None));
+        assert!(channel_matches_filter(&c, None, None));
+    }
+
+    #[test]
+    fn channel_filter_by_name_pattern() {
+        let mut c = cfg();
+        c.channel_name_patterns = vec!["ticket-*".into(), "support-*".into()];
+        assert!(channel_matches_filter(&c, Some("ticket-42"), None));
+        assert!(channel_matches_filter(&c, Some("support-vip"), None));
+        assert!(!channel_matches_filter(&c, Some("general"), None));
+        assert!(!channel_matches_filter(&c, None, None));
+    }
+
+    #[test]
+    fn channel_filter_by_category() {
+        let mut c = cfg();
+        c.category_allowlist = vec!["CAT123".into()];
+        assert!(channel_matches_filter(&c, None, Some("CAT123")));
+        assert!(channel_matches_filter(&c, None, Some("cat123")));
+        assert!(!channel_matches_filter(&c, None, Some("OTHER")));
+        assert!(!channel_matches_filter(&c, None, None));
+    }
+
+    #[test]
+    fn channel_filter_or_logic() {
+        let mut c = cfg();
+        c.channel_name_patterns = vec!["ticket-*".into()];
+        c.category_allowlist = vec!["CAT123".into()];
+
+        // Name matches, category doesn't → allowed
+        assert!(channel_matches_filter(&c, Some("ticket-1"), Some("OTHER")));
+        // Category matches, name doesn't → allowed
+        assert!(channel_matches_filter(&c, Some("general"), Some("CAT123")));
+        // Neither matches → denied
+        assert!(!channel_matches_filter(&c, Some("general"), Some("OTHER")));
+        // Both match → allowed
+        assert!(channel_matches_filter(&c, Some("ticket-1"), Some("CAT123")));
     }
 
     #[test]

--- a/crates/discord/src/access.rs
+++ b/crates/discord/src/access.rs
@@ -110,7 +110,6 @@ pub enum AccessDenied {
     GuildNotOnAllowlist,
     MentionModeNone,
     NotMentioned,
-    ChannelNotAllowed,
 }
 
 impl std::fmt::Display for AccessDenied {
@@ -122,7 +121,6 @@ impl std::fmt::Display for AccessDenied {
             Self::GuildNotOnAllowlist => write!(f, "guild not on allowlist"),
             Self::MentionModeNone => write!(f, "bot does not respond in guilds"),
             Self::NotMentioned => write!(f, "bot was not mentioned"),
-            Self::ChannelNotAllowed => write!(f, "channel not in name/category filter"),
         }
     }
 }

--- a/crates/discord/src/config.rs
+++ b/crates/discord/src/config.rs
@@ -244,23 +244,6 @@ impl DiscordAccountConfig {
             .or_else(|| self.model())
     }
 
-    /// Resolve effective provider with pattern override support.
-    pub fn resolve_provider_with_pattern(
-        &self,
-        channel_id: &str,
-        user_id: &str,
-        channel_name: Option<&str>,
-        category_id: Option<&str>,
-    ) -> Option<&str> {
-        self.user_model_provider(user_id)
-            .or_else(|| self.channel_model_provider(channel_id))
-            .or_else(|| {
-                self.find_pattern_override(channel_name, category_id)
-                    .and_then(|po| po.model_provider.as_deref())
-            })
-            .or_else(|| self.model_provider())
-    }
-
     /// Resolve effective agent ID with pattern override support.
     pub fn resolve_agent_with_pattern(
         &self,

--- a/crates/discord/src/config.rs
+++ b/crates/discord/src/config.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use {
     moltis_channels::{
         config_view::ChannelConfigView,
-        gating::{DmPolicy, GroupPolicy, MentionMode},
+        gating::{self, DmPolicy, GroupPolicy, MentionMode},
     },
     moltis_common::secret_serde,
     secrecy::Secret,
@@ -24,6 +24,31 @@ pub struct ChannelOverride {
 /// Per-user model/provider override.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct UserOverride {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub model_provider: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub agent_id: Option<String>,
+}
+
+/// Per-pattern override for guild channels matched by name or category.
+///
+/// When a guild channel's name matches `channel_name` (glob) or its parent
+/// category matches `category_id`, the fields here override the account
+/// defaults. The first matching override wins.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct PatternOverride {
+    /// Glob pattern matched against the Discord channel name (case-insensitive).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub channel_name: Option<String>,
+    /// Discord category (parent channel) ID.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub category_id: Option<String>,
+    /// Override mention mode for matched channels.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mention_mode: Option<MentionMode>,
+    /// Override model for matched channels.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub model: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -127,6 +152,24 @@ pub struct DiscordAccountConfig {
     /// Per-user model/provider overrides (user_id -> override).
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub user_overrides: HashMap<String, UserOverride>,
+
+    /// Glob patterns for guild channel names. When non-empty, the bot only
+    /// responds in guild channels whose name matches at least one pattern.
+    /// Matched channels also implicitly use `mention_mode: always`.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub channel_name_patterns: Vec<String>,
+
+    /// Discord category (parent channel) IDs. When non-empty, the bot only
+    /// responds in guild channels under one of these categories. Combined
+    /// with `channel_name_patterns` via OR.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub category_allowlist: Vec<String>,
+
+    /// Per-pattern model/agent/mention overrides for guild channels.
+    /// First matching override wins. Checked after exact channel_id overrides
+    /// but before account defaults during model/agent resolution.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub pattern_overrides: Vec<PatternOverride>,
 }
 
 impl std::fmt::Debug for DiscordAccountConfig {
@@ -150,7 +193,89 @@ impl std::fmt::Debug for DiscordAccountConfig {
             .field("otp_cooldown_secs", &self.otp_cooldown_secs)
             .field("channel_overrides", &self.channel_overrides)
             .field("user_overrides", &self.user_overrides)
+            .field("channel_name_patterns", &self.channel_name_patterns)
+            .field("category_allowlist", &self.category_allowlist)
+            .field("pattern_overrides", &self.pattern_overrides)
             .finish()
+    }
+}
+
+impl DiscordAccountConfig {
+    /// Find the first pattern override matching the given channel name/category.
+    pub fn find_pattern_override(
+        &self,
+        channel_name: Option<&str>,
+        category_id: Option<&str>,
+    ) -> Option<&PatternOverride> {
+        self.pattern_overrides.iter().find(|po| {
+            let name_ok = match (&po.channel_name, channel_name) {
+                (Some(pattern), Some(name)) => {
+                    gating::is_allowed(name, std::slice::from_ref(pattern))
+                },
+                (Some(_), None) => false,
+                (None, _) => true,
+            };
+            let cat_ok = match (&po.category_id, category_id) {
+                (Some(cat), Some(cid)) => cat.eq_ignore_ascii_case(cid),
+                (Some(_), None) => false,
+                (None, _) => true,
+            };
+            // Both criteria must match AND at least one must be specified.
+            name_ok && cat_ok && (po.channel_name.is_some() || po.category_id.is_some())
+        })
+    }
+
+    /// Resolve effective model with pattern override support.
+    ///
+    /// Priority: user > channel ID > pattern > account default.
+    pub fn resolve_model_with_pattern(
+        &self,
+        channel_id: &str,
+        user_id: &str,
+        channel_name: Option<&str>,
+        category_id: Option<&str>,
+    ) -> Option<&str> {
+        self.user_model(user_id)
+            .or_else(|| self.channel_model(channel_id))
+            .or_else(|| {
+                self.find_pattern_override(channel_name, category_id)
+                    .and_then(|po| po.model.as_deref())
+            })
+            .or_else(|| self.model())
+    }
+
+    /// Resolve effective provider with pattern override support.
+    pub fn resolve_provider_with_pattern(
+        &self,
+        channel_id: &str,
+        user_id: &str,
+        channel_name: Option<&str>,
+        category_id: Option<&str>,
+    ) -> Option<&str> {
+        self.user_model_provider(user_id)
+            .or_else(|| self.channel_model_provider(channel_id))
+            .or_else(|| {
+                self.find_pattern_override(channel_name, category_id)
+                    .and_then(|po| po.model_provider.as_deref())
+            })
+            .or_else(|| self.model_provider())
+    }
+
+    /// Resolve effective agent ID with pattern override support.
+    pub fn resolve_agent_with_pattern(
+        &self,
+        channel_id: &str,
+        user_id: &str,
+        channel_name: Option<&str>,
+        category_id: Option<&str>,
+    ) -> Option<&str> {
+        self.user_agent_id(user_id)
+            .or_else(|| self.channel_agent_id(channel_id))
+            .or_else(|| {
+                self.find_pattern_override(channel_name, category_id)
+                    .and_then(|po| po.agent_id.as_deref())
+            })
+            .or_else(|| self.agent_id())
     }
 }
 
@@ -241,6 +366,9 @@ impl Default for DiscordAccountConfig {
             otp_cooldown_secs: 300,
             channel_overrides: HashMap::new(),
             user_overrides: HashMap::new(),
+            channel_name_patterns: Vec::new(),
+            category_allowlist: Vec::new(),
+            pattern_overrides: Vec::new(),
         }
     }
 }
@@ -261,6 +389,9 @@ impl Serialize for RedactedConfig<'_> {
         count += c.status.is_some() as usize;
         count += !c.channel_overrides.is_empty() as usize;
         count += !c.user_overrides.is_empty() as usize;
+        count += !c.channel_name_patterns.is_empty() as usize;
+        count += !c.category_allowlist.is_empty() as usize;
+        count += !c.pattern_overrides.is_empty() as usize;
         let mut s = serializer.serialize_struct("DiscordAccountConfig", count)?;
         s.serialize_field("token", secret_serde::REDACTED)?;
         s.serialize_field("dm_policy", &c.dm_policy)?;
@@ -297,6 +428,15 @@ impl Serialize for RedactedConfig<'_> {
         }
         if !c.user_overrides.is_empty() {
             s.serialize_field("user_overrides", &c.user_overrides)?;
+        }
+        if !c.channel_name_patterns.is_empty() {
+            s.serialize_field("channel_name_patterns", &c.channel_name_patterns)?;
+        }
+        if !c.category_allowlist.is_empty() {
+            s.serialize_field("category_allowlist", &c.category_allowlist)?;
+        }
+        if !c.pattern_overrides.is_empty() {
+            s.serialize_field("pattern_overrides", &c.pattern_overrides)?;
         }
         s.end()
     }
@@ -669,6 +809,227 @@ mod tests {
         assert!(
             result.is_err(),
             "invalid status should fail deserialization"
+        );
+    }
+
+    // ── Channel name patterns & category allowlist ────────────────
+
+    #[test]
+    fn config_with_channel_name_patterns() {
+        let json = serde_json::json!({
+            "token": "Bot test",
+            "channel_name_patterns": ["ticket-*", "support-*"],
+            "category_allowlist": ["123456789"],
+        });
+        let cfg: DiscordAccountConfig =
+            serde_json::from_value(json).unwrap_or_else(|e| panic!("parse failed: {e}"));
+        assert_eq!(cfg.channel_name_patterns, vec!["ticket-*", "support-*"]);
+        assert_eq!(cfg.category_allowlist, vec!["123456789"]);
+
+        // Round-trip
+        let value = serde_json::to_value(&cfg).unwrap_or_else(|e| panic!("serialize failed: {e}"));
+        assert_eq!(
+            value["channel_name_patterns"],
+            serde_json::json!(["ticket-*", "support-*"])
+        );
+        assert_eq!(
+            value["category_allowlist"],
+            serde_json::json!(["123456789"])
+        );
+    }
+
+    #[test]
+    fn config_defaults_include_empty_pattern_fields() {
+        let cfg = DiscordAccountConfig::default();
+        assert!(cfg.channel_name_patterns.is_empty());
+        assert!(cfg.category_allowlist.is_empty());
+        assert!(cfg.pattern_overrides.is_empty());
+    }
+
+    #[test]
+    fn pattern_fields_omitted_when_empty() {
+        let cfg = DiscordAccountConfig::default();
+        let value = serde_json::to_value(&cfg).unwrap_or_else(|e| panic!("serialize failed: {e}"));
+        assert!(value.get("channel_name_patterns").is_none());
+        assert!(value.get("category_allowlist").is_none());
+        assert!(value.get("pattern_overrides").is_none());
+    }
+
+    // ── Pattern overrides ─────────────────────────────────────────
+
+    #[test]
+    fn pattern_overrides_round_trip() {
+        let json = serde_json::json!({
+            "token": "Bot test",
+            "pattern_overrides": [
+                {
+                    "channel_name": "ticket-*",
+                    "mention_mode": "always",
+                    "model": "claude-sonnet",
+                    "agent_id": "support"
+                },
+                {
+                    "category_id": "999888777",
+                    "model": "gpt-4o"
+                }
+            ]
+        });
+        let cfg: DiscordAccountConfig =
+            serde_json::from_value(json).unwrap_or_else(|e| panic!("parse failed: {e}"));
+        assert_eq!(cfg.pattern_overrides.len(), 2);
+        assert_eq!(
+            cfg.pattern_overrides[0].channel_name.as_deref(),
+            Some("ticket-*")
+        );
+        assert_eq!(
+            cfg.pattern_overrides[0].mention_mode,
+            Some(MentionMode::Always)
+        );
+        assert_eq!(
+            cfg.pattern_overrides[0].agent_id.as_deref(),
+            Some("support")
+        );
+        assert_eq!(
+            cfg.pattern_overrides[1].category_id.as_deref(),
+            Some("999888777")
+        );
+
+        let value = serde_json::to_value(&cfg).unwrap_or_else(|e| panic!("serialize failed: {e}"));
+        let cfg2: DiscordAccountConfig =
+            serde_json::from_value(value).unwrap_or_else(|e| panic!("re-parse failed: {e}"));
+        assert_eq!(cfg2.pattern_overrides.len(), 2);
+    }
+
+    #[test]
+    fn find_pattern_override_by_name() {
+        let cfg = DiscordAccountConfig {
+            pattern_overrides: vec![
+                PatternOverride {
+                    channel_name: Some("ticket-*".into()),
+                    agent_id: Some("support".into()),
+                    ..Default::default()
+                },
+                PatternOverride {
+                    channel_name: Some("vip-*".into()),
+                    agent_id: Some("vip".into()),
+                    ..Default::default()
+                },
+            ],
+            ..Default::default()
+        };
+
+        let po = cfg.find_pattern_override(Some("ticket-42"), None);
+        assert_eq!(po.and_then(|p| p.agent_id.as_deref()), Some("support"));
+
+        let po = cfg.find_pattern_override(Some("vip-lounge"), None);
+        assert_eq!(po.and_then(|p| p.agent_id.as_deref()), Some("vip"));
+
+        assert!(cfg.find_pattern_override(Some("general"), None).is_none());
+        assert!(cfg.find_pattern_override(None, None).is_none());
+    }
+
+    #[test]
+    fn find_pattern_override_by_category() {
+        let cfg = DiscordAccountConfig {
+            pattern_overrides: vec![PatternOverride {
+                category_id: Some("CAT123".into()),
+                model: Some("gpt-4o".into()),
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+
+        let po = cfg.find_pattern_override(None, Some("CAT123"));
+        assert_eq!(po.and_then(|p| p.model.as_deref()), Some("gpt-4o"));
+
+        // Case-insensitive category match
+        let po = cfg.find_pattern_override(None, Some("cat123"));
+        assert_eq!(po.and_then(|p| p.model.as_deref()), Some("gpt-4o"));
+
+        assert!(cfg.find_pattern_override(None, Some("OTHER")).is_none());
+    }
+
+    #[test]
+    fn resolve_model_with_pattern_override() {
+        let cfg = DiscordAccountConfig {
+            model: Some("default-model".into()),
+            pattern_overrides: vec![PatternOverride {
+                channel_name: Some("ticket-*".into()),
+                model: Some("ticket-model".into()),
+                ..Default::default()
+            }],
+            channel_overrides: {
+                let mut m = HashMap::new();
+                m.insert("C999".into(), ChannelOverride {
+                    model: Some("exact-model".into()),
+                    ..Default::default()
+                });
+                m
+            },
+            ..Default::default()
+        };
+
+        // Pattern override
+        assert_eq!(
+            cfg.resolve_model_with_pattern("C123", "U1", Some("ticket-42"), None),
+            Some("ticket-model")
+        );
+        // Exact channel override wins over pattern
+        assert_eq!(
+            cfg.resolve_model_with_pattern("C999", "U1", Some("ticket-42"), None),
+            Some("exact-model")
+        );
+        // No match falls to default
+        assert_eq!(
+            cfg.resolve_model_with_pattern("C123", "U1", Some("general"), None),
+            Some("default-model")
+        );
+    }
+
+    #[test]
+    fn resolve_agent_with_pattern_override() {
+        let cfg = DiscordAccountConfig {
+            agent_id: Some("default-agent".into()),
+            pattern_overrides: vec![PatternOverride {
+                channel_name: Some("ticket-*".into()),
+                agent_id: Some("support".into()),
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+
+        assert_eq!(
+            cfg.resolve_agent_with_pattern("C1", "U1", Some("ticket-1"), None),
+            Some("support")
+        );
+        assert_eq!(
+            cfg.resolve_agent_with_pattern("C1", "U1", Some("general"), None),
+            Some("default-agent")
+        );
+    }
+
+    #[test]
+    fn redacted_includes_pattern_fields() {
+        let cfg = DiscordAccountConfig {
+            channel_name_patterns: vec!["ticket-*".into()],
+            category_allowlist: vec!["123".into()],
+            pattern_overrides: vec![PatternOverride {
+                channel_name: Some("ticket-*".into()),
+                agent_id: Some("support".into()),
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+        let redacted = serde_json::to_value(RedactedConfig(&cfg))
+            .unwrap_or_else(|e| panic!("redacted serialize failed: {e}"));
+        assert_eq!(
+            redacted["channel_name_patterns"],
+            serde_json::json!(["ticket-*"])
+        );
+        assert_eq!(redacted["category_allowlist"], serde_json::json!(["123"]));
+        assert_eq!(
+            redacted["pattern_overrides"].as_array().map(|a| a.len()),
+            Some(1)
         );
     }
 }

--- a/crates/discord/src/handler/implementation.rs
+++ b/crates/discord/src/handler/implementation.rs
@@ -797,16 +797,11 @@ impl EventHandler for Handler {
             let filter_active =
                 !config.channel_name_patterns.is_empty() || !config.category_allowlist.is_empty();
             if filter_active {
-                let filter_ok = access::channel_matches_filter(
+                access::channel_matches_filter(
                     &config,
                     channel_name.as_deref(),
                     category_id.as_deref(),
-                );
-                // Pattern overrides implicitly extend the filter.
-                let override_ok = config
-                    .find_pattern_override(channel_name.as_deref(), category_id.as_deref())
-                    .is_some();
-                filter_ok || override_ok
+                )
             } else {
                 true
             }

--- a/crates/discord/src/handler/implementation.rs
+++ b/crates/discord/src/handler/implementation.rs
@@ -21,8 +21,7 @@ use {
     moltis_channels::{
         ChannelEvent, ChannelType, Error as ChannelError, InboundMediaDownloader,
         InboundMediaSource, Result as ChannelsResult,
-        config_view::ChannelConfigView,
-        gating::DmPolicy,
+        gating::{DmPolicy, MentionMode},
         message_log::MessageLogEntry,
         otp::{
             OtpInitResult, OtpVerifyResult, approve_sender_via_otp, emit_otp_challenge,
@@ -683,6 +682,21 @@ impl EventHandler for Handler {
         let sender_name = msg.author.global_name.clone().or_else(|| username.clone());
         let chat_id = msg.channel_id.to_string();
 
+        // Resolve channel name and category from cache (guild channels only).
+        let (channel_name, category_id) = if let Some(guild_id) = msg.guild_id {
+            ctx.cache
+                .guild(guild_id)
+                .and_then(|guild| {
+                    guild
+                        .channels
+                        .get(&msg.channel_id)
+                        .map(|ch| (Some(ch.name.clone()), ch.parent_id.map(|id| id.to_string())))
+                })
+                .unwrap_or((None, None))
+        } else {
+            (None, None)
+        };
+
         // Check if the bot is mentioned in a guild message.
         let bot_mentioned =
             bot_user_id.is_some_and(|bot_id| msg.mentions.iter().any(|u| u.id == bot_id));
@@ -737,16 +751,68 @@ impl EventHandler for Handler {
             moltis_common::types::ChatType::Dm
         };
         let guild_id_str = msg.guild_id.map(|g| g.to_string());
-        let policy_allowed = access::check_access(
+        let basic_access = access::check_access(
             &config,
             &chat_type,
             &peer_id,
             username.as_deref(),
             guild_id_str.as_deref(),
             bot_mentioned,
-        )
-        .is_ok();
-        let access_granted = policy_allowed;
+        );
+
+        // For guild messages, pattern overrides and channel filters can
+        // override the mention-mode check and restrict which channels the
+        // bot responds in.
+        let policy_allowed = if is_guild {
+            match basic_access {
+                Ok(()) => true,
+                Err(access::AccessDenied::NotMentioned) => {
+                    // A channel matching the name/category filter implicitly
+                    // gets mention_mode=always (active monitoring).
+                    let filter_active = !config.channel_name_patterns.is_empty()
+                        || !config.category_allowlist.is_empty();
+                    let filter_match = filter_active
+                        && access::channel_matches_filter(
+                            &config,
+                            channel_name.as_deref(),
+                            category_id.as_deref(),
+                        );
+
+                    // A pattern override with mention_mode=always also allows.
+                    let override_always = config
+                        .find_pattern_override(channel_name.as_deref(), category_id.as_deref())
+                        .and_then(|po| po.mention_mode.as_ref())
+                        .is_some_and(|mm| *mm == MentionMode::Always);
+
+                    filter_match || override_always
+                },
+                Err(_) => false,
+            }
+        } else {
+            basic_access.is_ok()
+        };
+
+        // Apply channel name / category filter (if active).
+        let access_granted = if policy_allowed && is_guild {
+            let filter_active =
+                !config.channel_name_patterns.is_empty() || !config.category_allowlist.is_empty();
+            if filter_active {
+                let filter_ok = access::channel_matches_filter(
+                    &config,
+                    channel_name.as_deref(),
+                    category_id.as_deref(),
+                );
+                // Pattern overrides implicitly extend the filter.
+                let override_ok = config
+                    .find_pattern_override(channel_name.as_deref(), category_id.as_deref())
+                    .is_some();
+                filter_ok || override_ok
+            } else {
+                true
+            }
+        } else {
+            policy_allowed
+        };
 
         // Emit inbound message event.
         if let Some(sink) = event_sink.as_ref() {
@@ -987,9 +1053,21 @@ impl EventHandler for Handler {
             username,
             sender_id: Some(peer_id.clone()),
             message_kind: Some(inferred_kind),
-            model: config.resolve_model(&chat_id, &peer_id).map(String::from),
+            model: config
+                .resolve_model_with_pattern(
+                    &chat_id,
+                    &peer_id,
+                    channel_name.as_deref(),
+                    category_id.as_deref(),
+                )
+                .map(String::from),
             agent_id: config
-                .resolve_agent_id(&chat_id, &peer_id)
+                .resolve_agent_with_pattern(
+                    &chat_id,
+                    &peer_id,
+                    channel_name.as_deref(),
+                    category_id.as_deref(),
+                )
                 .map(String::from),
             audio_filename,
             documents: None,

--- a/crates/web/src/assets/dist/chunks/onboarding-view.js
+++ b/crates/web/src/assets/dist/chunks/onboarding-view.js
@@ -821,6 +821,7 @@ function DiscordForm({ onConnected, error, setError }) {
   const [token, setToken] = d("");
   const [dmPolicy, setDmPolicy] = d("allowlist");
   const [allowlist, setAllowlist] = d("");
+  const [channelPatterns, setChannelPatterns] = d("");
   const [advancedConfig, setAdvancedConfig] = d("");
   const [saving, setSaving] = d(false);
   function onSubmit(e) {
@@ -838,12 +839,14 @@ function DiscordForm({ onConnected, error, setError }) {
     setError(null);
     setSaving(true);
     const allowlistEntries = allowlist.trim().split(/\n/).map((s) => s.trim()).filter(Boolean);
+    const patternEntries = channelPatterns.trim().split(/\n/).map((s) => s.trim()).filter(Boolean);
     const config = {
       token: token.trim(),
       dm_policy: dmPolicy,
       mention_mode: "mention",
       allowlist: allowlistEntries
     };
+    if (patternEntries.length > 0) config.channel_name_patterns = patternEntries;
     Object.assign(config, advancedPatch.value);
     addChannel("discord", accountId.trim(), config).then((res) => {
       setSaving(false);
@@ -953,6 +956,21 @@ function DiscordForm({ onConnected, error, setError }) {
         }
       ),
       /* @__PURE__ */ u("div", { className: "text-xs text-[var(--muted)] mt-1", children: "One username per line. These users can DM your bot." })
+    ] }),
+    /* @__PURE__ */ u("div", { children: [
+      /* @__PURE__ */ u("label", { className: "text-xs text-[var(--muted)] mb-1 block", children: "Channel Name Patterns (optional)" }),
+      /* @__PURE__ */ u(
+        "textarea",
+        {
+          className: "provider-key-input w-full",
+          rows: 2,
+          value: channelPatterns,
+          onInput: (e) => setChannelPatterns(targetValue(e)),
+          placeholder: "ticket-*",
+          style: "resize:vertical;font-family:var(--font-body);"
+        }
+      ),
+      /* @__PURE__ */ u("div", { className: "text-xs text-[var(--muted)] mt-1", children: "One glob pattern per line. When set, the bot only responds in matching guild channels (no @mention needed). Supports * wildcards. E.g., ticket-*, support-*." })
     ] }),
     /* @__PURE__ */ u(AdvancedConfigPatchField, { value: advancedConfig, onInput: setAdvancedConfig }),
     error && /* @__PURE__ */ u(ErrorPanel, { message: error }),

--- a/crates/web/src/assets/dist/chunks/projects2.js
+++ b/crates/web/src/assets/dist/chunks/projects2.js
@@ -21,7 +21,8 @@ const projects = {
     worktree: "worktree",
     setup: "setup",
     teardown: "teardown",
-    image: "image"
+    image: "image",
+    indexed: "indexed"
   },
   card: {
     systemPromptPrefix: "System prompt: ",
@@ -44,7 +45,8 @@ const projects = {
     branchPrefixPlaceholder: "default: moltis",
     sandboxImage: "Sandbox image",
     sandboxImagePlaceholder: "Default (ubuntu:25.10)",
-    autoWorktree: "Auto-create git worktree per session"
+    autoWorktree: "Auto-create git worktree per session",
+    codeIndex: "Enable code indexing (semantic search)"
   }
 };
 export {

--- a/crates/web/src/assets/dist/chunks/projects3.js
+++ b/crates/web/src/assets/dist/chunks/projects3.js
@@ -21,7 +21,8 @@ const projects = {
     worktree: "工作树",
     setup: "初始化",
     teardown: "清理",
-    image: "镜像"
+    image: "镜像",
+    indexed: "已索引"
   },
   card: {
     systemPromptPrefix: "系统提示：",
@@ -44,7 +45,8 @@ const projects = {
     branchPrefixPlaceholder: "默认：moltis",
     sandboxImage: "沙盒镜像",
     sandboxImagePlaceholder: "默认 (ubuntu:25.10)",
-    autoWorktree: "每个会话自动创建 git 工作树"
+    autoWorktree: "每个会话自动创建 git 工作树",
+    codeIndex: "启用代码索引（语义搜索）"
   }
 };
 export {

--- a/crates/web/src/assets/dist/main.js
+++ b/crates/web/src/assets/dist/main.js
@@ -6683,7 +6683,7 @@ function prettyConfigJson(value) {
     return "{}";
   }
 }
-function AllowlistInput({ value, onChange: onChange2, preserveAt }) {
+function AllowlistInput({ value, onChange: onChange2, preserveAt, placeholder }) {
   const input = useSignal("");
   function addTag(raw) {
     const tag = preserveAt ? raw.trim() : raw.trim().replace(/^@/, "");
@@ -6750,7 +6750,7 @@ function AllowlistInput({ value, onChange: onChange2, preserveAt }) {
               input.value = targetValue(e);
             },
             onKeyDown,
-            placeholder: value.length === 0 ? "Type a username and press Enter" : "",
+            placeholder: value.length === 0 ? placeholder || "Type a username and press Enter" : "",
             className: "flex-1 bg-transparent text-[var(--text)] text-sm outline-none border-none",
             style: { minWidth: "80px", padding: "2px 0", fontFamily: "var(--font-body)" }
           }
@@ -6815,6 +6815,8 @@ function AddDiscordModal() {
   const saving = useSignal(false);
   const addModel = useSignal("");
   const allowlistItems = useSignal([]);
+  const channelNamePatterns = useSignal([]);
+  const categoryAllowlist = useSignal([]);
   const accountDraft = useSignal("");
   const tokenDraft = useSignal("");
   const advancedConfigPatch = useSignal("");
@@ -6841,6 +6843,8 @@ function AddDiscordModal() {
       mention_mode: form.querySelector("[data-field=mentionMode]").value,
       allowlist: allowlistItems.value
     };
+    if (channelNamePatterns.value.length > 0) addConfig.channel_name_patterns = channelNamePatterns.value;
+    if (categoryAllowlist.value.length > 0) addConfig.category_allowlist = categoryAllowlist.value;
     if (addModel.value) {
       addConfig.model = addModel.value;
       const found = models$1.value.find((x) => x.id === addModel.value);
@@ -6855,6 +6859,8 @@ function AddDiscordModal() {
         showAddDiscord.value = false;
         addModel.value = "";
         allowlistItems.value = [];
+        channelNamePatterns.value = [];
+        categoryAllowlist.value = [];
         accountDraft.value = "";
         tokenDraft.value = "";
         advancedConfigPatch.value = "";
@@ -6935,6 +6941,30 @@ function AddDiscordModal() {
           /* @__PURE__ */ u("a", { href: inviteUrl, target: "_blank", className: "text-xs text-[var(--accent)] underline break-all", children: inviteUrl })
         ] }),
         /* @__PURE__ */ u(SharedChannelFields, { addModel, allowlistItems }),
+        /* @__PURE__ */ u("label", { className: "text-xs text-[var(--muted)]", children: "Channel Name Patterns (optional)" }),
+        /* @__PURE__ */ u(
+          AllowlistInput,
+          {
+            value: channelNamePatterns.value,
+            onChange: (v) => {
+              channelNamePatterns.value = v;
+            },
+            placeholder: "e.g. ticket-* (glob patterns, Enter to add)"
+          }
+        ),
+        /* @__PURE__ */ u("div", { className: "text-xs text-[var(--muted)] -mt-1", children: "When set, the bot only responds in guild channels whose name matches a pattern. Matched channels do not require @mention. Supports * wildcards." }),
+        /* @__PURE__ */ u("label", { className: "text-xs text-[var(--muted)]", children: "Category IDs (optional)" }),
+        /* @__PURE__ */ u(
+          AllowlistInput,
+          {
+            value: categoryAllowlist.value,
+            onChange: (v) => {
+              categoryAllowlist.value = v;
+            },
+            placeholder: "Discord category ID (Enter to add)"
+          }
+        ),
+        /* @__PURE__ */ u("div", { className: "text-xs text-[var(--muted)] -mt-1", children: "Only respond in channels under these Discord categories. Combined with name patterns via OR." }),
         /* @__PURE__ */ u(
           AdvancedConfigPatchField,
           {
@@ -8777,9 +8807,11 @@ function EditChannelModal() {
   const editMatrixOtpCooldown = useSignal("300");
   const editSignalAccount = useSignal("");
   const editSignalHttpUrl = useSignal("http://127.0.0.1:8080");
+  const editChannelNamePatterns = useSignal([]);
+  const editCategoryAllowlist = useSignal([]);
   const editAdvancedConfigPatch = useSignal("");
   y$1(() => {
-    var _a2, _b2, _c, _d, _e, _f, _g, _h, _i, _j, _k, _l, _m, _n, _o, _p, _q, _r, _s;
+    var _a2, _b2, _c, _d, _e, _f, _g, _h, _i, _j, _k, _l, _m, _n, _o, _p, _q, _r, _s, _t, _u;
     editModel.value = ((_a2 = ch == null ? void 0 : ch.config) == null ? void 0 : _a2.model) || "";
     allowlistItems.value = ((_b2 = ch == null ? void 0 : ch.config) == null ? void 0 : _b2.allowlist) || ((_c = ch == null ? void 0 : ch.config) == null ? void 0 : _c.user_allowlist) || ((_d = ch == null ? void 0 : ch.config) == null ? void 0 : _d.allowed_pubkeys) || [];
     roomAllowlistItems.value = ((_e = ch == null ? void 0 : ch.config) == null ? void 0 : _e.room_allowlist) || ((_f = ch == null ? void 0 : ch.config) == null ? void 0 : _f.group_allowlist) || [];
@@ -8798,6 +8830,8 @@ function EditChannelModal() {
     editMatrixOtpCooldown.value = String(((_q = ch == null ? void 0 : ch.config) == null ? void 0 : _q.otp_cooldown_secs) || 300);
     editSignalAccount.value = ((_r = ch == null ? void 0 : ch.config) == null ? void 0 : _r.account) || "";
     editSignalHttpUrl.value = ((_s = ch == null ? void 0 : ch.config) == null ? void 0 : _s.http_url) || "http://127.0.0.1:8080";
+    editChannelNamePatterns.value = ((_t = ch == null ? void 0 : ch.config) == null ? void 0 : _t.channel_name_patterns) || [];
+    editCategoryAllowlist.value = ((_u = ch == null ? void 0 : ch.config) == null ? void 0 : _u.category_allowlist) || [];
     editAdvancedConfigPatch.value = "";
   }, [ch]);
   if (!ch) return null;
@@ -8878,6 +8912,10 @@ function EditChannelModal() {
     }
     if (!(isWhatsApp || isNostr)) {
       updateConfig.mention_mode = ((_e = form.querySelector("[data-field=mentionMode]")) == null ? void 0 : _e.value) || "mention";
+    }
+    if (isDiscord) {
+      updateConfig.channel_name_patterns = editChannelNamePatterns.value;
+      updateConfig.category_allowlist = editCategoryAllowlist.value;
     }
     addChannelCredentials(updateConfig, form);
     addModelToConfig(updateConfig);
@@ -9041,6 +9079,32 @@ function EditChannelModal() {
               }
             }
           )
+        ] }),
+        isDiscord && /* @__PURE__ */ u(S, { children: [
+          /* @__PURE__ */ u("label", { className: "text-xs text-[var(--muted)]", children: "Channel Name Patterns (optional)" }),
+          /* @__PURE__ */ u(
+            AllowlistInput,
+            {
+              value: editChannelNamePatterns.value,
+              onChange: (v) => {
+                editChannelNamePatterns.value = v;
+              },
+              placeholder: "e.g. ticket-* (glob patterns, Enter to add)"
+            }
+          ),
+          /* @__PURE__ */ u("div", { className: "text-xs text-[var(--muted)] -mt-1", children: "When set, the bot only responds in guild channels whose name matches a pattern. Matched channels do not require @mention. Supports * wildcards." }),
+          /* @__PURE__ */ u("label", { className: "text-xs text-[var(--muted)]", children: "Category IDs (optional)" }),
+          /* @__PURE__ */ u(
+            AllowlistInput,
+            {
+              value: editCategoryAllowlist.value,
+              onChange: (v) => {
+                editCategoryAllowlist.value = v;
+              },
+              placeholder: "Discord category ID (Enter to add)"
+            }
+          ),
+          /* @__PURE__ */ u("div", { className: "text-xs text-[var(--muted)] -mt-1", children: "Only respond in channels under these Discord categories. Combined with name patterns via OR." })
         ] }),
         isNostr && /* @__PURE__ */ u(S, { children: [
           /* @__PURE__ */ u("div", { className: "flex flex-col gap-1", children: [

--- a/crates/web/ui/src/onboarding/steps/channel-forms.tsx
+++ b/crates/web/ui/src/onboarding/steps/channel-forms.tsx
@@ -322,6 +322,7 @@ export function DiscordForm({ onConnected, error, setError }: ChannelFormProps):
 	const [token, setToken] = useState("");
 	const [dmPolicy, setDmPolicy] = useState("allowlist");
 	const [allowlist, setAllowlist] = useState("");
+	const [channelPatterns, setChannelPatterns] = useState("");
 	const [advancedConfig, setAdvancedConfig] = useState("");
 	const [saving, setSaving] = useState(false);
 
@@ -344,12 +345,18 @@ export function DiscordForm({ onConnected, error, setError }: ChannelFormProps):
 			.split(/\n/)
 			.map((s) => s.trim())
 			.filter(Boolean);
+		const patternEntries = channelPatterns
+			.trim()
+			.split(/\n/)
+			.map((s) => s.trim())
+			.filter(Boolean);
 		const config: Record<string, unknown> = {
 			token: token.trim(),
 			dm_policy: dmPolicy,
 			mention_mode: "mention",
 			allowlist: allowlistEntries,
 		};
+		if (patternEntries.length > 0) config.channel_name_patterns = patternEntries;
 		Object.assign(config, advancedPatch.value);
 		(
 			addChannel("discord", accountId.trim(), config) as Promise<{
@@ -455,6 +462,21 @@ export function DiscordForm({ onConnected, error, setError }: ChannelFormProps):
 					style="resize:vertical;font-family:var(--font-body);"
 				/>
 				<div className="text-xs text-[var(--muted)] mt-1">One username per line. These users can DM your bot.</div>
+			</div>
+			<div>
+				<label className="text-xs text-[var(--muted)] mb-1 block">Channel Name Patterns (optional)</label>
+				<textarea
+					className="provider-key-input w-full"
+					rows={2}
+					value={channelPatterns}
+					onInput={(e) => setChannelPatterns(targetValue(e))}
+					placeholder="ticket-*"
+					style="resize:vertical;font-family:var(--font-body);"
+				/>
+				<div className="text-xs text-[var(--muted)] mt-1">
+					One glob pattern per line. When set, the bot only responds in matching guild channels (no @mention
+					needed). Supports * wildcards. E.g., ticket-*, support-*.
+				</div>
 			</div>
 			<AdvancedConfigPatchField value={advancedConfig} onInput={setAdvancedConfig} />
 			{error && <ErrorPanel message={error} />}

--- a/crates/web/ui/src/pages/channels/ChannelFields.tsx
+++ b/crates/web/ui/src/pages/channels/ChannelFields.tsx
@@ -71,9 +71,10 @@ interface AllowlistInputProps {
 	value: string[];
 	onChange: (items: string[]) => void;
 	preserveAt?: boolean;
+	placeholder?: string;
 }
 
-export function AllowlistInput({ value, onChange, preserveAt }: AllowlistInputProps): VNode {
+export function AllowlistInput({ value, onChange, preserveAt, placeholder }: AllowlistInputProps): VNode {
 	const input = useSignal("");
 
 	function addTag(raw: string): void {
@@ -134,7 +135,7 @@ export function AllowlistInput({ value, onChange, preserveAt }: AllowlistInputPr
 					input.value = targetValue(e);
 				}}
 				onKeyDown={onKeyDown}
-				placeholder={value.length === 0 ? "Type a username and press Enter" : ""}
+				placeholder={value.length === 0 ? (placeholder || "Type a username and press Enter") : ""}
 				className="flex-1 bg-transparent text-[var(--text)] text-sm outline-none border-none"
 				style={{ minWidth: "80px", padding: "2px 0", fontFamily: "var(--font-body)" }}
 			/>

--- a/crates/web/ui/src/pages/channels/modals/AddDiscordModal.tsx
+++ b/crates/web/ui/src/pages/channels/modals/AddDiscordModal.tsx
@@ -9,7 +9,7 @@ import { targetValue } from "../../../typed-events";
 import { ChannelType } from "../../../types";
 import { Modal } from "../../../ui";
 import { type ChannelConfig, ConnectionModeHint, loadChannels, showAddDiscord } from "../../ChannelsPage";
-import { AdvancedConfigPatchField, SharedChannelFields } from "../ChannelFields";
+import { AdvancedConfigPatchField, AllowlistInput, SharedChannelFields } from "../ChannelFields";
 
 // ── Discord invite URL helper ────────────────────────────────
 
@@ -31,6 +31,8 @@ export function AddDiscordModal(): VNode {
 	const saving = useSignal(false);
 	const addModel = useSignal("");
 	const allowlistItems = useSignal<string[]>([]);
+	const channelNamePatterns = useSignal<string[]>([]);
+	const categoryAllowlist = useSignal<string[]>([]);
 	const accountDraft = useSignal("");
 	const tokenDraft = useSignal("");
 	const advancedConfigPatch = useSignal("");
@@ -58,6 +60,8 @@ export function AddDiscordModal(): VNode {
 			mention_mode: (form.querySelector("[data-field=mentionMode]") as HTMLSelectElement).value,
 			allowlist: allowlistItems.value,
 		};
+		if (channelNamePatterns.value.length > 0) addConfig.channel_name_patterns = channelNamePatterns.value;
+		if (categoryAllowlist.value.length > 0) addConfig.category_allowlist = categoryAllowlist.value;
 		if (addModel.value) {
 			addConfig.model = addModel.value;
 			const found = modelsSig.value.find((x) => x.id === addModel.value);
@@ -71,6 +75,8 @@ export function AddDiscordModal(): VNode {
 				showAddDiscord.value = false;
 				addModel.value = "";
 				allowlistItems.value = [];
+				channelNamePatterns.value = [];
+				categoryAllowlist.value = [];
 				accountDraft.value = "";
 				tokenDraft.value = "";
 				advancedConfigPatch.value = "";
@@ -160,6 +166,29 @@ export function AddDiscordModal(): VNode {
 					</div>
 				)}
 				<SharedChannelFields addModel={addModel} allowlistItems={allowlistItems} />
+				<label className="text-xs text-[var(--muted)]">Channel Name Patterns (optional)</label>
+				<AllowlistInput
+					value={channelNamePatterns.value}
+					onChange={(v) => {
+						channelNamePatterns.value = v;
+					}}
+					placeholder="e.g. ticket-* (glob patterns, Enter to add)"
+				/>
+				<div className="text-xs text-[var(--muted)] -mt-1">
+					When set, the bot only responds in guild channels whose name matches a pattern. Matched channels do not
+					require @mention. Supports * wildcards.
+				</div>
+				<label className="text-xs text-[var(--muted)]">Category IDs (optional)</label>
+				<AllowlistInput
+					value={categoryAllowlist.value}
+					onChange={(v) => {
+						categoryAllowlist.value = v;
+					}}
+					placeholder="Discord category ID (Enter to add)"
+				/>
+				<div className="text-xs text-[var(--muted)] -mt-1">
+					Only respond in channels under these Discord categories. Combined with name patterns via OR.
+				</div>
 				<AdvancedConfigPatchField
 					value={advancedConfigPatch.value}
 					onInput={(value) => {

--- a/crates/web/ui/src/pages/channels/modals/EditChannelModal.tsx
+++ b/crates/web/ui/src/pages/channels/modals/EditChannelModal.tsx
@@ -44,6 +44,8 @@ export function EditChannelModal(): VNode | null {
 	const editMatrixOtpCooldown = useSignal("300");
 	const editSignalAccount = useSignal("");
 	const editSignalHttpUrl = useSignal("http://127.0.0.1:8080");
+	const editChannelNamePatterns = useSignal<string[]>([]);
+	const editCategoryAllowlist = useSignal<string[]>([]);
 	const editAdvancedConfigPatch = useSignal("");
 
 	useEffect(() => {
@@ -68,6 +70,8 @@ export function EditChannelModal(): VNode | null {
 		editMatrixOtpCooldown.value = String(ch?.config?.otp_cooldown_secs || 300);
 		editSignalAccount.value = (ch?.config?.account as string) || "";
 		editSignalHttpUrl.value = (ch?.config?.http_url as string) || "http://127.0.0.1:8080";
+		editChannelNamePatterns.value = (ch?.config?.channel_name_patterns || []) as string[];
+		editCategoryAllowlist.value = (ch?.config?.category_allowlist || []) as string[];
 		editAdvancedConfigPatch.value = "";
 	}, [ch]);
 
@@ -163,6 +167,10 @@ export function EditChannelModal(): VNode | null {
 		if (!(isWhatsApp || isNostr)) {
 			updateConfig.mention_mode =
 				(form.querySelector("[data-field=mentionMode]") as HTMLSelectElement)?.value || "mention";
+		}
+		if (isDiscord) {
+			updateConfig.channel_name_patterns = editChannelNamePatterns.value;
+			updateConfig.category_allowlist = editCategoryAllowlist.value;
 		}
 		addChannelCredentials(updateConfig, form);
 		addModelToConfig(updateConfig);
@@ -318,6 +326,33 @@ export function EditChannelModal(): VNode | null {
 							}}
 						/>
 					</div>
+				)}
+				{isDiscord && (
+					<>
+						<label className="text-xs text-[var(--muted)]">Channel Name Patterns (optional)</label>
+						<AllowlistInput
+							value={editChannelNamePatterns.value}
+							onChange={(v) => {
+								editChannelNamePatterns.value = v;
+							}}
+							placeholder="e.g. ticket-* (glob patterns, Enter to add)"
+						/>
+						<div className="text-xs text-[var(--muted)] -mt-1">
+							When set, the bot only responds in guild channels whose name matches a pattern. Matched channels
+							do not require @mention. Supports * wildcards.
+						</div>
+						<label className="text-xs text-[var(--muted)]">Category IDs (optional)</label>
+						<AllowlistInput
+							value={editCategoryAllowlist.value}
+							onChange={(v) => {
+								editCategoryAllowlist.value = v;
+							}}
+							placeholder="Discord category ID (Enter to add)"
+						/>
+						<div className="text-xs text-[var(--muted)] -mt-1">
+							Only respond in channels under these Discord categories. Combined with name patterns via OR.
+						</div>
+					</>
 				)}
 				{isNostr && (
 					<>


### PR DESCRIPTION
## Summary

- Add `channel_name_patterns` (glob filters like `ticket-*`) and `category_allowlist` (Discord category IDs) to restrict which guild channels the bot responds in
- Matched channels implicitly use `mention_mode: always` — no @mention needed
- Add `pattern_overrides` for per-pattern model/agent/mention_mode overrides (first match wins, resolution: user > channel ID > pattern > default)
- Handler resolves channel name + parent category from serenity's guild cache
- Web UI fields added to Discord onboarding, add modal, and edit modal

**Use case:** Integrating with tickettool.xyz — each `#ticket-*` channel automatically gets its own Moltis session with a configurable agent/prompt, no @mention required.

Example config:
```json
{
  "channel_name_patterns": ["ticket-*"],
  "agent_id": "support-ticket"
}
```

## Validation

### Completed
- [x] `cargo +nightly-2025-11-30 fmt --all -- --check`
- [x] `cargo clippy -p moltis-discord --all-targets -- -D warnings`
- [x] `cargo test -p moltis-discord` (114 tests, 13 new)
- [x] `npx tsc --noEmit` (0 errors)
- [x] `biome check --write crates/web/ui/src/`
- [x] `npm run build` (Vite build OK)

### Remaining
- [ ] `./scripts/local-validate.sh`
- [ ] Manual QA: connect Discord bot, set channel_name_patterns, verify bot responds in matching channels without @mention and ignores non-matching channels

## Manual QA

1. Add a Discord channel with `channel_name_patterns: ["ticket-*"]` and an `agent_id`
2. Send a message in a `#ticket-*` channel — bot should respond without @mention
3. Send a message in `#general` — bot should not respond (even with @mention, since the filter restricts)
4. Remove patterns — bot reverts to normal mention_mode behavior
5. Test `category_allowlist` with a Discord category ID
6. Test `pattern_overrides` via advanced config JSON for per-pattern agent/model

🤖 Generated with [Claude Code](https://claude.com/claude-code)