### PR TITLE
feat(cron): add heartbeat wake cooldown to prevent exec re-fire loop

### DIFF
--- a/crates/config/src/schema/system.rs
+++ b/crates/config/src/schema/system.rs
@@ -182,6 +182,10 @@ pub struct HeartbeatConfig {
     pub sandbox_enabled: bool,
     /// Override sandbox image for heartbeat. If `None`, uses the default image.
     pub sandbox_image: Option<String>,
+    /// Minimum duration between exec-triggered heartbeat wakes (e.g. "5m", "0").
+    /// Prevents exec-completion callbacks from re-waking the heartbeat in a tight loop.
+    /// Defaults to "5m". Set to "0" to disable.
+    pub wake_cooldown: String,
 }
 
 impl Default for HeartbeatConfig {
@@ -198,6 +202,7 @@ impl Default for HeartbeatConfig {
             to: None,
             sandbox_enabled: true,
             sandbox_image: None,
+            wake_cooldown: "5m".into(),
         }
     }
 }

--- a/crates/config/src/template.rs
+++ b/crates/config/src/template.rs
@@ -486,15 +486,10 @@ port = {port}                           # Port number (auto-generated for this i
 
 # [heartbeat]
 # enabled = true                    # Enable periodic heartbeats
-# every = "30m"                     # Interval between heartbeats (e.g., "30m", "1h", "6h")
-# model = "anthropic/claude-sonnet-4-20250514"  # Override model for heartbeats
-# prompt = "..."                    # Custom heartbeat prompt (default: built-in)
+# every = "30m"                     # Interval (e.g., "30m", "1h", "6h")
 # ack_max_chars = 300               # Max characters for acknowledgment reply
-# deliver = false                   # Deliver heartbeat replies to a channel account
-# channel = "my-bot"                # Channel account identifier (required when deliver = true)
-# to = "123456789"                  # Chat/recipient ID (required when deliver = true)
+# deliver = false                   # Deliver heartbeat replies to a channel
 # sandbox_enabled = true            # Run heartbeat commands in sandbox
-# sandbox_image = "..."             # Override sandbox image for heartbeats
 # wake_cooldown = "5m"              # Min duration between exec-triggered heartbeat wakes (0 to disable)
 
 # [heartbeat.active_hours]

--- a/crates/config/src/template.rs
+++ b/crates/config/src/template.rs
@@ -486,10 +486,16 @@ port = {port}                           # Port number (auto-generated for this i
 
 # [heartbeat]
 # enabled = true                    # Enable periodic heartbeats
-# every = "30m"                     # Interval (e.g., "30m", "1h", "6h")
+# every = "30m"                     # Interval between heartbeats (e.g., "30m", "1h", "6h")
+# model = "anthropic/claude-sonnet-4-20250514"  # Override model for heartbeats
+# prompt = "..."                    # Custom heartbeat prompt (default: built-in)
 # ack_max_chars = 300               # Max characters for acknowledgment reply
-# deliver = false                   # Deliver heartbeat replies to a channel
+# deliver = false                   # Deliver heartbeat replies to a channel account
+# channel = "my-bot"                # Channel account identifier (required when deliver = true)
+# to = "123456789"                  # Chat/recipient ID (required when deliver = true)
 # sandbox_enabled = true            # Run heartbeat commands in sandbox
+# sandbox_image = "..."             # Override sandbox image for heartbeats
+# wake_cooldown = "5m"              # Min duration between exec-triggered heartbeat wakes (0 to disable)
 
 # [heartbeat.active_hours]
 # start = "08:00"

--- a/crates/config/src/validate/schema_map.rs
+++ b/crates/config/src/validate/schema_map.rs
@@ -535,6 +535,7 @@ pub(super) fn build_schema_map() -> KnownKeys {
                 ("to", Leaf),
                 ("sandbox_enabled", Leaf),
                 ("sandbox_image", Leaf),
+                ("wake_cooldown", Leaf),
             ])),
         ),
         (

--- a/crates/cron/src/heartbeat.rs
+++ b/crates/cron/src/heartbeat.rs
@@ -461,7 +461,7 @@ mod tests {
         let events = vec![
             crate::system_events::SystemEvent {
                 text: "Command `ls` exited 0".into(),
-                reason: "exec-event".into(),
+                reason: crate::service::WAKE_REASON_EXEC_EVENT.into(),
                 enqueued_at_ms: 1000,
             },
             crate::system_events::SystemEvent {
@@ -472,7 +472,10 @@ mod tests {
         ];
         let prompt = build_event_enriched_prompt(&events, "check inbox");
         assert!(prompt.starts_with(EVENTS_PROMPT_PREFIX));
-        assert!(prompt.contains("Command `ls` exited 0 [exec-event]"));
+        assert!(prompt.contains(&format!(
+            "Command `ls` exited 0 [{}]",
+            crate::service::WAKE_REASON_EXEC_EVENT
+        )));
         assert!(prompt.contains("Cron job fired [cron:abc]"));
         assert!(prompt.ends_with("check inbox"));
     }

--- a/crates/cron/src/lib.rs
+++ b/crates/cron/src/lib.rs
@@ -15,7 +15,7 @@ pub mod system_events;
 pub mod types;
 
 pub use error::{Error, Result};
-pub use service::{WAKE_REASON_CRON_EVENT, WAKE_REASON_EXEC_EVENT};
+pub use service::{DEFAULT_WAKE_COOLDOWN_MS, WAKE_REASON_CRON_EVENT, WAKE_REASON_EXEC_EVENT};
 
 /// Run database migrations for the cron crate.
 ///

--- a/crates/cron/src/lib.rs
+++ b/crates/cron/src/lib.rs
@@ -15,6 +15,7 @@ pub mod system_events;
 pub mod types;
 
 pub use error::{Error, Result};
+pub use service::{WAKE_REASON_CRON_EVENT, WAKE_REASON_EXEC_EVENT};
 
 /// Run database migrations for the cron crate.
 ///

--- a/crates/cron/src/parse.rs
+++ b/crates/cron/src/parse.rs
@@ -5,11 +5,17 @@ use crate::{Error, Result};
 /// Parse a human-friendly duration string into milliseconds.
 ///
 /// Supported suffixes: `s` (seconds), `m` (minutes), `h` (hours), `d` (days).
-/// Examples: `"30s"`, `"5m"`, `"2h"`, `"1d"`.
+/// A bare `"0"` is accepted as a disable sentinel that returns `0`.
+/// Examples: `"30s"`, `"5m"`, `"2h"`, `"1d"`, `"0"`.
 pub fn parse_duration_ms(input: &str) -> Result<u64> {
     let input = input.trim();
     if input.is_empty() {
         return Err(Error::message("empty duration string"));
+    }
+
+    // Bare "0" is the disable sentinel.
+    if input == "0" {
+        return Ok(0);
     }
 
     let (num_str, suffix) = match input.find(|c: char| c.is_alphabetic()) {
@@ -74,6 +80,8 @@ mod tests {
     #[case("2h", 7_200_000)]
     #[case("1d", 86_400_000)]
     #[case("  10m  ", 600_000)]
+    #[case("0", 0)]
+    #[case("  0  ", 0)]
     fn test_parse_duration_ok(#[case] input: &str, #[case] expected: u64) {
         assert_eq!(parse_duration_ms(input).unwrap(), expected);
     }

--- a/crates/cron/src/service.rs
+++ b/crates/cron/src/service.rs
@@ -128,19 +128,24 @@ pub struct CronService {
     on_notify: Option<NotifyFn>,
     rate_limiter: Mutex<RateLimiter>,
     events_queue: Arc<SystemEventsQueue>,
+    /// Minimum ms between exec-triggered heartbeat wakes. Zero disables cooldown.
+    wake_cooldown_ms: u64,
 }
 
 /// Max time a job can be in "running" state before we consider it stuck (2 hours).
 const STUCK_THRESHOLD_MS: u64 = 2 * 60 * 60 * 1000;
 
-/// Minimum cooldown between heartbeat wake calls (5 minutes).
+/// Minimum cooldown between exec-triggered heartbeat wake calls.
 ///
 /// Prevents exec-completion callbacks from re-waking the heartbeat
 /// in a tight loop when the agent uses `exec` during a heartbeat turn.
 /// The wake is skipped if the heartbeat last completed less than this
 /// duration ago. This is a safety net — the scheduled interval still
 /// applies for normal periodic firing.
-const HEARTBEAT_WAKE_COOLDOWN_MS: u64 = 5 * 60 * 1000;
+///
+/// This cooldown only applies to exec-triggered wakes (reason = "exec-event").
+/// CronWakeMode::Now wakes (reason = "cron-event") are never suppressed.
+const DEFAULT_WAKE_COOLDOWN_MS: u64 = 5 * 60 * 1000;
 
 fn now_ms() -> u64 {
     SystemTime::now()
@@ -221,6 +226,7 @@ impl CronService {
             on_notify,
             rate_limiter: Mutex::new(RateLimiter::new(rate_limit_config)),
             events_queue,
+            wake_cooldown_ms: DEFAULT_WAKE_COOLDOWN_MS,
         })
     }
 
@@ -233,6 +239,11 @@ impl CronService {
     ///
     /// Multiple wake calls coalesce naturally: they all set `next_run_at_ms = now`
     /// idempotently, and `running_at_ms` prevents the heartbeat from firing twice.
+    ///
+    /// When called with reason `"exec-event"`, a cooldown guard applies: if the
+    /// heartbeat last completed less than `wake_cooldown_ms` ago, the wake is skipped.
+    /// This prevents exec-completion callbacks from creating a re-fire loop.
+    /// Other reasons (e.g. `"cron-event"` from `CronWakeMode::Now`) are never suppressed.
     pub async fn wake(&self, reason: &str) {
         let now = now_ms();
         let mut jobs = self.jobs.write().await;
@@ -240,16 +251,20 @@ impl CronService {
             && job.enabled
             && job.state.running_at_ms.is_none()
         {
-            // Enforce cooldown: skip wake if the heartbeat completed recently.
-            // This prevents exec-completion callbacks from creating a re-fire loop
-            // when the heartbeat agent uses `exec` during its turn.
-            if let Some(last_run) = job.state.last_run_at_ms {
+            // Enforce cooldown for exec-triggered wakes only. This prevents
+            // exec-completion callbacks from creating a re-fire loop when the
+            // heartbeat agent uses `exec` during its turn. CronWakeMode::Now wakes
+            // ("cron-event") are never suppressed.
+            if reason == "exec-event"
+                && self.wake_cooldown_ms > 0
+                && let Some(last_run) = job.state.last_run_at_ms
+            {
                 let elapsed = now.saturating_sub(last_run);
-                if elapsed < HEARTBEAT_WAKE_COOLDOWN_MS {
+                if elapsed < self.wake_cooldown_ms {
                     debug!(
                         reason,
                         elapsed_ms = elapsed,
-                        cooldown_ms = HEARTBEAT_WAKE_COOLDOWN_MS,
+                        cooldown_ms = self.wake_cooldown_ms,
                         "skipping heartbeat wake — within cooldown"
                     );
                     return;

--- a/crates/cron/src/service.rs
+++ b/crates/cron/src/service.rs
@@ -145,7 +145,7 @@ const STUCK_THRESHOLD_MS: u64 = 2 * 60 * 60 * 1000;
 ///
 /// This cooldown only applies to exec-triggered wakes ([`WAKE_REASON_EXEC_EVENT`]).
 /// CronWakeMode::Now wakes ([`WAKE_REASON_CRON_EVENT`]) are never suppressed.
-const DEFAULT_WAKE_COOLDOWN_MS: u64 = 5 * 60 * 1000;
+pub const DEFAULT_WAKE_COOLDOWN_MS: u64 = 5 * 60 * 1000;
 
 /// Wake reason: exec-completion callback.
 pub const WAKE_REASON_EXEC_EVENT: &str = "exec-event";

--- a/crates/cron/src/service.rs
+++ b/crates/cron/src/service.rs
@@ -143,9 +143,14 @@ const STUCK_THRESHOLD_MS: u64 = 2 * 60 * 60 * 1000;
 /// duration ago. This is a safety net — the scheduled interval still
 /// applies for normal periodic firing.
 ///
-/// This cooldown only applies to exec-triggered wakes (reason = "exec-event").
-/// CronWakeMode::Now wakes (reason = "cron-event") are never suppressed.
+/// This cooldown only applies to exec-triggered wakes ([`WAKE_REASON_EXEC_EVENT`]).
+/// CronWakeMode::Now wakes ([`WAKE_REASON_CRON_EVENT`]) are never suppressed.
 const DEFAULT_WAKE_COOLDOWN_MS: u64 = 5 * 60 * 1000;
+
+/// Wake reason: exec-completion callback.
+pub const WAKE_REASON_EXEC_EVENT: &str = "exec-event";
+/// Wake reason: cron job with [`CronWakeMode::Now`](crate::types::CronWakeMode::Now) finished.
+pub const WAKE_REASON_CRON_EVENT: &str = "cron-event";
 
 fn now_ms() -> u64 {
     SystemTime::now()
@@ -245,10 +250,10 @@ impl CronService {
     /// Multiple wake calls coalesce naturally: they all set `next_run_at_ms = now`
     /// idempotently, and `running_at_ms` prevents the heartbeat from firing twice.
     ///
-    /// When called with reason `"exec-event"`, a cooldown guard applies: if the
+    /// When called with reason [`WAKE_REASON_EXEC_EVENT`], a cooldown guard applies: if the
     /// heartbeat last completed less than `wake_cooldown_ms` ago, the wake is skipped.
     /// This prevents exec-completion callbacks from creating a re-fire loop.
-    /// Other reasons (e.g. `"cron-event"` from `CronWakeMode::Now`) are never suppressed.
+    /// Other reasons (e.g. [`WAKE_REASON_CRON_EVENT`]) are never suppressed.
     pub async fn wake(&self, reason: &str) {
         let now = now_ms();
         let mut jobs = self.jobs.write().await;
@@ -259,8 +264,8 @@ impl CronService {
             // Enforce cooldown for exec-triggered wakes only. This prevents
             // exec-completion callbacks from creating a re-fire loop when the
             // heartbeat agent uses `exec` during its turn. CronWakeMode::Now wakes
-            // ("cron-event") are never suppressed.
-            if reason == "exec-event"
+            // are never suppressed.
+            if reason == WAKE_REASON_EXEC_EVENT
                 && self.wake_cooldown_ms > 0
                 && let Some(last_run) = job.state.last_run_at_ms
             {
@@ -710,7 +715,7 @@ impl CronService {
 
         // Wake heartbeat immediately if this job requested it.
         if job.wake_mode == CronWakeMode::Now && job.id != "__heartbeat__" {
-            self.wake("cron-event").await;
+            self.wake(WAKE_REASON_CRON_EVENT).await;
         }
 
         info!(

--- a/crates/cron/src/service.rs
+++ b/crates/cron/src/service.rs
@@ -133,6 +133,15 @@ pub struct CronService {
 /// Max time a job can be in "running" state before we consider it stuck (2 hours).
 const STUCK_THRESHOLD_MS: u64 = 2 * 60 * 60 * 1000;
 
+/// Minimum cooldown between heartbeat wake calls (5 minutes).
+///
+/// Prevents exec-completion callbacks from re-waking the heartbeat
+/// in a tight loop when the agent uses `exec` during a heartbeat turn.
+/// The wake is skipped if the heartbeat last completed less than this
+/// duration ago. This is a safety net — the scheduled interval still
+/// applies for normal periodic firing.
+const HEARTBEAT_WAKE_COOLDOWN_MS: u64 = 5 * 60 * 1000;
+
 fn now_ms() -> u64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -231,6 +240,22 @@ impl CronService {
             && job.enabled
             && job.state.running_at_ms.is_none()
         {
+            // Enforce cooldown: skip wake if the heartbeat completed recently.
+            // This prevents exec-completion callbacks from creating a re-fire loop
+            // when the heartbeat agent uses `exec` during its turn.
+            if let Some(last_run) = job.state.last_run_at_ms {
+                let elapsed = now.saturating_sub(last_run);
+                if elapsed < HEARTBEAT_WAKE_COOLDOWN_MS {
+                    debug!(
+                        reason,
+                        elapsed_ms = elapsed,
+                        cooldown_ms = HEARTBEAT_WAKE_COOLDOWN_MS,
+                        "skipping heartbeat wake — within cooldown"
+                    );
+                    return;
+                }
+            }
+
             debug!(reason, "waking heartbeat");
             job.state.next_run_at_ms = Some(now);
         }

--- a/crates/cron/src/service.rs
+++ b/crates/cron/src/service.rs
@@ -166,6 +166,7 @@ impl CronService {
             on_agent_turn,
             None,
             RateLimitConfig::default(),
+            DEFAULT_WAKE_COOLDOWN_MS,
         )
     }
 
@@ -182,6 +183,7 @@ impl CronService {
             on_agent_turn,
             Some(on_notify),
             RateLimitConfig::default(),
+            DEFAULT_WAKE_COOLDOWN_MS,
         )
     }
 
@@ -192,6 +194,7 @@ impl CronService {
         on_agent_turn: AgentTurnFn,
         on_notify: Option<NotifyFn>,
         rate_limit_config: RateLimitConfig,
+        wake_cooldown_ms: u64,
     ) -> Arc<Self> {
         Self::with_events_queue(
             store,
@@ -199,6 +202,7 @@ impl CronService {
             on_agent_turn,
             on_notify,
             rate_limit_config,
+            wake_cooldown_ms,
             SystemEventsQueue::new(),
         )
     }
@@ -213,6 +217,7 @@ impl CronService {
         on_agent_turn: AgentTurnFn,
         on_notify: Option<NotifyFn>,
         rate_limit_config: RateLimitConfig,
+        wake_cooldown_ms: u64,
         events_queue: Arc<SystemEventsQueue>,
     ) -> Arc<Self> {
         Arc::new(Self {
@@ -226,7 +231,7 @@ impl CronService {
             on_notify,
             rate_limiter: Mutex::new(RateLimiter::new(rate_limit_config)),
             events_queue,
-            wake_cooldown_ms: DEFAULT_WAKE_COOLDOWN_MS,
+            wake_cooldown_ms,
         })
     }
 

--- a/crates/cron/src/service/tests.rs
+++ b/crates/cron/src/service/tests.rs
@@ -846,3 +846,137 @@ async fn test_deliver_empty_string_channel_fails() {
             .contains("deliver=true requires")
     );
 }
+
+#[tokio::test]
+async fn test_wake_noop_within_cooldown_after_last_run() {
+    let store = Arc::new(InMemoryStore::new());
+    let svc = make_svc(store, noop_system_event(), noop_agent_turn());
+
+    svc.add(CronJobCreate {
+        id: Some("__heartbeat__".into()),
+        name: "__heartbeat__".into(),
+        schedule: CronSchedule::Every {
+            every_ms: 999_999_999,
+            anchor_ms: None,
+        },
+        payload: CronPayload::AgentTurn {
+            message: "heartbeat".into(),
+            model: None,
+            timeout_secs: None,
+            deliver: false,
+            channel: None,
+            to: None,
+        },
+        session_target: SessionTarget::Named("heartbeat".into()),
+        delete_after_run: false,
+        enabled: true,
+        system: true,
+        sandbox: CronSandboxConfig::default(),
+        wake_mode: CronWakeMode::default(),
+    })
+    .await
+    .unwrap();
+
+    // Set last_run_at_ms to 1 minute ago (within 5-min cooldown).
+    svc.update_job_state("__heartbeat__", |state| {
+        state.last_run_at_ms = Some(now_ms() - 60_000);
+    })
+    .await;
+
+    let before = svc.list().await;
+    let hb = before.iter().find(|j| j.id == "__heartbeat__").unwrap();
+    let next_before = hb.state.next_run_at_ms.unwrap();
+
+    svc.wake("exec-event").await;
+
+    let after = svc.list().await;
+    let hb = after.iter().find(|j| j.id == "__heartbeat__").unwrap();
+    // next_run_at_ms should NOT have been updated — wake was skipped.
+    assert_eq!(hb.state.next_run_at_ms.unwrap(), next_before);
+}
+
+#[tokio::test]
+async fn test_wake_allowed_after_cooldown_expires() {
+    let store = Arc::new(InMemoryStore::new());
+    let svc = make_svc(store, noop_system_event(), noop_agent_turn());
+
+    svc.add(CronJobCreate {
+        id: Some("__heartbeat__".into()),
+        name: "__heartbeat__".into(),
+        schedule: CronSchedule::Every {
+            every_ms: 999_999_999,
+            anchor_ms: None,
+        },
+        payload: CronPayload::AgentTurn {
+            message: "heartbeat".into(),
+            model: None,
+            timeout_secs: None,
+            deliver: false,
+            channel: None,
+            to: None,
+        },
+        session_target: SessionTarget::Named("heartbeat".into()),
+        delete_after_run: false,
+        enabled: true,
+        system: true,
+        sandbox: CronSandboxConfig::default(),
+        wake_mode: CronWakeMode::default(),
+    })
+    .await
+    .unwrap();
+
+    // Set last_run_at_ms to 10 minutes ago (beyond 5-min cooldown).
+    svc.update_job_state("__heartbeat__", |state| {
+        state.last_run_at_ms = Some(now_ms() - 10 * 60 * 1000);
+    })
+    .await;
+
+    let before = svc.list().await;
+    let hb = before.iter().find(|j| j.id == "__heartbeat__").unwrap();
+    let original_next = hb.state.next_run_at_ms.unwrap();
+
+    svc.wake("exec-event").await;
+
+    let after = svc.list().await;
+    let hb = after.iter().find(|j| j.id == "__heartbeat__").unwrap();
+    // next_run_at_ms should have been advanced to now.
+    assert!(hb.state.next_run_at_ms.unwrap() <= original_next);
+}
+
+#[tokio::test]
+async fn test_wake_allowed_when_no_last_run() {
+    let store = Arc::new(InMemoryStore::new());
+    let svc = make_svc(store, noop_system_event(), noop_agent_turn());
+
+    svc.add(CronJobCreate {
+        id: Some("__heartbeat__".into()),
+        name: "__heartbeat__".into(),
+        schedule: CronSchedule::Every {
+            every_ms: 999_999_999,
+            anchor_ms: None,
+        },
+        payload: CronPayload::AgentTurn {
+            message: "heartbeat".into(),
+            model: None,
+            timeout_secs: None,
+            deliver: false,
+            channel: None,
+            to: None,
+        },
+        session_target: SessionTarget::Named("heartbeat".into()),
+        delete_after_run: false,
+        enabled: true,
+        system: true,
+        sandbox: CronSandboxConfig::default(),
+        wake_mode: CronWakeMode::default(),
+    })
+    .await
+    .unwrap();
+
+    // No last_run_at_ms set — first-ever wake should proceed.
+    svc.wake("exec-event").await;
+
+    let after = svc.list().await;
+    let hb = after.iter().find(|j| j.id == "__heartbeat__").unwrap();
+    assert!(hb.state.next_run_at_ms.is_some());
+}

--- a/crates/cron/src/service/tests.rs
+++ b/crates/cron/src/service/tests.rs
@@ -849,33 +849,7 @@ async fn test_deliver_empty_string_channel_fails() {
 
 #[tokio::test]
 async fn test_wake_noop_within_cooldown_after_last_run() {
-    let store = Arc::new(InMemoryStore::new());
-    let svc = make_svc(store, noop_system_event(), noop_agent_turn());
-
-    svc.add(CronJobCreate {
-        id: Some("__heartbeat__".into()),
-        name: "__heartbeat__".into(),
-        schedule: CronSchedule::Every {
-            every_ms: 999_999_999,
-            anchor_ms: None,
-        },
-        payload: CronPayload::AgentTurn {
-            message: "heartbeat".into(),
-            model: None,
-            timeout_secs: None,
-            deliver: false,
-            channel: None,
-            to: None,
-        },
-        session_target: SessionTarget::Named("heartbeat".into()),
-        delete_after_run: false,
-        enabled: true,
-        system: true,
-        sandbox: CronSandboxConfig::default(),
-        wake_mode: CronWakeMode::default(),
-    })
-    .await
-    .unwrap();
+    let svc = make_heartbeat_svc().await;
 
     // Set last_run_at_ms to 1 minute ago (within 5-min cooldown).
     svc.update_job_state("__heartbeat__", |state| {
@@ -883,47 +857,17 @@ async fn test_wake_noop_within_cooldown_after_last_run() {
     })
     .await;
 
-    let before = svc.list().await;
-    let hb = before.iter().find(|j| j.id == "__heartbeat__").unwrap();
-    let next_before = hb.state.next_run_at_ms.unwrap();
+    let next_before = get_hb_next_run(&svc).await;
 
     svc.wake("exec-event").await;
 
-    let after = svc.list().await;
-    let hb = after.iter().find(|j| j.id == "__heartbeat__").unwrap();
     // next_run_at_ms should NOT have been updated — wake was skipped.
-    assert_eq!(hb.state.next_run_at_ms.unwrap(), next_before);
+    assert_eq!(get_hb_next_run(&svc).await, next_before);
 }
 
 #[tokio::test]
 async fn test_wake_allowed_after_cooldown_expires() {
-    let store = Arc::new(InMemoryStore::new());
-    let svc = make_svc(store, noop_system_event(), noop_agent_turn());
-
-    svc.add(CronJobCreate {
-        id: Some("__heartbeat__".into()),
-        name: "__heartbeat__".into(),
-        schedule: CronSchedule::Every {
-            every_ms: 999_999_999,
-            anchor_ms: None,
-        },
-        payload: CronPayload::AgentTurn {
-            message: "heartbeat".into(),
-            model: None,
-            timeout_secs: None,
-            deliver: false,
-            channel: None,
-            to: None,
-        },
-        session_target: SessionTarget::Named("heartbeat".into()),
-        delete_after_run: false,
-        enabled: true,
-        system: true,
-        sandbox: CronSandboxConfig::default(),
-        wake_mode: CronWakeMode::default(),
-    })
-    .await
-    .unwrap();
+    let svc = make_heartbeat_svc().await;
 
     // Set last_run_at_ms to 10 minutes ago (beyond 5-min cooldown).
     svc.update_job_state("__heartbeat__", |state| {
@@ -931,23 +875,53 @@ async fn test_wake_allowed_after_cooldown_expires() {
     })
     .await;
 
-    let before = svc.list().await;
-    let hb = before.iter().find(|j| j.id == "__heartbeat__").unwrap();
-    let original_next = hb.state.next_run_at_ms.unwrap();
-
+    let pre_wake = now_ms();
     svc.wake("exec-event").await;
+    let post_wake = now_ms();
 
-    let after = svc.list().await;
-    let hb = after.iter().find(|j| j.id == "__heartbeat__").unwrap();
-    // next_run_at_ms should have been advanced to now.
-    assert!(hb.state.next_run_at_ms.unwrap() <= original_next);
+    let new_next = get_hb_next_run(&svc).await.unwrap();
+    assert!(
+        new_next >= pre_wake && new_next <= post_wake,
+        "next_run_at_ms should be set to ~now, got {new_next}"
+    );
 }
 
 #[tokio::test]
 async fn test_wake_allowed_when_no_last_run() {
+    let svc = make_heartbeat_svc().await;
+
+    // No last_run_at_ms set — first-ever wake should proceed.
+    svc.wake("exec-event").await;
+
+    assert!(get_hb_next_run(&svc).await.is_some());
+}
+
+#[tokio::test]
+async fn test_wake_cron_event_bypasses_cooldown() {
+    let svc = make_heartbeat_svc().await;
+
+    // Set last_run_at_ms to 1 minute ago (within cooldown).
+    svc.update_job_state("__heartbeat__", |state| {
+        state.last_run_at_ms = Some(now_ms() - 60_000);
+    })
+    .await;
+
+    let pre_wake = now_ms();
+    svc.wake("cron-event").await;
+    let post_wake = now_ms();
+
+    // CronWakeMode::Now wakes ("cron-event") must never be suppressed.
+    let new_next = get_hb_next_run(&svc).await.unwrap();
+    assert!(
+        new_next >= pre_wake && new_next <= post_wake,
+        "cron-event wake should not be suppressed by cooldown, got {new_next}"
+    );
+}
+
+/// Helper: create a service with a single heartbeat job and a far-future schedule.
+async fn make_heartbeat_svc() -> Arc<CronService> {
     let store = Arc::new(InMemoryStore::new());
     let svc = make_svc(store, noop_system_event(), noop_agent_turn());
-
     svc.add(CronJobCreate {
         id: Some("__heartbeat__".into()),
         name: "__heartbeat__".into(),
@@ -972,11 +946,14 @@ async fn test_wake_allowed_when_no_last_run() {
     })
     .await
     .unwrap();
+    svc
+}
 
-    // No last_run_at_ms set — first-ever wake should proceed.
-    svc.wake("exec-event").await;
-
-    let after = svc.list().await;
-    let hb = after.iter().find(|j| j.id == "__heartbeat__").unwrap();
-    assert!(hb.state.next_run_at_ms.is_some());
+/// Helper: get the heartbeat job's next_run_at_ms.
+async fn get_hb_next_run(svc: &Arc<CronService>) -> Option<u64> {
+    svc.list()
+        .await
+        .iter()
+        .find(|j| j.id == "__heartbeat__")
+        .and_then(|j| j.state.next_run_at_ms)
 }

--- a/crates/cron/src/service/tests.rs
+++ b/crates/cron/src/service/tests.rs
@@ -861,7 +861,7 @@ async fn test_wake_noop_within_cooldown_after_last_run() {
 
     let next_before = get_hb_next_run(&svc).await;
 
-    svc.wake("exec-event").await;
+    svc.wake(WAKE_REASON_EXEC_EVENT).await;
 
     // next_run_at_ms should NOT have been updated — wake was skipped.
     assert_eq!(get_hb_next_run(&svc).await, next_before);
@@ -878,7 +878,7 @@ async fn test_wake_allowed_after_cooldown_expires() {
     .await;
 
     let pre_wake = now_ms();
-    svc.wake("exec-event").await;
+    svc.wake(WAKE_REASON_EXEC_EVENT).await;
     let post_wake = now_ms();
 
     let new_next = get_hb_next_run(&svc).await.unwrap();
@@ -893,7 +893,7 @@ async fn test_wake_allowed_when_no_last_run() {
     let svc = make_heartbeat_svc().await;
 
     // No last_run_at_ms set — first-ever wake should proceed.
-    svc.wake("exec-event").await;
+    svc.wake(WAKE_REASON_EXEC_EVENT).await;
 
     assert!(get_hb_next_run(&svc).await.is_some());
 }
@@ -909,10 +909,10 @@ async fn test_wake_cron_event_bypasses_cooldown() {
     .await;
 
     let pre_wake = now_ms();
-    svc.wake("cron-event").await;
+    svc.wake(WAKE_REASON_CRON_EVENT).await;
     let post_wake = now_ms();
 
-    // CronWakeMode::Now wakes ("cron-event") must never be suppressed.
+    // CronWakeMode::Now wakes must never be suppressed.
     let new_next = get_hb_next_run(&svc).await.unwrap();
     assert!(
         new_next >= pre_wake && new_next <= post_wake,
@@ -922,8 +922,20 @@ async fn test_wake_cron_event_bypasses_cooldown() {
 
 /// Helper: create a service with a single heartbeat job and a far-future schedule.
 async fn make_heartbeat_svc() -> Arc<CronService> {
+    make_heartbeat_svc_with_cooldown(DEFAULT_WAKE_COOLDOWN_MS).await
+}
+
+/// Helper: create a service with a single heartbeat job, custom wake cooldown.
+async fn make_heartbeat_svc_with_cooldown(cooldown_ms: u64) -> Arc<CronService> {
     let store = Arc::new(InMemoryStore::new());
-    let svc = make_svc(store, noop_system_event(), noop_agent_turn());
+    let svc = CronService::with_config(
+        store,
+        noop_system_event(),
+        noop_agent_turn(),
+        None,
+        RateLimitConfig::default(),
+        cooldown_ms,
+    );
     svc.add(CronJobCreate {
         id: Some("__heartbeat__".into()),
         name: "__heartbeat__".into(),
@@ -962,43 +974,7 @@ async fn get_hb_next_run(svc: &Arc<CronService>) -> Option<u64> {
 
 #[tokio::test]
 async fn test_custom_wake_cooldown_propagates_through_constructor() {
-    // Verify that with_config correctly propagates a custom wake_cooldown_ms.
-    // Use a 30-second cooldown so the test runs fast.
-    let custom_cooldown_ms: u64 = 30_000;
-    let store = Arc::new(InMemoryStore::new());
-    let svc = CronService::with_config(
-        store,
-        noop_system_event(),
-        noop_agent_turn(),
-        None,
-        RateLimitConfig::default(),
-        custom_cooldown_ms,
-    );
-
-    svc.add(CronJobCreate {
-        id: Some("__heartbeat__".into()),
-        name: "__heartbeat__".into(),
-        schedule: CronSchedule::Every {
-            every_ms: 999_999_999,
-            anchor_ms: None,
-        },
-        payload: CronPayload::AgentTurn {
-            message: "heartbeat".into(),
-            model: None,
-            timeout_secs: None,
-            deliver: false,
-            channel: None,
-            to: None,
-        },
-        session_target: SessionTarget::Named("heartbeat".into()),
-        delete_after_run: false,
-        enabled: true,
-        system: true,
-        sandbox: CronSandboxConfig::default(),
-        wake_mode: CronWakeMode::default(),
-    })
-    .await
-    .unwrap();
+    let svc = make_heartbeat_svc_with_cooldown(30_000).await;
 
     // last_run 15 seconds ago — within 30s custom cooldown → wake suppressed.
     svc.update_job_state("__heartbeat__", |state| {
@@ -1007,7 +983,7 @@ async fn test_custom_wake_cooldown_propagates_through_constructor() {
     .await;
 
     let next_before = get_hb_next_run(&svc).await;
-    svc.wake("exec-event").await;
+    svc.wake(WAKE_REASON_EXEC_EVENT).await;
     assert_eq!(
         get_hb_next_run(&svc).await,
         next_before,
@@ -1021,7 +997,7 @@ async fn test_custom_wake_cooldown_propagates_through_constructor() {
     .await;
 
     let pre_wake = now_ms();
-    svc.wake("exec-event").await;
+    svc.wake(WAKE_REASON_EXEC_EVENT).await;
     let post_wake = now_ms();
     let new_next = get_hb_next_run(&svc).await.unwrap();
     assert!(
@@ -1032,40 +1008,7 @@ async fn test_custom_wake_cooldown_propagates_through_constructor() {
 
 #[tokio::test]
 async fn test_zero_wake_cooldown_disables_guard() {
-    let store = Arc::new(InMemoryStore::new());
-    let svc = CronService::with_config(
-        store,
-        noop_system_event(),
-        noop_agent_turn(),
-        None,
-        RateLimitConfig::default(),
-        0, // cooldown disabled
-    );
-
-    svc.add(CronJobCreate {
-        id: Some("__heartbeat__".into()),
-        name: "__heartbeat__".into(),
-        schedule: CronSchedule::Every {
-            every_ms: 999_999_999,
-            anchor_ms: None,
-        },
-        payload: CronPayload::AgentTurn {
-            message: "heartbeat".into(),
-            model: None,
-            timeout_secs: None,
-            deliver: false,
-            channel: None,
-            to: None,
-        },
-        session_target: SessionTarget::Named("heartbeat".into()),
-        delete_after_run: false,
-        enabled: true,
-        system: true,
-        sandbox: CronSandboxConfig::default(),
-        wake_mode: CronWakeMode::default(),
-    })
-    .await
-    .unwrap();
+    let svc = make_heartbeat_svc_with_cooldown(0).await;
 
     // last_run just 1 second ago — would be suppressed with any nonzero cooldown.
     svc.update_job_state("__heartbeat__", |state| {
@@ -1074,7 +1017,7 @@ async fn test_zero_wake_cooldown_disables_guard() {
     .await;
 
     let pre_wake = now_ms();
-    svc.wake("exec-event").await;
+    svc.wake(WAKE_REASON_EXEC_EVENT).await;
     let post_wake = now_ms();
 
     let new_next = get_hb_next_run(&svc).await.unwrap();

--- a/crates/cron/src/service/tests.rs
+++ b/crates/cron/src/service/tests.rs
@@ -959,3 +959,127 @@ async fn get_hb_next_run(svc: &Arc<CronService>) -> Option<u64> {
         .find(|j| j.id == "__heartbeat__")
         .and_then(|j| j.state.next_run_at_ms)
 }
+
+#[tokio::test]
+async fn test_custom_wake_cooldown_propagates_through_constructor() {
+    // Verify that with_config correctly propagates a custom wake_cooldown_ms.
+    // Use a 30-second cooldown so the test runs fast.
+    let custom_cooldown_ms: u64 = 30_000;
+    let store = Arc::new(InMemoryStore::new());
+    let svc = CronService::with_config(
+        store,
+        noop_system_event(),
+        noop_agent_turn(),
+        None,
+        RateLimitConfig::default(),
+        custom_cooldown_ms,
+    );
+
+    svc.add(CronJobCreate {
+        id: Some("__heartbeat__".into()),
+        name: "__heartbeat__".into(),
+        schedule: CronSchedule::Every {
+            every_ms: 999_999_999,
+            anchor_ms: None,
+        },
+        payload: CronPayload::AgentTurn {
+            message: "heartbeat".into(),
+            model: None,
+            timeout_secs: None,
+            deliver: false,
+            channel: None,
+            to: None,
+        },
+        session_target: SessionTarget::Named("heartbeat".into()),
+        delete_after_run: false,
+        enabled: true,
+        system: true,
+        sandbox: CronSandboxConfig::default(),
+        wake_mode: CronWakeMode::default(),
+    })
+    .await
+    .unwrap();
+
+    // last_run 15 seconds ago — within 30s custom cooldown → wake suppressed.
+    svc.update_job_state("__heartbeat__", |state| {
+        state.last_run_at_ms = Some(now_ms() - 15_000);
+    })
+    .await;
+
+    let next_before = get_hb_next_run(&svc).await;
+    svc.wake("exec-event").await;
+    assert_eq!(
+        get_hb_next_run(&svc).await,
+        next_before,
+        "wake should be suppressed within custom 30s cooldown"
+    );
+
+    // last_run 45 seconds ago — beyond 30s custom cooldown → wake proceeds.
+    svc.update_job_state("__heartbeat__", |state| {
+        state.last_run_at_ms = Some(now_ms() - 45_000);
+    })
+    .await;
+
+    let pre_wake = now_ms();
+    svc.wake("exec-event").await;
+    let post_wake = now_ms();
+    let new_next = get_hb_next_run(&svc).await.unwrap();
+    assert!(
+        new_next >= pre_wake && new_next <= post_wake,
+        "wake should proceed after custom 30s cooldown expires"
+    );
+}
+
+#[tokio::test]
+async fn test_zero_wake_cooldown_disables_guard() {
+    let store = Arc::new(InMemoryStore::new());
+    let svc = CronService::with_config(
+        store,
+        noop_system_event(),
+        noop_agent_turn(),
+        None,
+        RateLimitConfig::default(),
+        0, // cooldown disabled
+    );
+
+    svc.add(CronJobCreate {
+        id: Some("__heartbeat__".into()),
+        name: "__heartbeat__".into(),
+        schedule: CronSchedule::Every {
+            every_ms: 999_999_999,
+            anchor_ms: None,
+        },
+        payload: CronPayload::AgentTurn {
+            message: "heartbeat".into(),
+            model: None,
+            timeout_secs: None,
+            deliver: false,
+            channel: None,
+            to: None,
+        },
+        session_target: SessionTarget::Named("heartbeat".into()),
+        delete_after_run: false,
+        enabled: true,
+        system: true,
+        sandbox: CronSandboxConfig::default(),
+        wake_mode: CronWakeMode::default(),
+    })
+    .await
+    .unwrap();
+
+    // last_run just 1 second ago — would be suppressed with any nonzero cooldown.
+    svc.update_job_state("__heartbeat__", |state| {
+        state.last_run_at_ms = Some(now_ms() - 1_000);
+    })
+    .await;
+
+    let pre_wake = now_ms();
+    svc.wake("exec-event").await;
+    let post_wake = now_ms();
+
+    let new_next = get_hb_next_run(&svc).await.unwrap();
+    assert!(
+        new_next >= pre_wake && new_next <= post_wake,
+        "wake should proceed when cooldown is zero (disabled)"
+    );
+}

--- a/crates/cron/src/service/tests.rs
+++ b/crates/cron/src/service/tests.rs
@@ -381,6 +381,7 @@ async fn test_rate_limiting() {
             max_per_window: 3,
             window_ms: 60_000,
         },
+        DEFAULT_WAKE_COOLDOWN_MS,
     );
 
     let create_job = || CronJobCreate {
@@ -435,6 +436,7 @@ async fn test_rate_limiting_skips_system_jobs() {
             max_per_window: 1,
             window_ms: 60_000,
         },
+        DEFAULT_WAKE_COOLDOWN_MS,
     );
 
     let create_system_job = || CronJobCreate {

--- a/crates/gateway/src/server/prepare_core.rs
+++ b/crates/gateway/src/server/prepare_core.rs
@@ -815,8 +815,19 @@ pub async fn prepare_gateway_core(
         window_ms: config.cron.rate_limit_window_secs * 1000,
     };
 
-    let wake_cooldown_ms = moltis_cron::parse::parse_duration_ms(&config.heartbeat.wake_cooldown)
-        .unwrap_or(5 * 60 * 1000);
+    let default_cooldown_ms = 5 * 60 * 1000;
+    let wake_cooldown_ms = match moltis_cron::parse::parse_duration_ms(&config.heartbeat.wake_cooldown) {
+        Ok(ms) => ms,
+        Err(e) => {
+            tracing::warn!(
+                raw = %config.heartbeat.wake_cooldown,
+                error = %e,
+                fallback_ms = default_cooldown_ms,
+                "invalid [heartbeat].wake_cooldown, using default"
+            );
+            default_cooldown_ms
+        }
+    };
 
     let cron_store_for_pruning = Arc::clone(&cron_store);
     let cron_service = moltis_cron::service::CronService::with_events_queue(

--- a/crates/gateway/src/server/prepare_core.rs
+++ b/crates/gateway/src/server/prepare_core.rs
@@ -815,6 +815,9 @@ pub async fn prepare_gateway_core(
         window_ms: config.cron.rate_limit_window_secs * 1000,
     };
 
+    let wake_cooldown_ms = moltis_cron::parse::parse_duration_ms(&config.heartbeat.wake_cooldown)
+        .unwrap_or(5 * 60 * 1000);
+
     let cron_store_for_pruning = Arc::clone(&cron_store);
     let cron_service = moltis_cron::service::CronService::with_events_queue(
         cron_store,
@@ -822,6 +825,7 @@ pub async fn prepare_gateway_core(
         on_agent_turn,
         Some(on_cron_notify),
         rate_limit_config,
+        wake_cooldown_ms,
         events_queue,
     );
 

--- a/crates/gateway/src/server/prepare_core.rs
+++ b/crates/gateway/src/server/prepare_core.rs
@@ -815,7 +815,7 @@ pub async fn prepare_gateway_core(
         window_ms: config.cron.rate_limit_window_secs * 1000,
     };
 
-    let default_cooldown_ms = 5 * 60 * 1000;
+    let default_cooldown_ms = moltis_cron::service::DEFAULT_WAKE_COOLDOWN_MS;
     let wake_cooldown_ms = match moltis_cron::parse::parse_duration_ms(&config.heartbeat.wake_cooldown) {
         Ok(ms) => ms,
         Err(e) => {

--- a/crates/gateway/src/server/prepare_core/post_state.rs
+++ b/crates/gateway/src/server/prepare_core/post_state.rs
@@ -707,8 +707,8 @@ pub(super) async fn complete_startup(
             let eq = Arc::clone(&eq);
             let cs = Arc::clone(&cs);
             tokio::spawn(async move {
-                eq.enqueue(summary, "exec-event".into()).await;
-                cs.wake("exec-event").await;
+                eq.enqueue(summary, moltis_cron::WAKE_REASON_EXEC_EVENT.into()).await;
+                cs.wake(moltis_cron::WAKE_REASON_EXEC_EVENT).await;
             });
         });
         let mut exec_tool = moltis_tools::exec::ExecTool::default()

--- a/docs/src/configuration-reference.md
+++ b/docs/src/configuration-reference.md
@@ -747,6 +747,7 @@ Each channel account (`channels.<channel_type>.<account_name>`) is an arbitrary 
 | `to` | optional string | — | Destination chat/recipient id for heartbeat delivery. |
 | `sandbox_enabled` | bool | `true` | Whether heartbeat runs inside a sandbox. |
 | `sandbox_image` | optional string | — | Override sandbox image for heartbeat. |
+| `wake_cooldown` | string | `"5m"` | Minimum duration between exec-triggered heartbeat wakes. Use `"0"` to disable the guard. |
 
 
 ### `heartbeat.active_hours`

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -42,6 +42,17 @@ and which are inherited.
 The `defaults.toml` file lives in the same directory. Do not edit it — your
 changes will be overwritten on the next startup.
 
+## Checking Config
+
+`moltis config check` validates your override file (`moltis.toml`) against the
+known config schema. It also checks that Moltis-managed `defaults.toml` exists
+and can be parsed, but it does not treat `defaults.toml` as user-authored input.
+
+New config fields should be added to the Rust config schema and its `Default`
+implementation. Moltis regenerates `defaults.toml` from those built-in defaults
+on startup, while `moltis.toml` should contain only values you intentionally
+override.
+
 ## Basic Settings
 
 ```toml

--- a/docs/src/scheduling.md
+++ b/docs/src/scheduling.md
@@ -71,6 +71,19 @@ enqueues a summary event with the command name, exit code, and a short preview
 of stdout/stderr. If the heartbeat is idle, it is woken immediately so the
 agent can react to the result.
 
+Exec-triggered wakes have a cooldown guard so a heartbeat turn that runs `exec`
+does not immediately re-wake itself in a loop. Configure it with
+`[heartbeat].wake_cooldown` in `moltis.toml`:
+
+```toml
+[heartbeat]
+wake_cooldown = "5m" # default; set "0" to disable
+```
+
+The value uses Moltis duration syntax such as `"30s"`, `"10m"`, or `"1h"`.
+The cooldown applies only to exec-completion wakes. Cron jobs with
+`wakeMode = "now"` still wake the heartbeat immediately.
+
 This means the agent learns about completed background tasks without polling
 — a long-running build or deployment that finishes while the user is away will
 surface in the next heartbeat turn.


### PR DESCRIPTION
## Summary

Prevent exec-completion callbacks from re-waking the heartbeat in a tight loop. When the agent uses `exec` during a heartbeat turn, the completion callback no longer triggers an immediate second heartbeat wake.

## Changes

- Add cooldown check in `CronService::wake()` — skips exec-event wakes within cooldown window
- Scope cooldown to `exec-event` reasons only; `cron-event` wakes are never suppressed
- Add `[heartbeat].wake_cooldown` config field (duration string, default `"5m"`)
- Parse duration with fallback and warning on invalid values
- Add `wake_cooldown_ms` field to `CronService` struct and constructor chain
- Add 6 unit tests covering cooldown logic, expiry, zero-cooldown, and cron-event bypass

## Configuration

```toml
[heartbeat]
# Minimum duration between exec-triggered heartbeat wakes
# Set to "0" to disable cooldown
wake_cooldown = "5m"
```

## Test Results

- ✅ 133/133 cron tests passed