### PR TITLE
fix(providers): sanitize and strip user name field for channel messages

### DIFF
--- a/crates/agents/src/model.rs
+++ b/crates/agents/src/model.rs
@@ -157,7 +157,7 @@ impl ChatMessage {
     /// Sanitize a user name for the OpenAI `name` field.
     ///
     /// OpenAI requires `name` to match `^[a-zA-Z0-9_-]+$` with a max length of
-    /// 256 characters. Spaces are replaced with `_`, non-matching characters are
+    /// 64 characters. Spaces are replaced with `_`, non-matching characters are
     /// stripped, and the result is truncated to 64 chars.  Returns `None` if the
     /// sanitized result is empty.
     #[must_use]

--- a/crates/agents/src/model.rs
+++ b/crates/agents/src/model.rs
@@ -154,6 +154,33 @@ impl ChatMessage {
         }
     }
 
+    /// Sanitize a user name for the OpenAI `name` field.
+    ///
+    /// OpenAI requires `name` to match `^[a-zA-Z0-9_-]+$` with a max length of
+    /// 256 characters. Spaces are replaced with `_`, non-matching characters are
+    /// stripped, and the result is truncated to 64 chars.  Returns `None` if the
+    /// sanitized result is empty.
+    #[must_use]
+    pub fn sanitize_message_name(name: &str) -> Option<String> {
+        let sanitized: String = name
+            .chars()
+            .map(|c| {
+                if c == ' ' {
+                    '_'
+                } else {
+                    c
+                }
+            })
+            .filter(|c| c.is_ascii_alphanumeric() || *c == '_' || *c == '-')
+            .take(64)
+            .collect();
+        if sanitized.is_empty() {
+            None
+        } else {
+            Some(sanitized)
+        }
+    }
+
     /// Convert to OpenAI-compatible JSON format.
     ///
     /// Used by providers that speak the OpenAI Chat Completions API:
@@ -188,8 +215,9 @@ impl ChatMessage {
                         serde_json::json!({ "role": "user", "content": blocks })
                     },
                 };
-                if let Some(n) = name {
-                    msg["name"] = serde_json::Value::String(n.clone());
+                if let Some(sanitized) = name.as_ref().and_then(|n| Self::sanitize_message_name(n))
+                {
+                    msg["name"] = serde_json::Value::String(sanitized);
                 }
                 msg
             },
@@ -1279,6 +1307,36 @@ mod tests {
         assert_eq!(val["role"], "user");
         assert_eq!(val["content"], "hi");
         assert_eq!(val["name"], "Alice");
+    }
+
+    #[test]
+    fn to_openai_value_sanitizes_name_with_spaces() {
+        let msg = ChatMessage::user_named("hi", "Alice Smith");
+        let val = msg.to_openai_value();
+        assert_eq!(val["name"], "Alice_Smith");
+    }
+
+    #[test]
+    fn to_openai_value_sanitizes_name_with_unicode() {
+        let msg = ChatMessage::user_named("hi", "Алексей");
+        let val = msg.to_openai_value();
+        // All non-ASCII stripped → empty → name field omitted
+        assert!(val.get("name").is_none());
+    }
+
+    #[test]
+    fn to_openai_value_sanitizes_name_mixed_chars() {
+        let msg = ChatMessage::user_named("hi", "José García 🎉");
+        let val = msg.to_openai_value();
+        // Only ASCII alphanumeric, underscore, hyphen survive; spaces → _
+        assert_eq!(val["name"], "Jos_Garca_");
+    }
+
+    #[test]
+    fn sanitize_message_name_truncates_to_64_chars() {
+        let long_name = "a".repeat(100);
+        let result = ChatMessage::sanitize_message_name(&long_name);
+        assert_eq!(result.as_deref(), Some(&"a".repeat(64)[..]));
     }
 
     #[test]

--- a/crates/providers/src/openai/mod.rs
+++ b/crates/providers/src/openai/mod.rs
@@ -34,4 +34,10 @@ pub struct OpenAiProvider {
     /// Provider-scoped per-model context window overrides from
     /// `[providers.<name>.model_overrides.<id>]` config.
     context_window_provider: std::collections::HashMap<String, u32>,
+    /// Whether this provider accepts the `name` field on user messages.
+    ///
+    /// OpenAI and most compatible providers accept it (with character
+    /// restrictions handled by sanitization).  Mistral rejects it outright.
+    /// Defaults to `true`; set to `false` via `with_supports_user_name(false)`.
+    pub(crate) supports_user_name: bool,
 }

--- a/crates/providers/src/openai/provider/core.rs
+++ b/crates/providers/src/openai/provider/core.rs
@@ -37,6 +37,7 @@ impl OpenAiProvider {
             reasoning_content_override: None,
             context_window_global: std::collections::HashMap::new(),
             context_window_provider: std::collections::HashMap::new(),
+            supports_user_name: true,
         }
     }
 
@@ -46,6 +47,7 @@ impl OpenAiProvider {
         base_url: String,
         provider_name: String,
     ) -> Self {
+        let supports_user_name = !provider_name.eq_ignore_ascii_case("mistral");
         Self {
             api_key,
             model,
@@ -62,6 +64,7 @@ impl OpenAiProvider {
             reasoning_content_override: None,
             context_window_global: std::collections::HashMap::new(),
             context_window_provider: std::collections::HashMap::new(),
+            supports_user_name,
         }
     }
 
@@ -98,6 +101,15 @@ impl OpenAiProvider {
     #[must_use]
     pub fn with_reasoning_content(mut self, required: bool) -> Self {
         self.reasoning_content_override = Some(required);
+        self
+    }
+
+    /// Set whether this provider accepts the `name` field on user messages.
+    ///
+    /// Defaults to `true` for most providers; auto-set to `false` for Mistral.
+    #[must_use]
+    pub fn with_supports_user_name(mut self, supported: bool) -> Self {
+        self.supports_user_name = supported;
         self
     }
 
@@ -199,6 +211,7 @@ impl LlmProvider for OpenAiProvider {
             context_window_provider: self.context_window_provider.clone(),
             strict_tools_override: self.strict_tools_override,
             reasoning_content_override: self.reasoning_content_override,
+            supports_user_name: self.supports_user_name,
         }))
     }
 

--- a/crates/providers/src/openai/provider/core.rs
+++ b/crates/providers/src/openai/provider/core.rs
@@ -47,7 +47,8 @@ impl OpenAiProvider {
         base_url: String,
         provider_name: String,
     ) -> Self {
-        let supports_user_name = !provider_name.eq_ignore_ascii_case("mistral");
+        let supports_user_name = !provider_name.eq_ignore_ascii_case("mistral")
+            && !base_url.to_ascii_lowercase().contains("mistral.ai");
         Self {
             api_key,
             model,

--- a/crates/providers/src/openai/provider/request.rs
+++ b/crates/providers/src/openai/provider/request.rs
@@ -297,12 +297,18 @@ impl OpenAiProvider {
         messages: &[ChatMessage],
     ) -> Vec<serde_json::Value> {
         let needs_reasoning_content = self.requires_reasoning_content_on_tool_messages();
+        let strip_name = !self.supports_user_name;
         let mut remapped_tool_call_ids = HashMap::new();
         let mut used_tool_call_ids = HashSet::new();
         let mut out = Vec::with_capacity(messages.len());
 
         for message in messages {
             let mut value = message.to_openai_value();
+
+            // Strip the `name` field for providers that reject it entirely.
+            if strip_name && let Some(obj) = value.as_object_mut() {
+                obj.remove("name");
+            }
 
             if let Some(tool_calls) = value
                 .get_mut("tool_calls")
@@ -773,6 +779,51 @@ mod tests {
         assert!(
             assistant_msg.get("reasoning_content").is_some(),
             "assistant tool-call message must have reasoning_content, got: {assistant_msg}"
+        );
+    }
+
+    /// Mistral provider must strip the `name` field from user messages.
+    #[test]
+    fn mistral_provider_strips_user_name() {
+        let p = provider(
+            "mistral-small-latest",
+            "mistral",
+            "https://api.mistral.ai/v1",
+        );
+        assert!(!p.supports_user_name);
+
+        let messages = vec![ChatMessage::user_named("hello", "rokku")];
+        let serialized = p.serialize_messages_for_request(&messages);
+        assert_eq!(serialized.len(), 1);
+        assert!(
+            serialized[0].get("name").is_none(),
+            "Mistral must not have name field, got: {}",
+            serialized[0]
+        );
+    }
+
+    /// OpenAI provider must preserve the (sanitized) `name` field.
+    #[test]
+    fn openai_provider_preserves_user_name() {
+        let p = provider("gpt-4o", "openai", "https://api.openai.com/v1");
+        assert!(p.supports_user_name);
+
+        let messages = vec![ChatMessage::user_named("hello", "Alice")];
+        let serialized = p.serialize_messages_for_request(&messages);
+        assert_eq!(serialized[0]["name"], "Alice");
+    }
+
+    /// `with_supports_user_name(false)` overrides the default.
+    #[test]
+    fn supports_user_name_can_be_overridden() {
+        let p = provider("gpt-4o", "openai", "https://api.openai.com/v1")
+            .with_supports_user_name(false);
+
+        let messages = vec![ChatMessage::user_named("hello", "Alice")];
+        let serialized = p.serialize_messages_for_request(&messages);
+        assert!(
+            serialized[0].get("name").is_none(),
+            "name should be stripped when supports_user_name=false"
         );
     }
 

--- a/crates/providers/src/openai/provider/request.rs
+++ b/crates/providers/src/openai/provider/request.rs
@@ -802,6 +802,24 @@ mod tests {
         );
     }
 
+    /// Custom-named provider pointing at Mistral URL also strips name.
+    #[test]
+    fn mistral_url_detection_strips_user_name() {
+        let p = provider(
+            "mistral-small-latest",
+            "my-mistral-eu",
+            "https://api.mistral.ai/v1",
+        );
+        assert!(!p.supports_user_name);
+
+        let messages = vec![ChatMessage::user_named("hello", "rokku")];
+        let serialized = p.serialize_messages_for_request(&messages);
+        assert!(
+            serialized[0].get("name").is_none(),
+            "Mistral URL-based detection must strip name field"
+        );
+    }
+
     /// OpenAI provider must preserve the (sanitized) `name` field.
     #[test]
     fn openai_provider_preserves_user_name() {


### PR DESCRIPTION
## Summary

Fixes #905 — Telegram messages fail with Mistral (HTTP 422) and OpenAI (invalid `name` characters) because the sender's display name is passed unsanitized as the `name` field on user messages.

- **Sanitize names at serialization**: `ChatMessage::sanitize_message_name()` replaces spaces with `_`, strips non-`[a-zA-Z0-9_-]` characters, truncates to 64 chars, and omits the field entirely if the result is empty. Applied in `to_openai_value()`.
- **Dynamic provider capability**: Added `supports_user_name` field to `OpenAiProvider`, auto-detected from provider name (`false` for Mistral) and overridable via `with_supports_user_name()`. When `false`, `serialize_messages_for_request()` strips the `name` field entirely.

## Validation

### Completed
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p moltis-agents -p moltis-providers --all-targets -- -D warnings`
- [x] `cargo test -p moltis-agents -p moltis-providers` (all 550+ tests pass)
- [x] `cargo check --workspace` (clean, excluding pre-existing web asset warning)

### Remaining
- [ ] `./scripts/local-validate.sh`

## Manual QA

1. Configure Mistral as provider + Telegram as channel
2. Send a message from a Telegram account with a name containing spaces or Unicode
3. Verify the message reaches the LLM without HTTP 422
4. Verify web UI chat still works (no `name` field, unaffected)
5. Verify OpenAI provider with Telegram — name should be sanitized (spaces → `_`, special chars stripped)