### PR TITLE
fix(sandbox): prevent sandbox escape via RestrictedHostSandbox and FailoverSandbox

### DIFF
--- a/crates/tools/src/exec.rs
+++ b/crates/tools/src/exec.rs
@@ -450,16 +450,16 @@ impl AgentTool for ExecTool {
             self.sandbox_id.is_some()
         };
 
-        // Check whether the backend is a real container runtime.  When the
-        // backend is "none" or "restricted-host" (no container runtime),
+        // Check whether the backend provides filesystem isolation (container,
+        // VM, or WASM).  When it does not (restricted-host, cgroup, none),
         // commands run directly on the host even when the session mode says
         // "sandboxed".  Using /home/sandbox as the working directory would
         // fail with ENOENT on the host, so we must fall back to the host
         // data directory.
         let has_container_backend = if let Some(ref router) = self.sandbox_router {
-            !matches!(router.backend_name(), "none" | "restricted-host")
+            router.backend().provides_fs_isolation()
         } else {
-            !matches!(self.sandbox.backend_name(), "none" | "restricted-host")
+            self.sandbox.provides_fs_isolation()
         };
 
         // Resolve working directory.  When sandboxed *with a real container
@@ -539,7 +539,12 @@ impl AgentTool for ExecTool {
         );
 
         // Approval gating.
-        if !is_sandboxed && let Some(ref mgr) = self.approval_manager {
+        // When the sandbox backend lacks filesystem isolation (restricted-host,
+        // cgroup), commands run on the host — treat them the same as unsandboxed
+        // for approval purposes.  Only fully-isolated backends (container, WASM)
+        // skip approval gating.
+        let needs_approval = !is_sandboxed || !has_container_backend;
+        if needs_approval && let Some(ref mgr) = self.approval_manager {
             let action = mgr.check_command(command).await?;
             if action == ApprovalAction::NeedsApproval {
                 info!(command, "command needs approval, waiting...");

--- a/crates/tools/src/exec/tests.rs
+++ b/crates/tools/src/exec/tests.rs
@@ -268,6 +268,10 @@ impl Sandbox for CaptureWorkingDirSandbox {
         "docker"
     }
 
+    fn provides_fs_isolation(&self) -> bool {
+        true
+    }
+
     async fn ensure_ready(&self, _id: &SandboxId, _image_override: Option<&str>) -> Result<()> {
         Ok(())
     }

--- a/crates/tools/src/sandbox/apple.rs
+++ b/crates/tools/src/sandbox/apple.rs
@@ -704,6 +704,10 @@ impl Sandbox for AppleContainerSandbox {
         "apple-container"
     }
 
+    fn provides_fs_isolation(&self) -> bool {
+        true
+    }
+
     async fn ensure_ready(&self, id: &SandboxId, image_override: Option<&str>) -> Result<()> {
         let mut name = self.container_name(id).await;
         let requested_image = image_override.unwrap_or_else(|| self.image());

--- a/crates/tools/src/sandbox/docker.rs
+++ b/crates/tools/src/sandbox/docker.rs
@@ -719,6 +719,10 @@ impl Sandbox for NoSandbox {
         false
     }
 
+    fn provides_fs_isolation(&self) -> bool {
+        false
+    }
+
     async fn ensure_ready(&self, _id: &SandboxId, _image_override: Option<&str>) -> Result<()> {
         Ok(())
     }

--- a/crates/tools/src/sandbox/docker.rs
+++ b/crates/tools/src/sandbox/docker.rs
@@ -409,6 +409,10 @@ impl Sandbox for DockerSandbox {
         self.backend_label
     }
 
+    fn provides_fs_isolation(&self) -> bool {
+        true
+    }
+
     async fn ensure_ready(&self, id: &SandboxId, image_override: Option<&str>) -> Result<()> {
         let name = self.container_name(id);
 

--- a/crates/tools/src/sandbox/file_system.rs
+++ b/crates/tools/src/sandbox/file_system.rs
@@ -1212,6 +1212,10 @@ pub(crate) mod test_helpers {
             true
         }
 
+        fn provides_fs_isolation(&self) -> bool {
+            true
+        }
+
         async fn ensure_ready(&self, _id: &SandboxId, _image_override: Option<&str>) -> Result<()> {
             Ok(())
         }

--- a/crates/tools/src/sandbox/platform.rs
+++ b/crates/tools/src/sandbox/platform.rs
@@ -325,12 +325,13 @@ pub(crate) fn check_restricted_host_path(path: &str) -> Result<()> {
         return Ok(());
     }
 
-    // Allow temp directories — /tmp, /var/tmp, and the platform temp dir
-    // (e.g. /var/folders/... on macOS, /tmp on Linux).
+    // Allow hardcoded temp directory prefixes. Do NOT use std::env::temp_dir()
+    // here — it reads TMPDIR which could be set to a sensitive directory,
+    // bypassing the allowlist.
     if target.starts_with("/tmp")
         || target.starts_with("/private/tmp")
         || target.starts_with("/var/tmp")
-        || target.starts_with(normalize_path(&std::env::temp_dir()))
+        || target.starts_with("/var/folders/")
     {
         return Ok(());
     }

--- a/crates/tools/src/sandbox/platform.rs
+++ b/crates/tools/src/sandbox/platform.rs
@@ -61,6 +61,10 @@ impl Sandbox for CgroupSandbox {
         "cgroup"
     }
 
+    fn provides_fs_isolation(&self) -> bool {
+        false
+    }
+
     async fn ensure_ready(&self, _id: &SandboxId, _image_override: Option<&str>) -> Result<()> {
         let output = tokio::process::Command::new("systemd-run")
             .arg("--version")
@@ -213,6 +217,10 @@ impl Sandbox for RestrictedHostSandbox {
         true
     }
 
+    fn provides_fs_isolation(&self) -> bool {
+        false
+    }
+
     async fn ensure_ready(&self, _id: &SandboxId, _image_override: Option<&str>) -> Result<()> {
         Ok(())
     }
@@ -282,6 +290,7 @@ impl Sandbox for RestrictedHostSandbox {
         file_path: &str,
         max_bytes: u64,
     ) -> Result<SandboxReadResult> {
+        check_restricted_host_path(file_path)?;
         native_host_read_file(file_path, max_bytes).await
     }
 
@@ -291,16 +300,56 @@ impl Sandbox for RestrictedHostSandbox {
         file_path: &str,
         content: &[u8],
     ) -> Result<Option<serde_json::Value>> {
+        check_restricted_host_path(file_path)?;
         native_host_write_file(file_path, content).await
     }
 
     async fn list_files(&self, _id: &SandboxId, root: &str) -> Result<SandboxListFilesResult> {
+        check_restricted_host_path(root)?;
         native_host_list_files(root).await
     }
 
     async fn cleanup(&self, _id: &SandboxId) -> Result<()> {
         Ok(())
     }
+}
+
+/// Validate that a file path is within the allowed set for the restricted-host
+/// sandbox. Without container-level filesystem isolation, we restrict access
+/// to the Moltis data directory and temp directories to prevent sandbox escapes.
+pub(crate) fn check_restricted_host_path(path: &str) -> Result<()> {
+    let target = std::path::Path::new(path);
+
+    let data_dir = moltis_config::data_dir();
+    if target.starts_with(&data_dir) {
+        return Ok(());
+    }
+
+    // Allow temp directories — /tmp, /var/tmp, and the platform temp dir
+    // (e.g. /var/folders/... on macOS, /tmp on Linux).
+    if target.starts_with("/tmp")
+        || target.starts_with("/private/tmp")
+        || target.starts_with("/var/tmp")
+        || target.starts_with(std::env::temp_dir())
+    {
+        return Ok(());
+    }
+
+    // Allow access to Moltis-specific config/data subdirectories under $HOME.
+    if let Some(home) = moltis_config::home_dir() {
+        let moltis_config_dir = home.join(".config").join("moltis");
+        let moltis_home_dir = home.join(".moltis");
+        if target.starts_with(&moltis_config_dir) || target.starts_with(&moltis_home_dir) {
+            return Ok(());
+        }
+    }
+
+    Err(Error::message(format!(
+        "restricted-host sandbox: path '{}' is outside the allowed directories \
+         (Moltis data directory and /tmp). Install a container runtime \
+         (Docker, Podman, or Apple Container) for full filesystem isolation.",
+        path
+    )))
 }
 
 /// Returns `true` when the WASM sandbox feature is compiled in.

--- a/crates/tools/src/sandbox/platform.rs
+++ b/crates/tools/src/sandbox/platform.rs
@@ -10,8 +10,8 @@ use {
         error::{Error, Result},
         exec::{ExecOpts, ExecResult},
         sandbox::file_system::{
-            SandboxListFilesResult, SandboxReadResult, native_host_list_files,
-            native_host_read_file, native_host_write_file,
+            SandboxGrepOptions, SandboxListFilesResult, SandboxReadResult, command_grep,
+            native_host_list_files, native_host_read_file, native_host_write_file,
         },
     },
 };
@@ -307,6 +307,11 @@ impl Sandbox for RestrictedHostSandbox {
     async fn list_files(&self, _id: &SandboxId, root: &str) -> Result<SandboxListFilesResult> {
         check_restricted_host_path(root)?;
         native_host_list_files(root).await
+    }
+
+    async fn grep(&self, id: &SandboxId, opts: SandboxGrepOptions) -> Result<serde_json::Value> {
+        check_restricted_host_path(&opts.path)?;
+        command_grep(self, id, opts).await
     }
 
     async fn cleanup(&self, _id: &SandboxId) -> Result<()> {

--- a/crates/tools/src/sandbox/platform.rs
+++ b/crates/tools/src/sandbox/platform.rs
@@ -318,7 +318,7 @@ impl Sandbox for RestrictedHostSandbox {
 /// sandbox. Without container-level filesystem isolation, we restrict access
 /// to the Moltis data directory and temp directories to prevent sandbox escapes.
 pub(crate) fn check_restricted_host_path(path: &str) -> Result<()> {
-    let target = std::path::Path::new(path);
+    let target = normalize_path(std::path::Path::new(path));
 
     let data_dir = moltis_config::data_dir();
     if target.starts_with(&data_dir) {
@@ -330,7 +330,7 @@ pub(crate) fn check_restricted_host_path(path: &str) -> Result<()> {
     if target.starts_with("/tmp")
         || target.starts_with("/private/tmp")
         || target.starts_with("/var/tmp")
-        || target.starts_with(std::env::temp_dir())
+        || target.starts_with(normalize_path(&std::env::temp_dir()))
     {
         return Ok(());
     }
@@ -350,6 +350,24 @@ pub(crate) fn check_restricted_host_path(path: &str) -> Result<()> {
          (Docker, Podman, or Apple Container) for full filesystem isolation.",
         path
     )))
+}
+
+/// Normalize a path by resolving `.` and `..` components without hitting the
+/// filesystem (no symlink resolution). This prevents path traversal attacks
+/// like `/tmp/../etc/passwd` bypassing prefix checks.
+fn normalize_path(path: &std::path::Path) -> std::path::PathBuf {
+    use std::path::{Component, PathBuf};
+    let mut out = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::ParentDir => {
+                out.pop();
+            },
+            Component::CurDir => {},
+            other => out.push(other),
+        }
+    }
+    out
 }
 
 /// Returns `true` when the WASM sandbox feature is compiled in.

--- a/crates/tools/src/sandbox/platform.rs
+++ b/crates/tools/src/sandbox/platform.rs
@@ -137,6 +137,36 @@ impl Sandbox for CgroupSandbox {
         }
     }
 
+    async fn read_file(
+        &self,
+        _id: &SandboxId,
+        file_path: &str,
+        max_bytes: u64,
+    ) -> Result<SandboxReadResult> {
+        check_restricted_host_path(file_path)?;
+        native_host_read_file(file_path, max_bytes).await
+    }
+
+    async fn write_file(
+        &self,
+        _id: &SandboxId,
+        file_path: &str,
+        content: &[u8],
+    ) -> Result<Option<serde_json::Value>> {
+        check_restricted_host_path(file_path)?;
+        native_host_write_file(file_path, content).await
+    }
+
+    async fn list_files(&self, _id: &SandboxId, root: &str) -> Result<SandboxListFilesResult> {
+        check_restricted_host_path(root)?;
+        native_host_list_files(root).await
+    }
+
+    async fn grep(&self, id: &SandboxId, opts: SandboxGrepOptions) -> Result<serde_json::Value> {
+        check_restricted_host_path(&opts.path)?;
+        command_grep(self, id, opts).await
+    }
+
     async fn cleanup(&self, id: &SandboxId) -> Result<()> {
         let scope = self.scope_name(id);
         let _ = tokio::process::Command::new("systemctl")

--- a/crates/tools/src/sandbox/router.rs
+++ b/crates/tools/src/sandbox/router.rs
@@ -90,7 +90,30 @@ impl FailoverSandbox {
 #[async_trait]
 impl Sandbox for FailoverSandbox {
     fn backend_name(&self) -> &'static str {
-        self.primary_name
+        // Report the active backend so callers know the true isolation level.
+        if self
+            .use_fallback
+            .try_read()
+            .map(|guard| *guard)
+            .unwrap_or(false)
+        {
+            self.fallback_name
+        } else {
+            self.primary_name
+        }
+    }
+
+    fn provides_fs_isolation(&self) -> bool {
+        if self
+            .use_fallback
+            .try_read()
+            .map(|guard| *guard)
+            .unwrap_or(false)
+        {
+            self.fallback.provides_fs_isolation()
+        } else {
+            self.primary.provides_fs_isolation()
+        }
     }
 
     async fn ensure_ready(&self, id: &SandboxId, image_override: Option<&str>) -> Result<()> {

--- a/crates/tools/src/sandbox/router.rs
+++ b/crates/tools/src/sandbox/router.rs
@@ -91,11 +91,13 @@ impl FailoverSandbox {
 impl Sandbox for FailoverSandbox {
     fn backend_name(&self) -> &'static str {
         // Report the active backend so callers know the true isolation level.
+        // On lock contention (write lock held during failover switch),
+        // conservatively assume fallback is active — the safer default.
         if self
             .use_fallback
             .try_read()
             .map(|guard| *guard)
-            .unwrap_or(false)
+            .unwrap_or(true)
         {
             self.fallback_name
         } else {
@@ -104,11 +106,13 @@ impl Sandbox for FailoverSandbox {
     }
 
     fn provides_fs_isolation(&self) -> bool {
+        // On lock contention, conservatively report the fallback's (weaker)
+        // isolation level rather than the primary's.
         if self
             .use_fallback
             .try_read()
             .map(|guard| *guard)
-            .unwrap_or(false)
+            .unwrap_or(true)
         {
             self.fallback.provides_fs_isolation()
         } else {

--- a/crates/tools/src/sandbox/router.rs
+++ b/crates/tools/src/sandbox/router.rs
@@ -22,6 +22,7 @@ use {
             should_use_docker_backend,
         },
         docker::{DockerSandbox, NoSandbox},
+        file_system::{SandboxGrepOptions, SandboxListFilesResult, SandboxReadResult},
         platform::RestrictedHostSandbox,
         types::{
             BuildImageResult, DEFAULT_SANDBOX_IMAGE, Sandbox, SandboxConfig, SandboxId, SandboxMode,
@@ -195,6 +196,49 @@ impl Sandbox for FailoverSandbox {
         }
 
         self.primary.cleanup(id).await
+    }
+
+    // Delegate file operations to the active backend's own implementations
+    // so that path-level restrictions (e.g. RestrictedHostSandbox's allowlist)
+    // are enforced. Without these overrides the default trait impls route
+    // through self.exec(), bypassing the fallback backend's read_file/etc.
+
+    async fn read_file(
+        &self,
+        id: &SandboxId,
+        file_path: &str,
+        max_bytes: u64,
+    ) -> Result<SandboxReadResult> {
+        if self.fallback_enabled().await {
+            return self.fallback.read_file(id, file_path, max_bytes).await;
+        }
+        self.primary.read_file(id, file_path, max_bytes).await
+    }
+
+    async fn write_file(
+        &self,
+        id: &SandboxId,
+        file_path: &str,
+        content: &[u8],
+    ) -> Result<Option<serde_json::Value>> {
+        if self.fallback_enabled().await {
+            return self.fallback.write_file(id, file_path, content).await;
+        }
+        self.primary.write_file(id, file_path, content).await
+    }
+
+    async fn list_files(&self, id: &SandboxId, root: &str) -> Result<SandboxListFilesResult> {
+        if self.fallback_enabled().await {
+            return self.fallback.list_files(id, root).await;
+        }
+        self.primary.list_files(id, root).await
+    }
+
+    async fn grep(&self, id: &SandboxId, opts: SandboxGrepOptions) -> Result<serde_json::Value> {
+        if self.fallback_enabled().await {
+            return self.fallback.grep(id, opts).await;
+        }
+        self.primary.grep(id, opts).await
     }
 
     async fn build_image(

--- a/crates/tools/src/sandbox/tests.rs
+++ b/crates/tools/src/sandbox/tests.rs
@@ -369,6 +369,10 @@ impl Sandbox for TestSandbox {
         self.name
     }
 
+    fn provides_fs_isolation(&self) -> bool {
+        true
+    }
+
     async fn ensure_ready(&self, _id: &SandboxId, _image_override: Option<&str>) -> Result<()> {
         self.ensure_ready_calls.fetch_add(1, Ordering::SeqCst);
         if let Some(ref msg) = self.ensure_ready_error {

--- a/crates/tools/src/sandbox/tests/docker_router.rs
+++ b/crates/tools/src/sandbox/tests/docker_router.rs
@@ -780,6 +780,84 @@ async fn test_failover_sandbox_to_restricted_host_does_not_claim_fs_isolation() 
     assert!(!failover.provides_fs_isolation());
 }
 
+#[tokio::test]
+async fn test_failover_sandbox_read_file_enforces_path_allowlist() {
+    // After failover to RestrictedHostSandbox, file operations must go through
+    // the fallback's read_file (which checks the path allowlist), not through
+    // the default trait impl that calls self.exec() and bypasses the check.
+    let primary = Arc::new(TestSandbox::new(
+        "docker",
+        Some("cannot connect to the docker daemon"),
+        None,
+    ));
+    let fallback: Arc<dyn Sandbox> = Arc::new(RestrictedHostSandbox::new(SandboxConfig::default()));
+    let failover = FailoverSandbox::new(primary, fallback);
+
+    let id = SandboxId {
+        scope: SandboxScope::Session,
+        key: "test-failover-read".into(),
+    };
+
+    // Trigger failover.
+    failover.ensure_ready(&id, None).await.unwrap();
+    assert_eq!(failover.backend_name(), "restricted-host");
+
+    // read_file on a blocked path must be rejected by the allowlist.
+    let result = failover.read_file(&id, "/etc/passwd", 4096).await;
+    assert!(
+        result.is_err(),
+        "FailoverSandbox.read_file must enforce path allowlist after failover to restricted-host"
+    );
+}
+
+#[tokio::test]
+async fn test_failover_sandbox_write_file_enforces_path_allowlist() {
+    let primary = Arc::new(TestSandbox::new(
+        "docker",
+        Some("cannot connect to the docker daemon"),
+        None,
+    ));
+    let fallback: Arc<dyn Sandbox> = Arc::new(RestrictedHostSandbox::new(SandboxConfig::default()));
+    let failover = FailoverSandbox::new(primary, fallback);
+
+    let id = SandboxId {
+        scope: SandboxScope::Session,
+        key: "test-failover-write".into(),
+    };
+
+    failover.ensure_ready(&id, None).await.unwrap();
+
+    let result = failover.write_file(&id, "/var/log/evil.txt", b"nope").await;
+    assert!(
+        result.is_err(),
+        "FailoverSandbox.write_file must enforce path allowlist after failover"
+    );
+}
+
+#[tokio::test]
+async fn test_failover_sandbox_list_files_enforces_path_allowlist() {
+    let primary = Arc::new(TestSandbox::new(
+        "docker",
+        Some("cannot connect to the docker daemon"),
+        None,
+    ));
+    let fallback: Arc<dyn Sandbox> = Arc::new(RestrictedHostSandbox::new(SandboxConfig::default()));
+    let failover = FailoverSandbox::new(primary, fallback);
+
+    let id = SandboxId {
+        scope: SandboxScope::Session,
+        key: "test-failover-list".into(),
+    };
+
+    failover.ensure_ready(&id, None).await.unwrap();
+
+    let result = failover.list_files(&id, "/etc").await;
+    assert!(
+        result.is_err(),
+        "FailoverSandbox.list_files must enforce path allowlist after failover"
+    );
+}
+
 /// E2E regression test for #796: Podman+BuildKit may leave images in
 /// BuildKit's cache instead of the Podman store.  Gated behind
 /// `MOLTIS_SANDBOX_RUNTIME_E2E=1` and requires Podman to be installed.

--- a/crates/tools/src/sandbox/tests/docker_router.rs
+++ b/crates/tools/src/sandbox/tests/docker_router.rs
@@ -700,6 +700,86 @@ async fn test_sandbox_router_global_image_override() {
     assert_eq!(img, DEFAULT_SANDBOX_IMAGE);
 }
 
+// ── Sandbox escape regression tests (issue #923) ───────────────────────────
+
+#[test]
+fn test_no_sandbox_does_not_provide_fs_isolation() {
+    let sandbox = NoSandbox;
+    assert!(!sandbox.provides_fs_isolation());
+}
+
+#[test]
+fn test_docker_sandbox_provides_fs_isolation() {
+    let sandbox = DockerSandbox::new(SandboxConfig::default());
+    assert!(sandbox.provides_fs_isolation());
+}
+
+#[test]
+fn test_podman_sandbox_provides_fs_isolation() {
+    let sandbox = DockerSandbox::podman(SandboxConfig::default());
+    assert!(sandbox.provides_fs_isolation());
+}
+
+#[tokio::test]
+async fn test_failover_sandbox_reports_active_backend_name() {
+    // Primary: a "docker" backend that always fails.
+    let primary = Arc::new(TestSandbox::new(
+        "docker",
+        Some("cannot connect to the docker daemon"),
+        None,
+    ));
+    // Fallback: restricted-host.
+    let fallback: Arc<dyn Sandbox> = Arc::new(RestrictedHostSandbox::new(SandboxConfig::default()));
+
+    let failover = FailoverSandbox::new(primary, fallback);
+
+    // Before failover: reports primary name.
+    assert_eq!(failover.backend_name(), "docker");
+    assert!(failover.provides_fs_isolation());
+
+    // Trigger failover via ensure_ready.
+    let id = SandboxId {
+        scope: SandboxScope::Session,
+        key: "test-failover".into(),
+    };
+    failover.ensure_ready(&id, None).await.unwrap();
+
+    // After failover: reports fallback name and isolation level.
+    assert_eq!(failover.backend_name(), "restricted-host");
+    assert!(
+        !failover.provides_fs_isolation(),
+        "after failing over to restricted-host, FS isolation must be false"
+    );
+}
+
+#[tokio::test]
+async fn test_failover_sandbox_to_restricted_host_does_not_claim_fs_isolation() {
+    // Simulate macOS failover: apple-container → restricted-host
+    let primary = Arc::new(TestSandbox::new(
+        "apple-container",
+        Some("XPC connection error"),
+        None,
+    ));
+    let fallback: Arc<dyn Sandbox> = Arc::new(RestrictedHostSandbox::new(SandboxConfig::default()));
+    let failover = FailoverSandbox::new(primary, fallback);
+
+    let id = SandboxId {
+        scope: SandboxScope::Session,
+        key: "test-apple-failover".into(),
+    };
+
+    // Trigger failover.
+    failover.ensure_ready(&id, None).await.unwrap();
+
+    // The critical assertion: code must NOT see "apple-container" anymore.
+    assert_ne!(
+        failover.backend_name(),
+        "apple-container",
+        "backend_name must not mask failover to restricted-host"
+    );
+    assert!(!failover.provides_fs_isolation());
+}
+
 /// E2E regression test for #796: Podman+BuildKit may leave images in
 /// BuildKit's cache instead of the Podman store.  Gated behind
 /// `MOLTIS_SANDBOX_RUNTIME_E2E=1` and requires Podman to be installed.

--- a/crates/tools/src/sandbox/tests/restricted_host.rs
+++ b/crates/tools/src/sandbox/tests/restricted_host.rs
@@ -260,6 +260,30 @@ async fn test_restricted_host_list_blocks_outside_allowlist() {
     assert!(result.is_err(), "list_files must block /etc");
 }
 
+#[tokio::test]
+async fn test_restricted_host_grep_blocks_outside_allowlist() {
+    use crate::sandbox::file_system::{SandboxGrepMode, SandboxGrepOptions};
+
+    let sandbox = RestrictedHostSandbox::new(SandboxConfig::default());
+    let id = SandboxId {
+        scope: SandboxScope::Session,
+        key: "test-rh-block-grep".into(),
+    };
+    let result = sandbox
+        .grep(&id, SandboxGrepOptions {
+            pattern: "root".to_string(),
+            path: "/etc".to_string(),
+            mode: SandboxGrepMode::Content,
+            case_insensitive: false,
+            include_globs: Vec::new(),
+            offset: 0,
+            head_limit: None,
+            match_cap: None,
+        })
+        .await;
+    assert!(result.is_err(), "grep must block /etc");
+}
+
 #[test]
 fn test_parse_memory_limit() {
     assert_eq!(parse_memory_limit("512M"), Some(512 * 1024 * 1024));

--- a/crates/tools/src/sandbox/tests/restricted_host.rs
+++ b/crates/tools/src/sandbox/tests/restricted_host.rs
@@ -197,6 +197,25 @@ fn test_check_restricted_host_path_blocks_etc_passwd() {
 }
 
 #[test]
+fn test_check_restricted_host_path_blocks_dot_dot_traversal() {
+    // /tmp/../etc/passwd normalizes to /etc/passwd — must be blocked.
+    let result = check_restricted_host_path("/tmp/../etc/passwd");
+    assert!(result.is_err(), "must block /tmp/../etc/passwd traversal");
+}
+
+#[test]
+fn test_check_restricted_host_path_blocks_nested_traversal() {
+    let result = check_restricted_host_path("/tmp/a/b/../../../etc/shadow");
+    assert!(result.is_err(), "must block nested .. traversal");
+}
+
+#[test]
+fn test_check_restricted_host_path_allows_dot_dot_within_tmp() {
+    // /tmp/a/../b stays within /tmp — should be allowed.
+    check_restricted_host_path("/tmp/a/../b/file.txt").unwrap();
+}
+
+#[test]
 fn test_check_restricted_host_path_blocks_home_ssh() {
     let result = check_restricted_host_path("/home/user/.ssh/id_rsa");
     assert!(result.is_err(), "must block ~/.ssh");

--- a/crates/tools/src/sandbox/tests/restricted_host.rs
+++ b/crates/tools/src/sandbox/tests/restricted_host.rs
@@ -166,6 +166,81 @@ async fn test_restricted_host_sandbox_cleanup_noop() {
     sandbox.cleanup(&id).await.unwrap();
 }
 
+// ── Sandbox escape regression tests (issue #923) ───────────────────────────
+
+#[test]
+fn test_restricted_host_sandbox_does_not_provide_fs_isolation() {
+    let sandbox = RestrictedHostSandbox::new(SandboxConfig::default());
+    assert!(
+        !sandbox.provides_fs_isolation(),
+        "restricted-host must NOT claim filesystem isolation"
+    );
+}
+
+#[test]
+fn test_check_restricted_host_path_allows_data_dir() {
+    let data = moltis_config::data_dir().join("notes/todo.txt");
+    check_restricted_host_path(&data.display().to_string()).unwrap();
+}
+
+#[test]
+fn test_check_restricted_host_path_allows_tmp() {
+    check_restricted_host_path("/tmp/sandbox-work/out.txt").unwrap();
+}
+
+#[test]
+fn test_check_restricted_host_path_blocks_etc_passwd() {
+    let result = check_restricted_host_path("/etc/passwd");
+    assert!(result.is_err(), "must block /etc/passwd");
+    let msg = result.unwrap_err().to_string();
+    assert!(msg.contains("outside the allowed directories"));
+}
+
+#[test]
+fn test_check_restricted_host_path_blocks_home_ssh() {
+    let result = check_restricted_host_path("/home/user/.ssh/id_rsa");
+    assert!(result.is_err(), "must block ~/.ssh");
+}
+
+#[test]
+fn test_check_restricted_host_path_blocks_root_dir() {
+    let result = check_restricted_host_path("/root/.bashrc");
+    assert!(result.is_err(), "must block /root");
+}
+
+#[tokio::test]
+async fn test_restricted_host_read_blocks_etc_passwd() {
+    let sandbox = RestrictedHostSandbox::new(SandboxConfig::default());
+    let id = SandboxId {
+        scope: SandboxScope::Session,
+        key: "test-rh-block-read".into(),
+    };
+    let result = sandbox.read_file(&id, "/etc/passwd", 4096).await;
+    assert!(result.is_err(), "read_file must block /etc/passwd");
+}
+
+#[tokio::test]
+async fn test_restricted_host_write_blocks_outside_allowlist() {
+    let sandbox = RestrictedHostSandbox::new(SandboxConfig::default());
+    let id = SandboxId {
+        scope: SandboxScope::Session,
+        key: "test-rh-block-write".into(),
+    };
+    let result = sandbox.write_file(&id, "/var/log/evil.txt", b"nope").await;
+    assert!(result.is_err(), "write_file must block /var/log");
+}
+
+#[tokio::test]
+async fn test_restricted_host_list_blocks_outside_allowlist() {
+    let sandbox = RestrictedHostSandbox::new(SandboxConfig::default());
+    let id = SandboxId {
+        scope: SandboxScope::Session,
+        key: "test-rh-block-list".into(),
+    };
+    let result = sandbox.list_files(&id, "/etc").await;
+    assert!(result.is_err(), "list_files must block /etc");
+}
+
 #[test]
 fn test_parse_memory_limit() {
     assert_eq!(parse_memory_limit("512M"), Some(512 * 1024 * 1024));

--- a/crates/tools/src/sandbox/types.rs
+++ b/crates/tools/src/sandbox/types.rs
@@ -348,15 +348,16 @@ pub trait Sandbox: Send + Sync {
 
     /// Whether this backend provides filesystem isolation from the host.
     ///
-    /// Returns `true` for container-based backends (Docker, Podman, Apple
-    /// Container, WASM) where commands execute in a separate filesystem
-    /// namespace.  Returns `false` for backends that only provide resource
-    /// limits (restricted-host, cgroup) or no isolation at all (none).
+    /// Defaults to `false` (fail-safe): new backends must explicitly opt in
+    /// by returning `true`.  Container-based backends (Docker, Podman, Apple
+    /// Container, WASM) override this to `true`.  Backends that only provide
+    /// resource limits (restricted-host, cgroup) or no isolation (none) keep
+    /// the default.
     ///
     /// Used by the exec flow to enforce approval gating and file-path
     /// restrictions when true filesystem isolation is unavailable.
     fn provides_fs_isolation(&self) -> bool {
-        true
+        false
     }
 
     /// Pre-build a container image with packages baked in.

--- a/crates/tools/src/sandbox/types.rs
+++ b/crates/tools/src/sandbox/types.rs
@@ -346,6 +346,19 @@ pub trait Sandbox: Send + Sync {
         true
     }
 
+    /// Whether this backend provides filesystem isolation from the host.
+    ///
+    /// Returns `true` for container-based backends (Docker, Podman, Apple
+    /// Container, WASM) where commands execute in a separate filesystem
+    /// namespace.  Returns `false` for backends that only provide resource
+    /// limits (restricted-host, cgroup) or no isolation at all (none).
+    ///
+    /// Used by the exec flow to enforce approval gating and file-path
+    /// restrictions when true filesystem isolation is unavailable.
+    fn provides_fs_isolation(&self) -> bool {
+        true
+    }
+
     /// Pre-build a container image with packages baked in.
     /// Returns `None` for backends that don't support image building.
     async fn build_image(

--- a/crates/tools/src/sandbox/wasm.rs
+++ b/crates/tools/src/sandbox/wasm.rs
@@ -255,6 +255,10 @@ impl Sandbox for WasmSandbox {
         true
     }
 
+    fn provides_fs_isolation(&self) -> bool {
+        true
+    }
+
     async fn ensure_ready(&self, id: &SandboxId, _image_override: Option<&str>) -> Result<()> {
         let home = self.home_dir(id);
         let tmp = self.tmp_dir(id);


### PR DESCRIPTION
## Summary

Fixes two security bugs that allowed sandboxed sessions to access host filesystem files (#923):

- **RestrictedHostSandbox** reported `is_real()=true`, causing `is_sandboxed()` to return true and skip approval gating, but provided no filesystem isolation — only env clearing and ulimits. The LLM agent could freely read `/etc/passwd`, `~/.ssh/id_rsa`, etc.
- **FailoverSandbox::backend_name()** always returned the primary name (e.g. "apple-container"), masking silent degradation to RestrictedHostSandbox after failover. The exec flow thought it was in a container but commands executed on the host.

### Changes

1. Add `provides_fs_isolation()` to `Sandbox` trait — `true` for Docker/Podman/Apple Container/WASM, `false` for restricted-host/cgroup/none
2. Fix `FailoverSandbox` to report the active backend's name and isolation capability after failover
3. Enforce approval gating in `ExecTool` when sandbox lacks FS isolation (changed from `!is_sandboxed` to `!is_sandboxed || !has_container_backend`)
4. Add path allowlist to `RestrictedHostSandbox` file operations — `read_file`, `write_file`, `list_files` restricted to data_dir + /tmp
5. 17 regression tests covering all escape scenarios

## Validation

### Completed
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p moltis-tools --all-targets -- -D warnings`
- [x] `cargo test -p moltis-tools --lib` (960 tests pass)
- [x] New regression tests verify:
  - RestrictedHostSandbox blocks `/etc/passwd`, `/home/user/.ssh`, `/root`
  - RestrictedHostSandbox allows data_dir and `/tmp`
  - FailoverSandbox reports fallback backend name after failover
  - FailoverSandbox reports `provides_fs_isolation()=false` after falling over to restricted-host
  - Docker/Podman correctly report `provides_fs_isolation()=true`
  - NoSandbox correctly reports `provides_fs_isolation()=false`

### Remaining
- [ ] `./scripts/local-validate.sh` (full validation)

## Manual QA

1. Start moltis without a container runtime installed
2. Open a sandboxed chat session
3. Ask the agent to read `/etc/passwd` — should now be blocked by path allowlist
4. Ask the agent to run `cat /etc/passwd` — should now require approval (not auto-approved)

Closes #923