### PR TITLE
feat(local-llm): on-demand model loading/unloading with idle timeout

### DIFF
--- a/crates/chat/src/runtime.rs
+++ b/crates/chat/src/runtime.rs
@@ -147,6 +147,13 @@ pub trait ChatRuntime: Send + Sync {
     /// Ensure a local model is cached/downloaded. No-op if local-llm is disabled.
     async fn ensure_local_model_cached(&self, model_id: &str) -> crate::error::Result<bool>;
 
+    /// Ensure a local model is loaded into RAM (broadcasting lifecycle events).
+    /// No-op if local-llm is disabled or the model is already loaded.
+    async fn ensure_local_model_loaded(&self, model_id: &str) -> crate::error::Result<()> {
+        let _ = model_id;
+        Ok(())
+    }
+
     // ── Remote nodes ─────────────────────────────────────────────────────
 
     /// List currently connected remote nodes.

--- a/crates/chat/src/service/chat_impl/send.rs
+++ b/crates/chat/src/service/chat_impl/send.rs
@@ -533,7 +533,7 @@ impl LiveChatService {
             }
         };
 
-        // Check if this is a local model that needs downloading.
+        // Check if this is a local model that needs downloading/loading.
         // Only do this check for local-llm providers.
         #[cfg(feature = "local-llm")]
         if provider.name() == "local-llm" {
@@ -548,6 +548,11 @@ impl LiveChatService {
             );
             if let Err(e) = self.state.ensure_local_model_cached(&model_to_check).await {
                 return Err(format!("Failed to prepare local model: {}", e).into());
+            }
+            // Pre-load the model into RAM (broadcasts lifecycle events so the
+            // chat UI shows "Loading model X into memory..." before inference).
+            if let Err(e) = self.state.ensure_local_model_loaded(&model_to_check).await {
+                tracing::warn!(model = model_to_check, error = %e, "lifecycle pre-load failed, inference will still lazy-load");
             }
         }
 

--- a/crates/config/src/schema/providers.rs
+++ b/crates/config/src/schema/providers.rs
@@ -230,6 +230,14 @@ pub struct ProviderEntry {
     /// ```
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub model_overrides: HashMap<String, ModelOverride>,
+
+    /// Seconds of inactivity before auto-unloading local models.
+    ///
+    /// Only meaningful for `[providers.local-llm]`. Per-model values in
+    /// `local-llm.json` override this global default. `0` = never unload.
+    /// `None` (default) = models stay loaded indefinitely.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub idle_timeout_secs: Option<u64>,
 }
 
 impl std::fmt::Debug for ProviderEntry {
@@ -268,6 +276,7 @@ impl Default for ProviderEntry {
             strict_tools: None,
             policy: None,
             model_overrides: HashMap::new(),
+            idle_timeout_secs: None,
         }
     }
 }

--- a/crates/config/src/template.rs
+++ b/crates/config/src/template.rs
@@ -222,6 +222,7 @@ port = {port}                           # Port number (auto-generated for this i
 # ── Local LLM ─────────────────────────────────────────────────
 # [providers.local-llm]
 # models = ["qwen2.5-coder-7b-q4_k_m"]        # Optional; configure local models in onboarding
+# idle_timeout_secs = 300                      # Auto-unload local models after 5 minutes of inactivity (per-model overrides in local-llm.json)
 
 # ══════════════════════════════════════════════════════════════════════════════
 # MODEL OVERRIDES (GLOBAL)

--- a/crates/config/src/validate/schema_map.rs
+++ b/crates/config/src/validate/schema_map.rs
@@ -48,6 +48,7 @@ pub(super) fn build_schema_map() -> KnownKeys {
             ("strict_tools", Leaf),
             ("policy", tool_policy_entry()),
             ("model_overrides", Map(Box::new(model_override()))),
+            ("idle_timeout_secs", Leaf),
         ]))
     };
 

--- a/crates/gateway/src/chat.rs
+++ b/crates/gateway/src/chat.rs
@@ -213,6 +213,13 @@ impl ChatRuntime for GatewayChatRuntime {
         }
     }
 
+    async fn ensure_local_model_loaded(&self, model_id: &str) -> error::Result<()> {
+        let params = serde_json::json!({ "modelId": model_id });
+        // load_model is a no-op if already loaded; broadcasts lifecycle events otherwise.
+        let _ = self.state.services.local_llm.load_model(params).await;
+        Ok(())
+    }
+
     // ── Remote nodes ────────────────────────────────────────────────────────
 
     async fn connected_nodes(&self) -> Vec<runtime::ConnectedNodeSummary> {

--- a/crates/gateway/src/local_llm_setup.rs
+++ b/crates/gateway/src/local_llm_setup.rs
@@ -32,6 +32,7 @@ use crate::{
 
 mod cache;
 mod config;
+mod lifecycle;
 mod service;
 #[cfg(test)]
 mod tests;
@@ -39,5 +40,6 @@ mod tests;
 pub use {
     cache::{LocalModelCacheError, LocalModelCacheResult, ensure_local_model_cached},
     config::{LocalLlmConfig, LocalModelEntry, register_saved_local_models},
+    lifecycle::ModelLifecycleManager,
     service::{LiveLocalLlmService, LocalLlmStatus},
 };

--- a/crates/gateway/src/local_llm_setup/config.rs
+++ b/crates/gateway/src/local_llm_setup/config.rs
@@ -15,6 +15,10 @@ pub struct LocalModelEntry {
     /// Backend to use: "GGUF" or "MLX"
     #[serde(default = "default_backend")]
     pub backend: String,
+    /// Seconds of inactivity before auto-unloading this model.
+    /// `None` = use global default. `0` = never unload.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub idle_timeout_secs: Option<u64>,
 }
 
 pub(super) fn default_backend() -> String {
@@ -63,6 +67,7 @@ impl LocalLlmConfig {
                     hf_filename: None,
                     gpu_layers: legacy.gpu_layers,
                     backend: legacy.backend,
+                    idle_timeout_secs: None,
                 }],
             };
             // Save migrated config

--- a/crates/gateway/src/local_llm_setup/config.rs
+++ b/crates/gateway/src/local_llm_setup/config.rs
@@ -285,11 +285,14 @@ pub(super) fn unregister_local_model_ids_from_registry(
 pub(super) fn register_local_model_entry(
     registry: &mut ProviderRegistry,
     entry: &LocalModelEntry,
-) -> anyhow::Result<()> {
+) -> anyhow::Result<Arc<local_llm::LocalLlmProvider>> {
     let (info, provider) = build_local_provider_entry(entry, None)?;
     unregister_local_model_from_registry(registry, &entry.model_id);
-    registry.register(info, provider);
-    Ok(())
+    registry.register(
+        info,
+        Arc::clone(&provider) as Arc<dyn moltis_agents::model::LlmProvider>,
+    );
+    Ok(provider)
 }
 
 pub(super) fn register_local_model_entry_with_default_model_path(

--- a/crates/gateway/src/local_llm_setup/lifecycle.rs
+++ b/crates/gateway/src/local_llm_setup/lifecycle.rs
@@ -4,6 +4,7 @@ use std::{collections::HashMap, sync::Arc};
 
 use {
     serde::Serialize,
+    time::OffsetDateTime,
     tokio::sync::RwLock,
     tracing::{debug, info},
 };
@@ -76,23 +77,33 @@ impl ModelLifecycleManager {
 
     /// Manually load a model (calls `ensure_loaded`), broadcasting events.
     pub async fn load_model(&self, model_id: &str) -> anyhow::Result<()> {
-        let providers = self.providers.read().await;
-        let provider = providers
-            .get(model_id)
-            .ok_or_else(|| anyhow::anyhow!("unknown model: {model_id}"))?;
+        let provider = {
+            let providers = self.providers.read().await;
+            Arc::clone(
+                providers
+                    .get(model_id)
+                    .ok_or_else(|| anyhow::anyhow!("unknown model: {model_id}"))?,
+            )
+        };
 
         if provider.is_loaded().await {
             return Ok(());
         }
 
-        self.broadcast_lifecycle(model_id, "loading", 0, loaded_llama_model_bytes())
+        self.broadcast_lifecycle(model_id, "loading", 0, loaded_llama_model_bytes(), "manual")
             .await;
 
         provider.ensure_loaded().await?;
 
         let model_bytes = provider.model_size_bytes().await;
-        self.broadcast_lifecycle(model_id, "loaded", model_bytes, loaded_llama_model_bytes())
-            .await;
+        self.broadcast_lifecycle(
+            model_id,
+            "loaded",
+            model_bytes,
+            loaded_llama_model_bytes(),
+            "manual",
+        )
+        .await;
 
         info!(model = model_id, bytes = model_bytes, "model loaded");
         Ok(())
@@ -100,10 +111,14 @@ impl ModelLifecycleManager {
 
     /// Manually unload a model, broadcasting events.
     pub async fn unload_model(&self, model_id: &str) -> anyhow::Result<()> {
-        let providers = self.providers.read().await;
-        let provider = providers
-            .get(model_id)
-            .ok_or_else(|| anyhow::anyhow!("unknown model: {model_id}"))?;
+        let provider = {
+            let providers = self.providers.read().await;
+            Arc::clone(
+                providers
+                    .get(model_id)
+                    .ok_or_else(|| anyhow::anyhow!("unknown model: {model_id}"))?,
+            )
+        };
 
         let model_bytes = provider.model_size_bytes().await;
 
@@ -112,6 +127,7 @@ impl ModelLifecycleManager {
             "unloading",
             model_bytes,
             loaded_llama_model_bytes(),
+            "manual",
         )
         .await;
 
@@ -123,6 +139,7 @@ impl ModelLifecycleManager {
                 "unloaded",
                 model_bytes,
                 loaded_llama_model_bytes(),
+                "manual",
             )
             .await;
             info!(
@@ -168,21 +185,25 @@ impl ModelLifecycleManager {
 
     /// One pass of the idle checker.
     async fn check_idle_models(&self) {
-        let now = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_secs() as i64;
+        let now = OffsetDateTime::now_utc().unix_timestamp();
 
-        let providers = self.providers.read().await;
-        let timeouts = self.timeouts.read().await;
+        // Snapshot provider Arcs and timeouts so we don't hold locks across awaits.
+        let snapshot: Vec<(String, Arc<local_llm::LocalLlmProvider>, u64)> = {
+            let providers = self.providers.read().await;
+            let timeouts = self.timeouts.read().await;
+            providers
+                .iter()
+                .filter_map(|(id, prov)| {
+                    let timeout = timeouts.get(id).copied().flatten()?;
+                    if timeout == 0 {
+                        return None; // 0 = never unload
+                    }
+                    Some((id.clone(), Arc::clone(prov), timeout))
+                })
+                .collect()
+        };
 
-        for (model_id, provider) in providers.iter() {
-            let timeout = match timeouts.get(model_id).copied().flatten() {
-                Some(0) => continue, // 0 = never unload
-                Some(t) => t,
-                None => continue, // None = no timeout configured
-            };
-
+        for (model_id, provider, timeout) in &snapshot {
             if !provider.is_loaded().await {
                 continue;
             }
@@ -193,12 +214,12 @@ impl ModelLifecycleManager {
             }
 
             let idle_secs = now.saturating_sub(last) as u64;
-            if idle_secs <= timeout {
+            if idle_secs <= *timeout {
                 continue;
             }
 
             debug!(
-                model = model_id,
+                model = model_id.as_str(),
                 idle_secs, timeout, "model idle timeout reached, unloading"
             );
 
@@ -208,6 +229,7 @@ impl ModelLifecycleManager {
                 "unloading",
                 model_bytes,
                 loaded_llama_model_bytes(),
+                "idle",
             )
             .await;
 
@@ -218,10 +240,11 @@ impl ModelLifecycleManager {
                     "unloaded",
                     model_bytes,
                     loaded_llama_model_bytes(),
+                    "idle",
                 )
                 .await;
                 info!(
-                    model = model_id,
+                    model = model_id.as_str(),
                     freed_bytes = model_bytes,
                     idle_secs,
                     "model auto-unloaded after idle timeout"
@@ -236,6 +259,7 @@ impl ModelLifecycleManager {
         state_name: &str,
         model_size_bytes: u64,
         total_loaded_bytes: u64,
+        reason: &str,
     ) {
         let Some(state) = self.state.get() else {
             return;
@@ -248,6 +272,7 @@ impl ModelLifecycleManager {
                 "state": state_name,
                 "modelSizeBytes": model_size_bytes,
                 "totalLoadedBytes": total_loaded_bytes,
+                "reason": reason,
             }),
             BroadcastOpts::default(),
         )

--- a/crates/gateway/src/local_llm_setup/lifecycle.rs
+++ b/crates/gateway/src/local_llm_setup/lifecycle.rs
@@ -67,6 +67,12 @@ impl ModelLifecycleManager {
         self.timeouts.write().await.remove(model_id);
     }
 
+    /// Remove all models (used before re-populating after registry rebuild).
+    pub async fn clear(&self) {
+        self.providers.write().await.clear();
+        self.timeouts.write().await.clear();
+    }
+
     /// Update the idle timeout for a model.
     pub async fn set_timeout(&self, model_id: &str, timeout: Option<u64>) {
         self.timeouts

--- a/crates/gateway/src/local_llm_setup/lifecycle.rs
+++ b/crates/gateway/src/local_llm_setup/lifecycle.rs
@@ -1,0 +1,361 @@
+//! Model lifecycle manager — idle-timeout unloading and manual load/unload.
+
+use std::{collections::HashMap, sync::Arc};
+
+use {
+    serde::Serialize,
+    tokio::sync::RwLock,
+    tracing::{debug, info},
+};
+
+use moltis_providers::local_llm::{self, backend::loaded_llama_model_bytes};
+
+use crate::{
+    broadcast::{BroadcastOpts, broadcast},
+    state::GatewayState,
+};
+
+/// Per-model lifecycle state exposed to the web UI.
+#[derive(Debug, Clone, Serialize)]
+pub struct ModelState {
+    pub model_id: String,
+    pub is_loaded: bool,
+    pub memory_bytes: u64,
+    pub last_activity: i64,
+    pub idle_timeout_secs: Option<u64>,
+}
+
+/// Manages idle-timeout unloading and manual load/unload for local LLM models.
+pub struct ModelLifecycleManager {
+    providers: RwLock<HashMap<String, Arc<local_llm::LocalLlmProvider>>>,
+    timeouts: RwLock<HashMap<String, Option<u64>>>,
+    state: Arc<tokio::sync::OnceCell<Arc<GatewayState>>>,
+}
+
+impl ModelLifecycleManager {
+    pub fn new() -> Self {
+        Self {
+            providers: RwLock::new(HashMap::new()),
+            timeouts: RwLock::new(HashMap::new()),
+            state: Arc::new(tokio::sync::OnceCell::new()),
+        }
+    }
+
+    /// Set the gateway state for broadcasting lifecycle events.
+    pub fn set_state(&self, state: Arc<GatewayState>) {
+        let _ = self.state.set(state);
+    }
+
+    /// Register a model provider with its effective timeout.
+    pub async fn register(
+        &self,
+        model_id: String,
+        provider: Arc<local_llm::LocalLlmProvider>,
+        timeout: Option<u64>,
+    ) {
+        self.providers
+            .write()
+            .await
+            .insert(model_id.clone(), provider);
+        self.timeouts.write().await.insert(model_id, timeout);
+    }
+
+    /// Remove a model from lifecycle management.
+    pub async fn unregister(&self, model_id: &str) {
+        self.providers.write().await.remove(model_id);
+        self.timeouts.write().await.remove(model_id);
+    }
+
+    /// Update the idle timeout for a model.
+    pub async fn set_timeout(&self, model_id: &str, timeout: Option<u64>) {
+        self.timeouts
+            .write()
+            .await
+            .insert(model_id.to_string(), timeout);
+    }
+
+    /// Manually load a model (calls `ensure_loaded`), broadcasting events.
+    pub async fn load_model(&self, model_id: &str) -> anyhow::Result<()> {
+        let providers = self.providers.read().await;
+        let provider = providers
+            .get(model_id)
+            .ok_or_else(|| anyhow::anyhow!("unknown model: {model_id}"))?;
+
+        if provider.is_loaded().await {
+            return Ok(());
+        }
+
+        self.broadcast_lifecycle(model_id, "loading", 0, loaded_llama_model_bytes())
+            .await;
+
+        provider.ensure_loaded().await?;
+
+        let model_bytes = provider.model_size_bytes().await;
+        self.broadcast_lifecycle(model_id, "loaded", model_bytes, loaded_llama_model_bytes())
+            .await;
+
+        info!(model = model_id, bytes = model_bytes, "model loaded");
+        Ok(())
+    }
+
+    /// Manually unload a model, broadcasting events.
+    pub async fn unload_model(&self, model_id: &str) -> anyhow::Result<()> {
+        let providers = self.providers.read().await;
+        let provider = providers
+            .get(model_id)
+            .ok_or_else(|| anyhow::anyhow!("unknown model: {model_id}"))?;
+
+        let model_bytes = provider.model_size_bytes().await;
+
+        self.broadcast_lifecycle(
+            model_id,
+            "unloading",
+            model_bytes,
+            loaded_llama_model_bytes(),
+        )
+        .await;
+
+        let was_loaded = provider.unload().await;
+
+        if was_loaded {
+            self.broadcast_lifecycle(
+                model_id,
+                "unloaded",
+                model_bytes,
+                loaded_llama_model_bytes(),
+            )
+            .await;
+            info!(
+                model = model_id,
+                freed_bytes = model_bytes,
+                "model unloaded"
+            );
+        }
+
+        Ok(())
+    }
+
+    /// Return current state for all registered models.
+    pub async fn model_states(&self) -> Vec<ModelState> {
+        let providers = self.providers.read().await;
+        let timeouts = self.timeouts.read().await;
+        let mut states = Vec::with_capacity(providers.len());
+
+        for (model_id, provider) in providers.iter() {
+            states.push(ModelState {
+                model_id: model_id.clone(),
+                is_loaded: provider.is_loaded().await,
+                memory_bytes: provider.model_size_bytes().await,
+                last_activity: provider.last_activity_secs(),
+                idle_timeout_secs: timeouts.get(model_id).copied().flatten(),
+            });
+        }
+
+        states
+    }
+
+    /// Spawn the background idle-check timer. Returns the `JoinHandle`.
+    pub fn spawn_idle_checker(self: &Arc<Self>) -> tokio::task::JoinHandle<()> {
+        let mgr = Arc::clone(self);
+        tokio::spawn(async move {
+            let mut interval = tokio::time::interval(std::time::Duration::from_secs(30));
+            loop {
+                interval.tick().await;
+                mgr.check_idle_models().await;
+            }
+        })
+    }
+
+    /// One pass of the idle checker.
+    async fn check_idle_models(&self) {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs() as i64;
+
+        let providers = self.providers.read().await;
+        let timeouts = self.timeouts.read().await;
+
+        for (model_id, provider) in providers.iter() {
+            let timeout = match timeouts.get(model_id).copied().flatten() {
+                Some(0) => continue, // 0 = never unload
+                Some(t) => t,
+                None => continue, // None = no timeout configured
+            };
+
+            if !provider.is_loaded().await {
+                continue;
+            }
+
+            let last = provider.last_activity_secs();
+            if last == 0 {
+                continue; // never used yet
+            }
+
+            let idle_secs = now.saturating_sub(last) as u64;
+            if idle_secs <= timeout {
+                continue;
+            }
+
+            debug!(
+                model = model_id,
+                idle_secs, timeout, "model idle timeout reached, unloading"
+            );
+
+            let model_bytes = provider.model_size_bytes().await;
+            self.broadcast_lifecycle(
+                model_id,
+                "unloading",
+                model_bytes,
+                loaded_llama_model_bytes(),
+            )
+            .await;
+
+            let was_loaded = provider.unload().await;
+            if was_loaded {
+                self.broadcast_lifecycle(
+                    model_id,
+                    "unloaded",
+                    model_bytes,
+                    loaded_llama_model_bytes(),
+                )
+                .await;
+                info!(
+                    model = model_id,
+                    freed_bytes = model_bytes,
+                    idle_secs,
+                    "model auto-unloaded after idle timeout"
+                );
+            }
+        }
+    }
+
+    async fn broadcast_lifecycle(
+        &self,
+        model_id: &str,
+        state_name: &str,
+        model_size_bytes: u64,
+        total_loaded_bytes: u64,
+    ) {
+        let Some(state) = self.state.get() else {
+            return;
+        };
+        broadcast(
+            state,
+            "local-llm.lifecycle",
+            serde_json::json!({
+                "modelId": model_id,
+                "state": state_name,
+                "modelSizeBytes": model_size_bytes,
+                "totalLoadedBytes": total_loaded_bytes,
+            }),
+            BroadcastOpts::default(),
+        )
+        .await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_model_states_empty() {
+        let mgr = ModelLifecycleManager::new();
+        let states = mgr.model_states().await;
+        assert!(states.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_register_and_unregister() {
+        let mgr = ModelLifecycleManager::new();
+        let config = local_llm::LocalLlmConfig {
+            model_id: "test-model".into(),
+            ..Default::default()
+        };
+        let provider = Arc::new(local_llm::LocalLlmProvider::new(config));
+
+        mgr.register("test-model".into(), provider, Some(300)).await;
+        assert_eq!(mgr.model_states().await.len(), 1);
+
+        mgr.unregister("test-model").await;
+        assert!(mgr.model_states().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_model_state_fields() {
+        let mgr = ModelLifecycleManager::new();
+        let config = local_llm::LocalLlmConfig {
+            model_id: "test-model".into(),
+            ..Default::default()
+        };
+        let provider = Arc::new(local_llm::LocalLlmProvider::new(config));
+
+        mgr.register("test-model".into(), provider, Some(600)).await;
+
+        let states = mgr.model_states().await;
+        assert_eq!(states.len(), 1);
+        assert_eq!(states[0].model_id, "test-model");
+        assert!(!states[0].is_loaded);
+        assert_eq!(states[0].memory_bytes, 0);
+        assert_eq!(states[0].last_activity, 0);
+        assert_eq!(states[0].idle_timeout_secs, Some(600));
+    }
+
+    #[tokio::test]
+    async fn test_set_timeout() {
+        let mgr = ModelLifecycleManager::new();
+        let config = local_llm::LocalLlmConfig {
+            model_id: "test-model".into(),
+            ..Default::default()
+        };
+        let provider = Arc::new(local_llm::LocalLlmProvider::new(config));
+
+        mgr.register("test-model".into(), provider, None).await;
+        assert_eq!(mgr.model_states().await[0].idle_timeout_secs, None);
+
+        mgr.set_timeout("test-model", Some(120)).await;
+        assert_eq!(mgr.model_states().await[0].idle_timeout_secs, Some(120));
+    }
+
+    #[tokio::test]
+    async fn test_unload_unknown_model() {
+        let mgr = ModelLifecycleManager::new();
+        let result = mgr.unload_model("nonexistent").await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_load_unknown_model() {
+        let mgr = ModelLifecycleManager::new();
+        let result = mgr.load_model("nonexistent").await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_check_idle_models_no_timeout() {
+        // Models with no timeout should not be unloaded
+        let mgr = ModelLifecycleManager::new();
+        let config = local_llm::LocalLlmConfig {
+            model_id: "test".into(),
+            ..Default::default()
+        };
+        let provider = Arc::new(local_llm::LocalLlmProvider::new(config));
+        mgr.register("test".into(), provider, None).await;
+        // Should not panic
+        mgr.check_idle_models().await;
+    }
+
+    #[tokio::test]
+    async fn test_check_idle_models_zero_timeout() {
+        // Models with timeout=0 should never be unloaded
+        let mgr = ModelLifecycleManager::new();
+        let config = local_llm::LocalLlmConfig {
+            model_id: "test".into(),
+            ..Default::default()
+        };
+        let provider = Arc::new(local_llm::LocalLlmProvider::new(config));
+        mgr.register("test".into(), provider, Some(0)).await;
+        mgr.check_idle_models().await;
+    }
+}

--- a/crates/gateway/src/local_llm_setup/lifecycle.rs
+++ b/crates/gateway/src/local_llm_setup/lifecycle.rs
@@ -154,17 +154,30 @@ impl ModelLifecycleManager {
 
     /// Return current state for all registered models.
     pub async fn model_states(&self) -> Vec<ModelState> {
-        let providers = self.providers.read().await;
-        let timeouts = self.timeouts.read().await;
-        let mut states = Vec::with_capacity(providers.len());
+        // Snapshot Arcs and timeouts so we don't hold locks across awaits.
+        let snapshot: Vec<(String, Arc<local_llm::LocalLlmProvider>, Option<u64>)> = {
+            let providers = self.providers.read().await;
+            let timeouts = self.timeouts.read().await;
+            providers
+                .iter()
+                .map(|(id, prov)| {
+                    (
+                        id.clone(),
+                        Arc::clone(prov),
+                        timeouts.get(id).copied().flatten(),
+                    )
+                })
+                .collect()
+        };
 
-        for (model_id, provider) in providers.iter() {
+        let mut states = Vec::with_capacity(snapshot.len());
+        for (model_id, provider, timeout) in &snapshot {
             states.push(ModelState {
                 model_id: model_id.clone(),
                 is_loaded: provider.is_loaded().await,
                 memory_bytes: provider.model_size_bytes().await,
                 last_activity: provider.last_activity_secs(),
-                idle_timeout_secs: timeouts.get(model_id).copied().flatten(),
+                idle_timeout_secs: *timeout,
             });
         }
 

--- a/crates/gateway/src/local_llm_setup/service.rs
+++ b/crates/gateway/src/local_llm_setup/service.rs
@@ -340,6 +340,15 @@ impl LocalLlmService for LiveLocalLlmService {
             .save()
             .map_err(|e| format!("failed to save config: {e}"))?;
 
+        // Resolve effective idle timeout: per-model override → global default → None.
+        let effective_timeout = entry.idle_timeout_secs.or_else(|| {
+            let cfg = moltis_config::loader::discover_and_load();
+            cfg.providers
+                .get("local")
+                .or_else(|| cfg.providers.get("local-llm"))
+                .and_then(|e| e.idle_timeout_secs)
+        });
+
         // Trigger model download in background with progress updates
         let model_id_clone = model_id.clone();
         let status = Arc::clone(&self.status);
@@ -436,7 +445,7 @@ impl LocalLlmService for LiveLocalLlmService {
                     match register_local_model_entry(&mut reg, &entry) {
                         Ok(provider) => {
                             lifecycle
-                                .register(entry.model_id.clone(), provider, entry.idle_timeout_secs)
+                                .register(entry.model_id.clone(), provider, effective_timeout)
                                 .await;
                         },
                         Err(error) => {
@@ -600,6 +609,15 @@ impl LocalLlmService for LiveLocalLlmService {
             };
         }
 
+        // Resolve effective idle timeout: per-model override → global default → None.
+        let effective_timeout = entry.idle_timeout_secs.or_else(|| {
+            let cfg = moltis_config::loader::discover_and_load();
+            cfg.providers
+                .get("local")
+                .or_else(|| cfg.providers.get("local-llm"))
+                .and_then(|e| e.idle_timeout_secs)
+        });
+
         let status = Arc::clone(&self.status);
         let registry = Arc::clone(&self.registry);
         let state_cell = Arc::clone(&self.state);
@@ -700,7 +718,7 @@ impl LocalLlmService for LiveLocalLlmService {
                     match register_local_model_entry(&mut reg, &entry) {
                         Ok(provider) => {
                             lifecycle
-                                .register(entry.model_id.clone(), provider, entry.idle_timeout_secs)
+                                .register(entry.model_id.clone(), provider, effective_timeout)
                                 .await;
                         },
                         Err(error) => {

--- a/crates/gateway/src/local_llm_setup/service.rs
+++ b/crates/gateway/src/local_llm_setup/service.rs
@@ -60,14 +60,19 @@ impl LiveLocalLlmService {
     }
 
     /// Register all saved local models with the lifecycle manager.
+    ///
+    /// Re-registers providers in the registry so both share the same
+    /// `Arc<LocalLlmProvider>` — ensuring `last_activity` and `unload()`
+    /// affect the real instance used for inference.
     pub async fn populate_lifecycle(&self, global_timeout: Option<u64>) {
         let Some(config) = LocalLlmConfig::load() else {
             return;
         };
+        let mut reg = self.registry.write().await;
         for entry in &config.models {
             let effective_timeout = entry.idle_timeout_secs.or(global_timeout);
-            match build_local_provider_entry(entry, None) {
-                Ok((_, provider)) => {
+            match register_local_model_entry(&mut reg, entry) {
+                Ok(provider) => {
                     self.lifecycle
                         .register(entry.model_id.clone(), provider, effective_timeout)
                         .await;
@@ -425,18 +430,18 @@ impl LocalLlmService for LiveLocalLlmService {
                         .await;
                     }
 
-                    // Register the provider in the registry
-                    // Use LocalLlmProvider which auto-detects backend (GGUF or MLX)
+                    // Register the provider in the registry and lifecycle manager
+                    // (same Arc so last_activity and unload affect the real instance)
                     let mut reg = registry.write().await;
-                    if let Err(error) = register_local_model_entry(&mut reg, &entry) {
-                        tracing::error!(model = %model_id_clone, %error, "failed to register local model");
-                    }
-
-                    // Register with lifecycle manager
-                    if let Ok((_, provider)) = build_local_provider_entry(&entry, None) {
-                        lifecycle
-                            .register(entry.model_id.clone(), provider, entry.idle_timeout_secs)
-                            .await;
+                    match register_local_model_entry(&mut reg, &entry) {
+                        Ok(provider) => {
+                            lifecycle
+                                .register(entry.model_id.clone(), provider, entry.idle_timeout_secs)
+                                .await;
+                        },
+                        Err(error) => {
+                            tracing::error!(model = %model_id_clone, %error, "failed to register local model");
+                        },
                     }
 
                     let mut s = status.write().await;
@@ -692,15 +697,15 @@ impl LocalLlmService for LiveLocalLlmService {
                         &mut reg,
                         &superseded_model_ids_for_download,
                     );
-                    if let Err(error) = register_local_model_entry(&mut reg, &entry) {
-                        tracing::error!(model = %entry.model_id, %error, "failed to register custom local model");
-                    }
-
-                    // Register with lifecycle manager
-                    if let Ok((_, provider)) = build_local_provider_entry(&entry, None) {
-                        lifecycle
-                            .register(entry.model_id.clone(), provider, entry.idle_timeout_secs)
-                            .await;
+                    match register_local_model_entry(&mut reg, &entry) {
+                        Ok(provider) => {
+                            lifecycle
+                                .register(entry.model_id.clone(), provider, entry.idle_timeout_secs)
+                                .await;
+                        },
+                        Err(error) => {
+                            tracing::error!(model = %entry.model_id, %error, "failed to register custom local model");
+                        },
                     }
 
                     let mut s = status.write().await;

--- a/crates/gateway/src/local_llm_setup/service.rs
+++ b/crates/gateway/src/local_llm_setup/service.rs
@@ -31,6 +31,8 @@ pub struct LiveLocalLlmService {
     status: Arc<RwLock<LocalLlmStatus>>,
     /// State reference for broadcasting progress (set after state is created).
     state: Arc<OnceCell<Arc<GatewayState>>>,
+    /// Model lifecycle manager for idle-timeout unloading and manual load/unload.
+    lifecycle: Arc<ModelLifecycleManager>,
 }
 
 impl LiveLocalLlmService {
@@ -41,13 +43,40 @@ impl LiveLocalLlmService {
                 LocalLlmConfig::load().as_ref(),
             ))),
             state: Arc::new(OnceCell::new()),
+            lifecycle: Arc::new(ModelLifecycleManager::new()),
         }
     }
 
     /// Set the gateway state reference for broadcasting progress updates.
     pub fn set_state(&self, state: Arc<GatewayState>) {
         // Ignore if already set (shouldn't happen in normal operation)
-        let _ = self.state.set(state);
+        let _ = self.state.set(state.clone());
+        self.lifecycle.set_state(state);
+    }
+
+    /// Get a reference to the lifecycle manager.
+    pub fn lifecycle(&self) -> &Arc<ModelLifecycleManager> {
+        &self.lifecycle
+    }
+
+    /// Register all saved local models with the lifecycle manager.
+    pub async fn populate_lifecycle(&self, global_timeout: Option<u64>) {
+        let Some(config) = LocalLlmConfig::load() else {
+            return;
+        };
+        for entry in &config.models {
+            let effective_timeout = entry.idle_timeout_secs.or(global_timeout);
+            match build_local_provider_entry(entry, None) {
+                Ok((_, provider)) => {
+                    self.lifecycle
+                        .register(entry.model_id.clone(), provider, effective_timeout)
+                        .await;
+                },
+                Err(error) => {
+                    warn!(model_id = %entry.model_id, %error, "failed to create provider for lifecycle manager");
+                },
+            }
+        }
     }
 
     /// Get model display info for JSON response.
@@ -298,6 +327,7 @@ impl LocalLlmService for LiveLocalLlmService {
             hf_filename: None,
             gpu_layers: 0,
             backend: backend.clone(),
+            idle_timeout_secs: None,
         };
         let mut config = LocalLlmConfig::load().unwrap_or_default();
         config.add_model(entry.clone());
@@ -310,6 +340,7 @@ impl LocalLlmService for LiveLocalLlmService {
         let status = Arc::clone(&self.status);
         let registry = Arc::clone(&self.registry);
         let state_cell = Arc::clone(&self.state);
+        let lifecycle = Arc::clone(&self.lifecycle);
         let cache_dir = local_gguf::models::default_models_dir();
         let display_name = model_def.display_name.to_string();
         let backend_for_download = backend.clone();
@@ -399,6 +430,13 @@ impl LocalLlmService for LiveLocalLlmService {
                     let mut reg = registry.write().await;
                     if let Err(error) = register_local_model_entry(&mut reg, &entry) {
                         tracing::error!(model = %model_id_clone, %error, "failed to register local model");
+                    }
+
+                    // Register with lifecycle manager
+                    if let Ok((_, provider)) = build_local_provider_entry(&entry, None) {
+                        lifecycle
+                            .register(entry.model_id.clone(), provider, entry.idle_timeout_secs)
+                            .await;
                     }
 
                     let mut s = status.write().await;
@@ -524,6 +562,7 @@ impl LocalLlmService for LiveLocalLlmService {
             hf_filename: hf_filename.clone(),
             gpu_layers: 0,
             backend: backend.clone(),
+            idle_timeout_secs: None,
         };
         let display_name = entry.display_name();
 
@@ -559,6 +598,7 @@ impl LocalLlmService for LiveLocalLlmService {
         let status = Arc::clone(&self.status);
         let registry = Arc::clone(&self.registry);
         let state_cell = Arc::clone(&self.state);
+        let lifecycle = Arc::clone(&self.lifecycle);
         let cache_dir = local_gguf::models::default_models_dir();
         let model_id_clone = model_id.clone();
         let hf_repo_for_download = hf_repo.clone();
@@ -656,6 +696,13 @@ impl LocalLlmService for LiveLocalLlmService {
                         tracing::error!(model = %entry.model_id, %error, "failed to register custom local model");
                     }
 
+                    // Register with lifecycle manager
+                    if let Ok((_, provider)) = build_local_provider_entry(&entry, None) {
+                        lifecycle
+                            .register(entry.model_id.clone(), provider, entry.idle_timeout_secs)
+                            .await;
+                    }
+
                     let mut s = status.write().await;
                     *s = LocalLlmStatus::Ready {
                         model_id: entry.model_id.clone(),
@@ -713,11 +760,12 @@ impl LocalLlmService for LiveLocalLlmService {
             .save()
             .map_err(|e| format!("failed to save config: {e}"))?;
 
-        // Remove from provider registry
+        // Remove from provider registry and lifecycle manager
         {
             let mut reg = self.registry.write().await;
             unregister_local_model_from_registry(&mut reg, local_model_id);
         }
+        self.lifecycle.unregister(local_model_id).await;
 
         let removed_current_model = {
             let status = self.status.read().await;
@@ -741,6 +789,39 @@ impl LocalLlmService for LiveLocalLlmService {
             "ok": true,
             "modelId": local_model_id,
         }))
+    }
+
+    async fn load_model(&self, params: Value) -> ServiceResult {
+        let model_id = params
+            .get("modelId")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| "missing 'modelId' parameter".to_string())?;
+
+        self.lifecycle
+            .load_model(model_id)
+            .await
+            .map_err(|e| e.to_string())?;
+
+        Ok(serde_json::json!({ "ok": true, "modelId": model_id }))
+    }
+
+    async fn unload_model(&self, params: Value) -> ServiceResult {
+        let model_id = params
+            .get("modelId")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| "missing 'modelId' parameter".to_string())?;
+
+        self.lifecycle
+            .unload_model(model_id)
+            .await
+            .map_err(|e| e.to_string())?;
+
+        Ok(serde_json::json!({ "ok": true, "modelId": model_id }))
+    }
+
+    async fn model_states(&self) -> ServiceResult {
+        let states = self.lifecycle.model_states().await;
+        Ok(serde_json::to_value(&states).unwrap_or_else(|_| serde_json::json!([])))
     }
 }
 

--- a/crates/gateway/src/local_llm_setup/tests.rs
+++ b/crates/gateway/src/local_llm_setup/tests.rs
@@ -47,6 +47,7 @@ mod tests {
             hf_filename: None,
             gpu_layers: 0,
             backend: "GGUF".into(),
+            idle_timeout_secs: None,
         });
         let json = serde_json::to_string(&config).unwrap();
         assert!(json.contains("qwen2.5-coder-7b-q4_k_m"));
@@ -67,6 +68,7 @@ mod tests {
             hf_filename: Some("Qwen3-4B-Q4_K_M.gguf".into()),
             gpu_layers: 0,
             backend: "GGUF".into(),
+            idle_timeout_secs: None,
         };
         let second = LocalModelEntry {
             model_id: custom_gguf_model_id(repo, "Qwen3-4B-Q6_K.gguf"),
@@ -75,6 +77,7 @@ mod tests {
             hf_filename: Some("Qwen3-4B-Q6_K.gguf".into()),
             gpu_layers: 0,
             backend: "GGUF".into(),
+            idle_timeout_secs: None,
         };
 
         config.add_model(first.clone());
@@ -114,6 +117,7 @@ mod tests {
             hf_filename: None,
             gpu_layers: 0,
             backend: "GGUF".into(),
+            idle_timeout_secs: None,
         });
         config.add_model(LocalModelEntry {
             model_id: "model-2".into(),
@@ -122,6 +126,7 @@ mod tests {
             hf_filename: None,
             gpu_layers: 0,
             backend: "MLX".into(),
+            idle_timeout_secs: None,
         });
         assert_eq!(config.models.len(), 2);
 
@@ -402,6 +407,7 @@ mod tests {
                     hf_filename: None,
                     gpu_layers: 0,
                     backend: "GGUF".into(),
+                    idle_timeout_secs: None,
                 },
                 LocalModelEntry {
                     model_id: "custom-stale".into(),
@@ -410,6 +416,7 @@ mod tests {
                     hf_filename: Some(filename.into()),
                     gpu_layers: 0,
                     backend: "GGUF".into(),
+                    idle_timeout_secs: None,
                 },
                 LocalModelEntry {
                     model_id: custom_gguf_model_id(repo, "Qwen3-4B-Q6_K.gguf"),
@@ -418,6 +425,7 @@ mod tests {
                     hf_filename: Some("Qwen3-4B-Q6_K.gguf".into()),
                     gpu_layers: 0,
                     backend: "GGUF".into(),
+                    idle_timeout_secs: None,
                 },
             ],
         };
@@ -450,6 +458,7 @@ mod tests {
             hf_filename: Some("Qwen3-4B-Q4_K_M.gguf".into()),
             gpu_layers: 0,
             backend: "GGUF".into(),
+            idle_timeout_secs: None,
         };
 
         let resolved = entry.resolved_model_path(None, cache_dir).unwrap();
@@ -476,6 +485,7 @@ mod tests {
             hf_filename: Some("Qwen3-4B-Q4_K_M.gguf".into()),
             gpu_layers: 0,
             backend: "GGUF".into(),
+            idle_timeout_secs: None,
         };
 
         let resolved = entry.resolved_model_path(None, cache_dir).unwrap();
@@ -503,6 +513,7 @@ mod tests {
             hf_filename: None,
             gpu_layers: 0,
             backend: "GGUF".into(),
+            idle_timeout_secs: None,
         };
 
         let resolved = entry
@@ -521,6 +532,7 @@ mod tests {
             hf_filename: Some("Qwen3-4B-Q4_K_M.gguf".into()),
             gpu_layers: 0,
             backend: "GGUF".into(),
+            idle_timeout_secs: None,
         };
 
         assert_eq!(entry.display_name(), "Qwen3-4B-Q4_K_M.gguf");
@@ -541,6 +553,7 @@ mod tests {
             hf_filename: Some("Qwen3-4B-Q4_K_M.gguf".into()),
             gpu_layers: 0,
             backend: "GGUF".into(),
+            idle_timeout_secs: None,
         };
         let config = LocalLlmConfig {
             models: vec![entry.clone()],
@@ -590,6 +603,7 @@ mod tests {
             hf_filename: None,
             gpu_layers: 0,
             backend: "GGUF".into(),
+            idle_timeout_secs: None,
         };
 
         register_local_model_entry(&mut registry, &entry).unwrap();
@@ -618,6 +632,7 @@ mod tests {
             hf_filename: None,
             gpu_layers: 0,
             backend: "GGUF".into(),
+            idle_timeout_secs: None,
         };
         let stale_entry = LocalModelEntry {
             model_id: "custom-stale".into(),
@@ -626,6 +641,7 @@ mod tests {
             hf_filename: None,
             gpu_layers: 0,
             backend: "GGUF".into(),
+            idle_timeout_secs: None,
         };
         let active_entry = LocalModelEntry {
             model_id: custom_gguf_model_id(repo, "Qwen3-4B-Q6_K.gguf"),
@@ -634,6 +650,7 @@ mod tests {
             hf_filename: None,
             gpu_layers: 0,
             backend: "GGUF".into(),
+            idle_timeout_secs: None,
         };
 
         let mut registry = ProviderRegistry::empty();

--- a/crates/gateway/src/methods/services/system.rs
+++ b/crates/gateway/src/methods/services/system.rs
@@ -1084,6 +1084,48 @@ pub(super) fn register(reg: &mut MethodRegistry) {
         }),
     );
 
+    reg.register(
+        "providers.local.load",
+        Box::new(|ctx| {
+            Box::pin(async move {
+                ctx.state
+                    .services
+                    .local_llm
+                    .load_model(ctx.params.clone())
+                    .await
+                    .map_err(ErrorShape::from)
+            })
+        }),
+    );
+
+    reg.register(
+        "providers.local.unload",
+        Box::new(|ctx| {
+            Box::pin(async move {
+                ctx.state
+                    .services
+                    .local_llm
+                    .unload_model(ctx.params.clone())
+                    .await
+                    .map_err(ErrorShape::from)
+            })
+        }),
+    );
+
+    reg.register(
+        "providers.local.model_states",
+        Box::new(|ctx| {
+            Box::pin(async move {
+                ctx.state
+                    .services
+                    .local_llm
+                    .model_states()
+                    .await
+                    .map_err(ErrorShape::from)
+            })
+        }),
+    );
+
     // Voicewake
     reg.register(
         "voicewake.get",

--- a/crates/gateway/src/server/prepare_core/post_state.rs
+++ b/crates/gateway/src/server/prepare_core/post_state.rs
@@ -597,6 +597,14 @@ pub(super) async fn complete_startup(
         let provider_config_for_registry_rebuild = provider_config_for_startup_discovery.clone();
         let global_cw_overrides = moltis_providers::extract_cw_overrides(&config.models);
         let env_overrides_for_startup_discovery = config_env_overrides.clone();
+        #[cfg(feature = "local-llm")]
+        let local_llm_svc_for_discovery = local_llm_service.clone();
+        #[cfg(feature = "local-llm")]
+        let global_timeout_for_discovery = config
+            .providers
+            .get("local")
+            .or_else(|| config.providers.get("local-llm"))
+            .and_then(|e| e.idle_timeout_secs);
         tokio::spawn(async move {
             let startup_discovery_started = std::time::Instant::now();
             let prefetched = match tokio::task::spawn_blocking(move || {
@@ -644,6 +652,14 @@ pub(super) async fn complete_startup(
             {
                 let mut reg = registry_for_startup_discovery.write().await;
                 *reg = new_registry;
+            }
+
+            // Re-populate the lifecycle manager so it tracks the same
+            // Arcs the rebuilt registry uses for inference.
+            #[cfg(feature = "local-llm")]
+            if let Some(svc) = &local_llm_svc_for_discovery {
+                svc.lifecycle().clear().await;
+                svc.populate_lifecycle(global_timeout_for_discovery).await;
             }
 
             info!(

--- a/crates/gateway/src/server/prepare_core/post_state.rs
+++ b/crates/gateway/src/server/prepare_core/post_state.rs
@@ -523,6 +523,15 @@ pub(super) async fn complete_startup(
     #[cfg(feature = "local-llm")]
     if let Some(svc) = &local_llm_service {
         svc.set_state(Arc::clone(&state));
+
+        // Register existing local models with the lifecycle manager and start idle checker.
+        let global_timeout = config
+            .providers
+            .get("local")
+            .or_else(|| config.providers.get("local-llm"))
+            .and_then(|e| e.idle_timeout_secs);
+        svc.populate_lifecycle(global_timeout).await;
+        svc.lifecycle().spawn_idle_checker();
     }
 
     provider_setup_service.set_broadcaster(Arc::new(crate::provider_setup::GatewayBroadcaster {

--- a/crates/gateway/src/server/tests_legacy/llm.rs
+++ b/crates/gateway/src/server/tests_legacy/llm.rs
@@ -18,6 +18,7 @@ fn restore_saved_local_llm_models_rehydrates_custom_models_after_registry_rebuil
         hf_filename: Some("Qwen3-4B-Q4_K_M.gguf".into()),
         gpu_layers: 0,
         backend: "GGUF".into(),
+        idle_timeout_secs: None,
     };
     crate::local_llm_setup::LocalLlmConfig {
         models: vec![saved_entry.clone()],
@@ -77,6 +78,7 @@ fn restore_saved_local_llm_models_skips_when_local_provider_is_disabled() {
         hf_filename: Some("Qwen3-4B-Q4_K_M.gguf".into()),
         gpu_layers: 0,
         backend: "GGUF".into(),
+        idle_timeout_secs: None,
     };
     crate::local_llm_setup::LocalLlmConfig {
         models: vec![saved_entry.clone()],

--- a/crates/providers/src/local_llm/backend.rs
+++ b/crates/providers/src/local_llm/backend.rs
@@ -68,6 +68,11 @@ pub trait LocalBackend: Send + Sync {
     /// Get the context window size.
     fn context_window(&self) -> u32;
 
+    /// Approximate model size in bytes (for display and lifecycle events).
+    fn model_size_bytes(&self) -> u64 {
+        0
+    }
+
     /// Whether this backend supports grammar-constrained tool calling.
     fn supports_tools(&self) -> bool {
         false
@@ -506,6 +511,10 @@ pub mod gguf {
 
         fn context_window(&self) -> u32 {
             self.context_size
+        }
+
+        fn model_size_bytes(&self) -> u64 {
+            self.model.model_size_bytes
         }
 
         fn supports_tools(&self) -> bool {

--- a/crates/providers/src/local_llm/models.rs
+++ b/crates/providers/src/local_llm/models.rs
@@ -203,6 +203,28 @@ pub static MODEL_REGISTRY: &[LocalModelDef] = &[
     },
     // ── 32GB tier (Large) ──────────────────────────────────────────────────
     LocalModelDef {
+        id: "qwen3.6-35b-a3b-q4_k_m",
+        display_name: "Qwen 3.6 35B-A3B MoE (Q4_K_M)",
+        gguf_repo: "unsloth/Qwen3.6-35B-A3B-GGUF",
+        gguf_filename: "Qwen3.6-35B-A3B-UD-Q4_K_M.gguf",
+        mlx_repo: Some("mlx-community/Qwen3.6-35B-A3B-4bit"),
+        min_ram_gb: 32,
+        context_window: 262_144,
+        chat_template: Some(ChatTemplateHint::ChatML),
+        format: ModelFormat::Gguf,
+    },
+    LocalModelDef {
+        id: "qwen3.6-27b-q4_k_m",
+        display_name: "Qwen 3.6 27B (Q4_K_M)",
+        gguf_repo: "unsloth/Qwen3.6-27B-GGUF",
+        gguf_filename: "Qwen3.6-27B-Q4_K_M.gguf",
+        mlx_repo: Some("mlx-community/Qwen3.6-27B-4bit"),
+        min_ram_gb: 32,
+        context_window: 262_144,
+        chat_template: Some(ChatTemplateHint::ChatML),
+        format: ModelFormat::Gguf,
+    },
+    LocalModelDef {
         id: "qwen2.5-coder-32b-q4_k_m",
         display_name: "Qwen 2.5 Coder 32B (Q4_K_M)",
         gguf_repo: "Qwen/Qwen2.5-Coder-32B-Instruct-GGUF",

--- a/crates/providers/src/local_llm/provider.rs
+++ b/crates/providers/src/local_llm/provider.rs
@@ -1,4 +1,8 @@
-use std::{path::PathBuf, pin::Pin};
+use std::{
+    path::PathBuf,
+    pin::Pin,
+    sync::atomic::{AtomicI64, Ordering},
+};
 
 use {
     anyhow::Result, async_trait::async_trait, tokio::sync::RwLock, tokio_stream::Stream,
@@ -45,11 +49,20 @@ impl Default for LocalLlmConfig {
 /// Local LLM provider with lazy loading.
 ///
 /// Automatically selects the best backend for the current platform and
-/// loads the model on first use.
+/// loads the model on first use. Supports on-demand unloading to free RAM.
 pub struct LocalLlmProvider {
     config: LocalLlmConfig,
     inner: RwLock<Option<Box<dyn backend::LocalBackend>>>,
     selected_backend: RwLock<Option<backend::BackendType>>,
+    /// Unix timestamp (seconds) of the last `complete()` or `stream()` call.
+    last_activity: AtomicI64,
+}
+
+fn now_secs() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs() as i64
 }
 
 impl LocalLlmProvider {
@@ -59,7 +72,13 @@ impl LocalLlmProvider {
             config,
             inner: RwLock::new(None),
             selected_backend: RwLock::new(None),
+            last_activity: AtomicI64::new(0),
         }
+    }
+
+    /// Get the model ID for this provider.
+    pub fn model_id(&self) -> &str {
+        &self.config.model_id
     }
 
     /// Get the backend type that will be (or was) used.
@@ -72,12 +91,46 @@ impl LocalLlmProvider {
             .unwrap_or_else(backend::detect_best_backend)
     }
 
-    /// Ensure the backend is loaded.
-    async fn ensure_loaded(&self) -> Result<()> {
+    /// Whether the model backend is currently loaded in memory.
+    pub async fn is_loaded(&self) -> bool {
+        self.inner.read().await.is_some()
+    }
+
+    /// Unix timestamp (seconds) of the most recent inference call.
+    pub fn last_activity_secs(&self) -> i64 {
+        self.last_activity.load(Ordering::Relaxed)
+    }
+
+    /// Model size in bytes if the backend is loaded, 0 otherwise.
+    pub async fn model_size_bytes(&self) -> u64 {
+        self.inner
+            .read()
+            .await
+            .as_ref()
+            .map_or(0, |b| b.model_size_bytes())
+    }
+
+    /// Drop the loaded backend to free RAM.
+    ///
+    /// Returns `true` if the backend was loaded and has now been dropped.
+    /// The next `complete()`/`stream()` call will reload from disk.
+    pub async fn unload(&self) -> bool {
+        let mut guard = self.inner.write().await;
+        if guard.is_some() {
+            *guard = None;
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Ensure the backend is loaded, updating last-activity.
+    pub async fn ensure_loaded(&self) -> Result<()> {
         // Fast path: check if already loaded
         {
             let guard = self.inner.read().await;
             if guard.is_some() {
+                self.touch_activity();
                 return Ok(());
             }
         }
@@ -87,6 +140,7 @@ impl LocalLlmProvider {
 
         // Double-check after acquiring write lock
         if guard.is_some() {
+            self.touch_activity();
             return Ok(());
         }
 
@@ -105,7 +159,12 @@ impl LocalLlmProvider {
         let backend = backend::create_backend(backend_type, &self.config).await?;
         *guard = Some(backend);
 
+        self.touch_activity();
         Ok(())
+    }
+
+    fn touch_activity(&self) {
+        self.last_activity.store(now_secs(), Ordering::Relaxed);
     }
 }
 
@@ -136,16 +195,19 @@ impl LlmProvider for LocalLlmProvider {
         tools: &[serde_json::Value],
     ) -> Result<CompletionResponse> {
         self.ensure_loaded().await?;
+        self.touch_activity();
 
         let guard = self.inner.read().await;
         let backend = guard
             .as_ref()
             .ok_or_else(|| anyhow::anyhow!("backend should be loaded after ensure_loaded"))?;
-        if tools.is_empty() {
+        let result = if tools.is_empty() {
             backend.complete(messages).await
         } else {
             backend.complete_with_tools(messages, tools).await
-        }
+        };
+        self.touch_activity();
+        result
     }
 
     fn stream(
@@ -157,6 +219,7 @@ impl LlmProvider for LocalLlmProvider {
                 yield StreamEvent::Error(format!("failed to load model: {e}"));
                 return;
             }
+            self.touch_activity();
 
             let guard = self.inner.read().await;
             let Some(backend) = guard.as_ref() else {
@@ -168,6 +231,7 @@ impl LlmProvider for LocalLlmProvider {
             while let Some(event) = futures::StreamExt::next(&mut stream).await {
                 yield event;
             }
+            self.touch_activity();
         })
     }
 }
@@ -233,5 +297,33 @@ mod tests {
         let backends = backend::available_backends();
         // GGUF should always be available when compiled with local-llm feature
         assert!(backends.contains(&backend::BackendType::Gguf));
+    }
+
+    #[tokio::test]
+    async fn test_is_loaded_default_false() {
+        let provider = LocalLlmProvider::new(LocalLlmConfig::default());
+        assert!(!provider.is_loaded().await);
+    }
+
+    #[tokio::test]
+    async fn test_unload_when_not_loaded() {
+        let provider = LocalLlmProvider::new(LocalLlmConfig::default());
+        assert!(!provider.unload().await);
+    }
+
+    #[test]
+    fn test_last_activity_default_zero() {
+        let provider = LocalLlmProvider::new(LocalLlmConfig::default());
+        assert_eq!(provider.last_activity_secs(), 0);
+    }
+
+    #[test]
+    fn test_model_id() {
+        let config = LocalLlmConfig {
+            model_id: "test-model".into(),
+            ..Default::default()
+        };
+        let provider = LocalLlmProvider::new(config);
+        assert_eq!(provider.model_id(), "test-model");
     }
 }

--- a/crates/service-traits/src/interfaces.rs
+++ b/crates/service-traits/src/interfaces.rs
@@ -1141,6 +1141,9 @@ pub trait LocalLlmService: Send + Sync {
     async fn search_hf(&self, params: Value) -> ServiceResult;
     async fn configure_custom(&self, params: Value) -> ServiceResult;
     async fn remove_model(&self, params: Value) -> ServiceResult;
+    async fn load_model(&self, params: Value) -> ServiceResult;
+    async fn unload_model(&self, params: Value) -> ServiceResult;
+    async fn model_states(&self) -> ServiceResult;
 }
 
 pub struct NoopLocalLlmService;
@@ -1172,6 +1175,18 @@ impl LocalLlmService for NoopLocalLlmService {
     }
 
     async fn remove_model(&self, _params: Value) -> ServiceResult {
+        Err("local-llm feature not enabled".into())
+    }
+
+    async fn load_model(&self, _params: Value) -> ServiceResult {
+        Err("local-llm feature not enabled".into())
+    }
+
+    async fn unload_model(&self, _params: Value) -> ServiceResult {
+        Err("local-llm feature not enabled".into())
+    }
+
+    async fn model_states(&self) -> ServiceResult {
         Err("local-llm feature not enabled".into())
     }
 }

--- a/crates/web/src/assets/dist/chunks/onboarding-view.js
+++ b/crates/web/src/assets/dist/chunks/onboarding-view.js
@@ -13,6 +13,7 @@ var WsEventName = /* @__PURE__ */ ((WsEventName2) => {
   WsEventName2["SandboxHostProvision"] = "sandbox.host.provision";
   WsEventName2["BrowserImagePull"] = "browser.image.pull";
   WsEventName2["LocalLlmDownload"] = "local-llm.download";
+  WsEventName2["LocalLlmLifecycle"] = "local-llm.lifecycle";
   WsEventName2["ModelsUpdated"] = "models.updated";
   WsEventName2["LocationRequest"] = "location.request";
   WsEventName2["NetworkAuditEntry"] = "network.audit.entry";

--- a/crates/web/src/assets/dist/main.js
+++ b/crates/web/src/assets/dist/main.js
@@ -11884,7 +11884,7 @@ function initModelLifecycleTracking() {
     if (!p.modelId) return;
     const existing = modelStates[p.modelId];
     if (existing) {
-      existing.is_loaded = p.state === "loaded" || p.state === "loading";
+      existing.is_loaded = p.state === "loaded";
       existing.memory_bytes = p.modelSizeBytes ?? existing.memory_bytes;
     }
   });
@@ -34242,6 +34242,7 @@ function startApp() {
   }
   mount(path);
   connect();
+  initModelLifecycleTracking();
   fetchBootstrap();
   initInstallBanner();
 }

--- a/crates/web/src/assets/dist/main.js
+++ b/crates/web/src/assets/dist/main.js
@@ -11932,10 +11932,14 @@ function createLifecycleButton(modelId, container) {
     btn2.disabled = true;
     btn2.textContent = isLoaded ? "Unloading..." : "Loading...";
     const success = isLoaded ? await unloadModel(modelId) : await loadModel(modelId);
-    if (success) {
-      await refreshModelStates();
-    }
+    await refreshModelStates();
     container.textContent = "";
+    if (!success) {
+      const err = document.createElement("span");
+      err.className = "text-xs text-[var(--error)] mr-2";
+      err.textContent = "Failed";
+      container.appendChild(err);
+    }
     createLifecycleButton(modelId, container);
   });
   container.appendChild(btn2);

--- a/crates/web/src/assets/dist/main.js
+++ b/crates/web/src/assets/dist/main.js
@@ -1,7 +1,7 @@
 const __vite__mapDeps=(i,m=__vite__mapDeps,d=(m.f||(m.f=["chunks/index.js","chunks/theme.js","chunks/open-modal.js","chunks/ws-connect.js","chunks/branding.js","chunks/voice-utils.js","chunks/time-format.js"])))=>i.map(i=>d[i]);
 var _a, _b;
 import { u, f as forceReconnect, c as connectWs, s as subscribeEvents, _ as _wsConnect } from "./chunks/ws-connect.js";
-import { $, s as sessionTokens, f as formatTokens$1, c as chatMsgBox, u as updateCountdown, p as parseErrorMessage, a as chatInput, b as sendRpc, d as autoScrollMode, e as commandModeEnabled, g as sessionExecPromptSymbol, h as chatBatchLoading, i as sessionContextWindow, j as sessionToolsEnabled, k as sessionExecMode, l as sessionCurrentInputTokens, _ as __vitePreload, m as setUnseenErrors, n as setUnseenWarns, o as unseenErrors, q as unseenWarns, r as connected, t as sessionStore, v as sessions, w as activeSessionKey, x as lastHistoryIndex, y as setLastHistoryIndex, z as renderAudioPlayer, A as renderMarkdown, B as setSessionContextWindow, C as setSessionTokens, D as setSessionCurrentInputTokens, E as setSessionToolsEnabled, F as toolCallSummary, G as renderScreenshot, H as renderDocument, I as formatAssistantTokenUsage, J as formatTokenSpeed, K as tokenSpeedTone, L as modelStore, M as parseAgentsListPayload, N as setHostExecIsRoot, O as setSessionExecMode, P as setSessionExecPromptSymbol, Q as setChatBatchLoading, R as setChatSeq, S as y, T as g, U as nodeComboBtn, V as nodeDropdownList, W as nodeCombo, X as nodeDropdown, Y as nodeComboLabel, Z as projectComboLabel, a0 as t, a1 as projects, a2 as activeProjectId, a3 as projectCombo, a4 as projectDropdown, a5 as projectDropdownList, a6 as setActiveProjectId, a7 as projectComboBtn, a8 as j, a9 as setSessionSandboxEnabled, aa as hostExecIsRoot, ab as sandboxLabel, ac as sandboxToggleBtn, ad as sessionSandboxEnabled, ae as setSessionSandboxImage, af as sandboxImageLabel, ag as sandboxInfo, ah as sandboxImageDropdown, ai as sandboxImageBtn, aj as sessionSandboxImage, ak as projectStore, al as setSessions, am as insertSessionInOrder, an as Session, ao as chatSeq, ap as setSelectedModelId, aq as modelComboLabel, ar as setSessionSwitchInProgress, as as setStreamEl, at as setStreamText, au as setLastToolOutput, av as setVoicePending, aw as setActiveSessionKey, ax as y$1, ay as d, az as A, aA as S, aB as projectFilterId, aC as getById$1, aD as q, aE as setProjects, aF as setProjectFilterId, aG as warmAudioPlayback, aH as selectedModelId, aI as formatBytes$4, aJ as setCommandModeEnabled, aK as chatHistory, aL as chatHistoryIdx, aM as setChatHistoryDraft, aN as setChatHistoryIdx, aO as chatHistoryDraft, aP as setChatHistory, aQ as R, aR as setChatMsgBox, aS as setChatInput, aT as setChatSendBtn, aU as setModelCombo, aV as setModelComboBtn, aW as setModelComboLabel, aX as setModelDropdown, aY as setModelSearchInput, aZ as setModelDropdownList, a_ as setNodeCombo, a$ as setNodeComboBtn, b0 as setNodeComboLabel, b1 as setNodeDropdown, b2 as setNodeDropdownList, b3 as setSandboxToggleBtn, b4 as setSandboxLabel, b5 as setProjectCombo, b6 as setProjectComboBtn, b7 as setProjectComboLabel, b8 as setProjectDropdown, b9 as setProjectDropdownList, ba as setSandboxImageBtn, bb as setSandboxImageLabel, bc as setSandboxImageDropdown, bd as models, be as chatSendBtn, bf as setModels, bg as modelComboBtn, bh as modelSearchInput, bi as modelDropdownList, bj as modelCombo, bk as modelDropdown, bl as setModelIdx, bm as modelIdx, bn as REASONING_SEP, bo as models$1, bp as useSignal, bq as connected$1, br as setCachedChannels, bs as setRefreshChannelsPage, bt as cachedChannels, bu as setChannelEventUnsub, bv as channelEventUnsub, bw as refreshProvidersPage, bx as modelVersionScore, by as streamEl, bz as renderMapPointGroups, bA as renderMapLinks, bB as lastToolOutput, bC as localizeStructuredError, bD as voicePending, bE as streamText, bF as setSandboxInfo, bG as networkAuditEventHandler, bH as logsEventHandler, bI as setSubscribed, bJ as projects$1, bK as sandboxInfo$1, bL as localizedApiErrorMessage, bM as setLogsEventHandler, bN as setNetworkAuditEventHandler, bO as setRefreshProvidersPage, bP as setLocale, bQ as esc, bR as projectStore$1, bS as _modelStore, bT as S$1, bU as _sessionStoreModule, bV as _i18n, bW as _helpers, bX as initTheme, bY as injectMarkdownStyles, bZ as init, b_ as translateStaticElements, b$ as setAll$1, c0 as setAll$2, c1 as select$1, c2 as selectedModelId$1 } from "./chunks/theme.js";
+import { $, s as sessionTokens, f as formatTokens$1, c as chatMsgBox, u as updateCountdown, p as parseErrorMessage, a as chatInput, b as sendRpc, d as autoScrollMode, e as commandModeEnabled, g as sessionExecPromptSymbol, h as chatBatchLoading, i as sessionContextWindow, j as sessionToolsEnabled, k as sessionExecMode, l as sessionCurrentInputTokens, _ as __vitePreload, m as setUnseenErrors, n as setUnseenWarns, o as unseenErrors, q as unseenWarns, r as connected, t as sessionStore, v as sessions, w as activeSessionKey, x as lastHistoryIndex, y as setLastHistoryIndex, z as renderAudioPlayer, A as renderMarkdown, B as setSessionContextWindow, C as setSessionTokens, D as setSessionCurrentInputTokens, E as setSessionToolsEnabled, F as toolCallSummary, G as renderScreenshot, H as renderDocument, I as formatAssistantTokenUsage, J as formatTokenSpeed, K as tokenSpeedTone, L as modelStore, M as parseAgentsListPayload, N as setHostExecIsRoot, O as setSessionExecMode, P as setSessionExecPromptSymbol, Q as setChatBatchLoading, R as setChatSeq, S as y, T as g, U as nodeComboBtn, V as nodeDropdownList, W as nodeCombo, X as nodeDropdown, Y as nodeComboLabel, Z as projectComboLabel, a0 as t, a1 as projects, a2 as activeProjectId, a3 as projectCombo, a4 as projectDropdown, a5 as projectDropdownList, a6 as setActiveProjectId, a7 as projectComboBtn, a8 as j, a9 as setSessionSandboxEnabled, aa as hostExecIsRoot, ab as sandboxLabel, ac as sandboxToggleBtn, ad as sessionSandboxEnabled, ae as setSessionSandboxImage, af as sandboxImageLabel, ag as sandboxInfo, ah as sandboxImageDropdown, ai as sandboxImageBtn, aj as sessionSandboxImage, ak as projectStore, al as setSessions, am as insertSessionInOrder, an as Session, ao as chatSeq, ap as setSelectedModelId, aq as modelComboLabel, ar as setSessionSwitchInProgress, as as setStreamEl, at as setStreamText, au as setLastToolOutput, av as setVoicePending, aw as setActiveSessionKey, ax as y$1, ay as d, az as A, aA as S, aB as projectFilterId, aC as getById$1, aD as q, aE as setProjects, aF as setProjectFilterId, aG as warmAudioPlayback, aH as selectedModelId, aI as formatBytes$3, aJ as setCommandModeEnabled, aK as chatHistory, aL as chatHistoryIdx, aM as setChatHistoryDraft, aN as setChatHistoryIdx, aO as chatHistoryDraft, aP as setChatHistory, aQ as R, aR as setChatMsgBox, aS as setChatInput, aT as setChatSendBtn, aU as setModelCombo, aV as setModelComboBtn, aW as setModelComboLabel, aX as setModelDropdown, aY as setModelSearchInput, aZ as setModelDropdownList, a_ as setNodeCombo, a$ as setNodeComboBtn, b0 as setNodeComboLabel, b1 as setNodeDropdown, b2 as setNodeDropdownList, b3 as setSandboxToggleBtn, b4 as setSandboxLabel, b5 as setProjectCombo, b6 as setProjectComboBtn, b7 as setProjectComboLabel, b8 as setProjectDropdown, b9 as setProjectDropdownList, ba as setSandboxImageBtn, bb as setSandboxImageLabel, bc as setSandboxImageDropdown, bd as models, be as chatSendBtn, bf as setModels, bg as modelComboBtn, bh as modelSearchInput, bi as modelDropdownList, bj as modelCombo, bk as modelDropdown, bl as setModelIdx, bm as modelIdx, bn as REASONING_SEP, bo as models$1, bp as useSignal, bq as connected$1, br as setCachedChannels, bs as setRefreshChannelsPage, bt as cachedChannels, bu as setChannelEventUnsub, bv as channelEventUnsub, bw as refreshProvidersPage, bx as modelVersionScore, by as streamEl, bz as renderMapPointGroups, bA as renderMapLinks, bB as lastToolOutput, bC as localizeStructuredError, bD as voicePending, bE as streamText, bF as setSandboxInfo, bG as networkAuditEventHandler, bH as logsEventHandler, bI as setSubscribed, bJ as projects$1, bK as sandboxInfo$1, bL as localizedApiErrorMessage, bM as setLogsEventHandler, bN as setNetworkAuditEventHandler, bO as setRefreshProvidersPage, bP as setLocale, bQ as esc, bR as projectStore$1, bS as _modelStore, bT as S$1, bU as _sessionStoreModule, bV as _i18n, bW as _helpers, bX as initTheme, bY as injectMarkdownStyles, bZ as init, b_ as translateStaticElements, b$ as setAll$1, c0 as setAll$2, c1 as select$1, c2 as selectedModelId$1 } from "./chunks/theme.js";
 import { f as formatPageTitle, a as applyIdentityFavicon } from "./chunks/branding.js";
 import { g as get, o as onEvent, C as ChannelType, a as onChange, t as targetValue, v as validateChannelFields, p as parseChannelConfigPatch, b as addChannel, M as MATRIX_DEFAULT_HOMESERVER, c as MATRIX_ENCRYPTION_GUIDANCE, n as normalizeMatrixAuthMode, m as matrixAuthModeGuidance, d as targetChecked, e as normalizeMatrixOwnershipMode, f as matrixOwnershipModeGuidance, h as matrixCredentialLabel, i as matrixCredentialPlaceholder, j as MATRIX_DOCS_URL, k as deriveMatrixAccountId, l as normalizeMatrixOtpCooldown, q as fetchChannelStatus, r as deriveSignalAccountId, s as buildTeamsEndpoint, u as generateWebhookSecretHex, w as defaultTeamsBaseUrl, T as TabBar$1, x as channelStorageNote, y as providerApiKeyHelp, z as validateProviderKey, A as completeProviderOAuth, B as startProviderOAuth, D as saveProviderKey, E as testModel, F as isModelServiceNotConfigured, G as isTimeoutError, H as humanizeProbeError, I as eventListeners, J as refresh, K as isRepoSource, S as SkillSource, L as CATEGORY_META, N as categoryLabel, O as isDiscoveredSource, P as EmojiPicker, Q as validateIdentityFields, R as updateIdentity, U as set, V as prepareCreationOptions, W as detectPasskeyName, X as fetchVoiceProviders, Y as fetchPhrase, Z as testTts, _ as decodeBase64Safe, $ as transcribeAudio$1, a0 as toggleVoiceProvider, a1 as saveVoiceKey, a2 as saveVoiceSettings, a3 as gon, a4 as _events } from "./chunks/voice-utils.js";
 import "./chunks/time-format.js";
@@ -5629,7 +5629,7 @@ function renderContextProjectSection(card, data) {
       ctxFiles.forEach((f) => {
         const row = ctxEl("div", "ctx-file");
         row.appendChild(ctxEl("span", "ctx-file-path", f.path));
-        row.appendChild(ctxEl("span", "ctx-file-size", formatBytes$4(f.size ?? 0)));
+        row.appendChild(ctxEl("span", "ctx-file-size", formatBytes$3(f.size ?? 0)));
         sec.appendChild(row);
       });
     }
@@ -11901,49 +11901,6 @@ async function refreshModelStates() {
 function getModelState(modelId) {
   return modelStates[modelId];
 }
-async function loadModel(modelId) {
-  const res = await sendRpc("providers.local.load", { modelId });
-  return !!(res == null ? void 0 : res.ok);
-}
-async function unloadModel(modelId) {
-  const res = await sendRpc("providers.local.unload", { modelId });
-  return !!(res == null ? void 0 : res.ok);
-}
-function formatBytes$3(bytes) {
-  if (bytes < 1024) return `${bytes} B`;
-  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
-  if (bytes < 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
-  return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)} GB`;
-}
-function createLifecycleButton(modelId, container) {
-  const state = modelStates[modelId];
-  const isLoaded = (state == null ? void 0 : state.is_loaded) ?? false;
-  const btn2 = document.createElement("button");
-  btn2.className = isLoaded ? "provider-btn-danger text-xs px-2 py-1" : "provider-btn-secondary text-xs px-2 py-1";
-  btn2.textContent = isLoaded ? "Unload" : "Load";
-  if (isLoaded && (state == null ? void 0 : state.memory_bytes)) {
-    const badge = document.createElement("span");
-    badge.className = "text-xs text-[var(--muted)] ml-2";
-    badge.textContent = formatBytes$3(state.memory_bytes);
-    container.appendChild(badge);
-  }
-  btn2.addEventListener("click", async (e) => {
-    e.stopPropagation();
-    btn2.disabled = true;
-    btn2.textContent = isLoaded ? "Unloading..." : "Loading...";
-    const success = isLoaded ? await unloadModel(modelId) : await loadModel(modelId);
-    await refreshModelStates();
-    container.textContent = "";
-    if (!success) {
-      const err = document.createElement("span");
-      err.className = "text-xs text-[var(--error)] mr-2";
-      err.textContent = "Failed";
-      container.appendChild(err);
-    }
-    createLifecycleButton(modelId, container);
-  });
-  container.appendChild(btn2);
-}
 function showLocalModelFlow(provider) {
   const m = els();
   m.title.textContent = provider.displayName;
@@ -12527,20 +12484,16 @@ function pollLocalStatus(model, _provider, statusEl2, progressEl, offEvent) {
 const _providers = /* @__PURE__ */ Object.freeze(/* @__PURE__ */ Object.defineProperty({
   __proto__: null,
   closeProviderModal,
-  createLifecycleButton,
   getModelState,
   getProviderModal,
   initModelLifecycleTracking,
-  loadModel,
   openModelSelectorForProvider,
   openProviderModal,
-  refreshModelStates,
   showApiKeyForm,
   showCustomProviderForm,
   showLocalModelFlow,
   showModelDownloadProgress,
-  showOAuthFlow,
-  unloadModel
+  showOAuthFlow
 }, Symbol.toStringTag, { value: "Module" }));
 let deferredInstallPrompt = null;
 let swRegistration = null;

--- a/crates/web/src/assets/dist/main.js
+++ b/crates/web/src/assets/dist/main.js
@@ -1,7 +1,7 @@
 const __vite__mapDeps=(i,m=__vite__mapDeps,d=(m.f||(m.f=["chunks/index.js","chunks/theme.js","chunks/open-modal.js","chunks/ws-connect.js","chunks/branding.js","chunks/voice-utils.js","chunks/time-format.js"])))=>i.map(i=>d[i]);
 var _a, _b;
 import { u, f as forceReconnect, c as connectWs, s as subscribeEvents, _ as _wsConnect } from "./chunks/ws-connect.js";
-import { $, s as sessionTokens, f as formatTokens$1, c as chatMsgBox, u as updateCountdown, p as parseErrorMessage, a as chatInput, b as sendRpc, d as autoScrollMode, e as commandModeEnabled, g as sessionExecPromptSymbol, h as chatBatchLoading, i as sessionContextWindow, j as sessionToolsEnabled, k as sessionExecMode, l as sessionCurrentInputTokens, _ as __vitePreload, m as setUnseenErrors, n as setUnseenWarns, o as unseenErrors, q as unseenWarns, r as connected, t as sessionStore, v as sessions, w as activeSessionKey, x as lastHistoryIndex, y as setLastHistoryIndex, z as renderAudioPlayer, A as renderMarkdown, B as setSessionContextWindow, C as setSessionTokens, D as setSessionCurrentInputTokens, E as setSessionToolsEnabled, F as toolCallSummary, G as renderScreenshot, H as renderDocument, I as formatAssistantTokenUsage, J as formatTokenSpeed, K as tokenSpeedTone, L as modelStore, M as parseAgentsListPayload, N as setHostExecIsRoot, O as setSessionExecMode, P as setSessionExecPromptSymbol, Q as setChatBatchLoading, R as setChatSeq, S as y, T as g, U as nodeComboBtn, V as nodeDropdownList, W as nodeCombo, X as nodeDropdown, Y as nodeComboLabel, Z as projectComboLabel, a0 as t, a1 as projects, a2 as activeProjectId, a3 as projectCombo, a4 as projectDropdown, a5 as projectDropdownList, a6 as setActiveProjectId, a7 as projectComboBtn, a8 as j, a9 as setSessionSandboxEnabled, aa as hostExecIsRoot, ab as sandboxLabel, ac as sandboxToggleBtn, ad as sessionSandboxEnabled, ae as setSessionSandboxImage, af as sandboxImageLabel, ag as sandboxInfo, ah as sandboxImageDropdown, ai as sandboxImageBtn, aj as sessionSandboxImage, ak as projectStore, al as setSessions, am as insertSessionInOrder, an as Session, ao as chatSeq, ap as setSelectedModelId, aq as modelComboLabel, ar as setSessionSwitchInProgress, as as setStreamEl, at as setStreamText, au as setLastToolOutput, av as setVoicePending, aw as setActiveSessionKey, ax as y$1, ay as d, az as A, aA as S, aB as projectFilterId, aC as getById$1, aD as q, aE as setProjects, aF as setProjectFilterId, aG as warmAudioPlayback, aH as selectedModelId, aI as formatBytes$3, aJ as setCommandModeEnabled, aK as chatHistory, aL as chatHistoryIdx, aM as setChatHistoryDraft, aN as setChatHistoryIdx, aO as chatHistoryDraft, aP as setChatHistory, aQ as R, aR as setChatMsgBox, aS as setChatInput, aT as setChatSendBtn, aU as setModelCombo, aV as setModelComboBtn, aW as setModelComboLabel, aX as setModelDropdown, aY as setModelSearchInput, aZ as setModelDropdownList, a_ as setNodeCombo, a$ as setNodeComboBtn, b0 as setNodeComboLabel, b1 as setNodeDropdown, b2 as setNodeDropdownList, b3 as setSandboxToggleBtn, b4 as setSandboxLabel, b5 as setProjectCombo, b6 as setProjectComboBtn, b7 as setProjectComboLabel, b8 as setProjectDropdown, b9 as setProjectDropdownList, ba as setSandboxImageBtn, bb as setSandboxImageLabel, bc as setSandboxImageDropdown, bd as models, be as chatSendBtn, bf as setModels, bg as modelComboBtn, bh as modelSearchInput, bi as modelDropdownList, bj as modelCombo, bk as modelDropdown, bl as setModelIdx, bm as modelIdx, bn as REASONING_SEP, bo as models$1, bp as useSignal, bq as connected$1, br as setCachedChannels, bs as setRefreshChannelsPage, bt as cachedChannels, bu as setChannelEventUnsub, bv as channelEventUnsub, bw as refreshProvidersPage, bx as modelVersionScore, by as streamEl, bz as renderMapPointGroups, bA as renderMapLinks, bB as lastToolOutput, bC as localizeStructuredError, bD as voicePending, bE as streamText, bF as setSandboxInfo, bG as networkAuditEventHandler, bH as logsEventHandler, bI as setSubscribed, bJ as projects$1, bK as sandboxInfo$1, bL as localizedApiErrorMessage, bM as setLogsEventHandler, bN as setNetworkAuditEventHandler, bO as setRefreshProvidersPage, bP as setLocale, bQ as esc, bR as projectStore$1, bS as _modelStore, bT as S$1, bU as _sessionStoreModule, bV as _i18n, bW as _helpers, bX as initTheme, bY as injectMarkdownStyles, bZ as init, b_ as translateStaticElements, b$ as setAll$1, c0 as setAll$2, c1 as select$1, c2 as selectedModelId$1 } from "./chunks/theme.js";
+import { $, s as sessionTokens, f as formatTokens$1, c as chatMsgBox, u as updateCountdown, p as parseErrorMessage, a as chatInput, b as sendRpc, d as autoScrollMode, e as commandModeEnabled, g as sessionExecPromptSymbol, h as chatBatchLoading, i as sessionContextWindow, j as sessionToolsEnabled, k as sessionExecMode, l as sessionCurrentInputTokens, _ as __vitePreload, m as setUnseenErrors, n as setUnseenWarns, o as unseenErrors, q as unseenWarns, r as connected, t as sessionStore, v as sessions, w as activeSessionKey, x as lastHistoryIndex, y as setLastHistoryIndex, z as renderAudioPlayer, A as renderMarkdown, B as setSessionContextWindow, C as setSessionTokens, D as setSessionCurrentInputTokens, E as setSessionToolsEnabled, F as toolCallSummary, G as renderScreenshot, H as renderDocument, I as formatAssistantTokenUsage, J as formatTokenSpeed, K as tokenSpeedTone, L as modelStore, M as parseAgentsListPayload, N as setHostExecIsRoot, O as setSessionExecMode, P as setSessionExecPromptSymbol, Q as setChatBatchLoading, R as setChatSeq, S as y, T as g, U as nodeComboBtn, V as nodeDropdownList, W as nodeCombo, X as nodeDropdown, Y as nodeComboLabel, Z as projectComboLabel, a0 as t, a1 as projects, a2 as activeProjectId, a3 as projectCombo, a4 as projectDropdown, a5 as projectDropdownList, a6 as setActiveProjectId, a7 as projectComboBtn, a8 as j, a9 as setSessionSandboxEnabled, aa as hostExecIsRoot, ab as sandboxLabel, ac as sandboxToggleBtn, ad as sessionSandboxEnabled, ae as setSessionSandboxImage, af as sandboxImageLabel, ag as sandboxInfo, ah as sandboxImageDropdown, ai as sandboxImageBtn, aj as sessionSandboxImage, ak as projectStore, al as setSessions, am as insertSessionInOrder, an as Session, ao as chatSeq, ap as setSelectedModelId, aq as modelComboLabel, ar as setSessionSwitchInProgress, as as setStreamEl, at as setStreamText, au as setLastToolOutput, av as setVoicePending, aw as setActiveSessionKey, ax as y$1, ay as d, az as A, aA as S, aB as projectFilterId, aC as getById$1, aD as q, aE as setProjects, aF as setProjectFilterId, aG as warmAudioPlayback, aH as selectedModelId, aI as formatBytes$4, aJ as setCommandModeEnabled, aK as chatHistory, aL as chatHistoryIdx, aM as setChatHistoryDraft, aN as setChatHistoryIdx, aO as chatHistoryDraft, aP as setChatHistory, aQ as R, aR as setChatMsgBox, aS as setChatInput, aT as setChatSendBtn, aU as setModelCombo, aV as setModelComboBtn, aW as setModelComboLabel, aX as setModelDropdown, aY as setModelSearchInput, aZ as setModelDropdownList, a_ as setNodeCombo, a$ as setNodeComboBtn, b0 as setNodeComboLabel, b1 as setNodeDropdown, b2 as setNodeDropdownList, b3 as setSandboxToggleBtn, b4 as setSandboxLabel, b5 as setProjectCombo, b6 as setProjectComboBtn, b7 as setProjectComboLabel, b8 as setProjectDropdown, b9 as setProjectDropdownList, ba as setSandboxImageBtn, bb as setSandboxImageLabel, bc as setSandboxImageDropdown, bd as models, be as chatSendBtn, bf as setModels, bg as modelComboBtn, bh as modelSearchInput, bi as modelDropdownList, bj as modelCombo, bk as modelDropdown, bl as setModelIdx, bm as modelIdx, bn as REASONING_SEP, bo as models$1, bp as useSignal, bq as connected$1, br as setCachedChannels, bs as setRefreshChannelsPage, bt as cachedChannels, bu as setChannelEventUnsub, bv as channelEventUnsub, bw as refreshProvidersPage, bx as modelVersionScore, by as streamEl, bz as renderMapPointGroups, bA as renderMapLinks, bB as lastToolOutput, bC as localizeStructuredError, bD as voicePending, bE as streamText, bF as setSandboxInfo, bG as networkAuditEventHandler, bH as logsEventHandler, bI as setSubscribed, bJ as projects$1, bK as sandboxInfo$1, bL as localizedApiErrorMessage, bM as setLogsEventHandler, bN as setNetworkAuditEventHandler, bO as setRefreshProvidersPage, bP as setLocale, bQ as esc, bR as projectStore$1, bS as _modelStore, bT as S$1, bU as _sessionStoreModule, bV as _i18n, bW as _helpers, bX as initTheme, bY as injectMarkdownStyles, bZ as init, b_ as translateStaticElements, b$ as setAll$1, c0 as setAll$2, c1 as select$1, c2 as selectedModelId$1 } from "./chunks/theme.js";
 import { f as formatPageTitle, a as applyIdentityFavicon } from "./chunks/branding.js";
 import { g as get, o as onEvent, C as ChannelType, a as onChange, t as targetValue, v as validateChannelFields, p as parseChannelConfigPatch, b as addChannel, M as MATRIX_DEFAULT_HOMESERVER, c as MATRIX_ENCRYPTION_GUIDANCE, n as normalizeMatrixAuthMode, m as matrixAuthModeGuidance, d as targetChecked, e as normalizeMatrixOwnershipMode, f as matrixOwnershipModeGuidance, h as matrixCredentialLabel, i as matrixCredentialPlaceholder, j as MATRIX_DOCS_URL, k as deriveMatrixAccountId, l as normalizeMatrixOtpCooldown, q as fetchChannelStatus, r as deriveSignalAccountId, s as buildTeamsEndpoint, u as generateWebhookSecretHex, w as defaultTeamsBaseUrl, T as TabBar$1, x as channelStorageNote, y as providerApiKeyHelp, z as validateProviderKey, A as completeProviderOAuth, B as startProviderOAuth, D as saveProviderKey, E as testModel, F as isModelServiceNotConfigured, G as isTimeoutError, H as humanizeProbeError, I as eventListeners, J as refresh, K as isRepoSource, S as SkillSource, L as CATEGORY_META, N as categoryLabel, O as isDiscoveredSource, P as EmojiPicker, Q as validateIdentityFields, R as updateIdentity, U as set, V as prepareCreationOptions, W as detectPasskeyName, X as fetchVoiceProviders, Y as fetchPhrase, Z as testTts, _ as decodeBase64Safe, $ as transcribeAudio$1, a0 as toggleVoiceProvider, a1 as saveVoiceKey, a2 as saveVoiceSettings, a3 as gon, a4 as _events } from "./chunks/voice-utils.js";
 import "./chunks/time-format.js";
@@ -509,11 +509,6 @@ async function ensureLanguageLoaded(lang) {
   await inFlight;
   return highlighter.getLoadedLanguages().includes(lang);
 }
-function applyShikiStylesToPre(codeEl, shikiPre) {
-  const parentPre = codeEl.parentElement;
-  if (!(parentPre && parentPre.tagName === "PRE")) return;
-  parentPre.style.cssText = shikiPre.style.cssText;
-}
 function applyShikiMarkupToCode(codeEl, shikiPre) {
   const shikiCode = shikiPre.querySelector("code");
   if (!shikiCode) return;
@@ -548,7 +543,6 @@ async function highlightCodeElement(codeEl) {
     });
     const shikiPre = parseShikiPre(highlightedHtml ?? "");
     if (!shikiPre) return;
-    applyShikiStylesToPre(codeEl, shikiPre);
     applyShikiMarkupToCode(codeEl, shikiPre);
   } catch (_err) {
   }
@@ -5635,7 +5629,7 @@ function renderContextProjectSection(card, data) {
       ctxFiles.forEach((f) => {
         const row = ctxEl("div", "ctx-file");
         row.appendChild(ctxEl("span", "ctx-file-path", f.path));
-        row.appendChild(ctxEl("span", "ctx-file-size", formatBytes$3(f.size ?? 0)));
+        row.appendChild(ctxEl("span", "ctx-file-size", formatBytes$4(f.size ?? 0)));
         sec.appendChild(row);
       });
     }
@@ -11883,6 +11877,69 @@ function showCustomProviderForm() {
   urlInp.focus();
 }
 let selectedBackend = null;
+const modelStates = {};
+function initModelLifecycleTracking() {
+  onEvent("local-llm.lifecycle", (payload) => {
+    const p = payload;
+    if (!p.modelId) return;
+    const existing = modelStates[p.modelId];
+    if (existing) {
+      existing.is_loaded = p.state === "loaded" || p.state === "loading";
+      existing.memory_bytes = p.modelSizeBytes ?? existing.memory_bytes;
+    }
+  });
+  refreshModelStates();
+}
+async function refreshModelStates() {
+  const res = await sendRpc("providers.local.model_states", {});
+  if ((res == null ? void 0 : res.ok) && Array.isArray(res.payload)) {
+    for (const entry of res.payload) {
+      modelStates[entry.model_id] = entry;
+    }
+  }
+}
+function getModelState(modelId) {
+  return modelStates[modelId];
+}
+async function loadModel(modelId) {
+  const res = await sendRpc("providers.local.load", { modelId });
+  return !!(res == null ? void 0 : res.ok);
+}
+async function unloadModel(modelId) {
+  const res = await sendRpc("providers.local.unload", { modelId });
+  return !!(res == null ? void 0 : res.ok);
+}
+function formatBytes$3(bytes) {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  if (bytes < 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)} GB`;
+}
+function createLifecycleButton(modelId, container) {
+  const state = modelStates[modelId];
+  const isLoaded = (state == null ? void 0 : state.is_loaded) ?? false;
+  const btn2 = document.createElement("button");
+  btn2.className = isLoaded ? "provider-btn-danger text-xs px-2 py-1" : "provider-btn-secondary text-xs px-2 py-1";
+  btn2.textContent = isLoaded ? "Unload" : "Load";
+  if (isLoaded && (state == null ? void 0 : state.memory_bytes)) {
+    const badge = document.createElement("span");
+    badge.className = "text-xs text-[var(--muted)] ml-2";
+    badge.textContent = formatBytes$3(state.memory_bytes);
+    container.appendChild(badge);
+  }
+  btn2.addEventListener("click", async (e) => {
+    e.stopPropagation();
+    btn2.disabled = true;
+    btn2.textContent = isLoaded ? "Unloading..." : "Loading...";
+    const success = isLoaded ? await unloadModel(modelId) : await loadModel(modelId);
+    if (success) {
+      await refreshModelStates();
+    }
+    container.textContent = "";
+    createLifecycleButton(modelId, container);
+  });
+  container.appendChild(btn2);
+}
 function showLocalModelFlow(provider) {
   const m = els();
   m.title.textContent = provider.displayName;
@@ -12466,14 +12523,20 @@ function pollLocalStatus(model, _provider, statusEl2, progressEl, offEvent) {
 const _providers = /* @__PURE__ */ Object.freeze(/* @__PURE__ */ Object.defineProperty({
   __proto__: null,
   closeProviderModal,
+  createLifecycleButton,
+  getModelState,
   getProviderModal,
+  initModelLifecycleTracking,
+  loadModel,
   openModelSelectorForProvider,
   openProviderModal,
+  refreshModelStates,
   showApiKeyForm,
   showCustomProviderForm,
   showLocalModelFlow,
   showModelDownloadProgress,
-  showOAuthFlow
+  showOAuthFlow,
+  unloadModel
 }, Symbol.toStringTag, { value: "Module" }));
 let deferredInstallPrompt = null;
 let swRegistration = null;
@@ -13781,6 +13844,28 @@ function handleLocalLlmDownload(payload) {
     }
   }
 }
+let lifecycleIndicatorEl = null;
+function handleLocalLlmLifecycle(raw) {
+  const isChatPage = currentPrefix === "/chats";
+  if (!isChatPage) return;
+  const payload = raw;
+  const modelName = payload.modelId || "model";
+  if (payload.state === "loading") {
+    if (lifecycleIndicatorEl) {
+      lifecycleIndicatorEl.remove();
+    }
+    lifecycleIndicatorEl = chatAddMsg("system", `Loading model ${modelName} into memory…`);
+  } else if (payload.state === "loaded") {
+    if (lifecycleIndicatorEl) {
+      lifecycleIndicatorEl.remove();
+      lifecycleIndicatorEl = null;
+    }
+    const sizeStr = payload.modelSizeBytes ? ` (${(payload.modelSizeBytes / (1024 * 1024 * 1024)).toFixed(1)} GB)` : "";
+    chatAddMsg("system", `Model ${modelName} loaded${sizeStr}`);
+  } else if (payload.state === "unloaded") {
+    chatAddMsg("system", `Model ${modelName} unloaded after inactivity`);
+  }
+}
 function handleApprovalEvent(payload) {
   renderApprovalCard(payload.requestId, payload.command);
 }
@@ -13869,6 +13954,7 @@ const eventHandlers = {
   "sandbox.host.provision": handleSandboxHostProvision,
   "browser.image.pull": handleBrowserImagePull,
   "local-llm.download": handleLocalLlmDownload,
+  "local-llm.lifecycle": handleLocalLlmLifecycle,
   "models.updated": handleModelsUpdated,
   "location.request": handleLocationRequest,
   "network.audit.entry": handleNetworkAuditEntry

--- a/crates/web/src/assets/dist/main.js
+++ b/crates/web/src/assets/dist/main.js
@@ -13863,7 +13863,8 @@ function handleLocalLlmLifecycle(raw) {
     const sizeStr = payload.modelSizeBytes ? ` (${(payload.modelSizeBytes / (1024 * 1024 * 1024)).toFixed(1)} GB)` : "";
     chatAddMsg("system", `Model ${modelName} loaded${sizeStr}`);
   } else if (payload.state === "unloaded") {
-    chatAddMsg("system", `Model ${modelName} unloaded after inactivity`);
+    const msg = payload.reason === "idle" ? `Model ${modelName} unloaded after inactivity` : `Model ${modelName} unloaded`;
+    chatAddMsg("system", msg);
   }
 }
 function handleApprovalEvent(payload) {

--- a/crates/web/ui/src/app.tsx
+++ b/crates/web/ui/src/app.tsx
@@ -22,6 +22,7 @@ import * as _channelsPage from "./pages/ChannelsPage";
 import { renderSessionProjectSelect } from "./project-combo";
 import { fetchProjects, renderProjectSelect } from "./projects";
 import * as _providers from "./providers";
+import { initModelLifecycleTracking } from "./providers";
 import { initPWA } from "./pwa";
 import { initInstallBanner } from "./pwa-install";
 import { mount, navigate, registerPage, sessionPath } from "./router";
@@ -658,6 +659,7 @@ function startApp(): void {
 	}
 	mount(path);
 	connect();
+	initModelLifecycleTracking();
 	fetchBootstrap();
 	initInstallBanner();
 }

--- a/crates/web/ui/src/providers.ts
+++ b/crates/web/ui/src/providers.ts
@@ -6,14 +6,10 @@
 export { openModelSelectorForProvider, showApiKeyForm, showOAuthFlow } from "./providers/auth-flow";
 export { showCustomProviderForm } from "./providers/custom-provider";
 export {
-	createLifecycleButton,
 	getModelState,
 	initModelLifecycleTracking,
-	loadModel,
-	refreshModelStates,
 	showLocalModelFlow,
 	showModelDownloadProgress,
-	unloadModel,
 } from "./providers/local-models";
 export { closeProviderModal, getProviderModal, openProviderModal } from "./providers/shared";
 export type {

--- a/crates/web/ui/src/providers.ts
+++ b/crates/web/ui/src/providers.ts
@@ -5,16 +5,27 @@
 
 export { openModelSelectorForProvider, showApiKeyForm, showOAuthFlow } from "./providers/auth-flow";
 export { showCustomProviderForm } from "./providers/custom-provider";
-export { showLocalModelFlow, showModelDownloadProgress } from "./providers/local-models";
+export {
+	createLifecycleButton,
+	getModelState,
+	initModelLifecycleTracking,
+	loadModel,
+	refreshModelStates,
+	showLocalModelFlow,
+	showModelDownloadProgress,
+	unloadModel,
+} from "./providers/local-models";
 export { closeProviderModal, getProviderModal, openProviderModal } from "./providers/shared";
 export type {
 	AddCustomPayload,
 	BackendInfo,
 	HfSearchResult,
 	LocalLlmDownloadPayload,
+	LocalLlmLifecyclePayload,
 	LocalModelInfo,
 	ModelEntry,
 	ModelSelectorWrapper,
+	ModelStateEntry,
 	ModelsData,
 	ProbeResult,
 	ProviderInfo,

--- a/crates/web/ui/src/providers/local-models.ts
+++ b/crates/web/ui/src/providers/local-models.ts
@@ -100,11 +100,15 @@ export function createLifecycleButton(modelId: string, container: HTMLElement): 
 		btn.textContent = isLoaded ? "Unloading..." : "Loading...";
 
 		const success = isLoaded ? await unloadModel(modelId) : await loadModel(modelId);
-		if (success) {
-			await refreshModelStates();
-		}
-		// Recreate button with new state
+		await refreshModelStates();
+		// Recreate button with new state (reflects actual server state even on failure)
 		container.textContent = "";
+		if (!success) {
+			const err = document.createElement("span");
+			err.className = "text-xs text-[var(--error)] mr-2";
+			err.textContent = "Failed";
+			container.appendChild(err);
+		}
 		createLifecycleButton(modelId, container);
 	});
 

--- a/crates/web/ui/src/providers/local-models.ts
+++ b/crates/web/ui/src/providers/local-models.ts
@@ -10,8 +10,10 @@ import type {
 	BackendInfo,
 	HfSearchResult,
 	LocalLlmDownloadPayload,
+	LocalLlmLifecyclePayload,
 	LocalModelInfo,
 	ModelSelectorWrapper,
+	ModelStateEntry,
 	ModelsData,
 	ProviderInfo,
 	SystemInfo,
@@ -19,6 +21,95 @@ import type {
 
 // Store the selected backend for model configuration
 let selectedBackend: string | null = null;
+
+// ── Model lifecycle state tracking ──────────────────────────
+
+/** Cached model lifecycle states, keyed by model_id. */
+const modelStates: Record<string, ModelStateEntry> = {};
+
+/** Subscribe to lifecycle events. Call once on page load. */
+export function initModelLifecycleTracking(): void {
+	onEvent("local-llm.lifecycle", (payload: unknown) => {
+		const p = payload as LocalLlmLifecyclePayload;
+		if (!p.modelId) return;
+
+		const existing = modelStates[p.modelId];
+		if (existing) {
+			existing.is_loaded = p.state === "loaded" || p.state === "loading";
+			existing.memory_bytes = p.modelSizeBytes ?? existing.memory_bytes;
+		}
+	});
+
+	// Fetch initial state
+	refreshModelStates();
+}
+
+/** Fetch current model states from the gateway. */
+export async function refreshModelStates(): Promise<void> {
+	const res = await sendRpc<ModelStateEntry[]>("providers.local.model_states", {});
+	if (res?.ok && Array.isArray(res.payload)) {
+		for (const entry of res.payload) {
+			modelStates[entry.model_id] = entry;
+		}
+	}
+}
+
+/** Get the cached lifecycle state for a model. */
+export function getModelState(modelId: string): ModelStateEntry | undefined {
+	return modelStates[modelId];
+}
+
+/** Load a model into memory via RPC. */
+export async function loadModel(modelId: string): Promise<boolean> {
+	const res = await sendRpc<{ ok: boolean }>("providers.local.load", { modelId });
+	return !!res?.ok;
+}
+
+/** Unload a model from memory via RPC. */
+export async function unloadModel(modelId: string): Promise<boolean> {
+	const res = await sendRpc<{ ok: boolean }>("providers.local.unload", { modelId });
+	return !!res?.ok;
+}
+
+function formatBytes(bytes: number): string {
+	if (bytes < 1024) return `${bytes} B`;
+	if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+	if (bytes < 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+	return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)} GB`;
+}
+
+/** Create a Load/Unload button for a model row. */
+export function createLifecycleButton(modelId: string, container: HTMLElement): void {
+	const state = modelStates[modelId];
+	const isLoaded = state?.is_loaded ?? false;
+
+	const btn = document.createElement("button");
+	btn.className = isLoaded ? "provider-btn-danger text-xs px-2 py-1" : "provider-btn-secondary text-xs px-2 py-1";
+	btn.textContent = isLoaded ? "Unload" : "Load";
+
+	if (isLoaded && state?.memory_bytes) {
+		const badge = document.createElement("span");
+		badge.className = "text-xs text-[var(--muted)] ml-2";
+		badge.textContent = formatBytes(state.memory_bytes);
+		container.appendChild(badge);
+	}
+
+	btn.addEventListener("click", async (e) => {
+		e.stopPropagation();
+		btn.disabled = true;
+		btn.textContent = isLoaded ? "Unloading..." : "Loading...";
+
+		const success = isLoaded ? await unloadModel(modelId) : await loadModel(modelId);
+		if (success) {
+			await refreshModelStates();
+		}
+		// Recreate button with new state
+		container.textContent = "";
+		createLifecycleButton(modelId, container);
+	});
+
+	container.appendChild(btn);
+}
 
 export function showLocalModelFlow(provider: ProviderInfo): void {
 	const m = els();

--- a/crates/web/ui/src/providers/local-models.ts
+++ b/crates/web/ui/src/providers/local-models.ts
@@ -45,7 +45,7 @@ export function initModelLifecycleTracking(): void {
 }
 
 /** Fetch current model states from the gateway. */
-export async function refreshModelStates(): Promise<void> {
+async function refreshModelStates(): Promise<void> {
 	const res = await sendRpc<ModelStateEntry[]>("providers.local.model_states", {});
 	if (res?.ok && Array.isArray(res.payload)) {
 		for (const entry of res.payload) {
@@ -57,62 +57,6 @@ export async function refreshModelStates(): Promise<void> {
 /** Get the cached lifecycle state for a model. */
 export function getModelState(modelId: string): ModelStateEntry | undefined {
 	return modelStates[modelId];
-}
-
-/** Load a model into memory via RPC. */
-export async function loadModel(modelId: string): Promise<boolean> {
-	const res = await sendRpc<{ ok: boolean }>("providers.local.load", { modelId });
-	return !!res?.ok;
-}
-
-/** Unload a model from memory via RPC. */
-export async function unloadModel(modelId: string): Promise<boolean> {
-	const res = await sendRpc<{ ok: boolean }>("providers.local.unload", { modelId });
-	return !!res?.ok;
-}
-
-function formatBytes(bytes: number): string {
-	if (bytes < 1024) return `${bytes} B`;
-	if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
-	if (bytes < 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
-	return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)} GB`;
-}
-
-/** Create a Load/Unload button for a model row. */
-export function createLifecycleButton(modelId: string, container: HTMLElement): void {
-	const state = modelStates[modelId];
-	const isLoaded = state?.is_loaded ?? false;
-
-	const btn = document.createElement("button");
-	btn.className = isLoaded ? "provider-btn-danger text-xs px-2 py-1" : "provider-btn-secondary text-xs px-2 py-1";
-	btn.textContent = isLoaded ? "Unload" : "Load";
-
-	if (isLoaded && state?.memory_bytes) {
-		const badge = document.createElement("span");
-		badge.className = "text-xs text-[var(--muted)] ml-2";
-		badge.textContent = formatBytes(state.memory_bytes);
-		container.appendChild(badge);
-	}
-
-	btn.addEventListener("click", async (e) => {
-		e.stopPropagation();
-		btn.disabled = true;
-		btn.textContent = isLoaded ? "Unloading..." : "Loading...";
-
-		const success = isLoaded ? await unloadModel(modelId) : await loadModel(modelId);
-		await refreshModelStates();
-		// Recreate button with new state (reflects actual server state even on failure)
-		container.textContent = "";
-		if (!success) {
-			const err = document.createElement("span");
-			err.className = "text-xs text-[var(--error)] mr-2";
-			err.textContent = "Failed";
-			container.appendChild(err);
-		}
-		createLifecycleButton(modelId, container);
-	});
-
-	container.appendChild(btn);
 }
 
 export function showLocalModelFlow(provider: ProviderInfo): void {

--- a/crates/web/ui/src/providers/local-models.ts
+++ b/crates/web/ui/src/providers/local-models.ts
@@ -35,7 +35,7 @@ export function initModelLifecycleTracking(): void {
 
 		const existing = modelStates[p.modelId];
 		if (existing) {
-			existing.is_loaded = p.state === "loaded" || p.state === "loading";
+			existing.is_loaded = p.state === "loaded";
 			existing.memory_bytes = p.modelSizeBytes ?? existing.memory_bytes;
 		}
 	});

--- a/crates/web/ui/src/providers/types.ts
+++ b/crates/web/ui/src/providers/types.ts
@@ -102,13 +102,7 @@ export interface LocalLlmDownloadPayload {
 	total?: number;
 }
 
-export interface LocalLlmLifecyclePayload {
-	modelId: string;
-	state: "loading" | "loaded" | "unloading" | "unloaded";
-	modelSizeBytes?: number;
-	totalLoadedBytes?: number;
-	reason?: "idle" | "manual";
-}
+export type { LocalLlmLifecyclePayload } from "../types/ws-events";
 
 export interface ModelStateEntry {
 	model_id: string;

--- a/crates/web/ui/src/providers/types.ts
+++ b/crates/web/ui/src/providers/types.ts
@@ -107,6 +107,7 @@ export interface LocalLlmLifecyclePayload {
 	state: "loading" | "loaded" | "unloading" | "unloaded";
 	modelSizeBytes?: number;
 	totalLoadedBytes?: number;
+	reason?: "idle" | "manual";
 }
 
 export interface ModelStateEntry {

--- a/crates/web/ui/src/providers/types.ts
+++ b/crates/web/ui/src/providers/types.ts
@@ -102,6 +102,21 @@ export interface LocalLlmDownloadPayload {
 	total?: number;
 }
 
+export interface LocalLlmLifecyclePayload {
+	modelId: string;
+	state: "loading" | "loaded" | "unloading" | "unloaded";
+	modelSizeBytes?: number;
+	totalLoadedBytes?: number;
+}
+
+export interface ModelStateEntry {
+	model_id: string;
+	is_loaded: boolean;
+	memory_bytes: number;
+	last_activity: number;
+	idle_timeout_secs: number | null;
+}
+
 export interface ProbeResult {
 	error?: string;
 	timeout?: boolean;

--- a/crates/web/ui/src/types/ws-events.ts
+++ b/crates/web/ui/src/types/ws-events.ts
@@ -200,6 +200,7 @@ export interface LocalLlmLifecyclePayload {
 	state: "loading" | "loaded" | "unloading" | "unloaded";
 	modelSizeBytes?: number;
 	totalLoadedBytes?: number;
+	reason?: "idle" | "manual";
 }
 
 export interface ModelsUpdatedPayload {

--- a/crates/web/ui/src/types/ws-events.ts
+++ b/crates/web/ui/src/types/ws-events.ts
@@ -13,6 +13,7 @@ export enum WsEventName {
 	SandboxHostProvision = "sandbox.host.provision",
 	BrowserImagePull = "browser.image.pull",
 	LocalLlmDownload = "local-llm.download",
+	LocalLlmLifecycle = "local-llm.lifecycle",
 	ModelsUpdated = "models.updated",
 	LocationRequest = "location.request",
 	NetworkAuditEntry = "network.audit.entry",
@@ -194,6 +195,13 @@ export interface LocalLlmDownloadPayload {
 	total?: number;
 }
 
+export interface LocalLlmLifecyclePayload {
+	modelId: string;
+	state: "loading" | "loaded" | "unloading" | "unloaded";
+	modelSizeBytes?: number;
+	totalLoadedBytes?: number;
+}
+
 export interface ModelsUpdatedPayload {
 	phase?: string;
 	[key: string]: unknown;
@@ -247,6 +255,7 @@ export interface WsEventPayloadMap {
 	[WsEventName.SandboxHostProvision]: SandboxPhasePayload;
 	[WsEventName.BrowserImagePull]: SandboxPhasePayload;
 	[WsEventName.LocalLlmDownload]: LocalLlmDownloadPayload;
+	[WsEventName.LocalLlmLifecycle]: LocalLlmLifecyclePayload;
 	[WsEventName.ModelsUpdated]: ModelsUpdatedPayload;
 	[WsEventName.LocationRequest]: LocationRequestPayload;
 	[WsEventName.NetworkAuditEntry]: Record<string, unknown>;

--- a/crates/web/ui/src/websocket.ts
+++ b/crates/web/ui/src/websocket.ts
@@ -20,6 +20,7 @@ import { handleChatEvent } from "./ws/chat-handlers";
 import {
 	handleBrowserImagePull,
 	handleLocalLlmDownload,
+	handleLocalLlmLifecycle,
 	handleSandboxHostProvision,
 	handleSandboxImageBuild,
 	handleSandboxImageProvision,
@@ -64,6 +65,7 @@ const eventHandlers: Record<string, (payload: Record<string, unknown>, streamMet
 	"sandbox.host.provision": handleSandboxHostProvision as (payload: Record<string, unknown>) => void,
 	"browser.image.pull": handleBrowserImagePull as (payload: Record<string, unknown>) => void,
 	"local-llm.download": handleLocalLlmDownload as (payload: Record<string, unknown>) => void,
+	"local-llm.lifecycle": handleLocalLlmLifecycle,
 	"models.updated": handleModelsUpdated as (payload: Record<string, unknown>) => void,
 	"location.request": handleLocationRequest as (payload: Record<string, unknown>) => void,
 	"network.audit.entry": handleNetworkAuditEntry as (payload: Record<string, unknown>) => void,

--- a/crates/web/ui/src/ws/sandbox-handlers.ts
+++ b/crates/web/ui/src/ws/sandbox-handlers.ts
@@ -222,9 +222,7 @@ export function handleLocalLlmLifecycle(raw: Record<string, unknown>): void {
 		chatAddMsg("system", `Model ${modelName} loaded${sizeStr}`);
 	} else if (payload.state === "unloaded") {
 		const msg =
-			payload.reason === "idle"
-				? `Model ${modelName} unloaded after inactivity`
-				: `Model ${modelName} unloaded`;
+			payload.reason === "idle" ? `Model ${modelName} unloaded after inactivity` : `Model ${modelName} unloaded`;
 		chatAddMsg("system", msg);
 	}
 	// "unloading" state is transient — no need to show in chat

--- a/crates/web/ui/src/ws/sandbox-handlers.ts
+++ b/crates/web/ui/src/ws/sandbox-handlers.ts
@@ -3,7 +3,7 @@
 import { chatAddMsg, smartScrollToBottom } from "../chat-ui";
 import { currentPrefix } from "../router";
 import * as S from "../state";
-import type { LocalLlmDownloadPayload, SandboxPhasePayload } from "../types/ws-events";
+import type { LocalLlmDownloadPayload, LocalLlmLifecyclePayload, SandboxPhasePayload } from "../types/ws-events";
 import { clearChatEmptyState } from "./shared";
 
 /** Subset of SandboxInfo relevant to the building flag. */
@@ -195,4 +195,33 @@ export function handleLocalLlmDownload(payload: LocalLlmDownloadPayload): void {
 			textEl.textContent = `${downloadedMb} MB`;
 		}
 	}
+}
+
+// ── Local LLM lifecycle handler ──────────────────────────────
+
+let lifecycleIndicatorEl: HTMLElement | null = null;
+
+export function handleLocalLlmLifecycle(raw: Record<string, unknown>): void {
+	const isChatPage = currentPrefix === "/chats";
+	if (!isChatPage) return;
+
+	const payload = raw as unknown as LocalLlmLifecyclePayload;
+	const modelName = payload.modelId || "model";
+
+	if (payload.state === "loading") {
+		if (lifecycleIndicatorEl) {
+			lifecycleIndicatorEl.remove();
+		}
+		lifecycleIndicatorEl = chatAddMsg("system", `Loading model ${modelName} into memory\u2026`);
+	} else if (payload.state === "loaded") {
+		if (lifecycleIndicatorEl) {
+			lifecycleIndicatorEl.remove();
+			lifecycleIndicatorEl = null;
+		}
+		const sizeStr = payload.modelSizeBytes ? ` (${(payload.modelSizeBytes / (1024 * 1024 * 1024)).toFixed(1)} GB)` : "";
+		chatAddMsg("system", `Model ${modelName} loaded${sizeStr}`);
+	} else if (payload.state === "unloaded") {
+		chatAddMsg("system", `Model ${modelName} unloaded after inactivity`);
+	}
+	// "unloading" state is transient — no need to show in chat
 }

--- a/crates/web/ui/src/ws/sandbox-handlers.ts
+++ b/crates/web/ui/src/ws/sandbox-handlers.ts
@@ -221,7 +221,11 @@ export function handleLocalLlmLifecycle(raw: Record<string, unknown>): void {
 		const sizeStr = payload.modelSizeBytes ? ` (${(payload.modelSizeBytes / (1024 * 1024 * 1024)).toFixed(1)} GB)` : "";
 		chatAddMsg("system", `Model ${modelName} loaded${sizeStr}`);
 	} else if (payload.state === "unloaded") {
-		chatAddMsg("system", `Model ${modelName} unloaded after inactivity`);
+		const msg =
+			payload.reason === "idle"
+				? `Model ${modelName} unloaded after inactivity`
+				: `Model ${modelName} unloaded`;
+		chatAddMsg("system", msg);
 	}
 	// "unloading" state is transient — no need to show in chat
 }


### PR DESCRIPTION
## Summary

- Add idle-timeout-based automatic unloading of local LLM models to free RAM when idle
- Add manual Load/Unload RPC methods (`providers.local.load`, `providers.local.unload`, `providers.local.model_states`)
- Broadcast `local-llm.lifecycle` WebSocket events for model state changes
- Show chat system messages when models are loading/loaded/unloaded
- Two-level config: global default in `[providers.local-llm] idle_timeout_secs` (moltis.toml), per-model override in `local-llm.json`

## Validation

### Completed
- [x] `just format-check` passes
- [x] `cargo check` (full workspace) passes
- [x] `cargo check -p moltis-gateway --features local-llm` passes
- [x] `cargo test -p moltis-providers --features local-llm` — all pass (4 new provider tests)
- [x] `cargo test -p moltis-gateway --features local-llm -- local_llm_setup` — 40 tests pass
- [x] `cargo test -p moltis-gateway --features local-llm -- lifecycle` — 9 tests pass (8 new)
- [x] `cargo test -p moltis-config` — 284 tests pass
- [x] `cargo test -p moltis-service-traits` — 5 tests pass
- [x] `npx tsc --noEmit` — 0 errors
- [x] `biome check --write` — applied
- [x] `npm run build` — Vite build succeeds

### Remaining
- [ ] `./scripts/local-validate.sh` (full CI suite)
- [ ] Manual QA: configure a model with `idle_timeout_secs`, verify auto-unload after timeout, verify reload on next chat
- [ ] Manual QA: test Load/Unload buttons from web UI
- [ ] E2E tests for lifecycle WebSocket events (follow-up)

## Manual QA

1. Set `idle_timeout_secs = 60` in `[providers.local-llm]` section of moltis.toml
2. Start moltis, configure a local model, send a chat message
3. Observe "Loading model X into memory..." and "Model X loaded (N GB)" system messages in chat
4. Wait 60+ seconds without sending messages
5. Observe "Model X unloaded after inactivity" system message
6. Send another message — model should reload automatically
7. Call `providers.local.model_states` RPC to verify state tracking
8. Call `providers.local.unload` / `providers.local.load` to test manual control

🤖 Generated with [Claude Code](https://claude.com/claude-code)