### PR TITLE
feat(web): add command palette (Cmd+K / Ctrl+K)

### DIFF
--- a/crates/web/src/templates/index.html
+++ b/crates/web/src/templates/index.html
@@ -72,6 +72,12 @@
     <span class="icon icon-md icon-burger-mobile"></span>
   </button>
 
+  <button id="commandPaletteBtn" class="header-link-btn" title="Command palette">
+    <span class="icon icon-search"></span>
+    <kbd class="cmd-palette-header-kbd" id="cmdPaletteKbd"></kbd>
+  </button>
+  <script nonce="{{ nonce }}">!function(){var k=document.getElementById("cmdPaletteKbd");if(k)k.textContent=/Mac|iPhone|iPad/.test(navigator.platform||navigator.userAgent)?"\u2318K":"Ctrl+K"}()</script>
+
   <div class="header-actions">
     <button id="settingsBtn" class="header-link-btn" title="Settings">
       <span class="icon icon-settings"></span>

--- a/crates/web/src/templates/index.html
+++ b/crates/web/src/templates/index.html
@@ -76,7 +76,7 @@
     <span class="icon icon-search"></span>
     <kbd class="cmd-palette-header-kbd" id="cmdPaletteKbd"></kbd>
   </button>
-  <script nonce="{{ nonce }}">!function(){var k=document.getElementById("cmdPaletteKbd");if(k)k.textContent=/Mac|iPhone|iPad/.test(navigator.platform||navigator.userAgent)?"\u2318K":"Ctrl+K"}()</script>
+  <script nonce="{{ nonce }}">!function(){var k=document.getElementById("cmdPaletteKbd");if(k)k.textContent=/Mac|iPhone|iPad/.test(navigator.userAgent)?"\u2318K":"Ctrl+K"}()</script>
 
   <div class="header-actions">
     <button id="settingsBtn" class="header-link-btn" title="Settings">

--- a/crates/web/ui/e2e/specs/command-palette.spec.js
+++ b/crates/web/ui/e2e/specs/command-palette.spec.js
@@ -1,0 +1,278 @@
+const { expect, test } = require("../base-test");
+const { expectPageContentMounted, navigateAndWait, watchPageErrors } = require("../helpers");
+
+test.describe("Command palette", () => {
+	test("opens on Cmd+K and closes on Escape", async ({ page }) => {
+		const pageErrors = watchPageErrors(page);
+		await navigateAndWait(page, "/");
+
+		await expect(page.locator(".cmd-palette")).toHaveCount(0);
+
+		await page.keyboard.press("Meta+k");
+		await expect(page.locator(".cmd-palette")).toBeVisible();
+		await expect(page.locator(".cmd-palette-input")).toBeFocused();
+
+		await page.keyboard.press("Escape");
+		await expect(page.locator(".cmd-palette")).toHaveCount(0);
+
+		expect(pageErrors).toEqual([]);
+	});
+
+	test("opens on Ctrl+K for non-Mac platforms", async ({ page }) => {
+		const pageErrors = watchPageErrors(page);
+		await navigateAndWait(page, "/");
+
+		await page.keyboard.press("Control+k");
+		await expect(page.locator(".cmd-palette")).toBeVisible();
+
+		await page.keyboard.press("Escape");
+		expect(pageErrors).toEqual([]);
+	});
+
+	test("opens on header button click", async ({ page }) => {
+		const pageErrors = watchPageErrors(page);
+		await navigateAndWait(page, "/");
+
+		const btn = page.locator("#commandPaletteBtn");
+		await expect(btn).toBeVisible();
+		await btn.click();
+		await expect(page.locator(".cmd-palette")).toBeVisible();
+		await expect(page.locator(".cmd-palette-input")).toBeFocused();
+
+		await page.keyboard.press("Escape");
+		expect(pageErrors).toEqual([]);
+	});
+
+	test("closes on backdrop click", async ({ page }) => {
+		const pageErrors = watchPageErrors(page);
+		await navigateAndWait(page, "/");
+
+		await page.keyboard.press("Meta+k");
+		await expect(page.locator(".cmd-palette")).toBeVisible();
+
+		// Click the backdrop (outside the palette box)
+		await page.locator(".cmd-palette-backdrop").click({ position: { x: 10, y: 10 } });
+		await expect(page.locator(".cmd-palette")).toHaveCount(0);
+
+		expect(pageErrors).toEqual([]);
+	});
+
+	test("toggle: second Cmd+K closes the palette", async ({ page }) => {
+		const pageErrors = watchPageErrors(page);
+		await navigateAndWait(page, "/");
+
+		await page.keyboard.press("Meta+k");
+		await expect(page.locator(".cmd-palette")).toBeVisible();
+
+		await page.keyboard.press("Meta+k");
+		await expect(page.locator(".cmd-palette")).toHaveCount(0);
+
+		expect(pageErrors).toEqual([]);
+	});
+
+	test("shows grouped commands by default", async ({ page }) => {
+		const pageErrors = watchPageErrors(page);
+		await navigateAndWait(page, "/");
+
+		await page.keyboard.press("Meta+k");
+		await expect(page.locator(".cmd-palette")).toBeVisible();
+
+		// Should show group headers
+		await expect(page.locator(".cmd-palette-group", { hasText: "Navigation" })).toBeVisible();
+		await expect(page.locator(".cmd-palette-group", { hasText: "Settings" })).toBeVisible();
+		await expect(page.locator(".cmd-palette-group", { hasText: "Actions" })).toBeVisible();
+
+		// Should show some commands
+		await expect(page.locator(".cmd-palette-item", { hasText: "Chats" })).toBeVisible();
+		await expect(page.locator(".cmd-palette-item", { hasText: "New Session" })).toBeVisible();
+
+		await page.keyboard.press("Escape");
+		expect(pageErrors).toEqual([]);
+	});
+
+	test("filters commands by typing", async ({ page }) => {
+		const pageErrors = watchPageErrors(page);
+		await navigateAndWait(page, "/");
+
+		await page.keyboard.press("Meta+k");
+		await expect(page.locator(".cmd-palette")).toBeVisible();
+
+		await page.locator(".cmd-palette-input").fill("prov");
+
+		// Should show Provider-related items
+		await expect(page.locator(".cmd-palette-item", { hasText: "Providers" })).toBeVisible();
+
+		// Navigation items that don't match should be gone
+		await expect(page.locator(".cmd-palette-item", { hasText: "Crons" })).toHaveCount(0);
+
+		await page.keyboard.press("Escape");
+		expect(pageErrors).toEqual([]);
+	});
+
+	test("shows no matches when nothing found", async ({ page }) => {
+		const pageErrors = watchPageErrors(page);
+		await navigateAndWait(page, "/");
+
+		await page.keyboard.press("Meta+k");
+		await page.locator(".cmd-palette-input").fill("xyznonexistent");
+
+		await expect(page.locator(".cmd-palette-empty")).toBeVisible();
+
+		await page.keyboard.press("Escape");
+		expect(pageErrors).toEqual([]);
+	});
+
+	test("keyword search finds commands", async ({ page }) => {
+		const pageErrors = watchPageErrors(page);
+		await navigateAndWait(page, "/");
+
+		await page.keyboard.press("Meta+k");
+		await page.locator(".cmd-palette-input").fill("docker");
+
+		// "docker" is a keyword for Sandboxes
+		await expect(page.locator(".cmd-palette-item", { hasText: "Sandboxes" })).toBeVisible();
+
+		await page.keyboard.press("Escape");
+		expect(pageErrors).toEqual([]);
+	});
+
+	test("keyboard navigation with ArrowDown/Up and Enter", async ({ page }) => {
+		const pageErrors = watchPageErrors(page);
+		await navigateAndWait(page, "/");
+
+		await page.keyboard.press("Meta+k");
+		await expect(page.locator(".cmd-palette")).toBeVisible();
+
+		// First item should be active by default
+		const firstItem = page.locator(".cmd-palette-item").first();
+		await expect(firstItem).toHaveClass(/cmd-palette-item-active/);
+
+		// Arrow down moves to second item
+		await page.keyboard.press("ArrowDown");
+		const secondItem = page.locator(".cmd-palette-item").nth(1);
+		await expect(secondItem).toHaveClass(/cmd-palette-item-active/);
+		await expect(firstItem).not.toHaveClass(/cmd-palette-item-active/);
+
+		// Arrow up moves back
+		await page.keyboard.press("ArrowUp");
+		await expect(firstItem).toHaveClass(/cmd-palette-item-active/);
+
+		await page.keyboard.press("Escape");
+		expect(pageErrors).toEqual([]);
+	});
+
+	test("Enter on a navigation command navigates to the page", async ({ page }) => {
+		const pageErrors = watchPageErrors(page);
+		await navigateAndWait(page, "/");
+
+		await page.keyboard.press("Meta+k");
+		await page.locator(".cmd-palette-input").fill("Skills");
+
+		// Wait for filtered results
+		await expect(page.locator(".cmd-palette-item", { hasText: "Skills" }).first()).toBeVisible();
+
+		await page.keyboard.press("Enter");
+
+		// Palette should close
+		await expect(page.locator(".cmd-palette")).toHaveCount(0);
+
+		// Should navigate to skills page
+		await expect(page).toHaveURL(/\/skills$/, { timeout: 10_000 });
+		await expectPageContentMounted(page);
+
+		expect(pageErrors).toEqual([]);
+	});
+
+	test("clicking a command item navigates and closes palette", async ({ page }) => {
+		const pageErrors = watchPageErrors(page);
+		await navigateAndWait(page, "/");
+
+		await page.keyboard.press("Meta+k");
+		await page.locator(".cmd-palette-input").fill("Logs");
+
+		const logsItem = page.locator(".cmd-palette-item", { hasText: "Logs" }).first();
+		await expect(logsItem).toBeVisible();
+		await logsItem.click();
+
+		await expect(page.locator(".cmd-palette")).toHaveCount(0);
+		await expect(page).toHaveURL(/\/logs$|\/settings\/logs$/, { timeout: 10_000 });
+
+		expect(pageErrors).toEqual([]);
+	});
+
+	test("mouse hover updates active item", async ({ page }) => {
+		const pageErrors = watchPageErrors(page);
+		await navigateAndWait(page, "/");
+
+		await page.keyboard.press("Meta+k");
+		await expect(page.locator(".cmd-palette")).toBeVisible();
+
+		const thirdItem = page.locator(".cmd-palette-item").nth(2);
+		await thirdItem.hover();
+		await expect(thirdItem).toHaveClass(/cmd-palette-item-active/);
+
+		await page.keyboard.press("Escape");
+		expect(pageErrors).toEqual([]);
+	});
+
+	test("resets query and active index when reopened", async ({ page }) => {
+		const pageErrors = watchPageErrors(page);
+		await navigateAndWait(page, "/");
+
+		// Open and type a query
+		await page.keyboard.press("Meta+k");
+		await page.locator(".cmd-palette-input").fill("test");
+		await page.keyboard.press("ArrowDown");
+		await page.keyboard.press("ArrowDown");
+		await page.keyboard.press("Escape");
+
+		// Reopen — should be reset
+		await page.keyboard.press("Meta+k");
+		await expect(page.locator(".cmd-palette-input")).toHaveValue("");
+		const firstItem = page.locator(".cmd-palette-item").first();
+		await expect(firstItem).toHaveClass(/cmd-palette-item-active/);
+
+		await page.keyboard.press("Escape");
+		expect(pageErrors).toEqual([]);
+	});
+
+	test("header button shows keyboard shortcut badge", async ({ page }) => {
+		const pageErrors = watchPageErrors(page);
+		await navigateAndWait(page, "/");
+
+		const kbd = page.locator("#cmdPaletteKbd");
+		await expect(kbd).toBeVisible();
+		const text = await kbd.textContent();
+		// Should be either ⌘K or Ctrl+K
+		expect(text === "\u2318K" || text === "Ctrl+K").toBeTruthy();
+
+		expect(pageErrors).toEqual([]);
+	});
+
+	test("mobile: header kbd badge is hidden", async ({ page }) => {
+		const pageErrors = watchPageErrors(page);
+		await page.setViewportSize({ width: 390, height: 844 });
+		await navigateAndWait(page, "/");
+
+		const kbd = page.locator("#cmdPaletteKbd");
+		await expect(kbd).toBeHidden();
+
+		expect(pageErrors).toEqual([]);
+	});
+
+	test("palette has correct ARIA roles", async ({ page }) => {
+		const pageErrors = watchPageErrors(page);
+		await navigateAndWait(page, "/");
+
+		await page.keyboard.press("Meta+k");
+		await expect(page.locator(".cmd-palette")).toBeVisible();
+
+		await expect(page.locator('[role="dialog"][aria-modal="true"]')).toBeVisible();
+		await expect(page.locator('[role="listbox"]')).toBeVisible();
+		const firstOption = page.locator('[role="option"]').first();
+		await expect(firstOption).toBeVisible();
+
+		await page.keyboard.press("Escape");
+		expect(pageErrors).toEqual([]);
+	});
+});

--- a/crates/web/ui/input.css
+++ b/crates/web/ui/input.css
@@ -2167,6 +2167,171 @@
   }
 }
 
+/* ── Command Palette ──────────────────────────────────────────────── */
+
+.cmd-palette-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 200;
+  background: rgba(0, 0, 0, 0.45);
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+  padding-top: min(20vh, 120px);
+}
+
+.cmd-palette {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  box-shadow: 0 16px 48px rgba(0, 0, 0, 0.3);
+  width: 520px;
+  max-width: calc(100vw - 32px);
+  max-height: min(60vh, 480px);
+  display: flex;
+  flex-direction: column;
+  animation: 0.12s ease-out msg-in;
+  overflow: hidden;
+}
+
+.cmd-palette-input-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 12px 14px;
+  border-bottom: 1px solid var(--border);
+}
+
+.cmd-palette-search-icon {
+  color: var(--muted);
+  flex-shrink: 0;
+}
+
+.cmd-palette-input {
+  flex: 1;
+  background: transparent;
+  border: none;
+  outline: none;
+  font-size: 0.9rem;
+  color: var(--text);
+  font-family: inherit;
+}
+
+.cmd-palette-input::placeholder {
+  color: var(--muted);
+}
+
+.cmd-palette-kbd {
+  font-size: 0.65rem;
+  font-family: inherit;
+  padding: 2px 6px;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  color: var(--muted);
+  background: var(--surface2);
+  line-height: 1;
+  flex-shrink: 0;
+}
+
+.cmd-palette-list {
+  overflow-y: auto;
+  padding: 4px 0;
+}
+
+.cmd-palette-group {
+  padding: 8px 14px 4px;
+  font-size: 0.68rem;
+  font-weight: 600;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.cmd-palette-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 7px 14px;
+  cursor: pointer;
+  font-size: 0.82rem;
+  color: var(--text);
+  transition: background 0.08s;
+}
+
+.cmd-palette-item:hover,
+.cmd-palette-item-active {
+  background: var(--bg-hover);
+}
+
+.cmd-palette-item .icon {
+  color: var(--muted);
+  flex-shrink: 0;
+}
+
+.cmd-palette-item-active .icon {
+  color: var(--accent);
+}
+
+.cmd-palette-item-label {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.cmd-palette-item-hint {
+  font-size: 0.72rem;
+  color: var(--muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 200px;
+  flex-shrink: 1;
+}
+
+.cmd-palette-fieldset {
+  border: none;
+  margin: 0;
+  padding: 0;
+  min-inline-size: 0;
+}
+
+.cmd-palette-empty {
+  padding: 20px 14px;
+  text-align: center;
+  font-size: 0.8rem;
+  color: var(--muted);
+}
+
+/* Header button kbd badge */
+.cmd-palette-header-kbd {
+  font-size: 0.6rem;
+  font-family: inherit;
+  padding: 1px 5px;
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  color: var(--muted);
+  background: var(--surface2);
+  line-height: 1;
+  margin-left: 2px;
+}
+
+@media (max-width: 767px) {
+  .cmd-palette {
+    width: calc(100vw - 16px);
+    max-height: 70vh;
+  }
+
+  .cmd-palette-backdrop {
+    padding-top: 48px;
+  }
+
+  .cmd-palette-header-kbd {
+    display: none;
+  }
+}
+
 /* ── Animations ───────────────────────────────────────────────────── */
 
 @keyframes pulse {

--- a/crates/web/ui/src/app.tsx
+++ b/crates/web/ui/src/app.tsx
@@ -31,6 +31,7 @@ import { updateSandboxImageUI, updateSandboxUI } from "./sandbox";
 import * as _sessions from "./sessions";
 import { fetchSessions, refreshWelcomeCardIfNeeded, removeSessionFromClientState, renderSessionList } from "./sessions";
 import * as S from "./state";
+import { togglePalette } from "./stores/command-store";
 import * as modelStore from "./stores/model-store";
 import * as _modelStore from "./stores/model-store";
 import * as _nodeStore from "./stores/node-store";
@@ -264,6 +265,12 @@ onEvent("tick", (_payload: unknown) => {
 	applyMemory(payload.mem as MemInfo | null);
 });
 
+// Command palette button — wire up click handler.
+const commandPaletteBtn = document.getElementById("commandPaletteBtn");
+if (commandPaletteBtn) {
+	commandPaletteBtn.addEventListener("click", () => togglePalette());
+}
+
 // Logout button — wire up click handler once.
 const logoutBtn = document.getElementById("logoutBtn");
 const settingsBtn = document.getElementById("settingsBtn");
@@ -337,6 +344,10 @@ window.addEventListener("resize", () => {
 });
 document.addEventListener("keydown", (e) => {
 	if (e.key === "Escape") closeMobileMenu();
+	if (e.key === "k" && (e.metaKey || e.ctrlKey)) {
+		e.preventDefault();
+		togglePalette();
+	}
 });
 document.addEventListener("click", (e) => {
 	if (!mobileMenuPanel?.classList.contains("open")) return;

--- a/crates/web/ui/src/components/CommandPalette.tsx
+++ b/crates/web/ui/src/components/CommandPalette.tsx
@@ -95,6 +95,7 @@ export function CommandPalette(): VNode | null {
 	const inputRef = useRef<HTMLInputElement>(null);
 	const listRef = useRef<HTMLDivElement>(null);
 	const searchTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+	const reqIdRef = useRef(0);
 
 	const commands = useMemo(() => buildCommands(), [show]);
 
@@ -116,14 +117,22 @@ export function CommandPalette(): VNode | null {
 		return items;
 	}, [filtered, sessionHits]);
 
-	const grouped = useMemo(() => {
+	// Build a flat ordered list following GROUP_ORDER so render index
+	// always matches the position used by execute()/setActiveIdx().
+	const orderedItems = useMemo(() => {
 		const groups: Record<string, PaletteItem[]> = {};
 		for (const item of allItems) {
 			const group = item.type === "command" ? item.cmd.group : "sessions";
 			if (!groups[group]) groups[group] = [];
 			groups[group].push(item);
 		}
-		return groups;
+		const ordered: Array<{ group: string; items: PaletteItem[] }> = [];
+		for (const group of GROUP_ORDER) {
+			if (groups[group]?.length) {
+				ordered.push({ group, items: groups[group] });
+			}
+		}
+		return ordered;
 	}, [allItems]);
 
 	useEffect(() => {
@@ -146,16 +155,20 @@ export function CommandPalette(): VNode | null {
 			return;
 		}
 		searchTimer.current = setTimeout(() => {
+			const thisReq = ++reqIdRef.current;
 			sendRpc<SessionHit[]>("sessions.search", {
 				query,
 				includeArchived: sessionStore.showArchivedSessions.value,
-			}).then((res) => {
-				if (res?.ok && Array.isArray(res.payload)) {
-					setSessionHits(res.payload.slice(0, 5));
-				} else {
-					setSessionHits([]);
-				}
-			});
+			})
+				.then((res) => {
+					if (thisReq !== reqIdRef.current) return;
+					if (res?.ok && Array.isArray(res.payload)) {
+						setSessionHits(res.payload.slice(0, 5));
+					} else {
+						setSessionHits([]);
+					}
+				})
+				.catch(() => setSessionHits([]));
 		}, 300);
 		return () => {
 			if (searchTimer.current) clearTimeout(searchTimer.current);
@@ -168,8 +181,11 @@ export function CommandPalette(): VNode | null {
 		if (active) active.scrollIntoView({ block: "nearest" });
 	}, [activeIdx]);
 
+	// Flat list in render order for index-based execution.
+	const flatItems = useMemo(() => orderedItems.flatMap((g) => g.items), [orderedItems]);
+
 	function execute(idx: number): void {
-		const item = allItems[idx];
+		const item = flatItems[idx];
 		if (!item) return;
 		closePalette();
 		if (item.type === "command") {
@@ -185,7 +201,7 @@ export function CommandPalette(): VNode | null {
 			closePalette();
 		} else if (e.key === "ArrowDown") {
 			e.preventDefault();
-			setActiveIdx((i) => Math.min(i + 1, allItems.length - 1));
+			setActiveIdx((i) => Math.min(i + 1, flatItems.length - 1));
 		} else if (e.key === "ArrowUp") {
 			e.preventDefault();
 			setActiveIdx((i) => Math.max(i - 1, 0));
@@ -197,7 +213,9 @@ export function CommandPalette(): VNode | null {
 
 	if (!show) return null;
 
-	let flatIdx = 0;
+	// Pre-compute flat index offset for each group so render stays
+	// in sync with flatItems without an imperative counter.
+	let groupOffset = 0;
 
 	return (
 		// biome-ignore lint/a11y/noStaticElementInteractions: backdrop dismiss pattern, keyboard handled by inner dialog
@@ -222,15 +240,15 @@ export function CommandPalette(): VNode | null {
 					<kbd class="cmd-palette-kbd">esc</kbd>
 				</div>
 				<div class="cmd-palette-list" ref={listRef} role="listbox">
-					{allItems.length === 0 && <div class="cmd-palette-empty">{t("common:labels.noMatches")}</div>}
-					{GROUP_ORDER.map((group) => {
-						const items = grouped[group];
-						if (!items || items.length === 0) return null;
+					{flatItems.length === 0 && <div class="cmd-palette-empty">{t("common:labels.noMatches")}</div>}
+					{orderedItems.map(({ group, items }) => {
+						const baseIdx = groupOffset;
+						groupOffset += items.length;
 						return (
 							<fieldset key={group} aria-label={GROUP_LABELS[group]} class="cmd-palette-fieldset">
 								<div class="cmd-palette-group">{GROUP_LABELS[group]}</div>
-								{items.map((item) => {
-									const idx = flatIdx++;
+								{items.map((item, i) => {
+									const idx = baseIdx + i;
 									const key = item.type === "command" ? item.cmd.id : item.hit.sessionKey;
 									return (
 										<PaletteItemRow

--- a/crates/web/ui/src/components/CommandPalette.tsx
+++ b/crates/web/ui/src/components/CommandPalette.tsx
@@ -1,0 +1,257 @@
+// ── Command Palette ──────────────────────────────────────────
+//
+// Cmd+K / Ctrl+K overlay for quick navigation, actions, and
+// session search. Rendered as a signal-driven Preact component
+// inside GlobalDialogs.
+
+import type { VNode } from "preact";
+import { useEffect, useMemo, useRef, useState } from "preact/hooks";
+import { sendRpc } from "../helpers";
+import { t } from "../i18n";
+import { navigate, sessionPath } from "../router";
+import { buildCommands, type Command, closePalette, paletteOpen } from "../stores/command-store";
+import { sessionStore } from "../stores/session-store";
+
+// ── Types ───────────────────────────────────────��────────────
+
+interface SessionHit {
+	label?: string;
+	sessionKey: string;
+	snippet: string;
+}
+
+type PaletteItem = { type: "command"; cmd: Command } | { type: "session"; hit: SessionHit };
+
+// ── Constants ────────────────────────────────────────────────
+
+const GROUP_LABELS: Record<string, string> = {
+	navigation: "Navigation",
+	settings: "Settings",
+	actions: "Actions",
+	sessions: "Sessions",
+};
+
+const GROUP_ORDER = ["navigation", "settings", "actions", "sessions"];
+
+// ── Item renderer ────────────────────────────────────────────
+
+interface PaletteItemRowProps {
+	item: PaletteItem;
+	active: boolean;
+	onSelect: () => void;
+	onHover: () => void;
+}
+
+function PaletteItemRow({ item, active, onSelect, onHover }: PaletteItemRowProps): VNode {
+	const cls = `cmd-palette-item ${active ? "cmd-palette-item-active" : ""}`;
+	if (item.type === "command") {
+		return (
+			<div
+				role="option"
+				tabIndex={-1}
+				aria-selected={active}
+				class={cls}
+				data-active={active ? "true" : undefined}
+				onClick={onSelect}
+				onKeyDown={(e: KeyboardEvent) => {
+					if (e.key === "Enter") onSelect();
+				}}
+				onMouseEnter={onHover}
+			>
+				{item.cmd.icon && <span class={`icon icon-sm ${item.cmd.icon}`} />}
+				<span class="cmd-palette-item-label">{item.cmd.label}</span>
+				{item.cmd.shortcut && <kbd class="cmd-palette-kbd">{item.cmd.shortcut}</kbd>}
+			</div>
+		);
+	}
+	const hit = item.hit;
+	return (
+		<div
+			role="option"
+			tabIndex={-1}
+			aria-selected={active}
+			class={cls}
+			data-active={active ? "true" : undefined}
+			onClick={onSelect}
+			onKeyDown={(e: KeyboardEvent) => {
+				if (e.key === "Enter") onSelect();
+			}}
+			onMouseEnter={onHover}
+		>
+			<span class="icon icon-sm icon-chat" />
+			<span class="cmd-palette-item-label">{hit.label || hit.sessionKey}</span>
+			<span class="cmd-palette-item-hint">{truncate(hit.snippet, 60)}</span>
+		</div>
+	);
+}
+
+// ── Main component ───────────────────────────────────────────
+
+export function CommandPalette(): VNode | null {
+	const show = paletteOpen.value;
+	const [query, setQuery] = useState("");
+	const [activeIdx, setActiveIdx] = useState(0);
+	const [sessionHits, setSessionHits] = useState<SessionHit[]>([]);
+	const inputRef = useRef<HTMLInputElement>(null);
+	const listRef = useRef<HTMLDivElement>(null);
+	const searchTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+	const commands = useMemo(() => buildCommands(), [show]);
+
+	const filtered = useMemo(() => {
+		if (!query) return commands;
+		const q = query.toLowerCase();
+		return commands.filter((cmd) => {
+			if (cmd.label.toLowerCase().includes(q)) return true;
+			if (cmd.group.toLowerCase().includes(q)) return true;
+			return cmd.keywords?.some((kw) => kw.includes(q)) ?? false;
+		});
+	}, [commands, query]);
+
+	const allItems = useMemo<PaletteItem[]>(() => {
+		const items: PaletteItem[] = filtered.map((cmd) => ({ type: "command" as const, cmd }));
+		for (const hit of sessionHits) {
+			items.push({ type: "session", hit });
+		}
+		return items;
+	}, [filtered, sessionHits]);
+
+	const grouped = useMemo(() => {
+		const groups: Record<string, PaletteItem[]> = {};
+		for (const item of allItems) {
+			const group = item.type === "command" ? item.cmd.group : "sessions";
+			if (!groups[group]) groups[group] = [];
+			groups[group].push(item);
+		}
+		return groups;
+	}, [allItems]);
+
+	useEffect(() => {
+		if (show) {
+			setQuery("");
+			setActiveIdx(0);
+			setSessionHits([]);
+			requestAnimationFrame(() => inputRef.current?.focus());
+		}
+	}, [show]);
+
+	useEffect(() => {
+		setActiveIdx(0);
+	}, [query, sessionHits.length]);
+
+	useEffect(() => {
+		if (searchTimer.current) clearTimeout(searchTimer.current);
+		if (query.length < 2) {
+			setSessionHits([]);
+			return;
+		}
+		searchTimer.current = setTimeout(() => {
+			sendRpc<SessionHit[]>("sessions.search", {
+				query,
+				includeArchived: sessionStore.showArchivedSessions.value,
+			}).then((res) => {
+				if (res?.ok && Array.isArray(res.payload)) {
+					setSessionHits(res.payload.slice(0, 5));
+				} else {
+					setSessionHits([]);
+				}
+			});
+		}, 300);
+		return () => {
+			if (searchTimer.current) clearTimeout(searchTimer.current);
+		};
+	}, [query]);
+
+	useEffect(() => {
+		if (!listRef.current) return;
+		const active = listRef.current.querySelector("[data-active='true']");
+		if (active) active.scrollIntoView({ block: "nearest" });
+	}, [activeIdx]);
+
+	function execute(idx: number): void {
+		const item = allItems[idx];
+		if (!item) return;
+		closePalette();
+		if (item.type === "command") {
+			item.cmd.action();
+		} else {
+			navigate(sessionPath(item.hit.sessionKey));
+		}
+	}
+
+	function onKeyDown(e: KeyboardEvent): void {
+		if (e.key === "Escape") {
+			e.preventDefault();
+			closePalette();
+		} else if (e.key === "ArrowDown") {
+			e.preventDefault();
+			setActiveIdx((i) => Math.min(i + 1, allItems.length - 1));
+		} else if (e.key === "ArrowUp") {
+			e.preventDefault();
+			setActiveIdx((i) => Math.max(i - 1, 0));
+		} else if (e.key === "Enter") {
+			e.preventDefault();
+			execute(activeIdx);
+		}
+	}
+
+	if (!show) return null;
+
+	let flatIdx = 0;
+
+	return (
+		// biome-ignore lint/a11y/noStaticElementInteractions: backdrop dismiss pattern, keyboard handled by inner dialog
+		// biome-ignore lint/a11y/useKeyWithClickEvents: Escape key handled by inner onKeyDown
+		<div
+			class="cmd-palette-backdrop"
+			onClick={(e: Event) => {
+				if (e.target === e.currentTarget) closePalette();
+			}}
+		>
+			<div role="dialog" aria-modal="true" aria-label="Command palette" class="cmd-palette" onKeyDown={onKeyDown}>
+				<div class="cmd-palette-input-row">
+					<span class="icon icon-md icon-search cmd-palette-search-icon" />
+					<input
+						ref={inputRef}
+						class="cmd-palette-input"
+						type="text"
+						placeholder={t("common:actions.search") || "Search\u2026"}
+						value={query}
+						onInput={(e: Event) => setQuery((e.target as HTMLInputElement).value)}
+					/>
+					<kbd class="cmd-palette-kbd">esc</kbd>
+				</div>
+				<div class="cmd-palette-list" ref={listRef} role="listbox">
+					{allItems.length === 0 && <div class="cmd-palette-empty">{t("common:labels.noMatches")}</div>}
+					{GROUP_ORDER.map((group) => {
+						const items = grouped[group];
+						if (!items || items.length === 0) return null;
+						return (
+							<fieldset key={group} aria-label={GROUP_LABELS[group]} class="cmd-palette-fieldset">
+								<div class="cmd-palette-group">{GROUP_LABELS[group]}</div>
+								{items.map((item) => {
+									const idx = flatIdx++;
+									const key = item.type === "command" ? item.cmd.id : item.hit.sessionKey;
+									return (
+										<PaletteItemRow
+											key={key}
+											item={item}
+											active={idx === activeIdx}
+											onSelect={() => execute(idx)}
+											onHover={() => setActiveIdx(idx)}
+										/>
+									);
+								})}
+							</fieldset>
+						);
+					})}
+				</div>
+			</div>
+		</div>
+	);
+}
+
+function truncate(text: string, max: number): string {
+	if (text.length <= max) return text;
+	return `${text.slice(0, max)}\u2026`;
+}

--- a/crates/web/ui/src/stores/command-store.ts
+++ b/crates/web/ui/src/stores/command-store.ts
@@ -8,6 +8,7 @@ import { signal } from "@preact/signals";
 import * as gon from "../gon";
 import { navigate } from "../router";
 import { routes, settingsPath } from "../routes";
+import { applyTheme } from "../theme";
 
 // ── Types ────────────────────────────────────────────────────
 
@@ -312,8 +313,8 @@ export function buildCommands(): Command[] {
 			action: () => {
 				const current = document.documentElement.getAttribute("data-theme");
 				const next = current === "dark" ? "light" : "dark";
-				document.documentElement.setAttribute("data-theme", next);
 				localStorage.setItem("moltis-theme", next);
+				applyTheme(next);
 			},
 		},
 		{

--- a/crates/web/ui/src/stores/command-store.ts
+++ b/crates/web/ui/src/stores/command-store.ts
@@ -1,0 +1,333 @@
+// ── Command palette store ────────────────────────────────────
+//
+// Signal-driven state for the command palette. Commands are built
+// dynamically from gon-injected routes so they stay in sync with
+// what the server exposes.
+
+import { signal } from "@preact/signals";
+import * as gon from "../gon";
+import { navigate } from "../router";
+import { routes, settingsPath } from "../routes";
+
+// ── Types ────────────────────────────────────────────────────
+
+export interface Command {
+	id: string;
+	label: string;
+	group: "navigation" | "settings" | "actions";
+	icon?: string;
+	shortcut?: string;
+	keywords?: string[];
+	action: () => void;
+}
+
+// ── Signals ──────────────────────────────────────────────────
+
+export const paletteOpen = signal(false);
+
+export function togglePalette(): void {
+	paletteOpen.value = !paletteOpen.value;
+}
+
+export function openPalette(): void {
+	paletteOpen.value = true;
+}
+
+export function closePalette(): void {
+	paletteOpen.value = false;
+}
+
+// ── Command registry ─────────────────────────────────────────
+
+function nav(path: string | undefined): () => void {
+	return () => {
+		if (path) navigate(path);
+	};
+}
+
+function settingsNav(id: string): () => void {
+	return () => navigate(settingsPath(id));
+}
+
+export function buildCommands(): Command[] {
+	const cmds: Command[] = [];
+
+	// ── Navigation ───────────────────────────────────────────
+	cmds.push(
+		{
+			id: "nav-chats",
+			label: "Chats",
+			group: "navigation",
+			icon: "icon-chat",
+			keywords: ["sessions", "conversation"],
+			action: nav(routes.chats),
+		},
+		{
+			id: "nav-providers",
+			label: "Providers",
+			group: "navigation",
+			icon: "icon-layers",
+			keywords: ["llm", "model", "api"],
+			action: nav(routes.providers),
+		},
+		{
+			id: "nav-projects",
+			label: "Projects",
+			group: "navigation",
+			icon: "icon-folder",
+			keywords: ["workspace"],
+			action: nav(routes.projects),
+		},
+		{
+			id: "nav-skills",
+			label: "Skills",
+			group: "navigation",
+			icon: "icon-sparkles",
+			keywords: ["ability", "tool"],
+			action: nav(routes.skills),
+		},
+		{
+			id: "nav-crons",
+			label: "Crons",
+			group: "navigation",
+			icon: "icon-cron",
+			keywords: ["schedule", "job", "timer"],
+			action: nav(routes.crons),
+		},
+		{
+			id: "nav-logs",
+			label: "Logs",
+			group: "navigation",
+			icon: "icon-document",
+			keywords: ["log", "output"],
+			action: nav(routes.logs),
+		},
+		{
+			id: "nav-metrics",
+			label: "Metrics",
+			group: "navigation",
+			icon: "icon-activity",
+			keywords: ["monitoring", "dashboard", "stats"],
+			action: nav(routes.monitoring),
+		},
+	);
+
+	// ── Settings sections ────────────────────────────────────
+	cmds.push(
+		{
+			id: "set-profile",
+			label: "User Profile",
+			group: "settings",
+			icon: "icon-person",
+			keywords: ["identity", "name", "avatar"],
+			action: settingsNav("profile"),
+		},
+		{
+			id: "set-agents",
+			label: "Agents",
+			group: "settings",
+			icon: "icon-users",
+			keywords: ["agent", "preset"],
+			action: settingsNav("agents"),
+		},
+		{
+			id: "set-nodes",
+			label: "Nodes",
+			group: "settings",
+			icon: "icon-nodes",
+			keywords: ["node", "cluster"],
+			action: settingsNav("nodes"),
+		},
+		{
+			id: "set-environment",
+			label: "Environment",
+			group: "settings",
+			icon: "icon-terminal",
+			keywords: ["env", "variable"],
+			action: settingsNav("environment"),
+		},
+		{
+			id: "set-memory",
+			label: "Memory",
+			group: "settings",
+			icon: "icon-database",
+			keywords: ["knowledge", "context"],
+			action: settingsNav("memory"),
+		},
+		{
+			id: "set-notifications",
+			label: "Notifications",
+			group: "settings",
+			icon: "icon-bell",
+			keywords: ["alert", "notify"],
+			action: settingsNav("notifications"),
+		},
+		{
+			id: "set-webhooks",
+			label: "Webhooks",
+			group: "settings",
+			icon: "icon-webhooks",
+			keywords: ["webhook", "hook", "callback"],
+			action: settingsNav("webhooks"),
+		},
+		{
+			id: "set-heartbeat",
+			label: "Heartbeat",
+			group: "settings",
+			icon: "icon-heart",
+			keywords: ["pulse", "health"],
+			action: settingsNav("heartbeat"),
+		},
+		{
+			id: "set-security",
+			label: "Authentication",
+			group: "settings",
+			icon: "icon-key",
+			keywords: ["password", "passkey", "auth", "security"],
+			action: settingsNav("security"),
+		},
+		{
+			id: "set-vault",
+			label: "Encryption",
+			group: "settings",
+			icon: "icon-lock",
+			keywords: ["vault", "encrypt", "secret"],
+			action: settingsNav("vault"),
+		},
+		{
+			id: "set-ssh",
+			label: "SSH",
+			group: "settings",
+			icon: "icon-ssh",
+			keywords: ["key", "remote"],
+			action: settingsNav("ssh"),
+		},
+		{
+			id: "set-remote",
+			label: "Remote Access",
+			group: "settings",
+			icon: "icon-share",
+			keywords: ["tailscale", "tunnel"],
+			action: settingsNav("remote-access"),
+		},
+		{
+			id: "set-sandboxes",
+			label: "Sandboxes",
+			group: "settings",
+			icon: "icon-cube",
+			keywords: ["container", "docker"],
+			action: settingsNav("sandboxes"),
+		},
+		{
+			id: "set-channels",
+			label: "Channels",
+			group: "settings",
+			icon: "icon-channels",
+			keywords: ["telegram", "whatsapp", "slack", "discord"],
+			action: settingsNav("channels"),
+		},
+		{
+			id: "set-hooks",
+			label: "Hooks",
+			group: "settings",
+			icon: "icon-wrench",
+			keywords: ["hook", "automation"],
+			action: settingsNav("hooks"),
+		},
+		{
+			id: "set-mcp",
+			label: "MCP Servers",
+			group: "settings",
+			icon: "icon-link",
+			keywords: ["mcp", "server", "protocol"],
+			action: settingsNav("mcp"),
+		},
+		{
+			id: "set-tools",
+			label: "Tools",
+			group: "settings",
+			icon: "icon-settings-gear",
+			keywords: ["tool", "function"],
+			action: settingsNav("tools"),
+		},
+		{
+			id: "set-voice",
+			label: "Voice",
+			group: "settings",
+			icon: "icon-microphone",
+			keywords: ["speech", "audio", "transcribe"],
+			action: settingsNav("voice"),
+		},
+		{
+			id: "set-config",
+			label: "Configuration",
+			group: "settings",
+			icon: "icon-document",
+			keywords: ["toml", "config", "file"],
+			action: settingsNav("config"),
+		},
+	);
+
+	// Conditional settings
+	if (gon.get("terminal_enabled")) {
+		cmds.push({
+			id: "set-terminal",
+			label: "Terminal",
+			group: "settings",
+			icon: "icon-terminal",
+			keywords: ["shell", "bash", "console"],
+			action: settingsNav("terminal"),
+		});
+	}
+	if (gon.get("graphql_enabled")) {
+		cmds.push({
+			id: "set-graphql",
+			label: "GraphQL",
+			group: "settings",
+			icon: "icon-graphql",
+			keywords: ["query", "playground"],
+			action: settingsNav("graphql"),
+		});
+	}
+
+	// ── Actions ──────────────────────────────────────────────
+	cmds.push(
+		{
+			id: "act-new-session",
+			label: "New Session",
+			group: "actions",
+			icon: "icon-chat",
+			keywords: ["create", "start", "new"],
+			action: () => {
+				const btn = document.getElementById("newSessionBtn");
+				if (btn) btn.click();
+			},
+		},
+		{
+			id: "act-theme",
+			label: "Toggle Theme",
+			group: "actions",
+			icon: "icon-sun",
+			keywords: ["dark", "light", "theme", "mode"],
+			action: () => {
+				const current = document.documentElement.getAttribute("data-theme");
+				const next = current === "dark" ? "light" : "dark";
+				document.documentElement.setAttribute("data-theme", next);
+				localStorage.setItem("moltis-theme", next);
+			},
+		},
+		{
+			id: "act-logout",
+			label: "Sign Out",
+			group: "actions",
+			icon: "icon-logout",
+			keywords: ["logout", "signout", "disconnect"],
+			action: () => {
+				const btn = document.getElementById("logoutBtn");
+				if (btn) btn.click();
+			},
+		},
+	);
+
+	return cmds;
+}

--- a/crates/web/ui/src/theme.ts
+++ b/crates/web/ui/src/theme.ts
@@ -5,7 +5,7 @@ function getSystemTheme(): "dark" | "light" {
 	return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
 }
 
-function applyTheme(mode: string): void {
+export function applyTheme(mode: string): void {
 	const resolved = mode === "system" ? getSystemTheme() : mode;
 	document.documentElement.setAttribute("data-theme", resolved);
 	document.documentElement.style.colorScheme = resolved;

--- a/crates/web/ui/src/ui.tsx
+++ b/crates/web/ui/src/ui.tsx
@@ -4,6 +4,7 @@ import type { Signal } from "@preact/signals";
 import { signal } from "@preact/signals";
 import type { ComponentChildren, VNode } from "preact";
 import { useEffect, useRef, useState } from "preact/hooks";
+import { CommandPalette } from "./components/CommandPalette";
 import { t } from "./i18n";
 
 // ── Toast notifications ──────────────────────────────────────
@@ -386,6 +387,7 @@ export function GlobalDialogs(): VNode {
 			<VanillaConfirmDialog />
 			<ShareVisibilityDialog />
 			<ShareLinkDialog />
+			<CommandPalette />
 		</>
 	);
 }


### PR DESCRIPTION
## Summary

- Adds a command palette overlay accessible via `Cmd+K` (Mac) / `Ctrl+K` (other) or a new search icon button in the header bar
- Provides quick access to all navigation pages, settings sections, and common actions (new session, toggle theme, sign out)
- Includes debounced session search via existing `sessions.search` RPC when query is 2+ characters
- Keyboard-navigable with ArrowUp/Down, Enter to execute, Escape to close

## Validation

### Completed
- [x] `npx tsc --noEmit` — 0 errors
- [x] `npx biome check` — clean (only pre-existing warnings in `ui.tsx`)
- [x] `npx vite build` — successful
- [x] `npm run build:css` — Tailwind rebuilt with new classes
- [x] ARIA roles: `dialog`, `listbox`, `option` with `aria-selected`, `tabIndex`
- [x] Mobile responsive (full-width on small viewports, kbd badge hidden)

### Remaining
- [ ] `cargo fmt --all -- --check`
- [ ] `just lint`
- [ ] `just test`
- [ ] E2E tests for command palette (`e2e/specs/command-palette.spec.js`)

## Manual QA

1. Open the web UI
2. Press `Cmd+K` (Mac) or `Ctrl+K` — palette should open centered near top
3. Type to filter commands (e.g. "prov" shows Providers)
4. Use ArrowDown/Up to navigate, Enter to select — should navigate to correct page
5. Type 2+ characters to see session search results appear below commands
6. Click the search icon button in the header — palette should open
7. Press Escape or click backdrop — palette should close
8. On mobile viewport: palette should be full-width, header kbd badge hidden