### PR TITLE
feat: make telegram channel optional

### DIFF
--- a/crates/chat/Cargo.toml
+++ b/crates/chat/Cargo.toml
@@ -23,7 +23,7 @@ moltis-providers      = { workspace = true }
 moltis-service-traits = { workspace = true }
 moltis-sessions       = { workspace = true }
 moltis-skills         = { workspace = true }
-moltis-telegram       = { workspace = true }
+moltis-telegram       = { optional = true, workspace = true }
 moltis-tools          = { workspace = true }
 moltis-voice          = { workspace = true }
 serde                 = { workspace = true }
@@ -46,6 +46,7 @@ local-llm          = []
 metrics            = ["dep:moltis-metrics", "moltis-metrics/sqlite"]
 push-notifications = ["dep:chrono"]
 web-ui             = ["dep:chrono"]
+telegram           = ["dep:moltis-telegram"]
 
 default = ["llm-compaction"]
 

--- a/crates/chat/src/channels.rs
+++ b/crates/chat/src/channels.rs
@@ -517,71 +517,80 @@ async fn deliver_channel_replies_to_targets(
                                     "failed to send logbook follow-up: {e}"
                                 );
                             }
-                        } else if transcript.len()
-                            <= moltis_telegram::markdown::TELEGRAM_CAPTION_LIMIT
-                        {
-                            // Short transcript fits as a caption on the voice message.
-                            payload.text = transcript;
-                            if let Err(e) = outbound
-                                .send_media(&target.account_id, &to, &payload, reply_to)
-                                .await
-                            {
-                                warn!(
-                                    account_id = target.account_id,
-                                    chat_id = target.chat_id,
-                                    thread_id = target.thread_id.as_deref().unwrap_or("-"),
-                                    "failed to send channel voice reply: {e}"
-                                );
-                            }
-                            // Send logbook as a follow-up if present.
-                            if !logbook_html.is_empty()
-                                && let Err(e) = outbound
-                                    .send_html(&target.account_id, &to, &logbook_html, None)
-                                    .await
-                            {
-                                warn!(
-                                    account_id = target.account_id,
-                                    chat_id = target.chat_id,
-                                    thread_id = target.thread_id.as_deref().unwrap_or("-"),
-                                    "failed to send logbook follow-up: {e}"
-                                );
-                            }
                         } else {
-                            // Transcript too long for a caption — send voice
-                            // without caption, then the full text as a follow-up.
-                            if let Err(e) = outbound
-                                .send_media(&target.account_id, &to, &payload, reply_to)
-                                .await
-                            {
-                                warn!(
-                                    account_id = target.account_id,
-                                    chat_id = target.chat_id,
-                                    thread_id = target.thread_id.as_deref().unwrap_or("-"),
-                                    "failed to send channel voice reply: {e}"
-                                );
-                            }
-                            let text_result = if logbook_html.is_empty() {
-                                outbound
-                                    .send_text(&target.account_id, &to, &transcript, None)
+                            // Check if transcript fits as Telegram caption (when feature enabled).
+                            // When telegram feature is disabled, this evaluates to false and we
+                            // send voice + follow-up text.
+                            #[cfg(feature = "telegram")]
+                            let fits_in_caption = transcript.len()
+                                <= moltis_telegram::markdown::TELEGRAM_CAPTION_LIMIT;
+                            #[cfg(not(feature = "telegram"))]
+                            let fits_in_caption = false;
+
+                            if fits_in_caption {
+                                // Short transcript fits as a caption on the voice message.
+                                payload.text = transcript;
+                                if let Err(e) = outbound
+                                    .send_media(&target.account_id, &to, &payload, reply_to)
                                     .await
+                                {
+                                    warn!(
+                                        account_id = target.account_id,
+                                        chat_id = target.chat_id,
+                                        thread_id = target.thread_id.as_deref().unwrap_or("-"),
+                                        "failed to send channel voice reply: {e}"
+                                    );
+                                }
+                                // Send logbook as a follow-up if present.
+                                if !logbook_html.is_empty()
+                                    && let Err(e) = outbound
+                                        .send_html(&target.account_id, &to, &logbook_html, None)
+                                        .await
+                                {
+                                    warn!(
+                                        account_id = target.account_id,
+                                        chat_id = target.chat_id,
+                                        thread_id = target.thread_id.as_deref().unwrap_or("-"),
+                                        "failed to send logbook follow-up: {e}"
+                                    );
+                                }
                             } else {
-                                outbound
-                                    .send_text_with_suffix(
-                                        &target.account_id,
-                                        &to,
-                                        &transcript,
-                                        &logbook_html,
-                                        None,
-                                    )
+                                // Transcript too long for a caption — send voice
+                                // without caption, then the full text as a follow-up.
+                                if let Err(e) = outbound
+                                    .send_media(&target.account_id, &to, &payload, reply_to)
                                     .await
-                            };
-                            if let Err(e) = text_result {
-                                warn!(
-                                    account_id = target.account_id,
-                                    chat_id = target.chat_id,
-                                    thread_id = target.thread_id.as_deref().unwrap_or("-"),
-                                    "failed to send transcript follow-up: {e}"
-                                );
+                                {
+                                    warn!(
+                                        account_id = target.account_id,
+                                        chat_id = target.chat_id,
+                                        thread_id = target.thread_id.as_deref().unwrap_or("-"),
+                                        "failed to send channel voice reply: {e}"
+                                    );
+                                }
+                                let text_result = if logbook_html.is_empty() {
+                                    outbound
+                                        .send_text(&target.account_id, &to, &transcript, None)
+                                        .await
+                                } else {
+                                    outbound
+                                        .send_text_with_suffix(
+                                            &target.account_id,
+                                            &to,
+                                            &transcript,
+                                            &logbook_html,
+                                            None,
+                                        )
+                                        .await
+                                };
+                                if let Err(e) = text_result {
+                                    warn!(
+                                        account_id = target.account_id,
+                                        chat_id = target.chat_id,
+                                        thread_id = target.thread_id.as_deref().unwrap_or("-"),
+                                        "failed to send transcript follow-up: {e}"
+                                    );
+                                }
                             }
                         }
                     },

--- a/crates/gateway/Cargo.toml
+++ b/crates/gateway/Cargo.toml
@@ -57,7 +57,7 @@ moltis-signal           = { optional = true, workspace = true }
 moltis-skills           = { workspace = true }
 moltis-slack            = { optional = true, workspace = true }
 moltis-tailscale        = { optional = true, workspace = true }
-moltis-telegram         = { workspace = true }
+moltis-telegram         = { optional = true, workspace = true }
 moltis-tools            = { workspace = true }
 moltis-vault            = { optional = true, workspace = true }
 moltis-voice            = { optional = true, workspace = true }
@@ -173,6 +173,7 @@ vault = ["dep:moltis-vault", "moltis-auth/vault", "moltis-provider-setup/vault",
 voice = ["dep:moltis-voice"]
 wasm = ["moltis-tools/wasm"]
 web-ui = ["dep:include_dir", "dep:portable-pty", "dep:which", "moltis-chat/web-ui"]
+telegram = ["dep:moltis-telegram"]
 whatsapp = ["dep:moltis-whatsapp", "dep:qrcode", "moltis-whatsapp/metrics"]
 
 [dev-dependencies]

--- a/crates/gateway/Cargo.toml
+++ b/crates/gateway/Cargo.toml
@@ -119,6 +119,7 @@ default = [
   "signal",
   "slack",
   "tailscale",
+  "telegram",
   "tls",
   "trusted-network",
   "vault",
@@ -173,7 +174,7 @@ vault = ["dep:moltis-vault", "moltis-auth/vault", "moltis-provider-setup/vault",
 voice = ["dep:moltis-voice"]
 wasm = ["moltis-tools/wasm"]
 web-ui = ["dep:include_dir", "dep:portable-pty", "dep:which", "moltis-chat/web-ui"]
-telegram = ["dep:moltis-telegram"]
+telegram = ["dep:moltis-telegram", "moltis-chat/telegram"]
 whatsapp = ["dep:moltis-whatsapp", "dep:qrcode", "moltis-whatsapp/metrics"]
 
 [dev-dependencies]

--- a/crates/gateway/src/server/init_channels.rs
+++ b/crates/gateway/src/server/init_channels.rs
@@ -59,14 +59,17 @@ pub(crate) async fn init_channels(
     // Create plugins and register with the registry.
     let mut registry = ChannelRegistry::new();
 
-    let tg_plugin = Arc::new(tokio::sync::RwLock::new(
-        moltis_telegram::TelegramPlugin::new()
-            .with_message_log(Arc::clone(&message_log))
-            .with_event_sink(Arc::clone(&channel_sink)),
-    ));
-    registry
-        .register(tg_plugin as Arc<tokio::sync::RwLock<dyn ChannelPlugin>>)
-        .await;
+    #[cfg(feature = "telegram")]
+    {
+        let tg_plugin = Arc::new(tokio::sync::RwLock::new(
+            moltis_telegram::TelegramPlugin::new()
+                .with_message_log(Arc::clone(&message_log))
+                .with_event_sink(Arc::clone(&channel_sink)),
+        ));
+        registry
+            .register(tg_plugin as Arc<tokio::sync::RwLock<dyn ChannelPlugin>>)
+            .await;
+    }
 
     let msteams_plugin = Arc::new(tokio::sync::RwLock::new(
         moltis_msteams::MsTeamsPlugin::new()


### PR DESCRIPTION
## Summary

Makes the Telegram channel optional (opt-out by default) to reduce binary size and build time when Telegram integration is not needed.

Follows the existing optional-channel pattern already used by other channels in the workspace.

## Changes

- Gate `moltis-telegram` behind `telegram` feature flag in `chat` and `gateway` crates
- Conditional compilation (`#[cfg(feature = "telegram")]`) for Telegram channel registration
- Default features keep Telegram **enabled** (opt-out philosophy per project convention)

## Files Changed

| File | Change |
|------|--------|
| `crates/chat/Cargo.toml` | Add `telegram` feature flag |
| `crates/chat/src/channels.rs` | Conditional Telegram channel init |
| `crates/gateway/Cargo.toml` | Add `telegram` feature flag, make dep optional, add to defaults, forward moltis-chat/telegram |
| `crates/gateway/src/server/init_channels.rs` | Conditional Telegram channel setup |

## Testing

- Built with default features (telegram enabled) ✅
- Built with `--no-default-features` (telegram disabled) ✅

## Fixes (Greptile P1 review)

- **P1 #1:** Added `telegram` to gateway `default` features — was missing, silently disabling Telegram in all default builds
- **P1 #2:** Added `moltis-chat/telegram` propagation to gateway feature — caption-limit optimization was always compiled out