### PR TITLE
fix(gateway): derive bundled skill enabled state from config

### DIFF
--- a/crates/gateway/src/services/skills.rs
+++ b/crates/gateway/src/services/skills.rs
@@ -1262,6 +1262,12 @@ fn skill_detail_bundled(skill_name: &str) -> ServiceResult {
 
     let elig = check_requirements(meta);
 
+    let config = moltis_config::discover_and_load();
+    let enabled = meta
+        .category
+        .as_deref()
+        .is_none_or(|cat| !config.skills.disabled_bundled_categories.iter().any(|c| c == cat));
+
     Ok(serde_json::json!({
         "name": meta.name,
         "description": meta.description,
@@ -1275,7 +1281,7 @@ fn skill_detail_bundled(skill_name: &str) -> ServiceResult {
         "missing_bins": elig.missing_bins,
         "install_options": elig.install_options,
         "trusted": true,
-        "enabled": true,
+        "enabled": enabled,
         "protected": true,
         "body": body,
         "body_html": markdown_to_html(&body),


### PR DESCRIPTION
## Summary

Follow-up to #877 / #875.

`skill_detail_bundled()` hardcoded `"enabled": true` regardless of whether the skill's category was listed in `disabled_bundled_categories`. The detail view in the Web UI always showed bundled skills as enabled, even after disabling them.

## Changes

- Consult `disabled_bundled_categories` from config to derive the actual enabled state
- Skill with no category defaults to enabled (same as the category toggle logic)
- Uses `is_none_or` for the `Option<String>` category field

## Testing

- `cargo check -p moltis-gateway --no-default-features --features bundled-skills` — 0 errors