### PR TITLE
fix(web-ui) code snippets background turning white when chat stream is complete

### DIFF
--- a/crates/web/ui/src/code-highlight.ts
+++ b/crates/web/ui/src/code-highlight.ts
@@ -62,13 +62,6 @@ async function ensureLanguageLoaded(lang: string): Promise<boolean> {
 	return highlighter.getLoadedLanguages().includes(lang);
 }
 
-function applyShikiStylesToPre(codeEl: HTMLElement, shikiPre: HTMLElement): void {
-	const parentPre = codeEl.parentElement;
-	if (!(parentPre && parentPre.tagName === "PRE")) return;
-	// Copy Shiki's style attribute to the parent <pre> for theming.
-	parentPre.style.cssText = shikiPre.style.cssText;
-}
-
 function applyShikiMarkupToCode(codeEl: HTMLElement, shikiPre: HTMLElement): void {
 	const shikiCode = shikiPre.querySelector("code");
 	if (!shikiCode) return;
@@ -111,7 +104,6 @@ async function highlightCodeElement(codeEl: HTMLElement): Promise<void> {
 		});
 		const shikiPre = parseShikiPre(highlightedHtml ?? "");
 		if (!shikiPre) return;
-		applyShikiStylesToPre(codeEl, shikiPre);
 		applyShikiMarkupToCode(codeEl, shikiPre);
 	} catch (_err) {
 		// Highlighting failed for this block -- leave it as plain text.


### PR DESCRIPTION
Fixed a bug where code blocks would switch  to a white background immediately after the assistant finished streaming a response, while system's preference is dark

**Root Cause:**
The `applyShikiStylesToPre` function in `code-highlight.ts` was copying the entire `cssText` from the Shiki highlighter's temporary element to the final `<pre>` tag. Because Shiki's default base background is white, it injected an inline `background-color: rgb(255, 255, 255)` style, which took precedence over the UI's dark theme variables.

**Proposed solution:**
Removed the `applyShikiStylesToPre` function and its invocation. This prevents the injection of external inline styles and allows the background to be consistently handled by the global CSS (`var(--surface)`), preserving the user's chosen theme without impacting the syntax highlighting.