### PR TITLE
fix(docs): use $http_host in nginx proxy examples to preserve port

### DIFF
--- a/docs/src/security.md
+++ b/docs/src/security.md
@@ -441,8 +441,8 @@ If HTTP works but WebSockets fail, make sure your location block includes
 ```nginx
 location / {
     proxy_pass http://172.17.0.1:13131;
-    proxy_set_header Host $host;
-    proxy_set_header X-Forwarded-Host $host;
+    proxy_set_header Host $http_host;
+    proxy_set_header X-Forwarded-Host $http_host;
     proxy_set_header X-Forwarded-Proto $scheme;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header X-Real-IP $remote_addr;
@@ -474,13 +474,19 @@ If WebSockets fail behind NPM while HTTP works, ensure:
 Use this in NPM's **Advanced** field:
 
 ```nginx
-proxy_set_header Host $host;
-proxy_set_header X-Forwarded-Host $host;
+proxy_set_header Host $http_host;
+proxy_set_header X-Forwarded-Host $http_host;
 proxy_set_header X-Forwarded-Proto $scheme;
 proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 proxy_set_header Upgrade $http_upgrade;
 proxy_set_header Connection "upgrade";
 ```
+
+**Why `$http_host` instead of `$host`?** Nginx's `$host` strips the port,
+while `$http_host` preserves it. Moltis validates that the WebSocket `Origin`
+header matches the `Host` header (including port). On non-standard ports
+(e.g., `:444` instead of `:443`), using `$host` causes a mismatch and
+WebSocket connections are rejected with "cross-origin WebSocket upgrade".
 
 Upstream scheme guidance:
 


### PR DESCRIPTION
## Summary

- Use `$http_host` instead of `$host` in both nginx proxy config examples (direct nginx and Nginx Proxy Manager)
- Add explanation of why `$http_host` is needed for non-standard ports
- Fixes WebSocket "rejected cross-origin WebSocket upgrade" errors when running behind a reverse proxy on a non-standard port (e.g. `:444`)

## Context

A user reported WebSocket failures behind Nginx Proxy Manager on port 444. The root cause: nginx's `$host` strips the port from the `Host` header, so moltis sees `origin=https://domain:444` vs `host=domain` (which defaults to port 443), causing the origin check to fail.

## Validation

### Completed
- [x] Verified fix resolves the reported issue (confirmed by user)
- [x] Both nginx config examples updated consistently
- [x] No other docs reference `$host` in moltis proxy configs

### Remaining
- [ ] `mdbook serve` renders correctly

## Manual QA

1. Set up nginx reverse proxy on a non-standard HTTPS port (e.g. 444)
2. Verify WebSocket connects successfully with `$http_host`
3. Verify standard port (443) setups still work