### PR TITLE
fix(web-ui): stop auto-enabling all skills on repository import

### DIFF
--- a/crates/web/src/assets/dist/main.js
+++ b/crates/web/src/assets/dist/main.js
@@ -15490,6 +15490,7 @@ function DetailPanel({
       const res = await sendRpc("skills.clawhub.install", { slug });
       if (res == null ? void 0 : res.ok) {
         installed.value = true;
+        showToast$4("Installed — review and enable the skill in the Skills tab.", "success");
         onInstalled();
       } else {
         error2.value = String((res == null ? void 0 : res.error) || "Install failed");

--- a/crates/web/src/assets/dist/main.js
+++ b/crates/web/src/assets/dist/main.js
@@ -509,11 +509,6 @@ async function ensureLanguageLoaded(lang) {
   await inFlight;
   return highlighter.getLoadedLanguages().includes(lang);
 }
-function applyShikiStylesToPre(codeEl, shikiPre) {
-  const parentPre = codeEl.parentElement;
-  if (!(parentPre && parentPre.tagName === "PRE")) return;
-  parentPre.style.cssText = shikiPre.style.cssText;
-}
 function applyShikiMarkupToCode(codeEl, shikiPre) {
   const shikiCode = shikiPre.querySelector("code");
   if (!shikiCode) return;
@@ -548,7 +543,6 @@ async function highlightCodeElement(codeEl) {
     });
     const shikiPre = parseShikiPre(highlightedHtml ?? "");
     if (!shikiPre) return;
-    applyShikiStylesToPre(codeEl, shikiPre);
     applyShikiMarkupToCode(codeEl, shikiPre);
   } catch (_err) {
   }
@@ -15496,19 +15490,6 @@ function DetailPanel({
       const res = await sendRpc("skills.clawhub.install", { slug });
       if (res == null ? void 0 : res.ok) {
         installed.value = true;
-        const payload = res.payload;
-        const skills = (payload == null ? void 0 : payload.installed) || [];
-        const source = `clawhub:${slug}`;
-        let trustFailed = 0;
-        for (const skill of skills) {
-          if (!skill.name) continue;
-          const trustRes = await sendRpc("skills.skill.trust", { source, skill: skill.name, trusted: true });
-          const enableRes = await sendRpc("skills.skill.enable", { source, skill: skill.name, enabled: true });
-          if (!((trustRes == null ? void 0 : trustRes.ok) && (enableRes == null ? void 0 : enableRes.ok))) trustFailed++;
-        }
-        if (trustFailed > 0) {
-          error2.value = `${trustFailed} skill(s) could not be auto-trusted. Enable manually in Skills tab.`;
-        }
         onInstalled();
       } else {
         error2.value = String((res == null ? void 0 : res.error) || "Install failed");
@@ -15912,7 +15893,7 @@ function fetchAll() {
     loading$7.value = false;
   });
 }
-function doInstall(source, autoTrust = false) {
+function doInstall(source) {
   if (!(source && connected)) {
     if (!connected) showToast$3("Not connected to gateway.", "error");
     return Promise.resolve();
@@ -15923,19 +15904,10 @@ function doInstall(source, autoTrust = false) {
     if (res == null ? void 0 : res.ok) {
       const p = res.payload || {};
       const installed = p.installed || [];
-      showToast$3(`Installed ${source} (${installed.length} skills)`, "success");
-      if (autoTrust && installed.length > 0) {
-        let trustFailed = 0;
-        for (const skill of installed) {
-          if (!skill.name) continue;
-          const trustRes = await sendRpc("skills.skill.trust", { source, skill: skill.name, trusted: true });
-          const enableRes = await sendRpc("skills.skill.enable", { source, skill: skill.name, enabled: true });
-          if (!((trustRes == null ? void 0 : trustRes.ok) && (enableRes == null ? void 0 : enableRes.ok))) trustFailed++;
-        }
-        if (trustFailed > 0) {
-          showToast$3(`${trustFailed} skill(s) could not be auto-trusted. Enable them manually in Skills.`, "error");
-        }
-      }
+      showToast$3(
+        `Installed ${source} (${installed.length} skills) — review and enable the skills you need.`,
+        "success"
+      );
       fetchAll();
       stopInstallProgress(pid);
     } else {
@@ -16043,14 +16015,13 @@ function InstallBox$1() {
   ] });
 }
 const featuredSkills = [
-  { repo: "anthropics/skills", desc: "Official Anthropic agent skills", autoTrust: true },
-  { repo: "vercel-labs/agent-skills", desc: "Vercel agent skills collection", autoTrust: true },
-  { repo: "vercel-labs/skills", desc: "Vercel skills toolkit", autoTrust: true },
+  { repo: "anthropics/skills", desc: "Official Anthropic agent skills" },
+  { repo: "vercel-labs/agent-skills", desc: "Vercel agent skills collection" },
+  { repo: "vercel-labs/skills", desc: "Vercel skills toolkit" },
   {
     repo: "garrytan/gbrain",
     desc: "Knowledge graph with hybrid search for agent memory",
-    hasRecipe: true,
-    autoTrust: true
+    hasRecipe: true
   }
 ];
 async function checkPostInstallRecipe(source) {
@@ -16123,7 +16094,7 @@ function FeaturedCard$1({ skill: f }) {
         onClick: () => {
           if (isInstalled) return;
           installing.value = true;
-          doInstall(f.repo, f.autoTrust).then(() => {
+          doInstall(f.repo).then(() => {
             if (f.hasRecipe) checkPostInstallRecipe(f.repo).catch(console.error);
           }).catch((err) => console.error("install failed", err)).finally(() => {
             installing.value = false;

--- a/crates/web/ui/src/pages/SkillsPage.tsx
+++ b/crates/web/ui/src/pages/SkillsPage.tsx
@@ -163,7 +163,7 @@ function fetchAll(): void {
 		});
 }
 
-function doInstall(source: string, autoTrust = false): Promise<void> {
+function doInstall(source: string): Promise<void> {
 	if (!(source && S.connected)) {
 		if (!S.connected) showToast("Not connected to gateway.", "error");
 		return Promise.resolve();
@@ -174,21 +174,10 @@ function doInstall(source: string, autoTrust = false): Promise<void> {
 		if (res?.ok) {
 			const p = (res.payload || {}) as Record<string, unknown[]>;
 			const installed = (p.installed || []) as Array<{ name?: string }>;
-			showToast(`Installed ${source} (${installed.length} skills)`, "success");
-
-			if (autoTrust && installed.length > 0) {
-				let trustFailed = 0;
-				for (const skill of installed) {
-					if (!skill.name) continue;
-					const trustRes = await sendRpc("skills.skill.trust", { source, skill: skill.name, trusted: true });
-					const enableRes = await sendRpc("skills.skill.enable", { source, skill: skill.name, enabled: true });
-					if (!(trustRes?.ok && enableRes?.ok)) trustFailed++;
-				}
-				if (trustFailed > 0) {
-					showToast(`${trustFailed} skill(s) could not be auto-trusted. Enable them manually in Skills.`, "error");
-				}
-			}
-
+			showToast(
+				`Installed ${source} (${installed.length} skills) — review and enable the skills you need.`,
+				"success",
+			);
 			fetchAll();
 			stopInstallProgress(pid, true);
 		} else {
@@ -306,18 +295,15 @@ interface FeaturedSkill {
 	repo: string;
 	desc: string;
 	hasRecipe?: boolean;
-	/** When true, all skills in this repo are auto-trusted and enabled on install. */
-	autoTrust?: boolean;
 }
 const featuredSkills: FeaturedSkill[] = [
-	{ repo: "anthropics/skills", desc: "Official Anthropic agent skills", autoTrust: true },
-	{ repo: "vercel-labs/agent-skills", desc: "Vercel agent skills collection", autoTrust: true },
-	{ repo: "vercel-labs/skills", desc: "Vercel skills toolkit", autoTrust: true },
+	{ repo: "anthropics/skills", desc: "Official Anthropic agent skills" },
+	{ repo: "vercel-labs/agent-skills", desc: "Vercel agent skills collection" },
+	{ repo: "vercel-labs/skills", desc: "Vercel skills toolkit" },
 	{
 		repo: "garrytan/gbrain",
 		desc: "Knowledge graph with hybrid search for agent memory",
 		hasRecipe: true,
-		autoTrust: true,
 	},
 ];
 
@@ -393,7 +379,7 @@ function FeaturedCard({ skill: f }: { skill: FeaturedSkill }): VNode {
 				onClick={() => {
 					if (isInstalled) return;
 					installing.value = true;
-					doInstall(f.repo, f.autoTrust)
+					doInstall(f.repo)
 						.then(() => {
 							if (f.hasRecipe) checkPostInstallRecipe(f.repo).catch(console.error);
 						})

--- a/crates/web/ui/src/pages/skills/ClawHubSection.tsx
+++ b/crates/web/ui/src/pages/skills/ClawHubSection.tsx
@@ -164,19 +164,6 @@ function DetailPanel({
 			const res = await sendRpc("skills.clawhub.install", { slug });
 			if (res?.ok) {
 				installed.value = true;
-				const payload = res.payload as { installed?: Array<{ name?: string }> } | undefined;
-				const skills = payload?.installed || [];
-				const source = `clawhub:${slug}`;
-				let trustFailed = 0;
-				for (const skill of skills) {
-					if (!skill.name) continue;
-					const trustRes = await sendRpc("skills.skill.trust", { source, skill: skill.name, trusted: true });
-					const enableRes = await sendRpc("skills.skill.enable", { source, skill: skill.name, enabled: true });
-					if (!(trustRes?.ok && enableRes?.ok)) trustFailed++;
-				}
-				if (trustFailed > 0) {
-					error.value = `${trustFailed} skill(s) could not be auto-trusted. Enable manually in Skills tab.`;
-				}
 				onInstalled();
 			} else {
 				error.value = String(res?.error || "Install failed");

--- a/crates/web/ui/src/pages/skills/ClawHubSection.tsx
+++ b/crates/web/ui/src/pages/skills/ClawHubSection.tsx
@@ -3,6 +3,7 @@ import { useSignal } from "@preact/signals";
 import type { VNode } from "preact";
 import { useEffect, useRef } from "preact/hooks";
 import { sendRpc } from "../../helpers";
+import { showToast } from "../../ui";
 
 // ── Types ────────────────────────────────────────────────────
 
@@ -164,6 +165,7 @@ function DetailPanel({
 			const res = await sendRpc("skills.clawhub.install", { slug });
 			if (res?.ok) {
 				installed.value = true;
+				showToast("Installed — review and enable the skill in the Skills tab.", "success");
 				onInstalled();
 			} else {
 				error.value = String(res?.error || "Install failed");


### PR DESCRIPTION
## Summary

Fixes #881 — importing a skill repository via the web UI auto-trusted and auto-enabled **all** skills before the user could review them, bypassing the backend's quarantine safety model.

- Remove `autoTrust` parameter and loop from `doInstall()` in `SkillsPage.tsx`
- Remove auto-trust/enable loop from `ClawHubSection.tsx` `doInstall()`
- Remove `autoTrust` field from `FeaturedSkill` interface and all featured repo entries
- Update install toast to prompt users to review and enable skills manually

The backend already imports repos as quarantined with all skills disabled/untrusted — the bug was purely in the frontend overriding those defaults.

## Validation

### Completed
- [x] `biome check --write` passes
- [x] `npx tsc --noEmit` passes (0 errors)
- [x] `npm run build` succeeds (dist/ committed)
- [x] No remaining references to `autoTrust` in codebase
- [x] Existing e2e tests unaffected (no auto-trust assertions)

### Remaining
- [ ] `just lint` (Rust unchanged, but full CI should confirm)
- [ ] `npx playwright test e2e/specs/skills.spec.js`

## Manual QA

1. Navigate to Settings → Skills → Repositories
2. Install a featured repo (e.g. `anthropics/skills`) — all skills should appear **disabled**
3. Install a ClawHub skill — should appear **disabled**
4. Install a custom URL repo — should appear **disabled**
5. Manually enable individual skills — should work as before
6. Toast message should say "review and enable the skills you need"