### PR TITLE
feat(browser): add Obscura as lightweight sidecar browser backend

### DIFF
--- a/crates/browser/src/detect.rs
+++ b/crates/browser/src/detect.rs
@@ -178,6 +178,9 @@ impl DetectionResult {
 
 fn infer_kind_from_path(path: &Path) -> BrowserKind {
     let lower = path.to_string_lossy().to_ascii_lowercase();
+    if lower.contains("obscura") {
+        return BrowserKind::Obscura;
+    }
     if lower.contains("brave") {
         return BrowserKind::Brave;
     }
@@ -200,6 +203,31 @@ fn infer_kind_from_path(path: &Path) -> BrowserKind {
         return BrowserKind::Chrome;
     }
     BrowserKind::Custom
+}
+
+/// Detect the Obscura headless browser binary.
+///
+/// Checks (in order):
+/// 1. Custom path from config (if provided)
+/// 2. `OBSCURA` environment variable
+/// 3. `obscura` in PATH
+#[must_use]
+pub fn detect_obscura(custom_path: Option<&str>) -> Option<PathBuf> {
+    if let Some(path) = custom_path {
+        let p = PathBuf::from(path);
+        if p.exists() {
+            return Some(p);
+        }
+    }
+
+    if let Ok(path) = std::env::var("OBSCURA") {
+        let p = PathBuf::from(path);
+        if p.exists() {
+            return Some(p);
+        }
+    }
+
+    which::which("obscura").ok()
 }
 
 fn push_browser(
@@ -378,6 +406,8 @@ fn install_targets_for_preference(preference: BrowserPreference) -> Vec<BrowserK
         BrowserPreference::Opera => vec![BrowserKind::Opera],
         BrowserPreference::Vivaldi => vec![BrowserKind::Vivaldi],
         BrowserPreference::Arc => vec![BrowserKind::Arc],
+        // Obscura is not installed via package managers; users install it manually.
+        BrowserPreference::Obscura => vec![],
     }
 }
 
@@ -391,7 +421,7 @@ fn macos_install_commands(target: BrowserKind) -> Vec<InstallCommand> {
         BrowserKind::Opera => vec!["opera"],
         BrowserKind::Vivaldi => vec!["vivaldi"],
         BrowserKind::Arc => vec!["arc"],
-        BrowserKind::Custom => vec![],
+        BrowserKind::Obscura | BrowserKind::Custom => vec![],
     };
 
     casks
@@ -410,7 +440,7 @@ fn linux_package_candidates(target: BrowserKind) -> Vec<&'static str> {
         BrowserKind::Opera => vec!["opera-stable", "opera", "chromium"],
         BrowserKind::Vivaldi => vec!["vivaldi-stable", "vivaldi", "chromium"],
         BrowserKind::Arc => vec!["chromium"],
-        BrowserKind::Custom => vec![],
+        BrowserKind::Obscura | BrowserKind::Custom => vec![],
     }
 }
 
@@ -424,7 +454,7 @@ fn windows_package_ids(target: BrowserKind) -> Vec<&'static str> {
         BrowserKind::Opera => vec!["Opera.Opera"],
         BrowserKind::Vivaldi => vec!["VivaldiTechnologies.Vivaldi"],
         BrowserKind::Arc => vec!["TheBrowserCompany.Arc"],
-        BrowserKind::Custom => vec![],
+        BrowserKind::Obscura | BrowserKind::Custom => vec![],
     }
 }
 
@@ -981,6 +1011,14 @@ mod tests {
         assert_eq!(
             infer_kind_from_path(Path::new("/usr/local/bin/arc")),
             BrowserKind::Arc,
+        );
+    }
+
+    #[test]
+    fn test_infer_obscura_from_path() {
+        assert_eq!(
+            infer_kind_from_path(Path::new("/usr/local/bin/obscura")),
+            BrowserKind::Obscura,
         );
     }
 

--- a/crates/browser/src/detect.rs
+++ b/crates/browser/src/detect.rs
@@ -178,6 +178,9 @@ impl DetectionResult {
 
 fn infer_kind_from_path(path: &Path) -> BrowserKind {
     let lower = path.to_string_lossy().to_ascii_lowercase();
+    if lower.contains("lightpanda") {
+        return BrowserKind::Lightpanda;
+    }
     if lower.contains("obscura") {
         return BrowserKind::Obscura;
     }
@@ -213,6 +216,25 @@ fn infer_kind_from_path(path: &Path) -> BrowserKind {
 /// 3. `obscura` in PATH
 #[must_use]
 pub fn detect_obscura(custom_path: Option<&str>) -> Option<PathBuf> {
+    detect_sidecar_browser(custom_path, "OBSCURA", "obscura")
+}
+
+/// Detect the Lightpanda headless browser binary.
+///
+/// Checks (in order):
+/// 1. Custom path from config (if provided)
+/// 2. `LIGHTPANDA` environment variable
+/// 3. `lightpanda` in PATH
+#[must_use]
+pub fn detect_lightpanda(custom_path: Option<&str>) -> Option<PathBuf> {
+    detect_sidecar_browser(custom_path, "LIGHTPANDA", "lightpanda")
+}
+
+fn detect_sidecar_browser(
+    custom_path: Option<&str>,
+    env_var: &'static str,
+    binary_name: &'static str,
+) -> Option<PathBuf> {
     if let Some(path) = custom_path {
         let p = PathBuf::from(path);
         if p.exists() {
@@ -220,14 +242,14 @@ pub fn detect_obscura(custom_path: Option<&str>) -> Option<PathBuf> {
         }
     }
 
-    if let Ok(path) = std::env::var("OBSCURA") {
+    if let Ok(path) = std::env::var(env_var) {
         let p = PathBuf::from(path);
         if p.exists() {
             return Some(p);
         }
     }
 
-    which::which("obscura").ok()
+    which::which(binary_name).ok()
 }
 
 fn push_browser(
@@ -406,8 +428,8 @@ fn install_targets_for_preference(preference: BrowserPreference) -> Vec<BrowserK
         BrowserPreference::Opera => vec![BrowserKind::Opera],
         BrowserPreference::Vivaldi => vec![BrowserKind::Vivaldi],
         BrowserPreference::Arc => vec![BrowserKind::Arc],
-        // Obscura is not installed via package managers; users install it manually.
-        BrowserPreference::Obscura => vec![],
+        // Sidecar browsers are not installed via package managers; users install them manually.
+        BrowserPreference::Obscura | BrowserPreference::Lightpanda => vec![],
     }
 }
 
@@ -421,7 +443,7 @@ fn macos_install_commands(target: BrowserKind) -> Vec<InstallCommand> {
         BrowserKind::Opera => vec!["opera"],
         BrowserKind::Vivaldi => vec!["vivaldi"],
         BrowserKind::Arc => vec!["arc"],
-        BrowserKind::Obscura | BrowserKind::Custom => vec![],
+        BrowserKind::Obscura | BrowserKind::Lightpanda | BrowserKind::Custom => vec![],
     };
 
     casks
@@ -440,7 +462,7 @@ fn linux_package_candidates(target: BrowserKind) -> Vec<&'static str> {
         BrowserKind::Opera => vec!["opera-stable", "opera", "chromium"],
         BrowserKind::Vivaldi => vec!["vivaldi-stable", "vivaldi", "chromium"],
         BrowserKind::Arc => vec!["chromium"],
-        BrowserKind::Obscura | BrowserKind::Custom => vec![],
+        BrowserKind::Obscura | BrowserKind::Lightpanda | BrowserKind::Custom => vec![],
     }
 }
 
@@ -454,7 +476,7 @@ fn windows_package_ids(target: BrowserKind) -> Vec<&'static str> {
         BrowserKind::Opera => vec!["Opera.Opera"],
         BrowserKind::Vivaldi => vec!["VivaldiTechnologies.Vivaldi"],
         BrowserKind::Arc => vec!["TheBrowserCompany.Arc"],
-        BrowserKind::Obscura | BrowserKind::Custom => vec![],
+        BrowserKind::Obscura | BrowserKind::Lightpanda | BrowserKind::Custom => vec![],
     }
 }
 
@@ -1019,6 +1041,14 @@ mod tests {
         assert_eq!(
             infer_kind_from_path(Path::new("/usr/local/bin/obscura")),
             BrowserKind::Obscura,
+        );
+    }
+
+    #[test]
+    fn test_infer_lightpanda_from_path() {
+        assert_eq!(
+            infer_kind_from_path(Path::new("/usr/local/bin/lightpanda")),
+            BrowserKind::Lightpanda,
         );
     }
 

--- a/crates/browser/src/manager.rs
+++ b/crates/browser/src/manager.rs
@@ -1034,6 +1034,34 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn screenshot_with_lightpanda_preference_fails_without_launching() {
+        let manager = BrowserManager::default();
+        let response = manager
+            .handle_request(BrowserRequest {
+                session_id: None,
+                action: BrowserAction::Screenshot {
+                    full_page: false,
+                    highlight_ref: None,
+                },
+                timeout_ms: 1000,
+                sandbox: Some(false),
+                browser: Some(BrowserPreference::Lightpanda),
+            })
+            .await;
+
+        assert!(!response.success);
+        assert_eq!(manager.active_count().await, 0);
+        assert!(
+            response
+                .error
+                .as_deref()
+                .is_some_and(|error| error.contains("Screenshots are not supported by lightpanda")),
+            "expected Lightpanda screenshot unsupported error, got: {:?}",
+            response.error
+        );
+    }
+
+    #[tokio::test]
     async fn cleanup_stale_session_returns_connection_closed() {
         let manager = BrowserManager::default();
         let err = manager.cleanup_stale_session("sess-42", "screenshot").await;

--- a/crates/browser/src/manager.rs
+++ b/crates/browser/src/manager.rs
@@ -328,6 +328,18 @@ impl BrowserManager {
             .pool
             .get_or_create(session_id, sandbox, browser)
             .await?;
+
+        // Obscura has no pixel rendering — screenshots are unsupported.
+        if let Some(kind) = self.pool.browser_kind(&sid).await
+            && !kind.supports_screenshots()
+        {
+            return Err(Error::ScreenshotFailed(format!(
+                "Screenshots are not supported by {kind}. \
+                 Use 'snapshot' for DOM content, or switch to Chrome/Chromium \
+                 (set \"browser\": \"auto\") for pixel screenshots."
+            )));
+        }
+
         let page = self.pool.get_page(&sid).await?;
 
         // Optionally highlight an element before screenshot

--- a/crates/browser/src/manager.rs
+++ b/crates/browser/src/manager.rs
@@ -24,7 +24,10 @@ use crate::{
     snapshot::{
         extract_snapshot, find_element_by_ref, focus_element_by_ref, scroll_element_into_view,
     },
-    types::{BrowserAction, BrowserConfig, BrowserPreference, BrowserRequest, BrowserResponse},
+    types::{
+        BrowserAction, BrowserConfig, BrowserKind, BrowserPreference, BrowserRequest,
+        BrowserResponse,
+    },
 };
 
 /// Extract session_id or return an error for actions that require an existing session.
@@ -176,6 +179,30 @@ impl BrowserManager {
         ))
     }
 
+    fn unsupported_screenshot_error(kind: BrowserKind) -> Error {
+        Error::ScreenshotFailed(format!(
+            "Screenshots are not supported by {kind}. \
+             Use 'snapshot' for DOM content, or switch to Chrome/Chromium \
+             (set \"browser\": \"auto\") for pixel screenshots."
+        ))
+    }
+
+    async fn unsupported_screenshot_kind_before_launch(
+        &self,
+        session_id: Option<&str>,
+        browser: Option<BrowserPreference>,
+    ) -> Option<BrowserKind> {
+        if let Some(sid) = session_id.filter(|sid| !sid.is_empty())
+            && let Some(kind) = self.pool.browser_kind(sid).await
+        {
+            return (!kind.supports_screenshots()).then_some(kind);
+        }
+
+        browser
+            .and_then(BrowserPreference::preferred_kind)
+            .filter(|kind| !kind.supports_screenshots())
+    }
+
     /// Execute a browser action.
     async fn execute_action(
         &self,
@@ -324,20 +351,22 @@ impl BrowserManager {
         sandbox: bool,
         browser: Option<BrowserPreference>,
     ) -> Result<(String, BrowserResponse), Error> {
+        if let Some(kind) = self
+            .unsupported_screenshot_kind_before_launch(session_id, browser)
+            .await
+        {
+            return Err(Self::unsupported_screenshot_error(kind));
+        }
+
         let sid = self
             .pool
             .get_or_create(session_id, sandbox, browser)
             .await?;
 
-        // Obscura has no pixel rendering — screenshots are unsupported.
         if let Some(kind) = self.pool.browser_kind(&sid).await
             && !kind.supports_screenshots()
         {
-            return Err(Error::ScreenshotFailed(format!(
-                "Screenshots are not supported by {kind}. \
-                 Use 'snapshot' for DOM content, or switch to Chrome/Chromium \
-                 (set \"browser\": \"auto\") for pixel screenshots."
-            )));
+            return Err(Self::unsupported_screenshot_error(kind));
         }
 
         let page = self.pool.get_page(&sid).await?;
@@ -974,6 +1003,34 @@ mod tests {
         let manager = BrowserManager::default();
         manager.shutdown().await;
         assert_eq!(manager.active_count().await, 0);
+    }
+
+    #[tokio::test]
+    async fn screenshot_with_obscura_preference_fails_without_launching() {
+        let manager = BrowserManager::default();
+        let response = manager
+            .handle_request(BrowserRequest {
+                session_id: None,
+                action: BrowserAction::Screenshot {
+                    full_page: false,
+                    highlight_ref: None,
+                },
+                timeout_ms: 1000,
+                sandbox: Some(false),
+                browser: Some(BrowserPreference::Obscura),
+            })
+            .await;
+
+        assert!(!response.success);
+        assert_eq!(manager.active_count().await, 0);
+        assert!(
+            response
+                .error
+                .as_deref()
+                .is_some_and(|error| error.contains("Screenshots are not supported by obscura")),
+            "expected Obscura screenshot unsupported error, got: {:?}",
+            response.error
+        );
     }
 
     #[tokio::test]

--- a/crates/browser/src/pool.rs
+++ b/crates/browser/src/pool.rs
@@ -924,10 +924,26 @@ async fn drain_child_stderr(child: &mut tokio::process::Child) -> String {
     let Some(stderr) = child.stderr.as_mut() else {
         return String::new();
     };
-    let mut buf = Vec::with_capacity(4096);
-    // Use a short timeout so we don't block if the pipe is empty.
-    let _ = tokio::time::timeout(Duration::from_millis(100), stderr.read_to_end(&mut buf)).await;
-    String::from_utf8_lossy(&buf).trim().to_string()
+    let mut output = Vec::with_capacity(4096);
+    let mut chunk = [0; 4096];
+
+    loop {
+        match tokio::time::timeout(Duration::from_millis(10), stderr.read(&mut chunk)).await {
+            Ok(Ok(0)) | Err(_) => break,
+            Ok(Ok(read)) => {
+                output.extend_from_slice(&chunk[..read]);
+                if output.len() >= 64 * 1024 {
+                    break;
+                }
+            },
+            Ok(Err(error)) => {
+                warn!(%error, "failed to drain Obscura stderr");
+                break;
+            },
+        }
+    }
+
+    String::from_utf8_lossy(&output).trim().to_string()
 }
 
 impl Drop for BrowserPool {

--- a/crates/browser/src/pool.rs
+++ b/crates/browser/src/pool.rs
@@ -22,7 +22,7 @@ use {
 use crate::{
     container::{BrowserContainer, browserless_session_timeout_ms},
     error::Error,
-    types::{BrowserConfig, BrowserPreference, BrowserlessApiVersion},
+    types::{BrowserConfig, BrowserKind, BrowserPreference, BrowserlessApiVersion},
 };
 
 pub(crate) const MAX_BROWSER_INSTANCE_LIFETIME: Duration = Duration::from_secs(30 * 60);
@@ -104,11 +104,11 @@ struct BrowserInstance {
     /// Container for sandboxed instances (None for host browser).
     #[allow(dead_code)]
     container: Option<BrowserContainer>,
-    /// Child process for Obscura sidecar instances. Killed on drop.
+    /// Child process for lightweight sidecar instances. Killed on drop.
     #[allow(dead_code)]
     child_process: Option<tokio::process::Child>,
     /// The browser kind used for this instance.
-    kind: Option<crate::types::BrowserKind>,
+    kind: Option<BrowserKind>,
 }
 
 /// Pool of browser instances for reuse.
@@ -362,7 +362,7 @@ impl BrowserPool {
     }
 
     /// Get the browser kind for a session, if known.
-    pub async fn browser_kind(&self, session_id: &str) -> Option<crate::types::BrowserKind> {
+    pub async fn browser_kind(&self, session_id: &str) -> Option<BrowserKind> {
         let instances = self.instances.read().await;
         let instance = instances.get(session_id)?;
         let inst = instance.lock().await;
@@ -376,9 +376,8 @@ impl BrowserPool {
         sandbox: bool,
         browser: Option<BrowserPreference>,
     ) -> Result<BrowserInstance, Error> {
-        // Route to Obscura when explicitly requested.
-        if matches!(browser, Some(BrowserPreference::Obscura)) {
-            return self.launch_obscura_browser(session_id).await;
+        if let Some(spec) = browser.and_then(sidecar_browser_spec) {
+            return self.launch_sidecar_browser(session_id, spec).await;
         }
 
         if sandbox {
@@ -736,40 +735,46 @@ impl BrowserPool {
         })
     }
 
-    /// Launch an Obscura headless browser as a sidecar process and connect via CDP.
+    /// Launch a lightweight headless browser as a sidecar process and connect via CDP.
     ///
     /// Uses a retry loop to handle TOCTOU races on port selection: if a
-    /// picked port is stolen between bind-to-0 and `obscura serve`, we
-    /// try again with a fresh port (up to [`OBSCURA_PORT_RETRIES`] times).
-    async fn launch_obscura_browser(&self, session_id: &str) -> Result<BrowserInstance, Error> {
-        let obscura_path = crate::detect::detect_obscura(self.config.obscura_path.as_deref())
-            .ok_or_else(|| {
-                Error::LaunchFailed(
-                    "Obscura binary not found. Install it from \
-                     https://github.com/h4ckf0r0day/obscura or set \
-                     [tools.browser] obscura_path in config."
-                        .to_string(),
-                )
-            })?;
+    /// picked port is stolen between bind-to-0 and browser startup, we try
+    /// again with a fresh port (up to [`SIDECAR_PORT_RETRIES`] times).
+    async fn launch_sidecar_browser(
+        &self,
+        session_id: &str,
+        spec: SidecarBrowserSpec,
+    ) -> Result<BrowserInstance, Error> {
+        let browser_path = spec.detect(&self.config).ok_or_else(|| {
+            Error::LaunchFailed(format!(
+                "{} binary not found. Install it from {} or set \
+                 [tools.browser] {} in config.",
+                spec.display_name, spec.install_url, spec.config_key
+            ))
+        })?;
 
         let mut last_error = String::new();
 
-        for attempt in 0..OBSCURA_PORT_RETRIES {
+        for attempt in 0..SIDECAR_PORT_RETRIES {
             // Pick a random port for the CDP server.
             let port = pick_available_port().ok_or_else(|| {
-                Error::LaunchFailed("no available TCP port for Obscura CDP server".to_string())
+                Error::LaunchFailed(format!(
+                    "no available TCP port for {} CDP server",
+                    spec.display_name
+                ))
             })?;
 
             info!(
                 session_id,
                 port,
                 attempt,
-                path = %obscura_path.display(),
-                "launching Obscura sidecar"
+                browser = %spec.kind,
+                path = %browser_path.display(),
+                "launching browser sidecar"
             );
 
             match self
-                .try_launch_obscura(session_id, &obscura_path, port)
+                .try_launch_sidecar(session_id, spec, &browser_path, port)
                 .await
             {
                 Ok(instance) => return Ok(instance),
@@ -779,7 +784,8 @@ impl BrowserPool {
                         port,
                         attempt,
                         error = %e,
-                        "Obscura launch attempt failed, retrying with new port"
+                        browser = %spec.kind,
+                        "browser sidecar launch attempt failed, retrying with new port"
                     );
                     last_error = e.to_string();
                 },
@@ -787,34 +793,38 @@ impl BrowserPool {
         }
 
         Err(Error::LaunchFailed(format!(
-            "Obscura failed to start after {OBSCURA_PORT_RETRIES} attempts: {last_error}"
+            "{} failed to start after {SIDECAR_PORT_RETRIES} attempts: {last_error}",
+            spec.display_name
         )))
     }
 
-    /// Single attempt to spawn Obscura on a given port and connect via CDP.
-    async fn try_launch_obscura(
+    /// Single attempt to spawn a sidecar browser on a given port and connect via CDP.
+    async fn try_launch_sidecar(
         &self,
         session_id: &str,
-        obscura_path: &std::path::Path,
+        spec: SidecarBrowserSpec,
+        browser_path: &std::path::Path,
         port: u16,
     ) -> Result<BrowserInstance, Error> {
-        let mut child = tokio::process::Command::new(obscura_path)
+        let mut command = tokio::process::Command::new(browser_path);
+        command
             .arg("serve")
-            .arg("--port")
-            .arg(port.to_string())
             .stdout(std::process::Stdio::null())
             .stderr(std::process::Stdio::piped())
-            .kill_on_drop(true)
-            .spawn()
-            .map_err(|e| {
-                Error::LaunchFailed(format!(
-                    "failed to spawn Obscura at {}: {e}",
-                    obscura_path.display()
-                ))
-            })?;
+            .kill_on_drop(true);
+        for arg in spec.serve_args(port) {
+            command.arg(arg);
+        }
+        let mut child = command.spawn().map_err(|e| {
+            Error::LaunchFailed(format!(
+                "failed to spawn {} at {}: {e}",
+                spec.display_name,
+                browser_path.display()
+            ))
+        })?;
 
         // Poll until the CDP endpoint is ready (or the process exits).
-        let ws_url = format!("ws://127.0.0.1:{port}/devtools/browser");
+        let ws_url = spec.websocket_url(port);
         let addr: std::net::SocketAddr = ([127, 0, 0, 1], port).into();
         let deadline = Instant::now() + Duration::from_secs(10);
 
@@ -823,10 +833,17 @@ impl BrowserPool {
             if let Ok(Some(status)) = child.try_wait() {
                 let stderr = drain_child_stderr(&mut child).await;
                 if !stderr.is_empty() {
-                    warn!(session_id, port, stderr, "Obscura stderr before exit");
+                    warn!(
+                        session_id,
+                        port,
+                        stderr,
+                        browser = %spec.kind,
+                        "browser sidecar stderr before exit"
+                    );
                 }
                 return Err(Error::LaunchFailed(format!(
-                    "Obscura exited immediately with status {status}: {stderr}"
+                    "{} exited immediately with status {status}: {stderr}",
+                    spec.display_name
                 )));
             }
 
@@ -844,11 +861,18 @@ impl BrowserPool {
             if Instant::now() >= deadline {
                 let stderr = drain_child_stderr(&mut child).await;
                 if !stderr.is_empty() {
-                    warn!(session_id, port, stderr, "Obscura stderr at timeout");
+                    warn!(
+                        session_id,
+                        port,
+                        stderr,
+                        browser = %spec.kind,
+                        "browser sidecar stderr at timeout"
+                    );
                 }
                 let _ = child.kill().await;
                 return Err(Error::LaunchFailed(format!(
-                    "Obscura CDP server did not become ready within 10 seconds: {stderr}"
+                    "{} CDP server did not become ready within 10 seconds: {stderr}",
+                    spec.display_name
                 )));
             }
 
@@ -872,7 +896,10 @@ impl BrowserPool {
         let (browser, mut handler) = Browser::connect_with_config(&ws_url, handler_config)
             .await
             .map_err(|e| {
-                Error::LaunchFailed(format!("failed to connect to Obscura CDP at {ws_url}: {e}"))
+                Error::LaunchFailed(format!(
+                    "failed to connect to {} CDP at {ws_url}: {e}",
+                    spec.display_name
+                ))
             })?;
 
         // Spawn handler to process browser events.
@@ -882,16 +909,23 @@ impl BrowserPool {
                 debug!(
                     session_id = session_id_clone,
                     ?event,
-                    "obscura browser event"
+                    browser = %spec.kind,
+                    "sidecar browser event"
                 );
             }
             debug!(
                 session_id = session_id_clone,
-                "obscura browser event handler exited"
+                browser = %spec.kind,
+                "sidecar browser event handler exited"
             );
         });
 
-        info!(session_id, port, "Obscura sidecar connected via CDP");
+        info!(
+            session_id,
+            port,
+            browser = %spec.kind,
+            "browser sidecar connected via CDP"
+        );
 
         Ok(BrowserInstance {
             browser,
@@ -901,13 +935,72 @@ impl BrowserPool {
             sandboxed: false,
             container: None,
             child_process: Some(child),
-            kind: Some(crate::types::BrowserKind::Obscura),
+            kind: Some(spec.kind),
         })
     }
 }
 
-/// Maximum number of port-selection retries when launching Obscura.
-const OBSCURA_PORT_RETRIES: usize = 3;
+#[derive(Debug, Clone, Copy)]
+struct SidecarBrowserSpec {
+    kind: BrowserKind,
+    display_name: &'static str,
+    config_key: &'static str,
+    install_url: &'static str,
+}
+
+impl SidecarBrowserSpec {
+    fn detect(self, config: &BrowserConfig) -> Option<PathBuf> {
+        match self.kind {
+            BrowserKind::Obscura => crate::detect::detect_obscura(config.obscura_path.as_deref()),
+            BrowserKind::Lightpanda => {
+                crate::detect::detect_lightpanda(config.lightpanda_path.as_deref())
+            },
+            _ => None,
+        }
+    }
+
+    fn serve_args(self, port: u16) -> Vec<String> {
+        match self.kind {
+            BrowserKind::Obscura => vec!["--port".to_string(), port.to_string()],
+            BrowserKind::Lightpanda => vec![
+                "--host".to_string(),
+                "127.0.0.1".to_string(),
+                "--port".to_string(),
+                port.to_string(),
+            ],
+            _ => Vec::new(),
+        }
+    }
+
+    fn websocket_url(self, port: u16) -> String {
+        match self.kind {
+            BrowserKind::Obscura => format!("ws://127.0.0.1:{port}/devtools/browser"),
+            BrowserKind::Lightpanda => format!("ws://127.0.0.1:{port}"),
+            _ => format!("ws://127.0.0.1:{port}"),
+        }
+    }
+}
+
+fn sidecar_browser_spec(preference: BrowserPreference) -> Option<SidecarBrowserSpec> {
+    match preference {
+        BrowserPreference::Obscura => Some(SidecarBrowserSpec {
+            kind: BrowserKind::Obscura,
+            display_name: "Obscura",
+            config_key: "obscura_path",
+            install_url: "https://github.com/h4ckf0r0day/obscura",
+        }),
+        BrowserPreference::Lightpanda => Some(SidecarBrowserSpec {
+            kind: BrowserKind::Lightpanda,
+            display_name: "Lightpanda",
+            config_key: "lightpanda_path",
+            install_url: "https://github.com/lightpanda-io/browser",
+        }),
+        _ => None,
+    }
+}
+
+/// Maximum number of port-selection retries when launching a sidecar browser.
+const SIDECAR_PORT_RETRIES: usize = 3;
 
 /// Find an available TCP port by binding to port 0.
 fn pick_available_port() -> Option<u16> {
@@ -937,7 +1030,7 @@ async fn drain_child_stderr(child: &mut tokio::process::Child) -> String {
                 }
             },
             Ok(Err(error)) => {
-                warn!(%error, "failed to drain Obscura stderr");
+                warn!(%error, "failed to drain browser sidecar stderr");
                 break;
             },
         }
@@ -1123,6 +1216,35 @@ mod tests {
     #[test]
     fn low_memory_args_disabled_when_threshold_zero() {
         assert!(low_memory_chrome_args(512, 0).is_empty());
+    }
+
+    #[test]
+    fn lightpanda_sidecar_uses_host_port_args_and_root_ws_endpoint() {
+        let spec = sidecar_browser_spec(BrowserPreference::Lightpanda)
+            .unwrap_or_else(|| panic!("expected Lightpanda sidecar spec"));
+
+        assert_eq!(spec.serve_args(9222), vec![
+            "--host".to_string(),
+            "127.0.0.1".to_string(),
+            "--port".to_string(),
+            "9222".to_string(),
+        ]);
+        assert_eq!(spec.websocket_url(9222), "ws://127.0.0.1:9222");
+    }
+
+    #[test]
+    fn obscura_sidecar_uses_browser_ws_endpoint() {
+        let spec = sidecar_browser_spec(BrowserPreference::Obscura)
+            .unwrap_or_else(|| panic!("expected Obscura sidecar spec"));
+
+        assert_eq!(spec.serve_args(9222), vec![
+            "--port".to_string(),
+            "9222".to_string()
+        ]);
+        assert_eq!(
+            spec.websocket_url(9222),
+            "ws://127.0.0.1:9222/devtools/browser"
+        );
     }
 
     #[test]

--- a/crates/browser/src/pool.rs
+++ b/crates/browser/src/pool.rs
@@ -737,35 +737,73 @@ impl BrowserPool {
     }
 
     /// Launch an Obscura headless browser as a sidecar process and connect via CDP.
+    ///
+    /// Uses a retry loop to handle TOCTOU races on port selection: if a
+    /// picked port is stolen between bind-to-0 and `obscura serve`, we
+    /// try again with a fresh port (up to [`OBSCURA_PORT_RETRIES`] times).
     async fn launch_obscura_browser(&self, session_id: &str) -> Result<BrowserInstance, Error> {
         let obscura_path = crate::detect::detect_obscura(self.config.obscura_path.as_deref())
             .ok_or_else(|| {
                 Error::LaunchFailed(
                     "Obscura binary not found. Install it from \
-                     https://github.com/nicholasgasior/obscura or set \
+                     https://github.com/h4ckf0r0day/obscura or set \
                      [tools.browser] obscura_path in config."
                         .to_string(),
                 )
             })?;
 
-        // Pick a random port for the CDP server.
-        let port = pick_available_port().ok_or_else(|| {
-            Error::LaunchFailed("no available TCP port for Obscura CDP server".to_string())
-        })?;
+        let mut last_error = String::new();
 
-        info!(
-            session_id,
-            port,
-            path = %obscura_path.display(),
-            "launching Obscura sidecar"
-        );
+        for attempt in 0..OBSCURA_PORT_RETRIES {
+            // Pick a random port for the CDP server.
+            let port = pick_available_port().ok_or_else(|| {
+                Error::LaunchFailed("no available TCP port for Obscura CDP server".to_string())
+            })?;
 
-        let mut child = tokio::process::Command::new(&obscura_path)
+            info!(
+                session_id,
+                port,
+                attempt,
+                path = %obscura_path.display(),
+                "launching Obscura sidecar"
+            );
+
+            match self
+                .try_launch_obscura(session_id, &obscura_path, port)
+                .await
+            {
+                Ok(instance) => return Ok(instance),
+                Err(e) => {
+                    warn!(
+                        session_id,
+                        port,
+                        attempt,
+                        error = %e,
+                        "Obscura launch attempt failed, retrying with new port"
+                    );
+                    last_error = e.to_string();
+                },
+            }
+        }
+
+        Err(Error::LaunchFailed(format!(
+            "Obscura failed to start after {OBSCURA_PORT_RETRIES} attempts: {last_error}"
+        )))
+    }
+
+    /// Single attempt to spawn Obscura on a given port and connect via CDP.
+    async fn try_launch_obscura(
+        &self,
+        session_id: &str,
+        obscura_path: &std::path::Path,
+        port: u16,
+    ) -> Result<BrowserInstance, Error> {
+        let mut child = tokio::process::Command::new(obscura_path)
             .arg("serve")
             .arg("--port")
             .arg(port.to_string())
             .stdout(std::process::Stdio::null())
-            .stderr(std::process::Stdio::null())
+            .stderr(std::process::Stdio::piped())
             .kill_on_drop(true)
             .spawn()
             .map_err(|e| {
@@ -783,8 +821,12 @@ impl BrowserPool {
         loop {
             // Check that the child hasn't exited.
             if let Ok(Some(status)) = child.try_wait() {
+                let stderr = drain_child_stderr(&mut child).await;
+                if !stderr.is_empty() {
+                    warn!(session_id, port, stderr, "Obscura stderr before exit");
+                }
                 return Err(Error::LaunchFailed(format!(
-                    "Obscura exited immediately with status {status}"
+                    "Obscura exited immediately with status {status}: {stderr}"
                 )));
             }
 
@@ -800,11 +842,14 @@ impl BrowserPool {
             }
 
             if Instant::now() >= deadline {
-                // Kill the child so it doesn't leak.
+                let stderr = drain_child_stderr(&mut child).await;
+                if !stderr.is_empty() {
+                    warn!(session_id, port, stderr, "Obscura stderr at timeout");
+                }
                 let _ = child.kill().await;
-                return Err(Error::LaunchFailed(
-                    "Obscura CDP server did not become ready within 10 seconds".to_string(),
-                ));
+                return Err(Error::LaunchFailed(format!(
+                    "Obscura CDP server did not become ready within 10 seconds: {stderr}"
+                )));
             }
 
             tokio::time::sleep(Duration::from_millis(100)).await;
@@ -861,12 +906,28 @@ impl BrowserPool {
     }
 }
 
+/// Maximum number of port-selection retries when launching Obscura.
+const OBSCURA_PORT_RETRIES: usize = 3;
+
 /// Find an available TCP port by binding to port 0.
 fn pick_available_port() -> Option<u16> {
     std::net::TcpListener::bind("127.0.0.1:0")
         .ok()
         .and_then(|l| l.local_addr().ok())
         .map(|a| a.port())
+}
+
+/// Read whatever stderr the child has produced so far (non-blocking).
+async fn drain_child_stderr(child: &mut tokio::process::Child) -> String {
+    use tokio::io::AsyncReadExt;
+
+    let Some(stderr) = child.stderr.as_mut() else {
+        return String::new();
+    };
+    let mut buf = Vec::with_capacity(4096);
+    // Use a short timeout so we don't block if the pipe is empty.
+    let _ = tokio::time::timeout(Duration::from_millis(100), stderr.read_to_end(&mut buf)).await;
+    String::from_utf8_lossy(&buf).trim().to_string()
 }
 
 impl Drop for BrowserPool {

--- a/crates/browser/src/pool.rs
+++ b/crates/browser/src/pool.rs
@@ -104,6 +104,11 @@ struct BrowserInstance {
     /// Container for sandboxed instances (None for host browser).
     #[allow(dead_code)]
     container: Option<BrowserContainer>,
+    /// Child process for Obscura sidecar instances. Killed on drop.
+    #[allow(dead_code)]
+    child_process: Option<tokio::process::Child>,
+    /// The browser kind used for this instance.
+    kind: Option<crate::types::BrowserKind>,
 }
 
 /// Pool of browser instances for reuse.
@@ -356,6 +361,14 @@ impl BrowserPool {
         self.instances.read().await.len()
     }
 
+    /// Get the browser kind for a session, if known.
+    pub async fn browser_kind(&self, session_id: &str) -> Option<crate::types::BrowserKind> {
+        let instances = self.instances.read().await;
+        let instance = instances.get(session_id)?;
+        let inst = instance.lock().await;
+        inst.kind
+    }
+
     /// Launch a new browser instance.
     async fn launch_browser(
         &self,
@@ -363,6 +376,11 @@ impl BrowserPool {
         sandbox: bool,
         browser: Option<BrowserPreference>,
     ) -> Result<BrowserInstance, Error> {
+        // Route to Obscura when explicitly requested.
+        if matches!(browser, Some(BrowserPreference::Obscura)) {
+            return self.launch_obscura_browser(session_id).await;
+        }
+
         if sandbox {
             self.launch_sandboxed_browser(session_id).await
         } else {
@@ -538,6 +556,8 @@ impl BrowserPool {
             created_at: Instant::now(),
             sandboxed: true,
             container: Some(container),
+            child_process: None,
+            kind: None,
         })
     }
 
@@ -711,8 +731,142 @@ impl BrowserPool {
             created_at: Instant::now(),
             sandboxed: false,
             container: None,
+            child_process: None,
+            kind: Some(selected.kind),
         })
     }
+
+    /// Launch an Obscura headless browser as a sidecar process and connect via CDP.
+    async fn launch_obscura_browser(&self, session_id: &str) -> Result<BrowserInstance, Error> {
+        let obscura_path = crate::detect::detect_obscura(self.config.obscura_path.as_deref())
+            .ok_or_else(|| {
+                Error::LaunchFailed(
+                    "Obscura binary not found. Install it from \
+                     https://github.com/nicholasgasior/obscura or set \
+                     [tools.browser] obscura_path in config."
+                        .to_string(),
+                )
+            })?;
+
+        // Pick a random port for the CDP server.
+        let port = pick_available_port().ok_or_else(|| {
+            Error::LaunchFailed("no available TCP port for Obscura CDP server".to_string())
+        })?;
+
+        info!(
+            session_id,
+            port,
+            path = %obscura_path.display(),
+            "launching Obscura sidecar"
+        );
+
+        let mut child = tokio::process::Command::new(&obscura_path)
+            .arg("serve")
+            .arg("--port")
+            .arg(port.to_string())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .kill_on_drop(true)
+            .spawn()
+            .map_err(|e| {
+                Error::LaunchFailed(format!(
+                    "failed to spawn Obscura at {}: {e}",
+                    obscura_path.display()
+                ))
+            })?;
+
+        // Poll until the CDP endpoint is ready (or the process exits).
+        let ws_url = format!("ws://127.0.0.1:{port}/devtools/browser");
+        let addr: std::net::SocketAddr = ([127, 0, 0, 1], port).into();
+        let deadline = Instant::now() + Duration::from_secs(10);
+
+        loop {
+            // Check that the child hasn't exited.
+            if let Ok(Some(status)) = child.try_wait() {
+                return Err(Error::LaunchFailed(format!(
+                    "Obscura exited immediately with status {status}"
+                )));
+            }
+
+            // Try a TCP connect to see if the server is listening.
+            if tokio::time::timeout(
+                Duration::from_millis(200),
+                tokio::net::TcpStream::connect(addr),
+            )
+            .await
+            .is_ok_and(|r| r.is_ok())
+            {
+                break;
+            }
+
+            if Instant::now() >= deadline {
+                // Kill the child so it doesn't leak.
+                let _ = child.kill().await;
+                return Err(Error::LaunchFailed(
+                    "Obscura CDP server did not become ready within 10 seconds".to_string(),
+                ));
+            }
+
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+
+        // Connect via CDP using the existing chromiumoxide client.
+        let handler_config = HandlerConfig {
+            request_timeout: Duration::from_millis(self.config.navigation_timeout_ms),
+            viewport: Some(chromiumoxide::handler::viewport::Viewport {
+                width: self.config.viewport_width,
+                height: self.config.viewport_height,
+                device_scale_factor: Some(self.config.device_scale_factor),
+                emulating_mobile: false,
+                is_landscape: true,
+                has_touch: false,
+            }),
+            ..Default::default()
+        };
+
+        let (browser, mut handler) = Browser::connect_with_config(&ws_url, handler_config)
+            .await
+            .map_err(|e| {
+                Error::LaunchFailed(format!("failed to connect to Obscura CDP at {ws_url}: {e}"))
+            })?;
+
+        // Spawn handler to process browser events.
+        let session_id_clone = session_id.to_string();
+        tokio::spawn(async move {
+            while let Some(event) = handler.next().await {
+                debug!(
+                    session_id = session_id_clone,
+                    ?event,
+                    "obscura browser event"
+                );
+            }
+            debug!(
+                session_id = session_id_clone,
+                "obscura browser event handler exited"
+            );
+        });
+
+        info!(session_id, port, "Obscura sidecar connected via CDP");
+
+        Ok(BrowserInstance {
+            browser,
+            pages: HashMap::new(),
+            last_used: Instant::now(),
+            created_at: Instant::now(),
+            sandboxed: false,
+            container: None,
+            child_process: Some(child),
+            kind: Some(crate::types::BrowserKind::Obscura),
+        })
+    }
+}
+
+/// Find an available TCP port by binding to port 0.
+fn pick_available_port() -> Option<u16> {
+    std::net::TcpListener::bind("127.0.0.1:0")
+        .ok()
+        .and_then(|l| l.local_addr().ok())
+        .map(|a| a.port())
 }
 
 impl Drop for BrowserPool {

--- a/crates/browser/src/types.rs
+++ b/crates/browser/src/types.rs
@@ -92,6 +92,9 @@ pub enum BrowserKind {
     /// Obscura: lightweight Rust-based headless browser with CDP support.
     /// No pixel rendering (screenshots unavailable), but fast and low-memory.
     Obscura,
+    /// Lightpanda: lightweight Zig-based headless browser with CDP support.
+    /// No pixel rendering (screenshots unavailable), but fast and low-memory.
+    Lightpanda,
     Custom,
 }
 
@@ -106,6 +109,7 @@ impl BrowserKind {
             Self::Vivaldi => "vivaldi",
             Self::Arc => "arc",
             Self::Obscura => "obscura",
+            Self::Lightpanda => "lightpanda",
             Self::Custom => "custom",
         }
     }
@@ -113,7 +117,7 @@ impl BrowserKind {
     /// Returns `true` when this browser kind is known to lack pixel rendering
     /// (and therefore cannot take screenshots).
     pub fn supports_screenshots(self) -> bool {
-        !matches!(self, Self::Obscura)
+        !matches!(self, Self::Obscura | Self::Lightpanda)
     }
 }
 
@@ -137,6 +141,7 @@ pub enum BrowserPreference {
     Vivaldi,
     Arc,
     Obscura,
+    Lightpanda,
 }
 
 impl BrowserPreference {
@@ -151,6 +156,7 @@ impl BrowserPreference {
             Self::Vivaldi => Some(BrowserKind::Vivaldi),
             Self::Arc => Some(BrowserKind::Arc),
             Self::Obscura => Some(BrowserKind::Obscura),
+            Self::Lightpanda => Some(BrowserKind::Lightpanda),
         }
     }
 }
@@ -421,6 +427,9 @@ pub struct BrowserConfig {
     /// Path to the Obscura binary (auto-detected from PATH if not set).
     /// Obscura is a lightweight Rust-based headless browser that supports CDP.
     pub obscura_path: Option<String>,
+    /// Path to the Lightpanda binary (auto-detected from PATH if not set).
+    /// Lightpanda is a lightweight Zig-based headless browser that supports CDP.
+    pub lightpanda_path: Option<String>,
     /// Whether to run in headless mode.
     pub headless: bool,
     /// Default viewport width.
@@ -499,6 +508,7 @@ impl Default for BrowserConfig {
             enabled: true,
             chrome_path: None,
             obscura_path: None,
+            lightpanda_path: None,
             headless: true,
             viewport_width: 2560,
             viewport_height: 1440,
@@ -544,6 +554,7 @@ impl From<&moltis_config::schema::BrowserConfig> for BrowserConfig {
             enabled: cfg.enabled,
             chrome_path: cfg.chrome_path.clone(),
             obscura_path: cfg.obscura_path.clone(),
+            lightpanda_path: cfg.lightpanda_path.clone(),
             headless: cfg.headless,
             viewport_width: cfg.viewport_width,
             viewport_height: cfg.viewport_height,
@@ -655,6 +666,13 @@ mod tests {
             Err(error) => panic!("failed to deserialize browser preference: {error}"),
         };
         assert_eq!(value, BrowserPreference::Brave);
+    }
+
+    #[test]
+    fn renderless_browsers_do_not_support_screenshots() {
+        assert!(!BrowserKind::Obscura.supports_screenshots());
+        assert!(!BrowserKind::Lightpanda.supports_screenshots());
+        assert!(BrowserKind::Chrome.supports_screenshots());
     }
 
     #[test]

--- a/crates/browser/src/types.rs
+++ b/crates/browser/src/types.rs
@@ -89,6 +89,9 @@ pub enum BrowserKind {
     Opera,
     Vivaldi,
     Arc,
+    /// Obscura: lightweight Rust-based headless browser with CDP support.
+    /// No pixel rendering (screenshots unavailable), but fast and low-memory.
+    Obscura,
     Custom,
 }
 
@@ -102,8 +105,15 @@ impl BrowserKind {
             Self::Opera => "opera",
             Self::Vivaldi => "vivaldi",
             Self::Arc => "arc",
+            Self::Obscura => "obscura",
             Self::Custom => "custom",
         }
+    }
+
+    /// Returns `true` when this browser kind is known to lack pixel rendering
+    /// (and therefore cannot take screenshots).
+    pub fn supports_screenshots(self) -> bool {
+        !matches!(self, Self::Obscura)
     }
 }
 
@@ -126,6 +136,7 @@ pub enum BrowserPreference {
     Opera,
     Vivaldi,
     Arc,
+    Obscura,
 }
 
 impl BrowserPreference {
@@ -139,6 +150,7 @@ impl BrowserPreference {
             Self::Opera => Some(BrowserKind::Opera),
             Self::Vivaldi => Some(BrowserKind::Vivaldi),
             Self::Arc => Some(BrowserKind::Arc),
+            Self::Obscura => Some(BrowserKind::Obscura),
         }
     }
 }
@@ -406,6 +418,9 @@ pub struct BrowserConfig {
     pub enabled: bool,
     /// Path to Chrome/Chromium binary (auto-detected if not set).
     pub chrome_path: Option<String>,
+    /// Path to the Obscura binary (auto-detected from PATH if not set).
+    /// Obscura is a lightweight Rust-based headless browser that supports CDP.
+    pub obscura_path: Option<String>,
     /// Whether to run in headless mode.
     pub headless: bool,
     /// Default viewport width.
@@ -483,6 +498,7 @@ impl Default for BrowserConfig {
         Self {
             enabled: true,
             chrome_path: None,
+            obscura_path: None,
             headless: true,
             viewport_width: 2560,
             viewport_height: 1440,
@@ -527,6 +543,7 @@ impl From<&moltis_config::schema::BrowserConfig> for BrowserConfig {
         Self {
             enabled: cfg.enabled,
             chrome_path: cfg.chrome_path.clone(),
+            obscura_path: cfg.obscura_path.clone(),
             headless: cfg.headless,
             viewport_width: cfg.viewport_width,
             viewport_height: cfg.viewport_height,

--- a/crates/config/src/schema/tools.rs
+++ b/crates/config/src/schema/tools.rs
@@ -432,6 +432,9 @@ pub struct BrowserConfig {
     /// Path to the Obscura binary (auto-detected from PATH if not set).
     /// Set `browser = "obscura"` in requests to use this lightweight headless browser.
     pub obscura_path: Option<String>,
+    /// Path to the Lightpanda binary (auto-detected from PATH if not set).
+    /// Set `browser = "lightpanda"` in requests to use this lightweight headless browser.
+    pub lightpanda_path: Option<String>,
     /// Whether to run in headless mode.
     pub headless: bool,
     /// Default viewport width.
@@ -525,6 +528,7 @@ impl Default for BrowserConfig {
             enabled: true,
             chrome_path: None,
             obscura_path: None,
+            lightpanda_path: None,
             headless: true,
             viewport_width: 2560,
             viewport_height: 1440,

--- a/crates/config/src/schema/tools.rs
+++ b/crates/config/src/schema/tools.rs
@@ -429,6 +429,9 @@ pub struct BrowserConfig {
     pub enabled: bool,
     /// Path to Chrome/Chromium binary (auto-detected if not set).
     pub chrome_path: Option<String>,
+    /// Path to the Obscura binary (auto-detected from PATH if not set).
+    /// Set `browser = "obscura"` in requests to use this lightweight headless browser.
+    pub obscura_path: Option<String>,
     /// Whether to run in headless mode.
     pub headless: bool,
     /// Default viewport width.
@@ -521,6 +524,7 @@ impl Default for BrowserConfig {
         Self {
             enabled: true,
             chrome_path: None,
+            obscura_path: None,
             headless: true,
             viewport_width: 2560,
             viewport_height: 1440,

--- a/crates/config/src/template.rs
+++ b/crates/config/src/template.rs
@@ -438,6 +438,7 @@ port = {port}                           # Port number (auto-generated for this i
 # sandbox = false                   # Run browser in container for isolation
 # allowed_domains = []              # Domain restrictions (empty = all allowed)
 # chrome_path = "/path/to/chrome"   # Custom Chrome binary path
+# obscura_path = "/path/to/obscura" # Custom Obscura binary path for browser = "obscura"
 
 # ══════════════════════════════════════════════════════════════════════════════
 # SKILLS

--- a/crates/config/src/template.rs
+++ b/crates/config/src/template.rs
@@ -439,6 +439,7 @@ port = {port}                           # Port number (auto-generated for this i
 # allowed_domains = []              # Domain restrictions (empty = all allowed)
 # chrome_path = "/path/to/chrome"   # Custom Chrome binary path
 # obscura_path = "/path/to/obscura" # Custom Obscura binary path for browser = "obscura"
+# lightpanda_path = "/path/to/lightpanda" # Custom Lightpanda binary path for browser = "lightpanda"
 
 # ══════════════════════════════════════════════════════════════════════════════
 # SKILLS

--- a/crates/config/src/validate/schema_map.rs
+++ b/crates/config/src/validate/schema_map.rs
@@ -155,6 +155,7 @@ pub(super) fn build_schema_map() -> KnownKeys {
         Struct(HashMap::from([
             ("enabled", Leaf),
             ("chrome_path", Leaf),
+            ("obscura_path", Leaf),
             ("headless", Leaf),
             ("viewport_width", Leaf),
             ("viewport_height", Leaf),

--- a/crates/config/src/validate/schema_map.rs
+++ b/crates/config/src/validate/schema_map.rs
@@ -156,6 +156,7 @@ pub(super) fn build_schema_map() -> KnownKeys {
             ("enabled", Leaf),
             ("chrome_path", Leaf),
             ("obscura_path", Leaf),
+            ("lightpanda_path", Leaf),
             ("headless", Leaf),
             ("viewport_width", Leaf),
             ("viewport_height", Leaf),

--- a/crates/config/src/validate/tests/tools.rs
+++ b/crates/config/src/validate/tests/tools.rs
@@ -130,6 +130,24 @@ obscura_path = "/usr/local/bin/obscura"
 }
 
 #[test]
+fn browser_lightpanda_path_accepted() {
+    let toml = r#"
+[tools.browser]
+lightpanda_path = "/usr/local/bin/lightpanda"
+"#;
+    let result = validate_toml_str(toml);
+    let unknown = result
+        .diagnostics
+        .iter()
+        .find(|d| d.category == "unknown-field" && d.path == "tools.browser.lightpanda_path");
+    assert!(
+        unknown.is_none(),
+        "lightpanda_path should be accepted as a browser config field, got: {:?}",
+        result.diagnostics
+    );
+}
+
+#[test]
 fn tools_agent_max_iterations_must_be_positive() {
     let toml = r#"
 [tools]

--- a/crates/config/src/validate/tests/tools.rs
+++ b/crates/config/src/validate/tests/tools.rs
@@ -112,6 +112,24 @@ host = "ssh"
 }
 
 #[test]
+fn browser_obscura_path_accepted() {
+    let toml = r#"
+[tools.browser]
+obscura_path = "/usr/local/bin/obscura"
+"#;
+    let result = validate_toml_str(toml);
+    let unknown = result
+        .diagnostics
+        .iter()
+        .find(|d| d.category == "unknown-field" && d.path == "tools.browser.obscura_path");
+    assert!(
+        unknown.is_none(),
+        "obscura_path should be accepted as a browser config field, got: {:?}",
+        result.diagnostics
+    );
+}
+
+#[test]
 fn tools_agent_max_iterations_must_be_positive() {
     let toml = r#"
 [tools]

--- a/crates/gateway/src/server/prepare_core/post_state.rs
+++ b/crates/gateway/src/server/prepare_core/post_state.rs
@@ -151,10 +151,10 @@ impl moltis_tools::exec::EnvVarProvider for CredentialEnvVarProvider {
 /// one with `operator.read` + `operator.write` scopes. Returns the raw key.
 async fn ensure_sandbox_api_key(store: &auth::CredentialStore) -> Option<String> {
     // Check if we already have a sandbox-ctl key stored in env vars.
-    if let Ok(vals) = store.get_all_env_values().await {
-        if let Some((_, key)) = vals.iter().find(|(k, _)| k == "__MOLTIS_SANDBOX_API_KEY") {
-            return Some(key.clone());
-        }
+    if let Ok(vals) = store.get_all_env_values().await
+        && let Some((_, key)) = vals.iter().find(|(k, _)| k == "__MOLTIS_SANDBOX_API_KEY")
+    {
+        return Some(key.clone());
     }
 
     // Create a new API key scoped for sandbox use.

--- a/crates/tools/src/browser.rs
+++ b/crates/tools/src/browser.rs
@@ -184,8 +184,8 @@ impl AgentTool for BrowserTool {
                 },
                 "browser": {
                     "type": "string",
-                    "enum": ["auto", "chrome", "chromium", "edge", "brave", "opera", "vivaldi", "arc"],
-                    "description": "Browser to use for host mode. Default: auto (first installed browser)."
+                    "enum": ["auto", "chrome", "chromium", "edge", "brave", "opera", "vivaldi", "arc", "obscura"],
+                    "description": "Browser to use. Default: auto (first installed browser). Use 'obscura' for lightweight headless browsing (no screenshots)."
                 },
                 "url": {
                     "type": "string",

--- a/crates/tools/src/browser.rs
+++ b/crates/tools/src/browser.rs
@@ -155,7 +155,7 @@ impl AgentTool for BrowserTool {
          {\"action\": \"navigate\", \"url\": \"https://example.com\"}\n\n\
          Actions: navigate, screenshot, snapshot, click, type, scroll, evaluate, wait, close\n\n\
          BROWSER CHOICE: optionally set \"browser\" to choose one (auto, chrome, chromium, \
-         edge, brave, opera, vivaldi, arc). If no browser is installed, Moltis will try \
+         edge, brave, opera, vivaldi, arc, obscura, lightpanda). If no browser is installed, Moltis will try \
          to auto-install one.\n\n\
          SESSION: The browser session is automatically tracked per chat session. \
          After 'navigate', subsequent actions in the same chat will reuse the same \
@@ -184,8 +184,8 @@ impl AgentTool for BrowserTool {
                 },
                 "browser": {
                     "type": "string",
-                    "enum": ["auto", "chrome", "chromium", "edge", "brave", "opera", "vivaldi", "arc", "obscura"],
-                    "description": "Browser to use. Default: auto (first installed browser). Use 'obscura' for lightweight headless browsing (no screenshots)."
+                    "enum": ["auto", "chrome", "chromium", "edge", "brave", "opera", "vivaldi", "arc", "obscura", "lightpanda"],
+                    "description": "Browser to use. Default: auto (first installed browser). Use 'obscura' or 'lightpanda' for lightweight headless browsing (no screenshots)."
                 },
                 "url": {
                     "type": "string",
@@ -356,6 +356,11 @@ mod tests {
         assert!(
             required.iter().any(|v| v == "action"),
             "action should be in required fields"
+        );
+        let browser_values = schema["properties"]["browser"]["enum"].as_array().unwrap();
+        assert!(
+            browser_values.iter().any(|v| v == "lightpanda"),
+            "lightpanda should be a selectable browser"
         );
     }
 

--- a/docs/src/browser-automation.md
+++ b/docs/src/browser-automation.md
@@ -60,6 +60,7 @@ navigation_timeout_ms = 30000  # Page load timeout
 
 # Optional customization
 # chrome_path = "/path/to/chrome"  # Custom Chrome path
+# obscura_path = "/path/to/obscura"  # Custom Obscura path
 # user_agent = "Custom UA"         # Custom user agent
 # chrome_args = ["--disable-extensions"]  # Extra args
 
@@ -155,11 +156,15 @@ You can ask for a specific browser at runtime (host mode):
 ```
 
 Supported values: `auto`, `chrome`, `chromium`, `edge`, `brave`, `opera`,
-`vivaldi`, `arc`.
+`vivaldi`, `arc`, `obscura`.
 
 `auto` (default) picks the first detected installed browser. If none are
 installed, Moltis will attempt a best-effort auto-install, then retry
 detection.
+
+`obscura` launches the Obscura sidecar binary from `obscura_path`, the
+`OBSCURA` environment variable, or `PATH`. It supports DOM-oriented browsing
+through CDP, but not pixel screenshots.
 
 ### Workflow Example
 

--- a/docs/src/browser-automation.md
+++ b/docs/src/browser-automation.md
@@ -61,6 +61,7 @@ navigation_timeout_ms = 30000  # Page load timeout
 # Optional customization
 # chrome_path = "/path/to/chrome"  # Custom Chrome path
 # obscura_path = "/path/to/obscura"  # Custom Obscura path
+# lightpanda_path = "/path/to/lightpanda"  # Custom Lightpanda path
 # user_agent = "Custom UA"         # Custom user agent
 # chrome_args = ["--disable-extensions"]  # Extra args
 
@@ -156,7 +157,7 @@ You can ask for a specific browser at runtime (host mode):
 ```
 
 Supported values: `auto`, `chrome`, `chromium`, `edge`, `brave`, `opera`,
-`vivaldi`, `arc`, `obscura`.
+`vivaldi`, `arc`, `obscura`, `lightpanda`.
 
 `auto` (default) picks the first detected installed browser. If none are
 installed, Moltis will attempt a best-effort auto-install, then retry
@@ -164,6 +165,10 @@ detection.
 
 `obscura` launches the Obscura sidecar binary from `obscura_path`, the
 `OBSCURA` environment variable, or `PATH`. It supports DOM-oriented browsing
+through CDP, but not pixel screenshots.
+
+`lightpanda` launches the Lightpanda sidecar binary from `lightpanda_path`, the
+`LIGHTPANDA` environment variable, or `PATH`. It supports DOM-oriented browsing
 through CDP, but not pixel screenshots.
 
 ### Workflow Example

--- a/docs/src/configuration-reference.md
+++ b/docs/src/configuration-reference.md
@@ -451,6 +451,7 @@ Default `tool_overrides` entries:
 | `enabled` | bool | `true` | Whether browser support is enabled. |
 | `chrome_path` | optional string | `null` | Path to Chrome/Chromium binary (auto-detected if not set). |
 | `obscura_path` | optional string | `null` | Path to the Obscura binary for `browser = "obscura"` requests (auto-detected from `OBSCURA` or `PATH` if not set). |
+| `lightpanda_path` | optional string | `null` | Path to the Lightpanda binary for `browser = "lightpanda"` requests (auto-detected from `LIGHTPANDA` or `PATH` if not set). |
 | `headless` | bool | `true` | Whether to run in headless mode. |
 | `viewport_width` | integer | `2560` | Default viewport width in pixels. |
 | `viewport_height` | integer | `1440` | Default viewport height in pixels. |

--- a/docs/src/configuration-reference.md
+++ b/docs/src/configuration-reference.md
@@ -450,6 +450,7 @@ Default `tool_overrides` entries:
 |-----|------|---------|-------------|
 | `enabled` | bool | `true` | Whether browser support is enabled. |
 | `chrome_path` | optional string | `null` | Path to Chrome/Chromium binary (auto-detected if not set). |
+| `obscura_path` | optional string | `null` | Path to the Obscura binary for `browser = "obscura"` requests (auto-detected from `OBSCURA` or `PATH` if not set). |
 | `headless` | bool | `true` | Whether to run in headless mode. |
 | `viewport_width` | integer | `2560` | Default viewport width in pixels. |
 | `viewport_height` | integer | `1440` | Default viewport height in pixels. |


### PR DESCRIPTION
## Summary

- Adds [Obscura](https://github.com/h4ckf0r0day/obscura) as an opt-in browser backend selected with `"browser": "obscura"`
- Uses the sidecar pattern: spawns `obscura serve` as a child process and connects via the existing `chromiumoxide` CDP client — **zero new Rust dependencies**
- ~30MB memory per instance vs ~200MB for Chrome, instant startup, built-in anti-detection features
- Screenshots return a clear error directing users to `snapshot` or Chrome (Obscura has no pixel rendering)

## Validation

### Completed
- [x] `cargo +nightly-2025-11-30 fmt --all -- --check` passes
- [x] `cargo clippy -p moltis-browser -p moltis-tools -p moltis-config -- -D warnings` passes (0 warnings)
- [x] `cargo test -p moltis-browser` — 87 tests pass
- [x] `cargo test -p moltis-config` — 283 tests pass
- [x] `cargo test -p moltis-tools` — 943 tests pass
- [x] All match arms exhaustive for new `BrowserKind::Obscura` / `BrowserPreference::Obscura`

### Remaining
- [ ] `./scripts/local-validate.sh` (full CI suite)
- [ ] Manual QA with Obscura binary installed

## Manual QA

1. Install Obscura: `cargo install --git https://github.com/h4ckf0r0day/obscura`
2. Start moltis, use browser tool with `{"action": "navigate", "url": "https://example.com", "browser": "obscura"}`
3. Verify `snapshot` returns DOM content
4. Verify `screenshot` returns clear error message about Obscura limitations
5. Verify `close` kills the sidecar process
6. Verify `"browser": "auto"` still defaults to Chrome (no regression)