### PR TITLE
Consistent SessionMemoryHook dispatch across all session lifecycle paths

### DIFF
--- a/crates/gateway/src/channel_events/commands/session_handlers.rs
+++ b/crates/gateway/src/channel_events/commands/session_handlers.rs
@@ -106,7 +106,12 @@ pub(in crate::channel_events) async fn handle_new(
     );
 
     // Export the old session before the user moves on.
-    if let Some(ref hooks) = state.inner.read().await.hook_registry {
+    // NOTE: The active-session pointer has already been updated above, so the
+    // hook reads history by session_key directly rather than via the active
+    // mapping.  If export fails it is logged and swallowed — the old session's
+    // data remains in the store and can be exported manually.
+    let hooks = state.inner.read().await.hook_registry.clone();
+    if let Some(ref hooks) = hooks {
         crate::session::dispatch_command_hook(hooks, session_key, "new", sender_id).await;
     }
 

--- a/crates/gateway/src/channel_events/commands/session_handlers.rs
+++ b/crates/gateway/src/channel_events/commands/session_handlers.rs
@@ -105,6 +105,11 @@ pub(in crate::channel_events) async fn handle_new(
         "channel /new: created new session"
     );
 
+    // Export the old session before the user moves on.
+    if let Some(ref hooks) = state.inner.read().await.hook_registry {
+        crate::session::dispatch_command_hook(hooks, session_key, "new", sender_id).await;
+    }
+
     // Assign a model to the new session: prefer the channel's
     // configured model, fall back to the first registered model.
     let models_val = state.services.model.list().await.ok();

--- a/crates/gateway/src/methods/services/core.rs
+++ b/crates/gateway/src/methods/services/core.rs
@@ -636,10 +636,12 @@ pub(super) fn register(reg: &mut MethodRegistry) {
         Box::new(|ctx| {
             Box::pin(async move {
                 // Export the session before the clear destroys its history.
-                if let Some(session_key) = active_session_key_for_ctx(&ctx).await
-                    && let Some(ref hooks) = ctx.state.inner.read().await.hook_registry
-                {
-                    crate::session::dispatch_command_hook(hooks, &session_key, "reset", None).await;
+                if let Some(session_key) = active_session_key_for_ctx(&ctx).await {
+                    let hooks = ctx.state.inner.read().await.hook_registry.clone();
+                    if let Some(ref hooks) = hooks {
+                        crate::session::dispatch_command_hook(hooks, &session_key, "reset", None)
+                            .await;
+                    }
                 }
 
                 let mut params = ctx.params.clone();
@@ -840,12 +842,17 @@ pub(super) fn register(reg: &mut MethodRegistry) {
                 // Mark the session as seen so unread state clears.
                 ctx.state.services.session.mark_seen(key).await;
 
-                // Export the previous session before the user moves on.
+                // Export the previous session when the user creates a brand-new
+                // session (e.g. "+" button or /new).  Switching between two
+                // *existing* sessions intentionally skips export — only new-
+                // session creation signals the end of the previous conversation.
                 if !was_existing_session
                     && let Some(prev_key) = previous_active_key.as_deref().filter(|pk| *pk != key)
-                    && let Some(ref hooks) = ctx.state.inner.read().await.hook_registry
                 {
-                    crate::session::dispatch_command_hook(hooks, prev_key, "new", None).await;
+                    let hooks = ctx.state.inner.read().await.hook_registry.clone();
+                    if let Some(ref hooks) = hooks {
+                        crate::session::dispatch_command_hook(hooks, prev_key, "new", None).await;
+                    }
                 }
 
                 if let Some(pid) = ctx.params.get("project_id").and_then(|v| v.as_str()) {

--- a/crates/gateway/src/methods/services/core.rs
+++ b/crates/gateway/src/methods/services/core.rs
@@ -635,6 +635,13 @@ pub(super) fn register(reg: &mut MethodRegistry) {
         "chat.clear",
         Box::new(|ctx| {
             Box::pin(async move {
+                // Export the session before the clear destroys its history.
+                if let Some(session_key) = active_session_key_for_ctx(&ctx).await
+                    && let Some(ref hooks) = ctx.state.inner.read().await.hook_registry
+                {
+                    crate::session::dispatch_command_hook(hooks, &session_key, "reset", None).await;
+                }
+
                 let mut params = ctx.params.clone();
                 params["_conn_id"] = serde_json::json!(ctx.client_conn_id);
                 ctx.state
@@ -832,6 +839,14 @@ pub(super) fn register(reg: &mut MethodRegistry) {
 
                 // Mark the session as seen so unread state clears.
                 ctx.state.services.session.mark_seen(key).await;
+
+                // Export the previous session before the user moves on.
+                if !was_existing_session
+                    && let Some(prev_key) = previous_active_key.as_deref().filter(|pk| *pk != key)
+                    && let Some(ref hooks) = ctx.state.inner.read().await.hook_registry
+                {
+                    crate::session::dispatch_command_hook(hooks, prev_key, "new", None).await;
+                }
 
                 if let Some(pid) = ctx.params.get("project_id").and_then(|v| v.as_str()) {
                     let _ = ctx

--- a/crates/gateway/src/methods/services/sessions.rs
+++ b/crates/gateway/src/methods/services/sessions.rs
@@ -179,7 +179,8 @@ pub(super) fn register(reg: &mut MethodRegistry) {
                     crate::session::summary::run_session_summary_if_enabled(&ctx.state, key).await;
 
                     // Export the session before the reset destroys its history.
-                    if let Some(ref hooks) = ctx.state.inner.read().await.hook_registry {
+                    let hooks = ctx.state.inner.read().await.hook_registry.clone();
+                    if let Some(ref hooks) = hooks {
                         crate::session::dispatch_command_hook(hooks, key, "reset", None).await;
                     }
                 }

--- a/crates/gateway/src/methods/services/sessions.rs
+++ b/crates/gateway/src/methods/services/sessions.rs
@@ -177,6 +177,11 @@ pub(super) fn register(reg: &mut MethodRegistry) {
                 let key = ctx.params.get("key").and_then(|v| v.as_str()).unwrap_or("");
                 if !key.is_empty() {
                     crate::session::summary::run_session_summary_if_enabled(&ctx.state, key).await;
+
+                    // Export the session before the reset destroys its history.
+                    if let Some(ref hooks) = ctx.state.inner.read().await.hook_registry {
+                        crate::session::dispatch_command_hook(hooks, key, "reset", None).await;
+                    }
                 }
 
                 ctx.state

--- a/crates/gateway/src/session.rs
+++ b/crates/gateway/src/session.rs
@@ -66,6 +66,31 @@ fn resolve_hook_channel_binding(
     (!binding.is_empty()).then_some(binding)
 }
 
+/// Dispatch a [`HookPayload::Command`] event (e.g. "new" or "reset") for the
+/// given session.  This is called from every code-path that creates or clears a
+/// session so that the `SessionMemoryHook` can export the conversation before
+/// the history is lost.
+pub(crate) async fn dispatch_command_hook(
+    hook_registry: &HookRegistry,
+    session_key: &str,
+    action: &str,
+    sender_id: Option<&str>,
+) {
+    let payload = moltis_common::hooks::HookPayload::Command {
+        session_key: session_key.to_string(),
+        action: action.to_string(),
+        sender_id: sender_id.map(str::to_string),
+    };
+    if let Err(e) = hook_registry.dispatch(&payload).await {
+        warn!(
+            session = %session_key,
+            action = %action,
+            error = %e,
+            "Command hook dispatch failed"
+        );
+    }
+}
+
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct TtsStatusPayload {

--- a/crates/web/ui/src/pages/chat/slash-commands.ts
+++ b/crates/web/ui/src/pages/chat/slash-commands.ts
@@ -345,7 +345,12 @@ export function handleSlashCommand(cmdName: string, cmdArgs: string): void {
 		return;
 	}
 	if (cmdName === "reset") {
-		clearActiveSession();
+		// Use sessions.reset (not chat.clear) so the session summary also runs.
+		chatAddMsg("system", "Resetting session\u2026");
+		sendRpc("sessions.reset", { key: S.activeSessionKey }).then((res) => {
+			if (res.ok) switchSession(S.activeSessionKey);
+			else chatAddMsg("error", res.error?.message || "Reset failed");
+		});
 		return;
 	}
 	if (cmdName === "sh") {

--- a/crates/web/ui/src/pages/chat/slash-commands.ts
+++ b/crates/web/ui/src/pages/chat/slash-commands.ts
@@ -40,6 +40,8 @@ export const slashCommands: SlashCommand[] = [
 	{ name: "compact", description: "Summarize conversation to save tokens" },
 	{ name: "context", description: "Show session context and project info" },
 	{ name: "mode", description: "Switch session mode" },
+	{ name: "new", description: "Start a new session" },
+	{ name: "reset", description: "Clear conversation history" },
 	{ name: "sh", description: "Enter command mode (/sh off or Esc to exit)" },
 ];
 
@@ -335,6 +337,15 @@ export function handleSlashCommand(cmdName: string, cmdArgs: string): void {
 	}
 	if (cmdName === "mode") {
 		handleModeCommand(cmdArgs);
+		return;
+	}
+	if (cmdName === "new") {
+		const newKey = `session:${crypto.randomUUID()}`;
+		switchSession(newKey);
+		return;
+	}
+	if (cmdName === "reset") {
+		clearActiveSession();
 		return;
 	}
 	if (cmdName === "sh") {

--- a/crates/web/ui/src/pages/sections/MemorySection.tsx
+++ b/crates/web/ui/src/pages/sections/MemorySection.tsx
@@ -687,7 +687,7 @@ export function MemorySection(): VNode {
 							rerender();
 						}}
 					>
-						<option value="on-new-or-reset">On /new and /reset</option>
+						<option value="on-new-or-reset">On session change</option>
 						<option value="off">Off</option>
 					</select>
 				</div>


### PR DESCRIPTION
## Summary

- Add `dispatch_command_hook()` helper in `session.rs` that centralizes `HookPayload::Command` dispatch
- Dispatch `Command("new")` on the **previous** session when switching to a newly created session (`sessions.switch`, channel `handle_new()`)
- Dispatch `Command("reset")` **before** clearing history in `chat.clear` and `sessions.reset`
- Add `/new` and `/reset` as web UI slash commands
- Update memory settings label from "On /new and /reset" to "On session change"

The `SessionMemoryHook` subscribes to `HookEvent::Command` with actions "new" or "reset" to export session transcripts, but `HookPayload::Command` was never dispatched anywhere in production code. This change ensures session export fires transparently regardless of how the user creates or resets a session (web UI button, slash command, or channel command).

## Validation

### Completed
- [x] `cargo check` — clean
- [x] `just format-check` — clean
- [x] `just lint` — clean
- [x] `just test` — 5416 passed, 120 skipped
- [x] `biome check --write` — clean
- [x] `npm run build` — clean
- [x] `npx tsc --noEmit` — clean

### Remaining
- [ ] `./scripts/local-validate.sh` (full CI gate)

## Manual QA

1. Enable "Session Export" in Memory settings → confirm label reads "On session change"
2. Have a conversation, click "+" to start a new session → confirm previous session exported to `memory/session-*.md`
3. Have a conversation, type `/new` → confirm previous session exported
4. Have a conversation, click "Clear" → confirm session exported before clear
5. Have a conversation, type `/reset` → confirm session exported before clear
6. Have a conversation, type `/clear` → confirm session exported before clear
7. In a channel (e.g. Telegram), send `/new` → confirm old session exported
8. In a channel, send `/clear` → confirm session exported before clear