### PR TITLE
fix: use ApplicationType::Web for non-loopback Matrix OIDC redirect URIs

### DIFF
--- a/crates/matrix/src/oidc.rs
+++ b/crates/matrix/src/oidc.rs
@@ -152,7 +152,13 @@ const MOLTIS_CLIENT_URI: &str = "https://moltis.org/";
 
 fn is_loopback_uri(uri: &Url) -> bool {
     let host = uri.host_str().unwrap_or_default();
-    host == "localhost" || host == "127.0.0.1" || host == "::1" || host.ends_with(".localhost")
+    if host == "localhost" || host == "::1" || host.ends_with(".localhost") {
+        return true;
+    }
+    if let Ok(ip) = host.parse::<std::net::Ipv4Addr>() {
+        return ip.is_loopback();
+    }
+    false
 }
 
 /// Rewrite loopback redirect URIs from `https://` to `http://`.
@@ -176,10 +182,17 @@ fn build_client_metadata(redirect_uri: &Url) -> ChannelResult<ClientMetadata> {
         .parse()
         .map_err(|error| ChannelError::external("matrix oidc parse client uri", error))?;
     let client_uri = Localized::new(client_uri_url, std::iter::empty());
-    let registration_redirect = normalize_loopback_redirect(redirect_uri);
+    let is_loopback = is_loopback_uri(redirect_uri);
+    let registration_redirect = if is_loopback && redirect_uri.scheme() == "https" {
+        let mut normalized = redirect_uri.clone();
+        let _ = normalized.set_scheme("http");
+        normalized
+    } else {
+        redirect_uri.clone()
+    };
     // MAS requires `Native` for loopback redirect URIs (RFC 8252) and `Web`
     // for non-loopback URIs (e.g. behind a reverse proxy).
-    let app_type = if is_loopback_uri(redirect_uri) {
+    let app_type = if is_loopback {
         ApplicationType::Native
     } else {
         ApplicationType::Web
@@ -513,6 +526,30 @@ mod tests {
             ApplicationType::Native,
             "loopback redirect_uri must use ApplicationType::Native"
         );
+    }
+
+    #[test]
+    fn is_loopback_uri_covers_full_127_range() {
+        let url_127_0_0_2: Url = "http://127.0.0.2:8080/auth/callback"
+            .parse()
+            .unwrap_or_else(|error| panic!("{error}"));
+        assert!(
+            is_loopback_uri(&url_127_0_0_2),
+            "127.0.0.2 is in 127.0.0.0/8 and must be treated as loopback"
+        );
+
+        let url_127_255: Url = "http://127.255.255.255:8080/auth/callback"
+            .parse()
+            .unwrap_or_else(|error| panic!("{error}"));
+        assert!(
+            is_loopback_uri(&url_127_255),
+            "127.255.255.255 is in 127.0.0.0/8 and must be treated as loopback"
+        );
+
+        let url_external: Url = "https://10.0.0.1:8080/auth/callback"
+            .parse()
+            .unwrap_or_else(|error| panic!("{error}"));
+        assert!(!is_loopback_uri(&url_external), "10.0.0.1 is not loopback");
     }
 
     #[test]

--- a/crates/matrix/src/oidc.rs
+++ b/crates/matrix/src/oidc.rs
@@ -150,6 +150,11 @@ async fn load_oidc_session(account_id: &str) -> ChannelResult<Option<PersistedOi
 /// MAS validates this URL and rejects loopback addresses.
 const MOLTIS_CLIENT_URI: &str = "https://moltis.org/";
 
+fn is_loopback_uri(uri: &Url) -> bool {
+    let host = uri.host_str().unwrap_or_default();
+    host == "localhost" || host == "127.0.0.1" || host == "::1" || host.ends_with(".localhost")
+}
+
 /// Rewrite loopback redirect URIs from `https://` to `http://`.
 ///
 /// MAS follows RFC 8252 §7.3 and requires native/loopback redirect URIs to
@@ -157,10 +162,7 @@ const MOLTIS_CLIENT_URI: &str = "https://moltis.org/";
 /// HTTP-to-HTTPS redirect (or HSTS) will still deliver the callback to the
 /// HTTPS server, so the OAuth code+state arrive correctly.
 fn normalize_loopback_redirect(redirect_uri: &Url) -> Url {
-    let host = redirect_uri.host_str().unwrap_or_default();
-    let is_loopback =
-        host == "localhost" || host == "127.0.0.1" || host == "::1" || host.ends_with(".localhost");
-    if is_loopback && redirect_uri.scheme() == "https" {
+    if is_loopback_uri(redirect_uri) && redirect_uri.scheme() == "https" {
         let mut normalized = redirect_uri.clone();
         let _ = normalized.set_scheme("http");
         normalized
@@ -175,8 +177,15 @@ fn build_client_metadata(redirect_uri: &Url) -> ChannelResult<ClientMetadata> {
         .map_err(|error| ChannelError::external("matrix oidc parse client uri", error))?;
     let client_uri = Localized::new(client_uri_url, std::iter::empty());
     let registration_redirect = normalize_loopback_redirect(redirect_uri);
+    // MAS requires `Native` for loopback redirect URIs (RFC 8252) and `Web`
+    // for non-loopback URIs (e.g. behind a reverse proxy).
+    let app_type = if is_loopback_uri(redirect_uri) {
+        ApplicationType::Native
+    } else {
+        ApplicationType::Web
+    };
     Ok(ClientMetadata::new(
-        ApplicationType::Native,
+        app_type,
         vec![OAuthGrantType::AuthorizationCode {
             redirect_uris: vec![registration_redirect],
         }],
@@ -467,6 +476,42 @@ mod tests {
         assert_eq!(
             normalize_loopback_redirect(&url).as_str(),
             "http://localhost:8080/auth/callback"
+        );
+    }
+
+    #[test]
+    fn build_client_metadata_uses_web_application_type_for_reverse_proxy() {
+        let redirect: Url = "https://moltis.example.com/auth/callback"
+            .parse()
+            .unwrap_or_else(|error| panic!("{error}"));
+        let metadata = build_client_metadata(&redirect).unwrap_or_else(|error| panic!("{error}"));
+        assert_eq!(
+            metadata.application_type,
+            ApplicationType::Web,
+            "non-loopback redirect_uri must use ApplicationType::Web for MAS compatibility"
+        );
+        match &metadata.grant_types[0] {
+            OAuthGrantType::AuthorizationCode { redirect_uris } => {
+                assert_eq!(
+                    redirect_uris[0].as_str(),
+                    "https://moltis.example.com/auth/callback",
+                    "non-loopback redirect_uri must be preserved as-is"
+                );
+            },
+            other => panic!("expected AuthorizationCode, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn build_client_metadata_uses_native_application_type_for_loopback() {
+        let redirect: Url = "http://localhost:8080/auth/callback"
+            .parse()
+            .unwrap_or_else(|error| panic!("{error}"));
+        let metadata = build_client_metadata(&redirect).unwrap_or_else(|error| panic!("{error}"));
+        assert_eq!(
+            metadata.application_type,
+            ApplicationType::Native,
+            "loopback redirect_uri must use ApplicationType::Native"
         );
     }
 


### PR DESCRIPTION
## Summary

- Fix Matrix OIDC login failing with `invalid_redirect_uri` when behind a reverse proxy (discussion #872)
- `build_client_metadata()` always used `ApplicationType::Native`, which per RFC 8252 only permits loopback redirect URIs — MAS correctly rejects non-loopback URLs like `https://moltis.example.com/auth/callback`
- Now selects `ApplicationType::Web` for non-loopback redirect URIs and `ApplicationType::Native` for loopback ones

## Validation

### Completed
- [x] `cargo test -p moltis-matrix -- oidc::tests` — all 11 tests pass
- [x] `just format-check` — clean
- [x] `cargo clippy -p moltis-matrix -- -D warnings` — clean

### Remaining
- [ ] `./scripts/local-validate.sh`
- [ ] Manual QA with a reverse-proxy setup pointing at a MAS-enabled homeserver

## Manual QA

1. Run Moltis behind a reverse proxy (e.g. Caddy/nginx) with an external domain
2. Navigate to Channels → Add Matrix → OIDC auth mode
3. Confirm the OIDC login flow completes without `invalid_redirect_uri` error
4. Verify direct localhost access still works (ApplicationType::Native path)

Closes #872