### PR TITLE
test: add regression test for hook circuit breaker vs Block actions

### DIFF
--- a/crates/common/src/hooks.rs
+++ b/crates/common/src/hooks.rs
@@ -596,6 +596,9 @@ impl HookRegistry {
                     }
                 },
                 Ok(HookAction::Block(reason)) => {
+                    // Security: Block is an intentional action, not a failure.
+                    // record_success resets consecutive_failures so security
+                    // hooks that block repeatedly never trip the circuit breaker.
                     entry.stats.record_success(latency);
                     if self.dry_run {
                         info!(handler = entry.handler.name(), event = %event, reason = %reason, "hook block (dry-run, not applied)");
@@ -652,6 +655,7 @@ impl HookRegistry {
                     }
                 },
                 Ok(HookAction::Block(reason)) => {
+                    // Security: Block is intentional — see dispatch_sequential.
                     entry.stats.record_success(latency);
                     if self.dry_run {
                         info!(handler = entry.handler.name(), event = %event, reason = %reason, "hook block (dry-run, not applied)");
@@ -1189,5 +1193,35 @@ mod tests {
             },
             other => panic!("unexpected payload: {other:?}"),
         }
+    }
+
+    /// GH #547: Security hooks that return Block must never trip the circuit
+    /// breaker. Exit 1 from a shell hook maps to Ok(Block), which is recorded
+    /// as a success so consecutive_failures stays at 0.
+    #[tokio::test]
+    async fn blocking_hooks_never_trip_circuit_breaker() {
+        let mut registry = HookRegistry::new().with_circuit_breaker(2, Duration::from_millis(100));
+        registry.register(Arc::new(BlockingPriorityHandler {
+            handler_name: "security-filter".into(),
+            handler_priority: 0,
+            subscribed: vec![HookEvent::BeforeToolCall],
+        }));
+
+        let payload = modifying_payload();
+
+        // Block many more times than the circuit breaker threshold.
+        for _ in 0..10 {
+            let result = registry.dispatch(&payload).await.unwrap();
+            assert!(matches!(result, HookAction::Block(_)));
+        }
+
+        let stats = registry.handler_stats("security-filter").unwrap();
+        assert!(
+            !stats.disabled.load(Ordering::Relaxed),
+            "security hook must not be disabled by blocks"
+        );
+        assert_eq!(stats.consecutive_failures.load(Ordering::Relaxed), 0);
+        assert_eq!(stats.failure_count.load(Ordering::Relaxed), 0);
+        assert_eq!(stats.call_count.load(Ordering::Relaxed), 10);
     }
 }

--- a/crates/common/src/hooks.rs
+++ b/crates/common/src/hooks.rs
@@ -538,6 +538,7 @@ impl HookRegistry {
                 let result = handler.handle(event, &payload).await;
                 let latency = start.elapsed();
                 match &result {
+                    // Security: Ok includes Block — see dispatch_sequential.
                     Ok(_) => stats.record_success(latency),
                     Err(_) => stats.record_failure(latency),
                 }
@@ -1196,8 +1197,8 @@ mod tests {
     }
 
     /// GH #547: Security hooks that return Block must never trip the circuit
-    /// breaker. Exit 1 from a shell hook maps to Ok(Block), which is recorded
-    /// as a success so consecutive_failures stays at 0.
+    /// breaker (async path). Exit 1 from a shell hook maps to Ok(Block),
+    /// which is recorded as a success so consecutive_failures stays at 0.
     #[tokio::test]
     async fn blocking_hooks_never_trip_circuit_breaker() {
         let mut registry = HookRegistry::new().with_circuit_breaker(2, Duration::from_millis(100));
@@ -1219,6 +1220,33 @@ mod tests {
         assert!(
             !stats.disabled.load(Ordering::Relaxed),
             "security hook must not be disabled by blocks"
+        );
+        assert_eq!(stats.consecutive_failures.load(Ordering::Relaxed), 0);
+        assert_eq!(stats.failure_count.load(Ordering::Relaxed), 0);
+        assert_eq!(stats.call_count.load(Ordering::Relaxed), 10);
+    }
+
+    /// GH #547: Same invariant as above, but for the synchronous dispatch path.
+    #[test]
+    fn blocking_hooks_never_trip_circuit_breaker_sync() {
+        let mut registry = HookRegistry::new().with_circuit_breaker(2, Duration::from_millis(100));
+        registry.register(Arc::new(BlockingPriorityHandler {
+            handler_name: "security-filter-sync".into(),
+            handler_priority: 0,
+            subscribed: vec![HookEvent::BeforeToolCall],
+        }));
+
+        let payload = modifying_payload();
+
+        for _ in 0..10 {
+            let result = registry.dispatch_sync(&payload).unwrap();
+            assert!(matches!(result, HookAction::Block(_)));
+        }
+
+        let stats = registry.handler_stats("security-filter-sync").unwrap();
+        assert!(
+            !stats.disabled.load(Ordering::Relaxed),
+            "security hook must not be disabled by blocks (sync)"
         );
         assert_eq!(stats.consecutive_failures.load(Ordering::Relaxed), 0);
         assert_eq!(stats.failure_count.load(Ordering::Relaxed), 0);


### PR DESCRIPTION
## Summary

- Adds a regression test proving security hooks that return `Block` (exit 1) never trip the circuit breaker — closes #547
- Adds clarifying comments on the `dispatch_sequential` and `dispatch_sync` Block arms explaining the security-critical design: `Block` → `record_success()` → `consecutive_failures` reset to 0

## Context

Issue #547 raised a concern that shell hooks using `exit 1` to block dangerous tool calls could inadvertently trip the circuit breaker (threshold: 3 consecutive failures → hook auto-disabled for 60s), creating a bypass window for attackers.

**The code already handles this correctly.** In `ShellHookHandler::handle()`:
- `exit 1` → `Ok(HookAction::Block)` → treated as **success** by circuit breaker
- `exit > 1` / timeout → `Err(...)` → treated as **failure** (increments counter)

The new test explicitly verifies this by blocking 10 times (5× the threshold of 2) and asserting the handler stays enabled with zero failures.

## Validation

### Completed
- [x] `cargo test -p moltis-common -- hooks` — all 18 tests pass (including new one)
- [x] `cargo fmt --all -- --check` — clean

### Remaining
- [ ] `just lint`
- [ ] `just test`

## Manual QA

N/A — unit test only, no behavioral change.