### PR TITLE
refactor(config): unify provider name validation into single source of truth

### DIFF
--- a/crates/config/src/provider_env.rs
+++ b/crates/config/src/provider_env.rs
@@ -224,4 +224,38 @@ mod tests {
             Some("env:PROVIDER+API_KEY")
         );
     }
+
+    /// Every alias in `normalize_provider_name` must map to a canonical name
+    /// that exists in `KNOWN_PROVIDER_NAMES`.
+    #[test]
+    fn normalize_alias_outputs_are_in_canonical_list() {
+        use crate::schema::KNOWN_PROVIDER_NAMES;
+
+        let aliases = [
+            "claude",
+            "google",
+            "google-gemini",
+            "grok",
+            "local",
+            "z-ai",
+            "z.ai",
+            "zhipu",
+            "zhipu-ai",
+            "zai-code",
+            "zai-coding",
+            "zhipu-code",
+            "alibaba",
+            "alibaba-coding",
+            "dashscope-coding",
+        ];
+
+        for alias in aliases {
+            let canonical = normalize_provider_name(alias)
+                .unwrap_or_else(|| panic!("normalize_provider_name({alias:?}) returned None"));
+            assert!(
+                KNOWN_PROVIDER_NAMES.contains(&canonical.as_str()),
+                "alias \"{alias}\" normalizes to \"{canonical}\" which is not in KNOWN_PROVIDER_NAMES"
+            );
+        }
+    }
 }

--- a/crates/config/src/schema/providers.rs
+++ b/crates/config/src/schema/providers.rs
@@ -5,11 +5,16 @@ use {
     std::collections::HashMap,
 };
 
-/// Canonical list of known LLM provider names.
+/// Canonical list of known LLM provider names and accepted config-key aliases.
 ///
 /// This is the **single source of truth** for provider name validation.
 /// Config validation (`semantic.rs`) uses this to detect typos, and
 /// `moltis-providers` cross-validates its registrations against it.
+///
+/// The list includes both canonical provider names (used in registration)
+/// and config-key aliases that users may write in `[providers.<name>]`
+/// sections (e.g. `"local"` is an alias for `"local-llm"`, mapped at
+/// runtime by `ProvidersConfig::provider_entry`).
 ///
 /// When adding a new provider, add its config name here.  A compile-time
 /// test in `moltis-providers` will fail if a registered provider is

--- a/crates/config/src/schema/providers.rs
+++ b/crates/config/src/schema/providers.rs
@@ -5,6 +5,45 @@ use {
     std::collections::HashMap,
 };
 
+/// Canonical list of known LLM provider names.
+///
+/// This is the **single source of truth** for provider name validation.
+/// Config validation (`semantic.rs`) uses this to detect typos, and
+/// `moltis-providers` cross-validates its registrations against it.
+///
+/// When adding a new provider, add its config name here.  A compile-time
+/// test in `moltis-providers` will fail if a registered provider is
+/// missing from this list.
+pub const KNOWN_PROVIDER_NAMES: &[&str] = &[
+    // Built-in providers (always available)
+    "anthropic",
+    "openai",
+    // OpenAI-compatible providers (table-driven)
+    "alibaba-coding",
+    "cerebras",
+    "deepseek",
+    "fireworks",
+    "gemini",
+    "lmstudio",
+    "minimax",
+    "mistral",
+    "moonshot",
+    "ollama",
+    "openrouter",
+    "venice",
+    "zai",
+    "zai-code",
+    // Feature-gated providers
+    "github-copilot",
+    "kimi-code",
+    "local", // alias for local-llm
+    "local-llm",
+    "openai-codex",
+    // Providers registered via genai/async-openai backends
+    "groq",
+    "xai",
+];
+
 /// OAuth provider configuration (e.g. openai-codex).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct OAuthProviderConfig {
@@ -53,7 +92,7 @@ pub struct ProvidersConfig {
     pub show_legacy_models: bool,
 
     /// Provider-specific settings keyed by provider name.
-    /// Known keys: "anthropic", "openai", "gemini", "groq", "xai", "deepseek"
+    /// See [`KNOWN_PROVIDER_NAMES`] for the full list of recognised names.
     #[serde(flatten)]
     pub providers: HashMap<String, ProviderEntry>,
 

--- a/crates/config/src/template.rs
+++ b/crates/config/src/template.rs
@@ -129,10 +129,11 @@ port = {port}                           # Port number (auto-generated for this i
 # offered = ["local-llm", "lmstudio", "github-copilot", "openai-codex", "openai", "anthropic", "openrouter", "ollama", "moonshot", "minimax", "zai"]
                                     # Enabled providers and those shown in onboarding/picker UI ([] = enable/show all)
 # show_legacy_models = true         # Show models older than 1 year in the chat model selector (they always appear in Settings)
-# All available providers:
+# All available providers (canonical list in schema/providers.rs):
 #   "anthropic", "openai", "gemini", "groq", "xai", "deepseek",
 #   "fireworks", "mistral", "openrouter", "cerebras", "minimax",
-#   "moonshot", "zai", "zai-code", "venice", "ollama", "lmstudio", "local-llm", "openai-codex",
+#   "moonshot", "zai", "zai-code", "venice", "alibaba-coding",
+#   "ollama", "lmstudio", "local-llm", "openai-codex",
 #   "github-copilot", "kimi-code"
 
 # ── Anthropic (Claude) ────────────────────────────────────────

--- a/crates/config/src/validate/semantic.rs
+++ b/crates/config/src/validate/semantic.rs
@@ -1,22 +1,9 @@
-use {super::*, crate::schema::MoltisConfig, secrecy::ExposeSecret, std::path::Path};
-
-const KNOWN_PROVIDER_NAMES: &[&str] = &[
-    "anthropic",
-    "openai",
-    "gemini",
-    "groq",
-    "xai",
-    "deepseek",
-    "fireworks",
-    "mistral",
-    "openrouter",
-    "cerebras",
-    "minimax",
-    "moonshot",
-    "venice",
-    "ollama",
-    "lmstudio",
-];
+use {
+    super::*,
+    crate::schema::{KNOWN_PROVIDER_NAMES, MoltisConfig},
+    secrecy::ExposeSecret,
+    std::path::Path,
+};
 
 const PROVIDERS_META_KEYS: &[&str] = &["offered", "show_legacy_models"];
 

--- a/crates/config/src/validate/tests/providers.rs
+++ b/crates/config/src/validate/tests/providers.rs
@@ -100,6 +100,29 @@ enabled = true
 }
 
 #[test]
+fn all_canonical_providers_accepted_without_warning() {
+    use crate::schema::KNOWN_PROVIDER_NAMES;
+    for name in KNOWN_PROVIDER_NAMES {
+        let toml = format!(
+            r#"
+[providers.{name}]
+enabled = true
+"#
+        );
+        let result = validate_toml_str(&toml);
+        let warnings: Vec<_> = result
+            .diagnostics
+            .iter()
+            .filter(|d| d.category == "unknown-provider")
+            .collect();
+        assert!(
+            warnings.is_empty(),
+            "canonical provider \"{name}\" triggered unknown-provider warning: {warnings:?}"
+        );
+    }
+}
+
+#[test]
 fn env_section_passes_validation() {
     let toml = r#"
 [env]

--- a/crates/providers/src/model_catalogs.rs
+++ b/crates/providers/src/model_catalogs.rs
@@ -485,4 +485,56 @@ mod tests {
             "accounts/fireworks/routers/kimi-k2p5-turbo"
         ));
     }
+
+    /// Cross-validate that every provider registered in this crate appears in
+    /// the canonical `KNOWN_PROVIDER_NAMES` list in `moltis-config`.
+    ///
+    /// If this test fails, you added a provider to `moltis-providers` without
+    /// updating `crates/config/src/schema/providers.rs::KNOWN_PROVIDER_NAMES`.
+    #[test]
+    fn all_registered_providers_in_canonical_known_list() {
+        use moltis_config::schema::KNOWN_PROVIDER_NAMES;
+
+        // Built-in providers
+        let mut provider_names: Vec<&str> = vec!["anthropic", "openai"];
+
+        // OpenAI-compatible table-driven providers
+        for def in OPENAI_COMPAT_PROVIDERS {
+            provider_names.push(def.config_name);
+        }
+
+        // Feature-gated providers (always check names, regardless of feature)
+        provider_names.extend_from_slice(&[
+            "github-copilot",
+            "kimi-code",
+            "local-llm",
+            "openai-codex",
+            "groq",
+            "xai",
+        ]);
+
+        for name in &provider_names {
+            assert!(
+                KNOWN_PROVIDER_NAMES.contains(name),
+                "provider \"{name}\" is registered in moltis-providers but missing from \
+                 KNOWN_PROVIDER_NAMES in crates/config/src/schema/providers.rs — add it there"
+            );
+        }
+    }
+
+    /// Ensure `KNOWN_PROVIDER_NAMES` has no duplicates.
+    #[test]
+    fn canonical_known_list_has_no_duplicates() {
+        use moltis_config::schema::KNOWN_PROVIDER_NAMES;
+
+        let mut sorted: Vec<&str> = KNOWN_PROVIDER_NAMES.to_vec();
+        sorted.sort();
+        for window in sorted.windows(2) {
+            assert_ne!(
+                window[0], window[1],
+                "duplicate entry \"{0}\" in KNOWN_PROVIDER_NAMES",
+                window[0]
+            );
+        }
+    }
 }

--- a/crates/providers/src/model_catalogs.rs
+++ b/crates/providers/src/model_catalogs.rs
@@ -503,7 +503,14 @@ mod tests {
             provider_names.push(def.config_name);
         }
 
-        // Feature-gated providers (always check names, regardless of feature)
+        // Feature-gated providers (always check names, regardless of feature).
+        //
+        // NOTE: This list must be maintained manually because `#[cfg(feature)]`
+        // attributes make it impossible to discover these names at test time
+        // when the feature is disabled.  When adding a new feature-gated
+        // provider registration in `registry/registration.rs` (e.g. a new
+        // `register_*_providers` method gated behind a cargo feature), add its
+        // config name here too.
         provider_names.extend_from_slice(&[
             "github-copilot",
             "kimi-code",


### PR DESCRIPTION
## Summary

- Consolidate provider name validation into a single canonical `KNOWN_PROVIDER_NAMES` constant in `crates/config/src/schema/providers.rs`
- Fix 7 valid providers (`zai`, `zai-code`, `alibaba-coding`, `openai-codex`, `github-copilot`, `kimi-code`, `local-llm`) producing false "unknown provider" config warnings
- Add cross-validation tests that prevent future drift between config validation, provider registration, and alias normalization

## Validation

### Completed
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo test -p moltis-config` — 49 provider-related tests pass
- [x] `cargo test -p moltis-providers` — 30 tests pass including cross-validation
- [x] `cargo check -p moltis-config -p moltis-providers` — compiles clean

### Remaining
- [ ] `./scripts/local-validate.sh` (full suite)

## Manual QA

1. Add `[providers.zai]` or `[providers.alibaba-coding]` to `moltis.toml`
2. Run `moltis config validate`
3. Confirm no "unknown provider" warning appears (previously these were false positives)