### PR TITLE
fix(gateway): handle bundled skill disable/enable via config

### DIFF
--- a/crates/gateway/src/services/skills.rs
+++ b/crates/gateway/src/services/skills.rs
@@ -498,6 +498,10 @@ impl SkillsService for NoopSkillsService {
     }
 
     async fn skill_enable(&self, params: Value) -> ServiceResult {
+        let source = params.get("source").and_then(|v| v.as_str()).unwrap_or("");
+        if source == "bundled" {
+            return toggle_bundled_skill(&params, true);
+        }
         toggle_skill(&params, true)
     }
 
@@ -507,6 +511,10 @@ impl SkillsService for NoopSkillsService {
         // Personal/project skills live as files — delete the directory to disable.
         if source == "personal" || source == "project" {
             return delete_discovered_skill(source, &params);
+        }
+
+        if source == "bundled" {
+            return toggle_bundled_skill(&params, false);
         }
 
         toggle_skill(&params, false)
@@ -1281,6 +1289,56 @@ fn skill_detail_bundled(skill_name: &str) -> ServiceResult {
         "body_html": markdown_to_html(&body),
         "source": "bundled",
     }))
+}
+
+/// Toggle a bundled skill by adding/removing its category from
+/// `disabled_bundled_categories` in config. Bundled skills are not tracked
+/// in the manifest, so `toggle_skill()` cannot handle them.
+fn toggle_bundled_skill(params: &Value, enabled: bool) -> ServiceResult {
+    let skill_name = params
+        .get("skill")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| "missing 'skill' parameter".to_string())?;
+
+    // Find the category for this bundled skill.
+    #[cfg(feature = "bundled-skills")]
+    {
+        let store = moltis_skills::bundled::BundledSkillStore::new();
+        let skills = store.discover();
+        let category = skills
+            .iter()
+            .find(|s| s.name == skill_name)
+            .and_then(|s| s.category.clone())
+            .ok_or_else(|| format!("bundled skill '{skill_name}' not found"))?;
+
+        let cat_clone = category.clone();
+        if let Err(e) = moltis_config::update_config(|cfg| {
+            if enabled {
+                cfg.skills.disabled_bundled_categories.retain(|c| c != &cat_clone);
+            } else if !cfg.skills.disabled_bundled_categories.iter().any(|c| c == &cat_clone) {
+                cfg.skills.disabled_bundled_categories.push(cat_clone.clone());
+            }
+        }) {
+            return Err(format!("failed to save config: {e}").into());
+        }
+
+        security_audit(
+            "skills.skill.toggle",
+            serde_json::json!({
+                "source": "bundled",
+                "skill": skill_name,
+                "category": category,
+                "enabled": enabled,
+            }),
+        );
+
+        return Ok(serde_json::json!({ "source": "bundled", "skill": skill_name, "enabled": enabled }));
+    }
+    #[cfg(not(feature = "bundled-skills"))]
+    {
+        let _ = (skill_name, enabled);
+        Err("bundled skills are not available in this build".into())
+    }
 }
 
 fn toggle_skill(params: &Value, enabled: bool) -> ServiceResult {

--- a/crates/gateway/src/services/skills.rs
+++ b/crates/gateway/src/services/skills.rs
@@ -1305,18 +1305,21 @@ fn toggle_bundled_skill(params: &Value, enabled: bool) -> ServiceResult {
     {
         let store = moltis_skills::bundled::BundledSkillStore::new();
         let skills = store.discover();
-        let category = skills
+        let skill = skills
             .iter()
             .find(|s| s.name == skill_name)
-            .and_then(|s| s.category.clone())
             .ok_or_else(|| format!("bundled skill '{skill_name}' not found"))?;
+        let category = skill
+            .category
+            .clone()
+            .ok_or_else(|| format!("bundled skill '{skill_name}' has no category"))?;;
 
         let cat_clone = category.clone();
         if let Err(e) = moltis_config::update_config(|cfg| {
             if enabled {
                 cfg.skills.disabled_bundled_categories.retain(|c| c != &cat_clone);
             } else if !cfg.skills.disabled_bundled_categories.iter().any(|c| c == &cat_clone) {
-                cfg.skills.disabled_bundled_categories.push(cat_clone.clone());
+                cfg.skills.disabled_bundled_categories.push(cat_clone);
             }
         }) {
             return Err(format!("failed to save config: {e}").into());
@@ -1332,7 +1335,7 @@ fn toggle_bundled_skill(params: &Value, enabled: bool) -> ServiceResult {
             }),
         );
 
-        return Ok(serde_json::json!({ "source": "bundled", "skill": skill_name, "enabled": enabled }));
+        return Ok(serde_json::json!({ "source": "bundled", "skill": skill_name, "category": category, "enabled": enabled }));
     }
     #[cfg(not(feature = "bundled-skills"))]
     {


### PR DESCRIPTION
## Summary

Closes #875

Bundled skills are managed by category via `disabled_bundled_categories` in config — they are not tracked in the manifest `repos` list. Both `skill_disable` and `skill_enable` fell through to `toggle_skill()` which looks up the source in the manifest, producing:

```
skill 'apple-notes' not found in repo 'bundled'
```

## Changes

- Add `toggle_bundled_skill()` that resolves a skill's category via `BundledSkillStore::discover()` and toggles it in `disabled_bundled_categories` config
- `skill_enable` now intercepts `source == "bundled"` before reaching `toggle_skill()`
- `skill_disable` now intercepts `source == "bundled"` before reaching `toggle_skill()`
- Proper `#[cfg]` gating for both feature and no-feature builds
- Security audit log preserved (matches `toggle_skill` pattern)

## Testing

- `cargo check -p moltis-gateway --no-default-features` — 0 errors
- `cargo check -p moltis-gateway --no-default-features --features bundled-skills` — 0 errors
- Pre-commit clippy hooks passed

## Note

`skill_detail_bundled()` hardcodes `"enabled": true` — this is a pre-existing issue on main where the detail view does not consult `disabled_bundled_categories`. Out of scope for this fix but worth a follow-up.