### PR TITLE
feat: add /btw, /fast, /insights, /steer, /queue commands and auxiliary model config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8439,6 +8439,7 @@ dependencies = [
  "moltis-metrics",
  "moltis-network-filter",
  "moltis-providers",
+ "moltis-service-traits",
  "moltis-sessions",
  "moltis-skills",
  "pdf-extract",

--- a/crates/agents/src/runner/mod.rs
+++ b/crates/agents/src/runner/mod.rs
@@ -22,6 +22,12 @@ pub use {
     tool_result::{ExtractedImage, sanitize_tool_result, tool_result_to_content},
 };
 
+/// Shared inbox for mid-flight steering text (populated by `/steer` command).
+///
+/// The agent loop drains this between iterations and injects the text as a
+/// system notice so the LLM sees the guidance on its next call.
+pub type SteerInbox = std::sync::Arc<tokio::sync::Mutex<Vec<String>>>;
+
 // Re-export helpers at the module level so that sibling submodules
 // (`non_streaming`, `streaming`) can continue to import via `super::item_name`.
 pub(crate) use helpers::{

--- a/crates/agents/src/runner/streaming.rs
+++ b/crates/agents/src/runner/streaming.rs
@@ -868,13 +868,16 @@ pub async fn run_agent_loop_streaming(
             on_event,
         );
 
-        // Drain any pending /steer text and inject as user guidance.
+        // Drain any pending /steer text and inject as a system note.
+        // Uses system role to avoid consecutive-user-message violations
+        // with strict providers that enforce role alternation.
         if let Some(ref inbox) = steer_inbox {
             let mut guard = inbox.lock().await;
-            for text in guard.drain(..) {
-                debug!(steer_text = %text, "injecting /steer guidance");
-                messages.push(ChatMessage::user(format!(
-                    "[User steering note — adjust your approach accordingly]: {text}"
+            if !guard.is_empty() {
+                let combined = guard.drain(..).collect::<Vec<_>>().join("\n");
+                debug!(steer_text = %combined, "injecting /steer guidance");
+                messages.push(ChatMessage::system(format!(
+                    "[Steering note from the user — adjust your approach accordingly]: {combined}"
                 )));
             }
         }

--- a/crates/agents/src/runner/streaming.rs
+++ b/crates/agents/src/runner/streaming.rs
@@ -61,6 +61,7 @@ pub async fn run_agent_loop_streaming(
     tool_context: Option<serde_json::Value>,
     hook_registry: Option<Arc<HookRegistry>>,
     sender_name: Option<String>,
+    steer_inbox: Option<super::SteerInbox>,
 ) -> Result<AgentRunResult, AgentRunError> {
     let native_tools = provider.supports_tools();
     let config = moltis_config::discover_and_load();
@@ -866,5 +867,16 @@ pub async fn run_agent_loop_streaming(
             &mut strip_tools_next_iter,
             on_event,
         );
+
+        // Drain any pending /steer text and inject as user guidance.
+        if let Some(ref inbox) = steer_inbox {
+            let mut guard = inbox.lock().await;
+            for text in guard.drain(..) {
+                debug!(steer_text = %text, "injecting /steer guidance");
+                messages.push(ChatMessage::user(format!(
+                    "[User steering note — adjust your approach accordingly]: {text}"
+                )));
+            }
+        }
     }
 }

--- a/crates/agents/src/runner/tests/basic.rs
+++ b/crates/agents/src/runner/tests/basic.rs
@@ -198,6 +198,7 @@ async fn test_streaming_runner_preserves_cache_usage() {
         None,
         None,
         None,
+        None,
     )
     .await
     .unwrap();

--- a/crates/channels/src/commands.rs
+++ b/crates/channels/src/commands.rs
@@ -91,6 +91,27 @@ pub fn all_commands() -> &'static [CommandDef] {
             name: "update",
             description: "Update moltis to latest or specified version",
         },
+        // Quick actions
+        CommandDef {
+            name: "btw",
+            description: "Quick side question (no tools, not persisted)",
+        },
+        CommandDef {
+            name: "fast",
+            description: "Toggle fast/priority mode",
+        },
+        CommandDef {
+            name: "insights",
+            description: "Show session analytics and usage stats",
+        },
+        CommandDef {
+            name: "steer",
+            description: "Inject guidance into the current agent run",
+        },
+        CommandDef {
+            name: "queue",
+            description: "Queue a message for the next agent turn",
+        },
         // Meta
         CommandDef {
             name: "help",
@@ -205,6 +226,11 @@ mod tests {
             "stop",
             "peek",
             "update",
+            "btw",
+            "fast",
+            "insights",
+            "steer",
+            "queue",
             "help",
         ] {
             assert!(

--- a/crates/channels/src/commands.rs
+++ b/crates/channels/src/commands.rs
@@ -35,6 +35,10 @@ pub fn all_commands() -> &'static [CommandDef] {
             description: "Attach an existing session here",
         },
         CommandDef {
+            name: "fork",
+            description: "Fork this session into a new branch",
+        },
+        CommandDef {
             name: "clear",
             description: "Clear session history",
         },
@@ -210,6 +214,7 @@ mod tests {
         let names: Vec<&str> = all_commands().iter().map(|c| c.name).collect();
         for expected in [
             "new",
+            "fork",
             "clear",
             "compact",
             "context",

--- a/crates/channels/src/commands.rs
+++ b/crates/channels/src/commands.rs
@@ -95,6 +95,10 @@ pub fn all_commands() -> &'static [CommandDef] {
             name: "update",
             description: "Update moltis to latest or specified version",
         },
+        CommandDef {
+            name: "rollback",
+            description: "List or restore file checkpoints",
+        },
         // Quick actions
         CommandDef {
             name: "btw",
@@ -231,6 +235,7 @@ mod tests {
             "stop",
             "peek",
             "update",
+            "rollback",
             "btw",
             "fast",
             "insights",

--- a/crates/chat/src/compaction_run/structured.rs
+++ b/crates/chat/src/compaction_run/structured.rs
@@ -159,9 +159,9 @@ fn warn_if_unused_auxiliary_model_config(config: &CompactionConfig) {
     tracing::warn!(
         summary_model = ?config.summary_model,
         max_summary_tokens = config.max_summary_tokens,
-        "chat.compact: chat.compaction.summary_model / max_summary_tokens are reserved \
-         for the auxiliary-model subsystem (beads issue moltis-8me) and have no effect \
-         on the structured strategy yet — the session's primary provider will be used"
+        "chat.compact: chat.compaction.summary_model / max_summary_tokens are not wired \
+         into the structured strategy yet — the session's primary provider will be used. \
+         Use `[auxiliary] compaction = \"model-id\"` for auxiliary model routing once wired"
     );
 }
 

--- a/crates/chat/src/run_with_tools.rs
+++ b/crates/chat/src/run_with_tools.rs
@@ -858,8 +858,8 @@ pub(crate) async fn run_with_tools(
         let _ = steer_state.take_steer_text(&steer_session_key).await;
         loop {
             tokio::time::sleep(Duration::from_millis(500)).await;
-            if let Some(text) = steer_state.take_steer_text(&steer_session_key).await {
-                steer_inbox_writer.lock().await.push(text);
+            if let Some(texts) = steer_state.take_steer_text(&steer_session_key).await {
+                steer_inbox_writer.lock().await.extend(texts);
             }
         }
     });

--- a/crates/chat/src/run_with_tools.rs
+++ b/crates/chat/src/run_with_tools.rs
@@ -847,6 +847,21 @@ pub(crate) async fn run_with_tools(
         runtime_context,
     );
 
+    // Create a shared steer inbox that the gateway can push steering text into.
+    // A background task polls the ChatRuntime and forwards any `/steer` text.
+    let steer_inbox: moltis_agents::runner::SteerInbox = Arc::new(Mutex::new(Vec::new()));
+    let steer_inbox_writer = steer_inbox.clone();
+    let steer_state = state.clone();
+    let steer_session_key = session_key.to_string();
+    let steer_task = tokio::spawn(async move {
+        loop {
+            tokio::time::sleep(Duration::from_millis(500)).await;
+            if let Some(text) = steer_state.take_steer_text(&steer_session_key).await {
+                steer_inbox_writer.lock().await.push(text);
+            }
+        }
+    });
+
     let provider_ref = provider.clone();
     let first_result = run_agent_loop_streaming(
         provider,
@@ -858,8 +873,10 @@ pub(crate) async fn run_with_tools(
         Some(tool_context.clone()),
         hook_registry.clone(),
         sender_name.clone(),
+        Some(steer_inbox.clone()),
     )
     .await;
+    steer_task.abort();
 
     // On context-window overflow, compact the session and retry once.
     let result = match first_result {
@@ -956,6 +973,7 @@ pub(crate) async fn run_with_tools(
                         Some(tool_context),
                         hook_registry,
                         sender_name,
+                        Some(steer_inbox.clone()),
                     )
                     .await
                 },

--- a/crates/chat/src/run_with_tools.rs
+++ b/crates/chat/src/run_with_tools.rs
@@ -854,6 +854,8 @@ pub(crate) async fn run_with_tools(
     let steer_state = state.clone();
     let steer_session_key = session_key.to_string();
     let steer_task = tokio::spawn(async move {
+        // Drain any stale steering text left over from a previous run.
+        let _ = steer_state.take_steer_text(&steer_session_key).await;
         loop {
             tokio::time::sleep(Duration::from_millis(500)).await;
             if let Some(text) = steer_state.take_steer_text(&steer_session_key).await {
@@ -876,7 +878,6 @@ pub(crate) async fn run_with_tools(
         Some(steer_inbox.clone()),
     )
     .await;
-    steer_task.abort();
 
     // On context-window overflow, compact the session and retry once.
     let result = match first_result {
@@ -999,6 +1000,7 @@ pub(crate) async fn run_with_tools(
         },
         other => other,
     };
+    steer_task.abort();
 
     // Ensure all runner events (including deltas) are broadcast in order before
     // emitting terminal final/error frames.

--- a/crates/chat/src/runtime.rs
+++ b/crates/chat/src/runtime.rs
@@ -161,8 +161,8 @@ pub trait ChatRuntime: Send + Sync {
 
     // ── Mid-flight steering ──────────────────────────────────────────────
 
-    /// Take (drain) any pending `/steer` text for a session.
-    async fn take_steer_text(&self, _session_key: &str) -> Option<String> {
+    /// Take (drain) all pending `/steer` texts for a session.
+    async fn take_steer_text(&self, _session_key: &str) -> Option<Vec<String>> {
         None
     }
 

--- a/crates/chat/src/runtime.rs
+++ b/crates/chat/src/runtime.rs
@@ -158,4 +158,16 @@ pub trait ChatRuntime: Send + Sync {
 
     /// List currently connected remote nodes.
     async fn connected_nodes(&self) -> Vec<ConnectedNodeSummary>;
+
+    // ── Mid-flight steering ──────────────────────────────────────────────
+
+    /// Take (drain) any pending `/steer` text for a session.
+    async fn take_steer_text(&self, _session_key: &str) -> Option<String> {
+        None
+    }
+
+    /// Check whether fast/priority mode is enabled for a session.
+    async fn is_fast_mode(&self, _session_key: &str) -> bool {
+        false
+    }
 }

--- a/crates/config/src/schema.rs
+++ b/crates/config/src/schema.rs
@@ -255,6 +255,8 @@ pub struct MoltisConfig {
     pub caldav: CalDavConfig,
     pub home_assistant: HomeAssistantConfig,
     pub webhooks: WebhooksConfig,
+    /// Auxiliary model assignments for side tasks (compaction, titles, vision).
+    pub auxiliary: AuxiliaryModelsConfig,
     /// Code-index configuration for codebase search tools.
     pub code_index: CodeIndexTomlConfig,
     /// Per-model overrides that apply across all providers.

--- a/crates/config/src/schema/chat.rs
+++ b/crates/config/src/schema/chat.rs
@@ -297,3 +297,26 @@ pub enum ToolRegistryMode {
     /// Only `tool_search` is sent; the model discovers and activates tools on demand.
     Lazy,
 }
+
+/// Auxiliary model assignments for side tasks.
+///
+/// Route compression, title generation, and vision to cheaper/faster models
+/// while keeping the main session on a more capable model. Falls back to the
+/// session's primary provider when a field is `None`.
+///
+/// ```toml
+/// [auxiliary]
+/// compaction = "openrouter/google/gemini-2.5-flash"
+/// title_generation = "openrouter/google/gemini-2.5-flash"
+/// ```
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(default)]
+pub struct AuxiliaryModelsConfig {
+    /// Model for context compaction/summarization.
+    /// Overrides `chat.compaction.summary_model` when set.
+    pub compaction: Option<String>,
+    /// Model for session title generation.
+    pub title_generation: Option<String>,
+    /// Model for vision/image analysis tasks.
+    pub vision: Option<String>,
+}

--- a/crates/config/src/template.rs
+++ b/crates/config/src/template.rs
@@ -273,6 +273,17 @@ port = {port}                           # Port number (auto-generated for this i
 # show_settings_hint = true           # Append compaction mode hint to notices
 
 # ══════════════════════════════════════════════════════════════════════════════
+# AUXILIARY MODELS
+# ══════════════════════════════════════════════════════════════════════════════
+# Route side tasks to cheaper/faster models while keeping the main session on a
+# more capable model. Falls back to the session's primary provider when unset.
+#
+# [auxiliary]
+# compaction = "openrouter/google/gemini-2.5-flash"        # Model for context compaction
+# title_generation = "openrouter/google/gemini-2.5-flash"  # Model for session titles
+# vision = "openrouter/google/gemini-2.5-flash"            # Model for vision/image tasks
+
+# ══════════════════════════════════════════════════════════════════════════════
 # SUB-AGENT SPAWN PRESETS
 # ══════════════════════════════════════════════════════════════════════════════
 # Configure reusable presets for sub-agents spawned via the `spawn_agent` tool.

--- a/crates/config/src/validate/schema_map.rs
+++ b/crates/config/src/validate/schema_map.rs
@@ -599,6 +599,14 @@ pub(super) fn build_schema_map() -> KnownKeys {
             )])),
         ),
         (
+            "auxiliary",
+            Struct(HashMap::from([
+                ("compaction", Leaf),
+                ("title_generation", Leaf),
+                ("vision", Leaf),
+            ])),
+        ),
+        (
             "code_index",
             Struct(HashMap::from([
                 ("enabled", Leaf),

--- a/crates/ctl/src/commands/webhooks.rs
+++ b/crates/ctl/src/commands/webhooks.rs
@@ -8,6 +8,7 @@ use {
 use crate::client::CtlClient;
 
 #[derive(Subcommand)]
+#[allow(clippy::large_enum_variant)]
 pub enum WebhooksCommand {
     /// List all webhooks.
     List,
@@ -34,6 +35,18 @@ pub enum WebhooksCommand {
         /// System prompt suffix for agent runs.
         #[arg(long)]
         system_prompt: Option<String>,
+        /// Event types to accept (comma-separated, e.g. "pull_request,issues").
+        #[arg(long)]
+        events: Option<String>,
+        /// Skip agent, deliver rendered template directly to a channel.
+        #[arg(long)]
+        deliver_only: bool,
+        /// Template with {dot.notation} variables from the payload.
+        #[arg(long)]
+        prompt_template: Option<String>,
+        /// Target channel for deliver_only mode (telegram, discord, slack, etc.).
+        #[arg(long)]
+        deliver_to: Option<String>,
         /// Full JSON params (overrides individual flags).
         #[arg(long)]
         json: Option<String>,
@@ -73,6 +86,10 @@ pub async fn run(client: &mut CtlClient, cmd: WebhooksCommand) -> anyhow::Result
             auth_mode,
             session_mode,
             system_prompt,
+            events,
+            deliver_only,
+            prompt_template,
+            deliver_to,
             json: json_override,
         } => {
             let params = if let Some(raw) = json_override {
@@ -84,10 +101,22 @@ pub async fn run(client: &mut CtlClient, cmd: WebhooksCommand) -> anyhow::Result
                     "auth_mode": auth_mode,
                     "session_mode": session_mode,
                 });
+                let obj = p.as_object_mut().unwrap_or_else(|| unreachable!());
                 if let Some(sp) = system_prompt {
-                    p.as_object_mut()
-                        .unwrap_or_else(|| unreachable!())
-                        .insert("system_prompt_suffix".into(), json!(sp));
+                    obj.insert("system_prompt_suffix".into(), json!(sp));
+                }
+                if let Some(ev) = events {
+                    let allow: Vec<&str> = ev.split(',').map(str::trim).collect();
+                    obj.insert("event_filter".into(), json!({ "allow": allow }));
+                }
+                if deliver_only {
+                    obj.insert("deliver_only".into(), json!(true));
+                }
+                if let Some(pt) = prompt_template {
+                    obj.insert("prompt_template".into(), json!(pt));
+                }
+                if let Some(dt) = deliver_to {
+                    obj.insert("deliver_to".into(), json!(dt));
                 }
                 p
             };

--- a/crates/gateway/src/channel_events/commands/dispatch.rs
+++ b/crates/gateway/src/channel_events/commands/dispatch.rs
@@ -4,7 +4,7 @@ use moltis_channels::{ChannelReplyTarget, Error as ChannelError, Result as Chann
 
 use crate::state::GatewayState;
 
-use super::{super::resolve_channel_session, control_handlers, session_handlers};
+use super::{super::resolve_channel_session, control_handlers, quick_actions, session_handlers};
 
 pub(in crate::channel_events) async fn dispatch_interaction(
     state: &Arc<tokio::sync::OnceCell<Arc<GatewayState>>>,
@@ -115,6 +115,13 @@ pub(in crate::channel_events) async fn dispatch_command(
         "stop" => control_handlers::handle_stop(state, &session_key).await,
         "peek" => control_handlers::handle_peek(state, &session_key).await,
         "update" => control_handlers::handle_update(state, &reply_to, sender_id, args).await,
+
+        // Quick actions
+        "btw" => quick_actions::handle_btw(state, &session_key, args).await,
+        "fast" => quick_actions::handle_fast(state, session_metadata, &session_key, args).await,
+        "insights" => quick_actions::handle_insights(state, args).await,
+        "steer" => quick_actions::handle_steer(state, &session_key, args).await,
+        "queue" => quick_actions::handle_queue(state, &session_key, args).await,
         _ => Err(ChannelError::invalid_input(format!(
             "unknown command: /{cmd}"
         ))),
@@ -154,6 +161,11 @@ mod tests {
             "stop",
             "peek",
             "update",
+            "btw",
+            "fast",
+            "insights",
+            "steer",
+            "queue",
         ];
 
         for cmd in moltis_channels::commands::all_commands() {

--- a/crates/gateway/src/channel_events/commands/dispatch.rs
+++ b/crates/gateway/src/channel_events/commands/dispatch.rs
@@ -117,7 +117,7 @@ pub(in crate::channel_events) async fn dispatch_command(
         "peek" => control_handlers::handle_peek(state, &session_key).await,
         "update" => control_handlers::handle_update(state, &reply_to, sender_id, args).await,
 
-        "rollback" => quick_actions::handle_rollback(state, args).await,
+        "rollback" => quick_actions::handle_rollback(state, &session_key, args).await,
 
         // Quick actions
         "btw" => quick_actions::handle_btw(state, &session_key, args).await,

--- a/crates/gateway/src/channel_events/commands/dispatch.rs
+++ b/crates/gateway/src/channel_events/commands/dispatch.rs
@@ -117,6 +117,8 @@ pub(in crate::channel_events) async fn dispatch_command(
         "peek" => control_handlers::handle_peek(state, &session_key).await,
         "update" => control_handlers::handle_update(state, &reply_to, sender_id, args).await,
 
+        "rollback" => quick_actions::handle_rollback(state, args).await,
+
         // Quick actions
         "btw" => quick_actions::handle_btw(state, &session_key, args).await,
         "fast" => quick_actions::handle_fast(state, session_metadata, &session_key, args).await,
@@ -163,6 +165,7 @@ mod tests {
             "stop",
             "peek",
             "update",
+            "rollback",
             "btw",
             "fast",
             "insights",

--- a/crates/gateway/src/channel_events/commands/dispatch.rs
+++ b/crates/gateway/src/channel_events/commands/dispatch.rs
@@ -70,6 +70,7 @@ pub(in crate::channel_events) async fn dispatch_command(
             )
             .await
         },
+        "fork" => session_handlers::handle_fork(state, &session_key, args).await,
         "clear" => session_handlers::handle_clear(state, &session_key).await,
         "compact" => session_handlers::handle_compact(state, &session_key).await,
         "context" => session_handlers::handle_context(state, &session_key).await,
@@ -145,6 +146,7 @@ mod tests {
         // in sync with the match arms above.
         let dispatched = [
             "new",
+            "fork",
             "clear",
             "compact",
             "context",

--- a/crates/gateway/src/channel_events/commands/mod.rs
+++ b/crates/gateway/src/channel_events/commands/mod.rs
@@ -4,6 +4,7 @@ mod dispatch;
 pub(in crate::channel_events) mod formatting;
 mod location;
 mod media;
+mod quick_actions;
 mod session_handlers;
 
 // Re-export everything that `channel_events.rs` uses via `commands::*`.

--- a/crates/gateway/src/channel_events/commands/quick_actions.rs
+++ b/crates/gateway/src/channel_events/commands/quick_actions.rs
@@ -161,6 +161,7 @@ pub(in crate::channel_events) async fn handle_fast(
 
 pub(in crate::channel_events) async fn handle_rollback(
     state: &Arc<GatewayState>,
+    session_key: &str,
     args: &str,
 ) -> ChannelResult<String> {
     let data_dir = moltis_config::data_dir();
@@ -169,7 +170,7 @@ pub(in crate::channel_events) async fn handle_rollback(
     if args.is_empty() {
         // List recent turns.
         let turns = manager
-            .read_turns(10)
+            .read_turns(10, Some(session_key))
             .map_err(|e| ChannelError::unavailable(format!("failed to read turns: {e}")))?;
 
         if turns.is_empty() {
@@ -219,7 +220,7 @@ pub(in crate::channel_events) async fn handle_rollback(
             .parse()
             .map_err(|_| ChannelError::invalid_input("usage: /rollback diff <N>"))?;
         let turns = manager
-            .read_turns(n)
+            .read_turns(n, Some(session_key))
             .map_err(|e| ChannelError::unavailable(format!("failed to read turns: {e}")))?;
 
         if n == 0 || n > turns.len() {
@@ -254,7 +255,7 @@ pub(in crate::channel_events) async fn handle_rollback(
         .parse()
         .map_err(|_| ChannelError::invalid_input("usage: /rollback [<N>|diff <N>]"))?;
     let turns = manager
-        .read_turns(n)
+        .read_turns(n, Some(session_key))
         .map_err(|e| ChannelError::unavailable(format!("failed to read turns: {e}")))?;
 
     if n == 0 || n > turns.len() {

--- a/crates/gateway/src/channel_events/commands/quick_actions.rs
+++ b/crates/gateway/src/channel_events/commands/quick_actions.rs
@@ -157,6 +157,161 @@ pub(in crate::channel_events) async fn handle_fast(
     }
 }
 
+// ── /rollback — list or restore file checkpoints ────────────────────────────
+
+pub(in crate::channel_events) async fn handle_rollback(
+    state: &Arc<GatewayState>,
+    args: &str,
+) -> ChannelResult<String> {
+    let data_dir = moltis_config::data_dir();
+    let manager = moltis_tools::checkpoints::CheckpointManager::new(data_dir);
+
+    if args.is_empty() {
+        // List recent turns.
+        let turns = manager
+            .read_turns(10)
+            .map_err(|e| ChannelError::unavailable(format!("failed to read turns: {e}")))?;
+
+        if turns.is_empty() {
+            return Ok(
+                "No file checkpoints yet. Checkpoints are created automatically before file writes."
+                    .to_string(),
+            );
+        }
+
+        let mut lines = vec!["Recent turns with file changes:".to_string()];
+        let now = time::OffsetDateTime::now_utc().unix_timestamp();
+        for (i, turn) in turns.iter().enumerate() {
+            let age_secs = now.saturating_sub(turn.created_at);
+            let age_str = format_age(age_secs);
+            let file_count = turn.source_paths.len();
+            let file_label = if file_count == 1 {
+                "file"
+            } else {
+                "files"
+            };
+            let paths: Vec<&str> = turn
+                .source_paths
+                .iter()
+                .map(|p| p.rsplit('/').next().unwrap_or(p.as_str()))
+                .collect();
+            let paths_preview = if paths.len() <= 3 {
+                paths.join(", ")
+            } else {
+                format!("{}, {} +{} more", paths[0], paths[1], paths.len() - 2)
+            };
+            lines.push(format!(
+                "{}. {age_str} \u{2014} {file_count} {file_label} ({paths_preview})",
+                i + 1
+            ));
+        }
+        lines.push("\nUse /rollback <N> to restore, /rollback diff <N> to preview.".to_string());
+        return Ok(lines.join("\n"));
+    }
+
+    // /rollback diff <N>
+    if let Some(rest) = args
+        .strip_prefix("diff ")
+        .or_else(|| args.strip_prefix("diff\t"))
+    {
+        let n: usize = rest
+            .trim()
+            .parse()
+            .map_err(|_| ChannelError::invalid_input("usage: /rollback diff <N>"))?;
+        let turns = manager
+            .read_turns(n)
+            .map_err(|e| ChannelError::unavailable(format!("failed to read turns: {e}")))?;
+
+        if n == 0 || n > turns.len() {
+            return Err(ChannelError::invalid_input(format!(
+                "invalid turn number. Use 1\u{2013}{}.",
+                turns.len()
+            )));
+        }
+        let turn = &turns[n - 1];
+        let mut lines = vec![format!(
+            "Turn {n} \u{2014} {} checkpoints:",
+            turn.checkpoint_ids.len()
+        )];
+        for (id, path) in turn.checkpoint_ids.iter().zip(turn.source_paths.iter()) {
+            let exists = std::path::Path::new(path).exists();
+            let status = if exists {
+                "exists"
+            } else {
+                "missing"
+            };
+            lines.push(format!(
+                "  {path} ({status}) [cp:{id}]",
+                id = &id[..8.min(id.len())]
+            ));
+        }
+        return Ok(lines.join("\n"));
+    }
+
+    // /rollback <N> — restore all files from turn N
+    let n: usize = args
+        .trim()
+        .parse()
+        .map_err(|_| ChannelError::invalid_input("usage: /rollback [<N>|diff <N>]"))?;
+    let turns = manager
+        .read_turns(n)
+        .map_err(|e| ChannelError::unavailable(format!("failed to read turns: {e}")))?;
+
+    if n == 0 || n > turns.len() {
+        return Err(ChannelError::invalid_input(format!(
+            "invalid turn number. Use 1\u{2013}{}.",
+            turns.len()
+        )));
+    }
+    let turn = &turns[n - 1];
+
+    let mut restored = 0;
+    let mut errors = Vec::new();
+    for id in &turn.checkpoint_ids {
+        match manager.restore(id).await {
+            Ok(_) => restored += 1,
+            Err(e) => errors.push(format!("{id}: {e}")),
+        }
+    }
+
+    broadcast(
+        state,
+        "session",
+        serde_json::json!({
+            "kind": "rollback",
+            "turn": n,
+            "restored": restored,
+        }),
+        BroadcastOpts {
+            drop_if_slow: true,
+            ..Default::default()
+        },
+    )
+    .await;
+
+    if errors.is_empty() {
+        Ok(format!("Restored {restored} files from turn {n}."))
+    } else {
+        Ok(format!(
+            "Restored {restored} files from turn {n}. {} errors:\n{}",
+            errors.len(),
+            errors.join("\n")
+        ))
+    }
+}
+
+fn format_age(secs: i64) -> String {
+    if secs < 60 {
+        "just now".to_string()
+    } else if secs < 3600 {
+        format!("{}m ago", secs / 60)
+    } else if secs < 86400 {
+        format!("{}h ago", secs / 3600)
+    } else {
+        format!("{}d ago", secs / 86400)
+    }
+}
+
 // ── /insights — session analytics ───────────────────────────────────────────
 
 pub(in crate::channel_events) async fn handle_insights(

--- a/crates/gateway/src/channel_events/commands/quick_actions.rs
+++ b/crates/gateway/src/channel_events/commands/quick_actions.rs
@@ -23,15 +23,18 @@ pub(in crate::channel_events) async fn handle_btw(
         ));
     }
 
-    // Resolve a provider (same pattern as session summary).
-    let provider: Arc<dyn moltis_agents::model::LlmProvider> = {
+    // Resolve a provider. Clone the registry Arc out of the inner lock
+    // first, then drop `inner` before acquiring the registry read lock
+    // to avoid nested lock contention.
+    let registry = {
         let inner = state.inner.read().await;
-        let Some(ref registry) = inner.llm_providers else {
-            return Err(ChannelError::unavailable("no LLM providers available"));
-        };
+        inner.llm_providers.clone()
+    };
+    let Some(registry) = registry else {
+        return Err(ChannelError::unavailable("no LLM providers available"));
+    };
+    let provider: Arc<dyn moltis_agents::model::LlmProvider> = {
         let reg = registry.read().await;
-
-        // Prefer the session's model, fall back to first available.
         let session_model = if let Some(ref meta) = state.services.session_metadata {
             meta.get(session_key).await.and_then(|e| e.model.clone())
         } else {

--- a/crates/gateway/src/channel_events/commands/quick_actions.rs
+++ b/crates/gateway/src/channel_events/commands/quick_actions.rs
@@ -33,15 +33,18 @@ pub(in crate::channel_events) async fn handle_btw(
     let Some(registry) = registry else {
         return Err(ChannelError::unavailable("no LLM providers available"));
     };
+    // Resolve session model via async DB lookup *before* acquiring the
+    // registry read lock to avoid holding the lock across an await point.
+    let session_model = if let Some(ref meta) = state.services.session_metadata {
+        meta.get(session_key).await.and_then(|e| e.model.clone())
+    } else {
+        None
+    };
     let provider: Arc<dyn moltis_agents::model::LlmProvider> = {
         let reg = registry.read().await;
-        let session_model = if let Some(ref meta) = state.services.session_metadata {
-            meta.get(session_key).await.and_then(|e| e.model.clone())
-        } else {
-            None
-        };
         let resolved = session_model
-            .and_then(|id| reg.get(&id))
+            .as_deref()
+            .and_then(|id| reg.get(id))
             .or_else(|| reg.first());
         match resolved {
             Some(p) => p,
@@ -283,6 +286,7 @@ pub(in crate::channel_events) async fn handle_rollback(
         "session",
         serde_json::json!({
             "kind": "rollback",
+            "sessionKey": session_key,
             "turn": n,
             "restored": restored,
         }),

--- a/crates/gateway/src/channel_events/commands/quick_actions.rs
+++ b/crates/gateway/src/channel_events/commands/quick_actions.rs
@@ -1,0 +1,373 @@
+use std::sync::Arc;
+
+use {
+    moltis_channels::{Error as ChannelError, Result as ChannelResult},
+    moltis_sessions::metadata::SqliteSessionMetadata,
+};
+
+use crate::{
+    broadcast::{BroadcastOpts, broadcast},
+    state::GatewayState,
+};
+
+// ── /btw — ephemeral side question ──────────────────────────────────────────
+
+pub(in crate::channel_events) async fn handle_btw(
+    state: &Arc<GatewayState>,
+    session_key: &str,
+    args: &str,
+) -> ChannelResult<String> {
+    if args.is_empty() {
+        return Err(ChannelError::invalid_input(
+            "usage: /btw <question>\nAsk a quick side question without tools or persisting to history.",
+        ));
+    }
+
+    // Resolve a provider (same pattern as session summary).
+    let provider: Arc<dyn moltis_agents::model::LlmProvider> = {
+        let inner = state.inner.read().await;
+        let Some(ref registry) = inner.llm_providers else {
+            return Err(ChannelError::unavailable("no LLM providers available"));
+        };
+        let reg = registry.read().await;
+
+        // Prefer the session's model, fall back to first available.
+        let session_model = if let Some(ref meta) = state.services.session_metadata {
+            meta.get(session_key).await.and_then(|e| e.model.clone())
+        } else {
+            None
+        };
+        let resolved = session_model
+            .and_then(|id| reg.get(&id))
+            .or_else(|| reg.first());
+        match resolved {
+            Some(p) => p,
+            None => return Err(ChannelError::unavailable("no LLM provider configured")),
+        }
+    };
+
+    // Read recent session history for context (last ~20 messages).
+    let context_msgs = if let Some(ref store) = state.services.session_store {
+        let history = store.read(session_key).await.unwrap_or_default();
+        let chat_msgs = moltis_agents::model::values_to_chat_messages(&history);
+        let tail_start = chat_msgs.len().saturating_sub(20);
+        chat_msgs[tail_start..].to_vec()
+    } else {
+        Vec::new()
+    };
+
+    // Build a minimal prompt and call the LLM with no tools.
+    let system_prompt = "You are a helpful assistant. Answer the user's side question \
+                         concisely. You have no tools available — answer from context only.";
+    let mut messages = vec![moltis_agents::ChatMessage::system(system_prompt)];
+    messages.extend(context_msgs);
+    messages.push(moltis_agents::ChatMessage::user(args));
+
+    match provider.complete(&messages, &[]).await {
+        Ok(response) => {
+            let text = response.text.as_deref().unwrap_or("(no response)");
+            Ok(text.to_string())
+        },
+        Err(e) => Err(ChannelError::unavailable(format!(
+            "btw LLM call failed: {e}"
+        ))),
+    }
+}
+
+// ── /fast — toggle fast/priority mode ───────────────────────────────────────
+
+pub(in crate::channel_events) async fn handle_fast(
+    state: &Arc<GatewayState>,
+    _session_metadata: &SqliteSessionMetadata,
+    session_key: &str,
+    args: &str,
+) -> ChannelResult<String> {
+    let current = state.is_fast_mode(session_key).await;
+
+    match args {
+        "" => {
+            // Toggle
+            let new_val = !current;
+            state.set_fast_mode(session_key, new_val).await;
+            broadcast(
+                state,
+                "session",
+                serde_json::json!({
+                    "kind": "patched",
+                    "sessionKey": session_key,
+                    "fastMode": new_val,
+                }),
+                BroadcastOpts {
+                    drop_if_slow: true,
+                    ..Default::default()
+                },
+            )
+            .await;
+            if new_val {
+                Ok("Fast mode enabled. Using priority processing where supported.".to_string())
+            } else {
+                Ok("Fast mode disabled. Using standard processing.".to_string())
+            }
+        },
+        "on" | "fast" => {
+            state.set_fast_mode(session_key, true).await;
+            broadcast(
+                state,
+                "session",
+                serde_json::json!({
+                    "kind": "patched",
+                    "sessionKey": session_key,
+                    "fastMode": true,
+                }),
+                BroadcastOpts {
+                    drop_if_slow: true,
+                    ..Default::default()
+                },
+            )
+            .await;
+            Ok("Fast mode enabled. Using priority processing where supported.".to_string())
+        },
+        "off" | "normal" => {
+            state.set_fast_mode(session_key, false).await;
+            broadcast(
+                state,
+                "session",
+                serde_json::json!({
+                    "kind": "patched",
+                    "sessionKey": session_key,
+                    "fastMode": false,
+                }),
+                BroadcastOpts {
+                    drop_if_slow: true,
+                    ..Default::default()
+                },
+            )
+            .await;
+            Ok("Fast mode disabled. Using standard processing.".to_string())
+        },
+        "status" => {
+            let label = if current {
+                "enabled"
+            } else {
+                "disabled"
+            };
+            Ok(format!("Fast mode is {label}."))
+        },
+        _ => Err(ChannelError::invalid_input("usage: /fast [on|off|status]")),
+    }
+}
+
+// ── /insights — session analytics ───────────────────────────────────────────
+
+pub(in crate::channel_events) async fn handle_insights(
+    state: &Arc<GatewayState>,
+    args: &str,
+) -> ChannelResult<String> {
+    #[cfg(not(feature = "metrics"))]
+    {
+        let _ = (state, args);
+        return Err(ChannelError::unavailable(
+            "metrics feature is not enabled in this build",
+        ));
+    }
+
+    #[cfg(feature = "metrics")]
+    {
+        let days: u64 = if args.is_empty() {
+            30
+        } else {
+            args.trim()
+                .parse()
+                .map_err(|_| ChannelError::invalid_input("usage: /insights [days]"))?
+        };
+
+        let store = state
+            .metrics_store
+            .as_ref()
+            .ok_or_else(|| ChannelError::unavailable("metrics store not available"))?;
+
+        let now_ms = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis() as u64;
+        let since_ms = now_ms.saturating_sub(days * 24 * 60 * 60 * 1000);
+
+        let history = store
+            .load_history(since_ms, 100_000)
+            .await
+            .map_err(|e| ChannelError::external("loading metrics history", e))?;
+
+        if history.is_empty() {
+            return Ok(format!("No metrics data in the last {days} days."));
+        }
+
+        // Aggregate
+        let mut total_completions: u64 = 0;
+        let mut total_input_tokens: u64 = 0;
+        let mut total_output_tokens: u64 = 0;
+        let mut total_errors: u64 = 0;
+        let mut total_tool_executions: u64 = 0;
+        let mut total_tool_errors: u64 = 0;
+        let mut provider_totals: std::collections::HashMap<String, (u64, u64, u64)> =
+            std::collections::HashMap::new();
+
+        // Use deltas between consecutive points (metrics are cumulative counters)
+        let mut prev: Option<&crate::state::MetricsHistoryPoint> = None;
+        for point in &history {
+            if let Some(p) = prev {
+                total_completions += point.llm_completions.saturating_sub(p.llm_completions);
+                total_input_tokens += point.llm_input_tokens.saturating_sub(p.llm_input_tokens);
+                total_output_tokens += point.llm_output_tokens.saturating_sub(p.llm_output_tokens);
+                total_errors += point.llm_errors.saturating_sub(p.llm_errors);
+                total_tool_executions += point.tool_executions.saturating_sub(p.tool_executions);
+                total_tool_errors += point.tool_errors.saturating_sub(p.tool_errors);
+
+                for (provider, tokens) in &point.by_provider {
+                    let prev_tokens = p.by_provider.get(provider);
+                    let delta_in = tokens
+                        .input_tokens
+                        .saturating_sub(prev_tokens.map_or(0, |pt| pt.input_tokens));
+                    let delta_out = tokens
+                        .output_tokens
+                        .saturating_sub(prev_tokens.map_or(0, |pt| pt.output_tokens));
+                    let delta_completions = tokens
+                        .completions
+                        .saturating_sub(prev_tokens.map_or(0, |pt| pt.completions));
+                    let entry = provider_totals.entry(provider.clone()).or_default();
+                    entry.0 += delta_in;
+                    entry.1 += delta_out;
+                    entry.2 += delta_completions;
+                }
+            }
+            prev = Some(point);
+        }
+
+        let total_tokens = total_input_tokens + total_output_tokens;
+        let first_ts = history.first().map(|p| p.timestamp).unwrap_or(0);
+        let last_ts = history.last().map(|p| p.timestamp).unwrap_or(0);
+        let span_hours = (last_ts.saturating_sub(first_ts)) as f64 / 3_600_000.0;
+
+        let mut lines = Vec::new();
+        lines.push(format!("Insights \u{2014} last {days} days"));
+        lines.push(String::new());
+        lines.push(format!(
+            "LLM completions: {total_completions}  (errors: {total_errors})"
+        ));
+        lines.push(format!(
+            "Tokens: {total_tokens} total ({total_input_tokens} in / {total_output_tokens} out)"
+        ));
+        lines.push(format!(
+            "Tools: {total_tool_executions} executions  (errors: {total_tool_errors})"
+        ));
+        if span_hours > 0.0 {
+            let completions_per_hour = total_completions as f64 / span_hours;
+            lines.push(format!("Rate: {completions_per_hour:.1} completions/hour"));
+        }
+
+        if !provider_totals.is_empty() {
+            lines.push(String::new());
+            lines.push("By provider:".to_string());
+            let mut providers: Vec<_> = provider_totals.into_iter().collect();
+            providers.sort_by(|a, b| (b.1.0 + b.1.1).cmp(&(a.1.0 + a.1.1)));
+            for (provider, (input, output, completions)) in &providers {
+                lines.push(format!(
+                    "  {provider}: {completions} completions, {} tokens ({input} in / {output} out)",
+                    input + output
+                ));
+            }
+        }
+
+        let data_points = history.len();
+        lines.push(String::new());
+        lines.push(format!(
+            "Based on {data_points} data points over {span_hours:.1} hours."
+        ));
+
+        Ok(lines.join("\n"))
+    }
+}
+
+// ── /steer — inject guidance into active run ────────────────────────────────
+
+pub(in crate::channel_events) async fn handle_steer(
+    state: &Arc<GatewayState>,
+    session_key: &str,
+    args: &str,
+) -> ChannelResult<String> {
+    if args.is_empty() {
+        return Err(ChannelError::invalid_input(
+            "usage: /steer <guidance>\nInject a steering note into the current agent run.",
+        ));
+    }
+
+    // Check if there's an active run for this session.
+    let chat = state.chat().await;
+    let peek_res = chat
+        .peek(serde_json::json!({ "sessionKey": session_key }))
+        .await
+        .map_err(|e| ChannelError::external("peek", e))?;
+
+    let active = peek_res
+        .get("active")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+
+    if !active {
+        return Err(ChannelError::invalid_input(
+            "No active agent run to steer. Use /steer while the agent is working.",
+        ));
+    }
+
+    state.set_steer_text(session_key, args.to_string()).await;
+
+    broadcast(
+        state,
+        "chat",
+        serde_json::json!({
+            "sessionKey": session_key,
+            "state": "steered",
+            "text": args,
+        }),
+        BroadcastOpts {
+            drop_if_slow: true,
+            ..Default::default()
+        },
+    )
+    .await;
+
+    Ok(format!("Steering applied: {args}"))
+}
+
+// ── /queue — queue a message for the next agent turn ────────────────────────
+
+pub(in crate::channel_events) async fn handle_queue(
+    state: &Arc<GatewayState>,
+    session_key: &str,
+    args: &str,
+) -> ChannelResult<String> {
+    if args.is_empty() {
+        return Err(ChannelError::invalid_input(
+            "usage: /queue <message>\nQueue a message for the next agent turn without interrupting the current one.",
+        ));
+    }
+
+    // Use the chat service's send method — when a run is active, it will
+    // automatically queue the message according to MessageQueueMode.
+    let chat = state.chat().await;
+    let params = serde_json::json!({
+        "text": args,
+        "_session_key": session_key,
+    });
+
+    match chat.send(params).await {
+        Ok(res) => {
+            let queued = res.get("queued").and_then(|v| v.as_bool()).unwrap_or(false);
+            if queued {
+                Ok(format!("Queued for next turn: {args}"))
+            } else {
+                Ok("No active run \u{2014} message sent immediately.".to_string())
+            }
+        },
+        Err(e) => Err(ChannelError::external("queue", e)),
+    }
+}

--- a/crates/gateway/src/channel_events/commands/session_handlers.rs
+++ b/crates/gateway/src/channel_events/commands/session_handlers.rs
@@ -178,6 +178,55 @@ pub(in crate::channel_events) async fn handle_new(
     }
 }
 
+pub(in crate::channel_events) async fn handle_fork(
+    state: &Arc<GatewayState>,
+    session_key: &str,
+    args: &str,
+) -> ChannelResult<String> {
+    let label = if args.is_empty() {
+        None
+    } else {
+        Some(args.trim())
+    };
+
+    let mut params = serde_json::json!({ "key": session_key });
+    if let Some(l) = label {
+        params["label"] = serde_json::json!(l);
+    }
+
+    let res = state
+        .services
+        .session
+        .fork(params)
+        .await
+        .map_err(ChannelError::unavailable)?;
+
+    let new_key = res
+        .get("sessionKey")
+        .and_then(|v| v.as_str())
+        .unwrap_or("unknown");
+    let fork_point = res.get("forkPoint").and_then(|v| v.as_u64()).unwrap_or(0);
+
+    broadcast(
+        state,
+        "session",
+        serde_json::json!({
+            "kind": "created",
+            "sessionKey": new_key,
+        }),
+        BroadcastOpts {
+            drop_if_slow: true,
+            ..Default::default()
+        },
+    )
+    .await;
+
+    let label_str = res.get("label").and_then(|v| v.as_str()).unwrap_or(new_key);
+    Ok(format!(
+        "Forked at message {fork_point} into: {label_str}\nUse /sessions to switch."
+    ))
+}
+
 pub(in crate::channel_events) async fn handle_clear(
     state: &Arc<GatewayState>,
     session_key: &str,

--- a/crates/gateway/src/chat.rs
+++ b/crates/gateway/src/chat.rs
@@ -252,7 +252,7 @@ impl ChatRuntime for GatewayChatRuntime {
             .collect()
     }
 
-    async fn take_steer_text(&self, session_key: &str) -> Option<String> {
+    async fn take_steer_text(&self, session_key: &str) -> Option<Vec<String>> {
         self.state.take_steer_text(session_key).await
     }
 

--- a/crates/gateway/src/chat.rs
+++ b/crates/gateway/src/chat.rs
@@ -251,4 +251,12 @@ impl ChatRuntime for GatewayChatRuntime {
             })
             .collect()
     }
+
+    async fn take_steer_text(&self, session_key: &str) -> Option<String> {
+        self.state.take_steer_text(session_key).await
+    }
+
+    async fn is_fast_mode(&self, session_key: &str) -> bool {
+        self.state.is_fast_mode(session_key).await
+    }
 }

--- a/crates/gateway/src/server/hooks.rs
+++ b/crates/gateway/src/server/hooks.rs
@@ -205,6 +205,12 @@ fn builtin_hook_metadata() -> Vec<(
             vec![HookEvent::Command],
             "crates/plugins/src/bundled/session_memory.rs",
         ),
+        (
+            "auto-checkpoint",
+            "Snapshots files before Write/Edit/MultiEdit tool calls so /rollback can restore them.",
+            vec![HookEvent::BeforeToolCall],
+            "crates/tools/src/auto_checkpoint.rs",
+        ),
     ]
 }
 
@@ -307,6 +313,11 @@ pub(crate) async fn discover_and_build_hooks(
             let memory_hook = SessionMemoryHook::new(data.clone(), Arc::clone(store));
             registry.register(Arc::new(memory_hook));
         }
+
+        // Auto-checkpoint: snapshot files before Write/Edit/MultiEdit tool calls.
+        let checkpoint_manager = Arc::new(moltis_tools::checkpoints::CheckpointManager::new(data));
+        let auto_cp = moltis_tools::auto_checkpoint::AutoCheckpointHook::new(checkpoint_manager);
+        registry.register(Arc::new(auto_cp));
     }
 
     for (name, description, events, source_file) in builtin_hook_metadata() {

--- a/crates/gateway/src/server/prepare_core/post_state.rs
+++ b/crates/gateway/src/server/prepare_core/post_state.rs
@@ -871,6 +871,9 @@ pub(super) async fn complete_startup(
         tool_registry.register(Box::new(process_tool));
         tool_registry.register(Box::new(sandbox_packages_tool));
         tool_registry.register(Box::new(cron_tool));
+        tool_registry.register(Box::new(moltis_tools::webhook_tool::WebhookTool::new(
+            Arc::clone(&state.services.webhooks),
+        )));
         tool_registry.register(Box::new(crate::channel_agent_tools::SendMessageTool::new(
             Arc::clone(&state.services.channel),
         )));

--- a/crates/gateway/src/state.rs
+++ b/crates/gateway/src/state.rs
@@ -286,8 +286,9 @@ pub struct GatewayInner {
     pub channel_command_mode_sessions: HashSet<String>,
     /// Sessions with fast/priority mode enabled.
     pub fast_mode_sessions: HashSet<String>,
-    /// Per-session steering text injected mid-run via `/steer`.
-    pub steer_text: HashMap<String, String>,
+    /// Per-session steering text queue injected mid-run via `/steer`.
+    /// Multiple `/steer` calls accumulate; all are drained on the next poll.
+    pub steer_text: HashMap<String, Vec<String>>,
     /// Which channel types are offered in the web UI (from config).
     pub channels_offered: Vec<String>,
     /// Hostnames that were discovered after passkeys already existed.
@@ -767,18 +768,26 @@ impl GatewayState {
             .contains(session_key)
     }
 
-    /// Set steering text for an active session run.
+    /// Append steering text for an active session run.
+    /// Multiple calls accumulate; all are drained on the next poll.
     pub async fn set_steer_text(&self, session_key: &str, text: String) {
         self.inner
             .write()
             .await
             .steer_text
-            .insert(session_key.to_string(), text);
+            .entry(session_key.to_string())
+            .or_default()
+            .push(text);
     }
 
-    /// Take (drain) any pending steering text for a session.
-    pub async fn take_steer_text(&self, session_key: &str) -> Option<String> {
-        self.inner.write().await.steer_text.remove(session_key)
+    /// Take (drain) all pending steering texts for a session.
+    pub async fn take_steer_text(&self, session_key: &str) -> Option<Vec<String>> {
+        let texts = self.inner.write().await.steer_text.remove(session_key)?;
+        if texts.is_empty() {
+            None
+        } else {
+            Some(texts)
+        }
     }
 
     /// Mark a hostname as needing passkey refresh.

--- a/crates/gateway/src/state.rs
+++ b/crates/gateway/src/state.rs
@@ -284,6 +284,10 @@ pub struct GatewayInner {
     pub channel_status_log: HashMap<String, Vec<String>>,
     /// Sessions currently in channel command mode (/sh passthrough).
     pub channel_command_mode_sessions: HashSet<String>,
+    /// Sessions with fast/priority mode enabled.
+    pub fast_mode_sessions: HashSet<String>,
+    /// Per-session steering text injected mid-run via `/steer`.
+    pub steer_text: HashMap<String, String>,
     /// Which channel types are offered in the web UI (from config).
     pub channels_offered: Vec<String>,
     /// Hostnames that were discovered after passkeys already existed.
@@ -323,6 +327,8 @@ impl GatewayInner {
             cached_location: moltis_config::resolve_user_profile().location,
             channel_status_log: HashMap::new(),
             channel_command_mode_sessions: HashSet::new(),
+            fast_mode_sessions: HashSet::new(),
+            steer_text: HashMap::new(),
             channels_offered: vec![
                 "telegram".into(),
                 "whatsapp".into(),
@@ -740,6 +746,39 @@ impl GatewayState {
             .await
             .channel_command_mode_sessions
             .contains(session_key)
+    }
+
+    /// Enable or disable fast/priority mode for a session.
+    pub async fn set_fast_mode(&self, session_key: &str, enabled: bool) {
+        let mut inner = self.inner.write().await;
+        if enabled {
+            inner.fast_mode_sessions.insert(session_key.to_string());
+        } else {
+            inner.fast_mode_sessions.remove(session_key);
+        }
+    }
+
+    /// Check whether fast/priority mode is enabled for a session.
+    pub async fn is_fast_mode(&self, session_key: &str) -> bool {
+        self.inner
+            .read()
+            .await
+            .fast_mode_sessions
+            .contains(session_key)
+    }
+
+    /// Set steering text for an active session run.
+    pub async fn set_steer_text(&self, session_key: &str, text: String) {
+        self.inner
+            .write()
+            .await
+            .steer_text
+            .insert(session_key.to_string(), text);
+    }
+
+    /// Take (drain) any pending steering text for a session.
+    pub async fn take_steer_text(&self, session_key: &str) -> Option<String> {
+        self.inner.write().await.steer_text.remove(session_key)
     }
 
     /// Mark a hostname as needing passkey refresh.

--- a/crates/gateway/src/webhooks.rs
+++ b/crates/gateway/src/webhooks.rs
@@ -563,6 +563,10 @@ mod tests {
                 allowed_cidrs: Vec::new(),
                 max_body_bytes: 1024,
                 rate_limit_per_minute: 60,
+                deliver_only: false,
+                prompt_template: None,
+                deliver_to: None,
+                deliver_extra: None,
             })
             .await
             .unwrap();
@@ -613,6 +617,10 @@ mod tests {
                 allowed_cidrs: Vec::new(),
                 max_body_bytes: 1024,
                 rate_limit_per_minute: 60,
+                deliver_only: false,
+                prompt_template: None,
+                deliver_to: None,
+                deliver_extra: None,
             })
             .await
             .unwrap();

--- a/crates/httpd/src/metrics_routes.rs
+++ b/crates/httpd/src/metrics_routes.rs
@@ -141,3 +141,133 @@ pub async fn api_metrics_history_handler(State(state): State<AppState>) -> impl 
         "points": points,
     }))
 }
+
+/// Insights endpoint: longer-range usage analytics from the SQLite metrics store.
+///
+/// Query parameters:
+/// - `days`: Number of days to look back (default: 30, max: 365)
+#[cfg(feature = "metrics")]
+pub async fn api_metrics_insights_handler(
+    State(state): State<AppState>,
+    axum::extract::Query(params): axum::extract::Query<std::collections::HashMap<String, String>>,
+) -> impl IntoResponse {
+    let days: u64 = params
+        .get("days")
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(30)
+        .min(365);
+
+    let Some(ref store) = state.gateway.metrics_store else {
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(serde_json::json!({ "error": METRICS_NOT_ENABLED })),
+        )
+            .into_response();
+    };
+
+    let now_ms = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as u64;
+    let since_ms = now_ms.saturating_sub(days * 24 * 60 * 60 * 1000);
+
+    let history = match store.load_history(since_ms, 100_000).await {
+        Ok(h) => h,
+        Err(e) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({ "error": format!("failed to load history: {e}") })),
+            )
+                .into_response();
+        },
+    };
+
+    if history.is_empty() {
+        return Json(serde_json::json!({
+            "days": days,
+            "completions": 0,
+            "input_tokens": 0,
+            "output_tokens": 0,
+            "errors": 0,
+            "tool_executions": 0,
+            "tool_errors": 0,
+            "by_provider": {},
+            "data_points": 0,
+        }))
+        .into_response();
+    }
+
+    // Compute deltas between consecutive points (metrics are cumulative counters).
+    let mut total_completions: u64 = 0;
+    let mut total_input_tokens: u64 = 0;
+    let mut total_output_tokens: u64 = 0;
+    let mut total_errors: u64 = 0;
+    let mut total_tool_executions: u64 = 0;
+    let mut total_tool_errors: u64 = 0;
+    let mut provider_totals: std::collections::HashMap<String, serde_json::Value> =
+        std::collections::HashMap::new();
+
+    let mut prev: Option<&moltis_metrics::MetricsHistoryPoint> = None;
+    for point in &history {
+        if let Some(p) = prev {
+            total_completions += point.llm_completions.saturating_sub(p.llm_completions);
+            total_input_tokens += point.llm_input_tokens.saturating_sub(p.llm_input_tokens);
+            total_output_tokens += point.llm_output_tokens.saturating_sub(p.llm_output_tokens);
+            total_errors += point.llm_errors.saturating_sub(p.llm_errors);
+            total_tool_executions += point.tool_executions.saturating_sub(p.tool_executions);
+            total_tool_errors += point.tool_errors.saturating_sub(p.tool_errors);
+
+            for (provider, tokens) in &point.by_provider {
+                let prev_tokens = p.by_provider.get(provider);
+                let delta_in = tokens
+                    .input_tokens
+                    .saturating_sub(prev_tokens.map_or(0, |pt| pt.input_tokens));
+                let delta_out = tokens
+                    .output_tokens
+                    .saturating_sub(prev_tokens.map_or(0, |pt| pt.output_tokens));
+                let delta_completions = tokens
+                    .completions
+                    .saturating_sub(prev_tokens.map_or(0, |pt| pt.completions));
+
+                let entry = provider_totals.entry(provider.clone()).or_insert_with(|| {
+                    serde_json::json!({
+                        "input_tokens": 0u64,
+                        "output_tokens": 0u64,
+                        "completions": 0u64,
+                    })
+                });
+                if let Some(obj) = entry.as_object_mut() {
+                    *obj.entry("input_tokens").or_insert(serde_json::json!(0)) =
+                        serde_json::json!(obj["input_tokens"].as_u64().unwrap_or(0) + delta_in);
+                    *obj.entry("output_tokens").or_insert(serde_json::json!(0)) =
+                        serde_json::json!(obj["output_tokens"].as_u64().unwrap_or(0) + delta_out);
+                    *obj.entry("completions").or_insert(serde_json::json!(0)) = serde_json::json!(
+                        obj["completions"].as_u64().unwrap_or(0) + delta_completions
+                    );
+                }
+            }
+        }
+        prev = Some(point);
+    }
+
+    let first_ts = history.first().map(|p| p.timestamp).unwrap_or(0);
+    let last_ts = history.last().map(|p| p.timestamp).unwrap_or(0);
+    let span_hours = (last_ts.saturating_sub(first_ts)) as f64 / 3_600_000.0;
+
+    Json(serde_json::json!({
+        "days": days,
+        "completions": total_completions,
+        "input_tokens": total_input_tokens,
+        "output_tokens": total_output_tokens,
+        "total_tokens": total_input_tokens + total_output_tokens,
+        "errors": total_errors,
+        "tool_executions": total_tool_executions,
+        "tool_errors": total_tool_errors,
+        "by_provider": provider_totals,
+        "data_points": history.len(),
+        "span_hours": span_hours,
+        "first_timestamp": first_ts,
+        "last_timestamp": last_ts,
+    }))
+    .into_response()
+}

--- a/crates/skills/src/assets/devops/webhook-subscriptions/SKILL.md
+++ b/crates/skills/src/assets/devops/webhook-subscriptions/SKILL.md
@@ -260,6 +260,59 @@ Then in GitHub repo → Settings → Webhooks → Add webhook:
 }
 ```
 
+## Deliver-Only Mode (Zero LLM Tokens)
+
+Set `deliver_only: true` to skip the agent and forward a rendered template directly
+to a channel. This is a webhook proxy — zero LLM cost, sub-second delivery.
+
+Use `prompt_template` with `{dot.notation}` variables and `deliver_to` for the target channel.
+
+### Template syntax
+
+- `{field}` — top-level field from the payload
+- `{object.nested.field}` — nested access
+- `{__raw__}` — full payload as JSON (truncated)
+- Missing keys are left as `{key}` literals
+
+### Example: GitHub issues → Telegram (no LLM)
+
+```json
+{
+  "name": "github-issues-notify",
+  "source_profile": "github",
+  "auth_mode": "github_hmac_sha256",
+  "auth_config": { "secret": "whsec_..." },
+  "event_filter": { "allow": ["issues.opened", "issues.closed"] },
+  "deliver_only": true,
+  "prompt_template": "#{issue.number} {issue.title} ({action} by {sender.login})",
+  "deliver_to": "telegram"
+}
+```
+
+### Example: Stripe payments → Discord (no LLM)
+
+```json
+{
+  "name": "stripe-notify",
+  "source_profile": "stripe",
+  "auth_mode": "stripe_webhook_signature",
+  "auth_config": { "secret": "whsec_..." },
+  "event_filter": { "allow": ["payment_intent.succeeded"] },
+  "deliver_only": true,
+  "prompt_template": "Payment: {data.object.amount} {data.object.currency} — {data.object.status}",
+  "deliver_to": "discord"
+}
+```
+
+## Agent Tool
+
+The `webhook` tool is available to agents. Ask the agent to create webhooks:
+
+> "Set up a GitHub webhook for PR reviews on my repo"
+> "Create a deliver-only webhook that forwards Stripe payments to my Telegram"
+
+The agent uses the `webhook` tool with actions: `list`, `create`, `get`, `update`, `delete`, `profiles`, `deliveries`.
+
 ## Rate Limiting
 
 Global config in `moltis.toml`:

--- a/crates/tools/Cargo.toml
+++ b/crates/tools/Cargo.toml
@@ -45,6 +45,7 @@ moltis-media          = { workspace = true }
 moltis-metrics        = { optional = true, workspace = true }
 moltis-network-filter = { workspace = true }
 moltis-providers      = { workspace = true }
+moltis-service-traits = { workspace = true }
 moltis-sessions       = { workspace = true }
 moltis-skills         = { workspace = true }
 pdf-extract           = { optional = true, workspace = true }

--- a/crates/tools/src/auto_checkpoint.rs
+++ b/crates/tools/src/auto_checkpoint.rs
@@ -1,0 +1,169 @@
+//! Automatic per-turn file checkpointing via the hook system.
+//!
+//! Registers a [`HookHandler`] that snapshots files before `Write`, `Edit`, and
+//! `MultiEdit` tool calls. Checkpoints are grouped by run (turn) and exposed to
+//! the user via the `/rollback` channel command.
+
+use std::{collections::HashMap, path::PathBuf, sync::Arc};
+
+use {
+    async_trait::async_trait,
+    moltis_common::hooks::{HookAction, HookEvent, HookHandler, HookPayload},
+    serde_json::Value,
+    time::OffsetDateTime,
+    tokio::sync::Mutex,
+    tracing::{debug, warn},
+};
+
+use crate::checkpoints::{CheckpointManager, TurnRecord};
+
+/// File-mutating tool names that trigger automatic checkpoints.
+const CHECKPOINT_TOOLS: &[&str] = &["Write", "Edit", "MultiEdit"];
+
+/// In-progress turn state for a single session.
+struct ActiveTurn {
+    run_id: String,
+    session_key: String,
+    checkpoint_ids: Vec<String>,
+    source_paths: Vec<String>,
+    created_at: i64,
+}
+
+/// Hook handler that automatically checkpoints files before mutation tools.
+pub struct AutoCheckpointHook {
+    manager: Arc<CheckpointManager>,
+    /// Active turns keyed by session_key. Flushed when run_id changes.
+    active: Mutex<HashMap<String, ActiveTurn>>,
+}
+
+impl AutoCheckpointHook {
+    pub fn new(manager: Arc<CheckpointManager>) -> Self {
+        Self {
+            manager,
+            active: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// Extract the file path from tool arguments.
+    fn extract_file_path(args: &Value) -> Option<&str> {
+        // Write and Edit use "file_path"
+        args.get("file_path")
+            .and_then(|v| v.as_str())
+            // MultiEdit uses "file_path" too
+            .or_else(|| args.get("path").and_then(|v| v.as_str()))
+    }
+
+    /// Extract run_id from tool arguments (injected by tool context).
+    fn extract_run_id(args: &Value) -> Option<&str> {
+        args.get("_run_id").and_then(|v| v.as_str())
+    }
+}
+
+#[async_trait]
+impl HookHandler for AutoCheckpointHook {
+    fn name(&self) -> &str {
+        "auto_checkpoint"
+    }
+
+    fn events(&self) -> &[HookEvent] {
+        &[HookEvent::BeforeToolCall]
+    }
+
+    fn priority(&self) -> i32 {
+        // Run early so the checkpoint is created before the tool modifies the file.
+        100
+    }
+
+    async fn handle(
+        &self,
+        _event: HookEvent,
+        payload: &HookPayload,
+    ) -> moltis_common::Result<HookAction> {
+        let HookPayload::BeforeToolCall {
+            session_key,
+            tool_name,
+            arguments,
+            ..
+        } = payload
+        else {
+            return Ok(HookAction::Continue);
+        };
+
+        if !CHECKPOINT_TOOLS.iter().any(|t| t == tool_name) {
+            return Ok(HookAction::Continue);
+        }
+
+        let Some(file_path) = Self::extract_file_path(arguments) else {
+            return Ok(HookAction::Continue);
+        };
+
+        let run_id = Self::extract_run_id(arguments)
+            .unwrap_or("unknown")
+            .to_string();
+
+        // Snapshot the file before the tool modifies it.
+        let path = PathBuf::from(file_path);
+        let checkpoint = match self.manager.checkpoint_path(&path, tool_name).await {
+            Ok(cp) => cp,
+            Err(e) => {
+                // Don't block the tool call if checkpointing fails.
+                warn!(
+                    file = %file_path,
+                    tool = %tool_name,
+                    error = %e,
+                    "auto-checkpoint failed, tool will proceed without snapshot"
+                );
+                return Ok(HookAction::Continue);
+            },
+        };
+
+        debug!(
+            file = %file_path,
+            tool = %tool_name,
+            checkpoint_id = %checkpoint.id,
+            "auto-checkpointed file before mutation"
+        );
+
+        // Track this checkpoint in the active turn for this session.
+        let mut active = self.active.lock().await;
+        let turn = active
+            .entry(session_key.clone())
+            .or_insert_with(|| ActiveTurn {
+                run_id: run_id.clone(),
+                session_key: session_key.clone(),
+                checkpoint_ids: Vec::new(),
+                source_paths: Vec::new(),
+                created_at: OffsetDateTime::now_utc().unix_timestamp(),
+            });
+
+        // If the run_id changed, flush the previous turn and start a new one.
+        if turn.run_id != run_id {
+            let prev = std::mem::replace(turn, ActiveTurn {
+                run_id: run_id.clone(),
+                session_key: session_key.clone(),
+                checkpoint_ids: Vec::new(),
+                source_paths: Vec::new(),
+                created_at: OffsetDateTime::now_utc().unix_timestamp(),
+            });
+            // Flush in background to avoid blocking the tool call.
+            let self_ref = Arc::clone(&self.manager);
+            let record = TurnRecord {
+                run_id: prev.run_id,
+                session_key: prev.session_key,
+                created_at: prev.created_at,
+                checkpoint_ids: prev.checkpoint_ids,
+                source_paths: prev.source_paths,
+            };
+            tokio::spawn(async move {
+                if let Err(e) = self_ref.append_turn(&record) {
+                    warn!(error = %e, "failed to flush previous turn record");
+                }
+            });
+        }
+
+        turn.checkpoint_ids.push(checkpoint.id);
+        turn.source_paths.push(file_path.to_string());
+
+        Ok(HookAction::Continue)
+    }
+}

--- a/crates/tools/src/auto_checkpoint.rs
+++ b/crates/tools/src/auto_checkpoint.rs
@@ -66,7 +66,7 @@ impl HookHandler for AutoCheckpointHook {
     }
 
     fn events(&self) -> &[HookEvent] {
-        &[HookEvent::BeforeToolCall]
+        &[HookEvent::BeforeToolCall, HookEvent::AgentEnd]
     }
 
     fn priority(&self) -> i32 {
@@ -79,6 +79,29 @@ impl HookHandler for AutoCheckpointHook {
         _event: HookEvent,
         payload: &HookPayload,
     ) -> moltis_common::Result<HookAction> {
+        // On AgentEnd, flush any in-progress turn so it is persisted.
+        if let HookPayload::AgentEnd { session_key, .. } = payload {
+            let mut active = self.active.lock().await;
+            if let Some(turn) = active.remove(session_key)
+                && !turn.checkpoint_ids.is_empty()
+            {
+                let manager = Arc::clone(&self.manager);
+                let record = TurnRecord {
+                    run_id: turn.run_id,
+                    session_key: turn.session_key,
+                    created_at: turn.created_at,
+                    checkpoint_ids: turn.checkpoint_ids,
+                    source_paths: turn.source_paths,
+                };
+                tokio::spawn(async move {
+                    if let Err(e) = manager.append_turn(&record) {
+                        warn!(error = %e, "failed to flush turn record at agent end");
+                    }
+                });
+            }
+            return Ok(HookAction::Continue);
+        }
+
         let HookPayload::BeforeToolCall {
             session_key,
             tool_name,

--- a/crates/tools/src/checkpoints.rs
+++ b/crates/tools/src/checkpoints.rs
@@ -20,6 +20,10 @@ use crate::{
 
 const DEFAULT_LIST_LIMIT: usize = 20;
 const MAX_LIST_LIMIT: usize = 100;
+/// Prune when checkpoint count exceeds this threshold.
+const CLEANUP_CHECKPOINT_THRESHOLD: usize = 500;
+/// Fraction of checkpoints to remove when pruning.
+const CLEANUP_PRUNE_RATIO: f64 = 0.2;
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -109,6 +113,136 @@ impl CheckpointManager {
             .await
             .map_err(|error| Error::message(format!("checkpoint restore task failed: {error}")))?
     }
+}
+
+// ── Turn index ──────────────────────────────────────────────────────────────
+
+/// A group of checkpoints created during a single agent turn (run).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TurnRecord {
+    pub run_id: String,
+    pub session_key: String,
+    pub created_at: i64,
+    pub checkpoint_ids: Vec<String>,
+    /// Source paths for display (parallel to checkpoint_ids).
+    pub source_paths: Vec<String>,
+}
+
+impl CheckpointManager {
+    /// Path to the turns index file.
+    fn turns_path(&self) -> PathBuf {
+        self.base_dir.join("turns.jsonl")
+    }
+
+    /// Append a turn record to the index.
+    pub fn append_turn(&self, record: &TurnRecord) -> Result<()> {
+        fs::create_dir_all(&self.base_dir)?;
+        let mut line = serde_json::to_string(record)?;
+        line.push('\n');
+        let mut file = fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(self.turns_path())?;
+        std::io::Write::write_all(&mut file, line.as_bytes())?;
+        Ok(())
+    }
+
+    /// Read all turn records (newest first).
+    pub fn read_turns(&self, limit: usize) -> Result<Vec<TurnRecord>> {
+        let path = self.turns_path();
+        let content = match fs::read_to_string(&path) {
+            Ok(c) => c,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+            Err(e) => return Err(e.into()),
+        };
+        let mut turns: Vec<TurnRecord> = content
+            .lines()
+            .filter(|line| !line.trim().is_empty())
+            .filter_map(|line| serde_json::from_str(line).ok())
+            .collect();
+        turns.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+        turns.truncate(limit);
+        Ok(turns)
+    }
+
+    /// Remove old checkpoints when the total count exceeds the threshold.
+    ///
+    /// Deletes the oldest checkpoints (by `created_at`) until the count is
+    /// under the threshold. Also removes corresponding turn records.
+    pub async fn cleanup_if_needed(&self) -> Result<usize> {
+        let base_dir = self.base_dir.clone();
+        tokio::task::spawn_blocking(move || cleanup_blocking(&base_dir))
+            .await
+            .map_err(|e| Error::message(format!("checkpoint cleanup failed: {e}")))?
+    }
+}
+
+fn cleanup_blocking(base_dir: &Path) -> Result<usize> {
+    let mut all = read_all_manifests(base_dir)?;
+    if all.len() <= CLEANUP_CHECKPOINT_THRESHOLD {
+        return Ok(0);
+    }
+
+    // Sort oldest first, delete the oldest CLEANUP_PRUNE_RATIO fraction.
+    all.sort_by_key(|r| r.created_at);
+    let to_remove = (all.len() as f64 * CLEANUP_PRUNE_RATIO).ceil() as usize;
+    let removed_ids: std::collections::HashSet<String> =
+        all.iter().take(to_remove).map(|r| r.id.clone()).collect();
+
+    let mut deleted = 0;
+    for id in &removed_ids {
+        let dir = base_dir.join(id);
+        if dir.is_dir() {
+            if let Err(e) = fs::remove_dir_all(&dir) {
+                tracing::warn!(checkpoint = %id, error = %e, "failed to remove old checkpoint");
+            } else {
+                deleted += 1;
+            }
+        }
+    }
+
+    // Rewrite turns.jsonl without references to deleted checkpoints.
+    let turns_path = base_dir.join("turns.jsonl");
+    if turns_path.exists()
+        && let Ok(content) = fs::read_to_string(&turns_path)
+    {
+        let filtered: Vec<String> = content
+            .lines()
+            .filter(|line| !line.trim().is_empty())
+            .filter_map(|line| {
+                let mut turn: TurnRecord = serde_json::from_str(line).ok()?;
+                let orig_len = turn.checkpoint_ids.len();
+                let mut new_ids = Vec::new();
+                let mut new_paths = Vec::new();
+                for (id, path) in turn
+                    .checkpoint_ids
+                    .into_iter()
+                    .zip(turn.source_paths.into_iter())
+                {
+                    if !removed_ids.contains(&id) {
+                        new_ids.push(id);
+                        new_paths.push(path);
+                    }
+                }
+                if new_ids.is_empty() && orig_len > 0 {
+                    return None; // entire turn pruned
+                }
+                turn.checkpoint_ids = new_ids;
+                turn.source_paths = new_paths;
+                serde_json::to_string(&turn).ok()
+            })
+            .collect();
+        let _ = fs::write(&turns_path, filtered.join("\n") + "\n");
+    }
+
+    if deleted > 0 {
+        tracing::info!(
+            deleted,
+            remaining = all.len() - deleted,
+            "pruned old checkpoints"
+        );
+    }
+    Ok(deleted)
 }
 
 pub struct CheckpointsListTool {

--- a/crates/tools/src/checkpoints.rs
+++ b/crates/tools/src/checkpoints.rs
@@ -147,8 +147,8 @@ impl CheckpointManager {
         Ok(())
     }
 
-    /// Read all turn records (newest first).
-    pub fn read_turns(&self, limit: usize) -> Result<Vec<TurnRecord>> {
+    /// Read turn records (newest first), optionally filtered by session key.
+    pub fn read_turns(&self, limit: usize, session_key: Option<&str>) -> Result<Vec<TurnRecord>> {
         let path = self.turns_path();
         let content = match fs::read_to_string(&path) {
             Ok(c) => c,
@@ -159,6 +159,7 @@ impl CheckpointManager {
             .lines()
             .filter(|line| !line.trim().is_empty())
             .filter_map(|line| serde_json::from_str(line).ok())
+            .filter(|turn: &TurnRecord| session_key.is_none_or(|sk| turn.session_key == sk))
             .collect();
         turns.sort_by(|a, b| b.created_at.cmp(&a.created_at));
         turns.truncate(limit);

--- a/crates/tools/src/lib.rs
+++ b/crates/tools/src/lib.rs
@@ -52,6 +52,7 @@ pub mod wasm_limits;
 pub mod wasm_tool_runner;
 pub mod web_fetch;
 pub mod web_search;
+pub mod webhook_tool;
 
 pub use {
     client::{build_http_client, init_shared_http_client, shared_http_client},

--- a/crates/tools/src/lib.rs
+++ b/crates/tools/src/lib.rs
@@ -7,6 +7,7 @@
 //! per-group, per-sender, sandbox).
 
 pub mod approval;
+pub mod auto_checkpoint;
 pub mod branch_session;
 pub mod browser;
 pub mod calc;

--- a/crates/tools/src/webhook_tool.rs
+++ b/crates/tools/src/webhook_tool.rs
@@ -1,0 +1,222 @@
+//! Agent-callable webhook tool for managing webhook subscriptions.
+
+use std::sync::Arc;
+
+use {
+    async_trait::async_trait,
+    moltis_agents::tool_registry::AgentTool,
+    moltis_service_traits::WebhooksService,
+    serde_json::{Value, json},
+};
+
+/// The webhook management tool exposed to LLM agents.
+pub struct WebhookTool {
+    service: Arc<dyn WebhooksService>,
+}
+
+impl WebhookTool {
+    pub fn new(service: Arc<dyn WebhooksService>) -> Self {
+        Self { service }
+    }
+}
+
+#[async_trait]
+impl AgentTool for WebhookTool {
+    fn name(&self) -> &str {
+        "webhook"
+    }
+
+    fn description(&self) -> &str {
+        "Manage webhook subscriptions. External services (GitHub, GitLab, Stripe, etc.) \
+         POST events to Moltis, which either runs an agent in response or forwards the \
+         event directly to a channel (deliver_only mode, zero LLM tokens).\n\n\
+         Actions:\n\
+         - list: List all webhooks\n\
+         - create: Create a new webhook endpoint\n\
+         - get: Get webhook details by ID\n\
+         - update: Update webhook settings\n\
+         - delete: Delete a webhook\n\
+         - profiles: List available source profiles\n\
+         - deliveries: View delivery history for a webhook"
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "required": ["action"],
+            "properties": {
+                "action": {
+                    "type": "string",
+                    "enum": ["list", "create", "get", "update", "delete", "profiles", "deliveries"],
+                    "description": "The operation to perform."
+                },
+                "id": {
+                    "type": "integer",
+                    "description": "Webhook ID (for get, update, delete)."
+                },
+                "name": {
+                    "type": "string",
+                    "description": "Webhook name (for create)."
+                },
+                "source_profile": {
+                    "type": "string",
+                    "enum": ["generic", "github", "gitlab", "stripe", "linear", "pagerduty", "sentry"],
+                    "description": "Source profile (for create). Default: generic."
+                },
+                "auth_mode": {
+                    "type": "string",
+                    "enum": ["none", "static_header", "bearer", "github_hmac_sha256", "gitlab_token",
+                             "stripe_webhook_signature", "linear_webhook_signature",
+                             "pagerduty_v2_signature", "sentry_webhook_signature"],
+                    "description": "Authentication mode (for create)."
+                },
+                "events": {
+                    "type": "array",
+                    "items": { "type": "string" },
+                    "description": "Event types to accept (for create). Empty means accept all."
+                },
+                "system_prompt_suffix": {
+                    "type": "string",
+                    "description": "Extra text appended to the agent system prompt."
+                },
+                "deliver_only": {
+                    "type": "boolean",
+                    "description": "When true, skip the agent and forward the rendered template directly \
+                                    to a channel. Zero LLM tokens, sub-second delivery."
+                },
+                "prompt_template": {
+                    "type": "string",
+                    "description": "Template with {dot.notation} variables from the payload. \
+                                    Example: 'Issue #{issue.number}: {issue.title}'"
+                },
+                "deliver_to": {
+                    "type": "string",
+                    "description": "Target channel for deliver_only mode (telegram, discord, slack, etc.)."
+                },
+                "webhook_id": {
+                    "type": "integer",
+                    "description": "Webhook ID (for deliveries)."
+                },
+                "limit": {
+                    "type": "integer",
+                    "description": "Max results (for deliveries). Default: 20."
+                },
+                "patch": {
+                    "type": "object",
+                    "description": "Fields to update (for update). Any subset of webhook fields."
+                }
+            }
+        })
+    }
+
+    async fn execute(&self, params: Value) -> anyhow::Result<Value> {
+        let action = params
+            .get("action")
+            .and_then(|v| v.as_str())
+            .unwrap_or("list");
+
+        match action {
+            "list" => self
+                .service
+                .list()
+                .await
+                .map_err(|e| anyhow::anyhow!("{e}")),
+
+            "profiles" => self
+                .service
+                .profiles()
+                .await
+                .map_err(|e| anyhow::anyhow!("{e}")),
+
+            "get" => {
+                let id = params
+                    .get("id")
+                    .and_then(|v| v.as_i64())
+                    .ok_or_else(|| anyhow::anyhow!("missing 'id' for get"))?;
+                self.service
+                    .get(json!({ "id": id }))
+                    .await
+                    .map_err(|e| anyhow::anyhow!("{e}"))
+            },
+
+            "create" => {
+                let name = params
+                    .get("name")
+                    .and_then(|v| v.as_str())
+                    .ok_or_else(|| anyhow::anyhow!("missing 'name' for create"))?;
+
+                let mut create_params = json!({
+                    "name": name,
+                    "source_profile": params.get("source_profile").and_then(|v| v.as_str()).unwrap_or("generic"),
+                    "auth_mode": params.get("auth_mode").and_then(|v| v.as_str()).unwrap_or("none"),
+                    "session_mode": params.get("session_mode").and_then(|v| v.as_str()).unwrap_or("per_delivery"),
+                });
+
+                let obj = create_params
+                    .as_object_mut()
+                    .unwrap_or_else(|| unreachable!());
+
+                if let Some(events) = params.get("events").and_then(|v| v.as_array()) {
+                    let allow: Vec<&str> = events.iter().filter_map(|v| v.as_str()).collect();
+                    obj.insert("event_filter".into(), json!({ "allow": allow }));
+                }
+                if let Some(suffix) = params.get("system_prompt_suffix").and_then(|v| v.as_str()) {
+                    obj.insert("system_prompt_suffix".into(), json!(suffix));
+                }
+                if let Some(true) = params.get("deliver_only").and_then(|v| v.as_bool()) {
+                    obj.insert("deliver_only".into(), json!(true));
+                }
+                if let Some(pt) = params.get("prompt_template").and_then(|v| v.as_str()) {
+                    obj.insert("prompt_template".into(), json!(pt));
+                }
+                if let Some(dt) = params.get("deliver_to").and_then(|v| v.as_str()) {
+                    obj.insert("deliver_to".into(), json!(dt));
+                }
+
+                self.service
+                    .create(create_params)
+                    .await
+                    .map_err(|e| anyhow::anyhow!("{e}"))
+            },
+
+            "update" => {
+                let id = params
+                    .get("id")
+                    .and_then(|v| v.as_i64())
+                    .ok_or_else(|| anyhow::anyhow!("missing 'id' for update"))?;
+                let patch = params.get("patch").cloned().unwrap_or(json!({}));
+                self.service
+                    .update(json!({ "id": id, "patch": patch }))
+                    .await
+                    .map_err(|e| anyhow::anyhow!("{e}"))
+            },
+
+            "delete" => {
+                let id = params
+                    .get("id")
+                    .and_then(|v| v.as_i64())
+                    .ok_or_else(|| anyhow::anyhow!("missing 'id' for delete"))?;
+                self.service
+                    .delete(json!({ "id": id }))
+                    .await
+                    .map_err(|e| anyhow::anyhow!("{e}"))
+            },
+
+            "deliveries" => {
+                let webhook_id = params
+                    .get("webhook_id")
+                    .and_then(|v| v.as_i64())
+                    .ok_or_else(|| anyhow::anyhow!("missing 'webhook_id' for deliveries"))?;
+                let limit = params.get("limit").and_then(|v| v.as_i64()).unwrap_or(20);
+                self.service
+                    .deliveries(json!({ "webhookId": webhook_id, "limit": limit }))
+                    .await
+                    .map_err(|e| anyhow::anyhow!("{e}"))
+            },
+
+            other => Err(anyhow::anyhow!(
+                "unknown action '{other}'. Use: list, create, get, update, delete, profiles, deliveries"
+            )),
+        }
+    }
+}

--- a/crates/web/src/lib.rs
+++ b/crates/web/src/lib.rs
@@ -227,6 +227,10 @@ fn build_api_routes() -> Router<AppState> {
         .route(
             "/api/metrics/history",
             get(moltis_httpd::metrics_routes::api_metrics_history_handler),
+        )
+        .route(
+            "/api/metrics/insights",
+            get(moltis_httpd::metrics_routes::api_metrics_insights_handler),
         );
 
     protected

--- a/crates/web/ui/src/pages/MetricsPage.tsx
+++ b/crates/web/ui/src/pages/MetricsPage.tsx
@@ -739,6 +739,155 @@ function PrometheusEndpoint(): VNode {
 	);
 }
 
+// ── Insights tab ────────────────────────────────────────────────
+
+interface InsightsData {
+	days: number;
+	completions: number;
+	input_tokens: number;
+	output_tokens: number;
+	total_tokens: number;
+	errors: number;
+	tool_executions: number;
+	tool_errors: number;
+	by_provider: Record<string, { input_tokens: number; output_tokens: number; completions: number }>;
+	data_points: number;
+	span_hours: number;
+}
+
+const INSIGHTS_RANGES = [
+	{ label: "7 days", days: 7 },
+	{ label: "30 days", days: 30 },
+	{ label: "90 days", days: 90 },
+];
+
+function InsightsTab(): VNode {
+	const [data, setData] = useState<InsightsData | null>(null);
+	const [insightsDays, setInsightsDays] = useState(30);
+	const [insightsLoading, setInsightsLoading] = useState(true);
+
+	useEffect(() => {
+		setInsightsLoading(true);
+		fetch(`/api/metrics/insights?days=${insightsDays}`)
+			.then((resp) => {
+				if (resp.ok) return resp.json();
+				throw new Error(`HTTP ${resp.status}`);
+			})
+			.then((d: InsightsData) => {
+				setData(d);
+				setInsightsLoading(false);
+			})
+			.catch(() => {
+				setData(null);
+				setInsightsLoading(false);
+			});
+	}, [insightsDays]);
+
+	if (insightsLoading) {
+		return <div className="flex items-center justify-center h-32 text-[var(--muted)]">Loading insights...</div>;
+	}
+
+	if (!data || data.data_points === 0) {
+		return (
+			<div className="text-center text-[var(--muted)] py-16">
+				<p className="text-lg mb-2">No usage data yet</p>
+				<p className="text-sm">Metrics are collected while the gateway is running.</p>
+			</div>
+		);
+	}
+
+	const providers = Object.entries(data.by_provider).sort(
+		(a, b) => b[1].input_tokens + b[1].output_tokens - (a[1].input_tokens + a[1].output_tokens),
+	);
+
+	const completionsPerHour = data.span_hours > 0 ? (data.completions / data.span_hours).toFixed(1) : "—";
+
+	return (
+		<div className="space-y-8">
+			{/* Time range selector */}
+			<div className="flex gap-2">
+				{INSIGHTS_RANGES.map((r) => (
+					<button
+						key={r.days}
+						type="button"
+						className={`px-3 py-1.5 rounded text-sm transition-colors ${
+							insightsDays === r.days
+								? "bg-[var(--accent)] text-white"
+								: "bg-[var(--bg-secondary)] text-[var(--fg)] hover:bg-[var(--bg-hover)]"
+						}`}
+						onClick={() => setInsightsDays(r.days)}
+					>
+						{r.label}
+					</button>
+				))}
+			</div>
+
+			{/* Summary cards */}
+			<div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+				<InsightCard label="LLM Completions" value={formatNumber(data.completions)} />
+				<InsightCard label="Total Tokens" value={formatNumber(data.total_tokens)} />
+				<InsightCard label="Input Tokens" value={formatNumber(data.input_tokens)} />
+				<InsightCard label="Output Tokens" value={formatNumber(data.output_tokens)} />
+				<InsightCard label="Completions/hour" value={completionsPerHour} />
+				<InsightCard label="LLM Errors" value={formatNumber(data.errors)} alert={data.errors > 0} />
+				<InsightCard label="Tool Executions" value={formatNumber(data.tool_executions)} />
+				<InsightCard label="Tool Errors" value={formatNumber(data.tool_errors)} alert={data.tool_errors > 0} />
+			</div>
+
+			{/* Provider breakdown */}
+			{providers.length > 0 && (
+				<div>
+					<h3 className="text-sm font-semibold text-[var(--muted)] uppercase tracking-wider mb-4">Usage by Provider</h3>
+					<div className="border border-[var(--border)] rounded-lg overflow-hidden">
+						<table className="w-full text-sm">
+							<thead>
+								<tr className="bg-[var(--bg-secondary)] text-[var(--muted)]">
+									<th className="text-left px-4 py-2 font-medium">Provider</th>
+									<th className="text-right px-4 py-2 font-medium">Completions</th>
+									<th className="text-right px-4 py-2 font-medium">Input Tokens</th>
+									<th className="text-right px-4 py-2 font-medium">Output Tokens</th>
+									<th className="text-right px-4 py-2 font-medium">Total</th>
+								</tr>
+							</thead>
+							<tbody>
+								{providers.map(([name, stats]) => (
+									<tr key={name} className="border-t border-[var(--border)]">
+										<td className="px-4 py-2 font-medium">{name}</td>
+										<td className="text-right px-4 py-2 tabular-nums">{formatNumber(stats.completions)}</td>
+										<td className="text-right px-4 py-2 tabular-nums">{formatNumber(stats.input_tokens)}</td>
+										<td className="text-right px-4 py-2 tabular-nums">{formatNumber(stats.output_tokens)}</td>
+										<td className="text-right px-4 py-2 tabular-nums font-medium">
+											{formatNumber(stats.input_tokens + stats.output_tokens)}
+										</td>
+									</tr>
+								))}
+							</tbody>
+						</table>
+					</div>
+				</div>
+			)}
+
+			{/* Footer */}
+			<p className="text-xs text-[var(--muted)]">
+				Based on {formatNumber(data.data_points)} data points over {data.span_hours.toFixed(1)} hours.
+			</p>
+		</div>
+	);
+}
+
+function InsightCard({ label, value, alert }: { label: string; value: string; alert?: boolean }): VNode {
+	return (
+		<div
+			className={`p-4 rounded-lg border ${
+				alert ? "border-[var(--error)] bg-[var(--error-bg)]" : "border-[var(--border)] bg-[var(--bg-secondary)]"
+			}`}
+		>
+			<div className="text-xs text-[var(--muted)] mb-1">{label}</div>
+			<div className={`text-xl font-semibold tabular-nums ${alert ? "text-[var(--error)]" : ""}`}>{value}</div>
+		</div>
+	);
+}
+
 function MonitoringPage({ initialTab }: { initialTab: string }): VNode {
 	const [activeTab, setActiveTab] = useState(initialTab || "overview");
 	const [timeRange, setTimeRange] = useState("1h");
@@ -747,7 +896,7 @@ function MonitoringPage({ initialTab }: { initialTab: string }): VNode {
 	function handleTabChange(tab: string): void {
 		setActiveTab(tab);
 		if (monitoringSyncPath) {
-			const newPath = tab === "charts" ? `${monitoringPathBase}/charts` : monitoringPathBase;
+			const newPath = tab === "overview" ? monitoringPathBase : `${monitoringPathBase}/${tab}`;
 			if (window.location.pathname !== newPath) {
 				history.pushState(null, "", newPath);
 			}
@@ -806,6 +955,7 @@ function MonitoringPage({ initialTab }: { initialTab: string }): VNode {
 						tabs={[
 							{ id: "overview", label: t("metrics:tabs.overview") },
 							{ id: "charts", label: t("metrics:tabs.charts") },
+							{ id: "insights", label: "Insights" },
 						]}
 						active={activeTab}
 						onChange={handleTabChange}
@@ -826,6 +976,8 @@ function MonitoringPage({ initialTab }: { initialTab: string }): VNode {
 				{activeTab === "charts" && (
 					<ChartsSection points={historyPoints.value} timeRange={timeRange} onTimeRangeChange={setTimeRange} />
 				)}
+
+				{activeTab === "insights" && <InsightsTab />}
 			</div>
 		</div>
 	);
@@ -836,7 +988,7 @@ export function initMonitoring(container: HTMLElement, param?: string | null, op
 	_monitoringContainer = container;
 	monitoringPathBase = options?.pathBase || routes.monitoring;
 	monitoringSyncPath = options?.syncPath !== false;
-	const initialTab = param === "charts" ? "charts" : "overview";
+	const initialTab = param === "charts" ? "charts" : param === "insights" ? "insights" : "overview";
 	render(<MonitoringPage initialTab={initialTab} />, container);
 }
 

--- a/crates/web/ui/src/pages/chat/slash-commands.ts
+++ b/crates/web/ui/src/pages/chat/slash-commands.ts
@@ -29,6 +29,26 @@ interface ModePayload {
 	prompt: string;
 }
 
+interface InsightsApiResponse {
+	days: number;
+	completions: number;
+	input_tokens: number;
+	output_tokens: number;
+	total_tokens: number;
+	errors: number;
+	tool_executions: number;
+	tool_errors: number;
+	by_provider: Record<string, { input_tokens: number; output_tokens: number; completions: number }>;
+	data_points: number;
+	span_hours: number;
+}
+
+function fmtNum(n: number): string {
+	if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+	if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
+	return n.toLocaleString();
+}
+
 interface ModesListPayload {
 	modes: ModePayload[];
 }
@@ -36,12 +56,17 @@ interface ModesListPayload {
 // ── Slash commands list ─────────────────────────────────────
 
 export const slashCommands: SlashCommand[] = [
+	{ name: "btw", description: "Quick side question (no tools, not persisted)" },
 	{ name: "clear", description: "Clear conversation history" },
 	{ name: "compact", description: "Summarize conversation to save tokens" },
 	{ name: "context", description: "Show session context and project info" },
+	{ name: "fast", description: "Toggle fast/priority mode" },
+	{ name: "fork", description: "Fork this session into a new branch" },
+	{ name: "insights", description: "Show usage analytics (tokens, providers)" },
 	{ name: "mode", description: "Switch session mode (/mode none to clear)" },
 	{ name: "new", description: "Start a new session" },
 	{ name: "reset", description: "Clear conversation history" },
+	{ name: "rollback", description: "List or restore file checkpoints" },
 	{ name: "sh", description: "Enter command mode (/sh off or Esc to exit)" },
 ];
 
@@ -366,5 +391,94 @@ export function handleSlashCommand(cmdName: string, cmdArgs: string): void {
 			renderMarkdown(`**Command:** mode enabled (${commandModeSummary()}) \u00b7 exit with /sh off or Esc`),
 			true,
 		);
+		return;
+	}
+	if (cmdName === "insights") {
+		const days = cmdArgs.trim() || "30";
+		chatAddMsg("system", `Loading insights for last ${days} days\u2026`);
+		fetch(`/api/metrics/insights?days=${days}`)
+			.then((resp) => (resp.ok ? resp.json() : Promise.reject(new Error(`HTTP ${resp.status}`))))
+			.then((data: InsightsApiResponse) => {
+				if (S.chatMsgBox?.lastChild) S.chatMsgBox.removeChild(S.chatMsgBox.lastChild);
+				const lines: string[] = [];
+				lines.push(`**Insights** \u2014 last ${data.days} days\n`);
+				lines.push(`| Metric | Value |`);
+				lines.push(`|--------|-------|`);
+				lines.push(`| LLM completions | ${fmtNum(data.completions)} |`);
+				lines.push(`| Total tokens | ${fmtNum(data.total_tokens)} |`);
+				lines.push(`| Input tokens | ${fmtNum(data.input_tokens)} |`);
+				lines.push(`| Output tokens | ${fmtNum(data.output_tokens)} |`);
+				lines.push(`| LLM errors | ${fmtNum(data.errors)} |`);
+				lines.push(`| Tool executions | ${fmtNum(data.tool_executions)} |`);
+				if (data.span_hours > 0) {
+					lines.push(`| Completions/hour | ${(data.completions / data.span_hours).toFixed(1)} |`);
+				}
+				if (data.by_provider && Object.keys(data.by_provider).length > 0) {
+					lines.push(`\n**By provider:**\n`);
+					lines.push(`| Provider | Completions | Tokens |`);
+					lines.push(`|----------|-------------|--------|`);
+					const sorted = Object.entries(data.by_provider).sort(
+						(a, b) => b[1].input_tokens + b[1].output_tokens - (a[1].input_tokens + a[1].output_tokens),
+					);
+					for (const [name, stats] of sorted) {
+						lines.push(
+							`| ${name} | ${fmtNum(stats.completions)} | ${fmtNum(stats.input_tokens + stats.output_tokens)} |`,
+						);
+					}
+				}
+				lines.push(`\n*${fmtNum(data.data_points)} data points over ${data.span_hours.toFixed(1)} hours*`);
+				chatAddMsg("system", renderMarkdown(lines.join("\n")), true);
+			})
+			.catch((err: Error) => chatAddMsg("error", `Insights failed: ${err.message}`));
+		return;
+	}
+	if (cmdName === "btw") {
+		if (!cmdArgs.trim()) {
+			chatAddMsg("error", "Usage: /btw <question>");
+			return;
+		}
+		chatAddMsg("system", "Thinking\u2026");
+		sendRpc("chat.send_sync", { text: cmdArgs, _ephemeral: true }).then((res) => {
+			if (S.chatMsgBox?.lastChild) S.chatMsgBox.removeChild(S.chatMsgBox.lastChild);
+			if (res.ok && res.payload) {
+				const text = typeof res.payload === "string" ? res.payload : (res.payload as UnknownRecord).text;
+				chatAddMsg("system", renderMarkdown(String(text || "(no response)")), true);
+			} else chatAddMsg("error", res.error?.message || "/btw failed");
+		});
+		return;
+	}
+	if (cmdName === "fast") {
+		const arg = cmdArgs.trim().toLowerCase();
+		const label = arg || "toggle";
+		chatAddMsg("system", `Fast mode: ${label}\u2026`);
+		sendRpc("chat.send_sync", { text: `/fast ${arg}`.trim() }).then((res) => {
+			if (S.chatMsgBox?.lastChild) S.chatMsgBox.removeChild(S.chatMsgBox.lastChild);
+			if (res.ok && res.payload) {
+				const text = typeof res.payload === "string" ? res.payload : (res.payload as UnknownRecord).text;
+				chatAddMsg("system", String(text || "Done"));
+			} else chatAddMsg("error", res.error?.message || "/fast failed");
+		});
+		return;
+	}
+	if (cmdName === "fork") {
+		chatAddMsg("system", "Forking session\u2026");
+		sendRpc("sessions.fork", { key: S.activeSessionKey, label: cmdArgs.trim() || undefined }).then((res) => {
+			if (S.chatMsgBox?.lastChild) S.chatMsgBox.removeChild(S.chatMsgBox.lastChild);
+			if (res.ok && res.payload) {
+				const key = (res.payload as UnknownRecord).sessionKey as string;
+				const label = (res.payload as UnknownRecord).label as string;
+				chatAddMsg("system", `Forked into: ${label || key}. Use the session list to switch.`);
+				fetchSessions();
+			} else chatAddMsg("error", res.error?.message || "Fork failed");
+		});
+		return;
+	}
+	if (cmdName === "rollback") {
+		chatAddMsg(
+			"system",
+			renderMarkdown("Rollback is available via the `/rollback` channel command (Telegram, Discord, etc.) or the CLI."),
+			true,
+		);
+		return;
 	}
 }

--- a/crates/web/ui/src/pages/chat/slash-commands.ts
+++ b/crates/web/ui/src/pages/chat/slash-commands.ts
@@ -8,10 +8,28 @@ import { type ContextData, renderContextCard } from "./context-card";
 
 // ── Types ────────────────────────────────────────────────────
 
+/** Known slash command names — adding a name here requires a handler in `slashHandlers`. */
+type SlashCommandName =
+	| "btw"
+	| "clear"
+	| "compact"
+	| "context"
+	| "fast"
+	| "fork"
+	| "insights"
+	| "mode"
+	| "new"
+	| "reset"
+	| "rollback"
+	| "sh";
+
 export interface SlashCommand {
-	name: string;
+	name: SlashCommandName;
 	description: string;
 }
+
+/** Handler function for a slash command. */
+type SlashHandler = (args: string) => void;
 
 export interface ParsedSlash {
 	name: string;
@@ -332,20 +350,22 @@ function handleModeCommand(cmdArgs: string): void {
 	});
 }
 
-export function handleSlashCommand(cmdName: string, cmdArgs: string): void {
-	if (cmdName === "clear") {
-		clearActiveSession();
-		return;
-	}
-	if (cmdName === "compact") {
+/**
+ * Handler map — every `SlashCommandName` must have an entry here.
+ * TypeScript will error at `satisfies` if a command is missing.
+ */
+const slashHandlers: Record<SlashCommandName, SlashHandler> = {
+	clear: () => clearActiveSession(),
+
+	compact: () => {
 		chatAddMsg("system", "Compacting conversation\u2026");
 		sendRpc("chat.compact", {}).then((res) => {
 			if (res.ok) switchSession(S.activeSessionKey);
 			else chatAddMsg("error", res.error?.message || "Compact failed");
 		});
-		return;
-	}
-	if (cmdName === "context") {
+	},
+
+	context: () => {
 		chatAddMsg("system", "Loading context\u2026");
 		sendRpc("chat.context", {}).then((res) => {
 			if (S.chatMsgBox?.lastChild) S.chatMsgBox.removeChild(S.chatMsgBox.lastChild);
@@ -358,28 +378,22 @@ export function handleSlashCommand(cmdName: string, cmdArgs: string): void {
 				}
 			} else chatAddMsg("error", res.error?.message || "Context failed");
 		});
-		return;
-	}
-	if (cmdName === "mode") {
-		handleModeCommand(cmdArgs);
-		return;
-	}
-	if (cmdName === "new") {
-		const newKey = `session:${crypto.randomUUID()}`;
-		switchSession(newKey);
-		return;
-	}
-	if (cmdName === "reset") {
-		// Use sessions.reset (not chat.clear) so the session summary also runs.
+	},
+
+	mode: (args) => handleModeCommand(args),
+
+	new: () => switchSession(`session:${crypto.randomUUID()}`),
+
+	reset: () => {
 		chatAddMsg("system", "Resetting session\u2026");
 		sendRpc("sessions.reset", { key: S.activeSessionKey }).then((res) => {
 			if (res.ok) switchSession(S.activeSessionKey);
 			else chatAddMsg("error", res.error?.message || "Reset failed");
 		});
-		return;
-	}
-	if (cmdName === "sh") {
-		const normalized = (cmdArgs || "").toLowerCase();
+	},
+
+	sh: (args) => {
+		const normalized = (args || "").toLowerCase();
 		if (normalized === "off" || normalized === "exit") {
 			setCommandMode(false);
 			chatAddMsg("system", renderMarkdown("**Command:** mode disabled"), true);
@@ -391,10 +405,10 @@ export function handleSlashCommand(cmdName: string, cmdArgs: string): void {
 			renderMarkdown(`**Command:** mode enabled (${commandModeSummary()}) \u00b7 exit with /sh off or Esc`),
 			true,
 		);
-		return;
-	}
-	if (cmdName === "insights") {
-		const days = cmdArgs.trim() || "30";
+	},
+
+	insights: (args) => {
+		const days = args.trim() || "30";
 		chatAddMsg("system", `Loading insights for last ${days} days\u2026`);
 		fetch(`/api/metrics/insights?days=${days}`)
 			.then((resp) => (resp.ok ? resp.json() : Promise.reject(new Error(`HTTP ${resp.status}`))))
@@ -402,8 +416,8 @@ export function handleSlashCommand(cmdName: string, cmdArgs: string): void {
 				if (S.chatMsgBox?.lastChild) S.chatMsgBox.removeChild(S.chatMsgBox.lastChild);
 				const lines: string[] = [];
 				lines.push(`**Insights** \u2014 last ${data.days} days\n`);
-				lines.push(`| Metric | Value |`);
-				lines.push(`|--------|-------|`);
+				lines.push("| Metric | Value |");
+				lines.push("|--------|-------|");
 				lines.push(`| LLM completions | ${fmtNum(data.completions)} |`);
 				lines.push(`| Total tokens | ${fmtNum(data.total_tokens)} |`);
 				lines.push(`| Input tokens | ${fmtNum(data.input_tokens)} |`);
@@ -414,9 +428,9 @@ export function handleSlashCommand(cmdName: string, cmdArgs: string): void {
 					lines.push(`| Completions/hour | ${(data.completions / data.span_hours).toFixed(1)} |`);
 				}
 				if (data.by_provider && Object.keys(data.by_provider).length > 0) {
-					lines.push(`\n**By provider:**\n`);
-					lines.push(`| Provider | Completions | Tokens |`);
-					lines.push(`|----------|-------------|--------|`);
+					lines.push("\n**By provider:**\n");
+					lines.push("| Provider | Completions | Tokens |");
+					lines.push("|----------|-------------|--------|");
 					const sorted = Object.entries(data.by_provider).sort(
 						(a, b) => b[1].input_tokens + b[1].output_tokens - (a[1].input_tokens + a[1].output_tokens),
 					);
@@ -430,27 +444,26 @@ export function handleSlashCommand(cmdName: string, cmdArgs: string): void {
 				chatAddMsg("system", renderMarkdown(lines.join("\n")), true);
 			})
 			.catch((err: Error) => chatAddMsg("error", `Insights failed: ${err.message}`));
-		return;
-	}
-	if (cmdName === "btw") {
-		if (!cmdArgs.trim()) {
+	},
+
+	btw: (args) => {
+		if (!args.trim()) {
 			chatAddMsg("error", "Usage: /btw <question>");
 			return;
 		}
 		chatAddMsg("system", "Thinking\u2026");
-		sendRpc("chat.send_sync", { text: cmdArgs, _ephemeral: true }).then((res) => {
+		sendRpc("chat.send_sync", { text: args, _ephemeral: true }).then((res) => {
 			if (S.chatMsgBox?.lastChild) S.chatMsgBox.removeChild(S.chatMsgBox.lastChild);
 			if (res.ok && res.payload) {
 				const text = typeof res.payload === "string" ? res.payload : (res.payload as UnknownRecord).text;
 				chatAddMsg("system", renderMarkdown(String(text || "(no response)")), true);
 			} else chatAddMsg("error", res.error?.message || "/btw failed");
 		});
-		return;
-	}
-	if (cmdName === "fast") {
-		const arg = cmdArgs.trim().toLowerCase();
-		const label = arg || "toggle";
-		chatAddMsg("system", `Fast mode: ${label}\u2026`);
+	},
+
+	fast: (args) => {
+		const arg = args.trim().toLowerCase();
+		chatAddMsg("system", `Fast mode: ${arg || "toggle"}\u2026`);
 		sendRpc("chat.send_sync", { text: `/fast ${arg}`.trim() }).then((res) => {
 			if (S.chatMsgBox?.lastChild) S.chatMsgBox.removeChild(S.chatMsgBox.lastChild);
 			if (res.ok && res.payload) {
@@ -458,11 +471,11 @@ export function handleSlashCommand(cmdName: string, cmdArgs: string): void {
 				chatAddMsg("system", String(text || "Done"));
 			} else chatAddMsg("error", res.error?.message || "/fast failed");
 		});
-		return;
-	}
-	if (cmdName === "fork") {
+	},
+
+	fork: (args) => {
 		chatAddMsg("system", "Forking session\u2026");
-		sendRpc("sessions.fork", { key: S.activeSessionKey, label: cmdArgs.trim() || undefined }).then((res) => {
+		sendRpc("sessions.fork", { key: S.activeSessionKey, label: args.trim() || undefined }).then((res) => {
 			if (S.chatMsgBox?.lastChild) S.chatMsgBox.removeChild(S.chatMsgBox.lastChild);
 			if (res.ok && res.payload) {
 				const key = (res.payload as UnknownRecord).sessionKey as string;
@@ -471,14 +484,18 @@ export function handleSlashCommand(cmdName: string, cmdArgs: string): void {
 				fetchSessions();
 			} else chatAddMsg("error", res.error?.message || "Fork failed");
 		});
-		return;
-	}
-	if (cmdName === "rollback") {
+	},
+
+	rollback: () => {
 		chatAddMsg(
 			"system",
 			renderMarkdown("Rollback is available via the `/rollback` channel command (Telegram, Discord, etc.) or the CLI."),
 			true,
 		);
-		return;
-	}
+	},
+};
+
+export function handleSlashCommand(cmdName: string, cmdArgs: string): void {
+	const handler = slashHandlers[cmdName as SlashCommandName];
+	if (handler) handler(cmdArgs);
 }

--- a/crates/webhooks/migrations/20260429000000_deliver_only.sql
+++ b/crates/webhooks/migrations/20260429000000_deliver_only.sql
@@ -1,0 +1,5 @@
+-- Add deliver_only mode and template fields.
+ALTER TABLE webhooks ADD COLUMN deliver_only INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE webhooks ADD COLUMN prompt_template TEXT;
+ALTER TABLE webhooks ADD COLUMN deliver_to TEXT;
+ALTER TABLE webhooks ADD COLUMN deliver_extra_json TEXT;

--- a/crates/webhooks/src/normalize.rs
+++ b/crates/webhooks/src/normalize.rs
@@ -73,10 +73,16 @@ pub fn render_template(template: &str, payload: &serde_json::Value) -> String {
                 }
                 key.push(inner);
             }
-            if !found_close || key.is_empty() {
-                // Malformed — emit literal.
+            if !found_close {
+                // Malformed (no closing brace) — emit literal.
                 result.push('{');
                 result.push_str(&key);
+                continue;
+            }
+            if key.is_empty() {
+                // Empty braces `{}` — emit literal.
+                result.push('{');
+                result.push('}');
                 continue;
             }
 

--- a/crates/webhooks/src/normalize.rs
+++ b/crates/webhooks/src/normalize.rs
@@ -50,6 +50,83 @@ pub fn build_delivery_message(
     msg
 }
 
+/// Render a template string with `{dot.notation}` variable substitution from a
+/// JSON payload.
+///
+/// - `{pull_request.title}` → `payload["pull_request"]["title"]`
+/// - `{__raw__}` → full payload as indented JSON (truncated at 4000 chars)
+/// - Missing keys are left as literal `{key}` in the output.
+/// - Nested objects/arrays are JSON-serialized (truncated at 2000 chars).
+pub fn render_template(template: &str, payload: &serde_json::Value) -> String {
+    let mut result = String::with_capacity(template.len() * 2);
+    let mut chars = template.chars().peekable();
+
+    while let Some(ch) = chars.next() {
+        if ch == '{' {
+            // Collect until closing brace.
+            let mut key = String::new();
+            let mut found_close = false;
+            for inner in chars.by_ref() {
+                if inner == '}' {
+                    found_close = true;
+                    break;
+                }
+                key.push(inner);
+            }
+            if !found_close || key.is_empty() {
+                // Malformed — emit literal.
+                result.push('{');
+                result.push_str(&key);
+                continue;
+            }
+
+            if key == "__raw__" {
+                let raw = serde_json::to_string_pretty(payload).unwrap_or_default();
+                result.push_str(truncate_str(&raw, 4000));
+                continue;
+            }
+
+            // Resolve dot-notation path.
+            let resolved = resolve_path(payload, &key);
+            match resolved {
+                Some(serde_json::Value::String(s)) => result.push_str(s),
+                Some(serde_json::Value::Number(n)) => result.push_str(&n.to_string()),
+                Some(serde_json::Value::Bool(b)) => {
+                    result.push_str(if *b {
+                        "true"
+                    } else {
+                        "false"
+                    });
+                },
+                Some(serde_json::Value::Null) => result.push_str("null"),
+                Some(other) => {
+                    let serialized = serde_json::to_string(&other).unwrap_or_default();
+                    result.push_str(truncate_str(&serialized, 2000));
+                },
+                None => {
+                    // Missing key — leave literal.
+                    result.push('{');
+                    result.push_str(&key);
+                    result.push('}');
+                },
+            }
+        } else {
+            result.push(ch);
+        }
+    }
+
+    result
+}
+
+/// Resolve a dot-notation path like `"pull_request.user.login"` against a JSON value.
+fn resolve_path<'a>(value: &'a serde_json::Value, path: &str) -> Option<&'a serde_json::Value> {
+    let mut current = value;
+    for segment in path.split('.') {
+        current = current.get(segment)?;
+    }
+    Some(current)
+}
+
 /// Extract selected headers from a request for logging.
 /// Only includes headers that are useful for debugging; skips auth secrets.
 pub fn extract_safe_headers(headers: &axum::http::HeaderMap) -> serde_json::Value {

--- a/crates/webhooks/src/store.rs
+++ b/crates/webhooks/src/store.rs
@@ -155,6 +155,12 @@ fn row_to_webhook(row: &sqlx::sqlite::SqliteRow) -> Result<Webhook> {
         last_delivery_at: row.get("last_delivery_at"),
         created_at: row.get("created_at"),
         updated_at: row.get("updated_at"),
+        deliver_only: row.get::<i32, _>("deliver_only") != 0,
+        prompt_template: row.get("prompt_template"),
+        deliver_to: row.get("deliver_to"),
+        deliver_extra: row
+            .get::<Option<String>, _>("deliver_extra_json")
+            .and_then(|s| serde_json::from_str(&s).ok()),
     })
 }
 
@@ -242,13 +248,19 @@ impl WebhookStore for SqliteWebhookStore {
             .map(serde_json::to_string)
             .transpose()?;
         let allowed_cidrs_json = serde_json::to_string(&create.allowed_cidrs)?;
+        let deliver_extra_json = create
+            .deliver_extra
+            .as_ref()
+            .map(serde_json::to_string)
+            .transpose()?;
 
         let result = sqlx::query(
             "INSERT INTO webhooks (name, description, public_id, agent_id, model, system_prompt_suffix, \
              tool_policy_json, auth_mode, auth_config_json, source_profile, source_config_json, \
              event_filter_json, session_mode, named_session_key, allowed_cidrs_json, \
-             max_body_bytes, rate_limit_per_minute, created_at, updated_at) \
-             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+             max_body_bytes, rate_limit_per_minute, deliver_only, prompt_template, deliver_to, \
+             deliver_extra_json, created_at, updated_at) \
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
         )
         .bind(&create.name)
         .bind(&create.description)
@@ -267,6 +279,10 @@ impl WebhookStore for SqliteWebhookStore {
         .bind(&allowed_cidrs_json)
         .bind(create.max_body_bytes as i64)
         .bind(create.rate_limit_per_minute as i64)
+        .bind(create.deliver_only as i32)
+        .bind(&create.prompt_template)
+        .bind(&create.deliver_to)
+        .bind(&deliver_extra_json)
         .bind(&now)
         .bind(&now)
         .execute(&self.pool)
@@ -327,6 +343,18 @@ impl WebhookStore for SqliteWebhookStore {
         if let Some(rl) = patch.rate_limit_per_minute {
             webhook.rate_limit_per_minute = rl;
         }
+        if let Some(do_) = patch.deliver_only {
+            webhook.deliver_only = do_;
+        }
+        if let Some(pt) = patch.prompt_template {
+            webhook.prompt_template = pt;
+        }
+        if let Some(dt) = patch.deliver_to {
+            webhook.deliver_to = dt;
+        }
+        if let Some(de) = patch.deliver_extra {
+            webhook.deliver_extra = de;
+        }
 
         let auth_mode_str = serde_json::to_value(&webhook.auth_mode)?
             .as_str()
@@ -353,12 +381,19 @@ impl WebhookStore for SqliteWebhookStore {
             .map(serde_json::to_string)
             .transpose()?;
         let allowed_cidrs_json = serde_json::to_string(&webhook.allowed_cidrs)?;
+        let deliver_extra_json = webhook
+            .deliver_extra
+            .as_ref()
+            .map(serde_json::to_string)
+            .transpose()?;
 
         sqlx::query(
             "UPDATE webhooks SET name = ?, description = ?, enabled = ?, agent_id = ?, model = ?, \
              system_prompt_suffix = ?, tool_policy_json = ?, auth_mode = ?, auth_config_json = ?, \
              source_config_json = ?, event_filter_json = ?, session_mode = ?, named_session_key = ?, \
-             allowed_cidrs_json = ?, max_body_bytes = ?, rate_limit_per_minute = ?, updated_at = ? \
+             allowed_cidrs_json = ?, max_body_bytes = ?, rate_limit_per_minute = ?, \
+             deliver_only = ?, prompt_template = ?, deliver_to = ?, deliver_extra_json = ?, \
+             updated_at = ? \
              WHERE id = ?",
         )
         .bind(&webhook.name)
@@ -377,6 +412,10 @@ impl WebhookStore for SqliteWebhookStore {
         .bind(&allowed_cidrs_json)
         .bind(webhook.max_body_bytes as i64)
         .bind(webhook.rate_limit_per_minute as i64)
+        .bind(webhook.deliver_only as i32)
+        .bind(&webhook.prompt_template)
+        .bind(&webhook.deliver_to)
+        .bind(&deliver_extra_json)
         .bind(&now)
         .bind(id)
         .execute(&self.pool)
@@ -624,6 +663,10 @@ mod tests {
             allowed_cidrs: vec![],
             max_body_bytes: 1_048_576,
             rate_limit_per_minute: 60,
+            deliver_only: false,
+            prompt_template: None,
+            deliver_to: None,
+            deliver_extra: None,
         }
     }
 

--- a/crates/webhooks/src/types.rs
+++ b/crates/webhooks/src/types.rs
@@ -55,6 +55,24 @@ pub struct Webhook {
     /// Rate limit: max deliveries per minute.
     #[serde(default = "default_rate_limit")]
     pub rate_limit_per_minute: u32,
+    /// When true, skip the agent and deliver the rendered prompt template
+    /// directly to the target channel. Zero LLM cost, sub-second delivery.
+    #[serde(default)]
+    pub deliver_only: bool,
+    /// Template for the delivery message. Supports `{dot.notation}` variable
+    /// substitution from the webhook payload (e.g. `{pull_request.title}`).
+    /// Used as the agent prompt (normal mode) or the direct message body
+    /// (`deliver_only` mode). When empty, the default normalized payload is used.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub prompt_template: Option<String>,
+    /// Channel to deliver to in `deliver_only` mode (e.g. "telegram", "discord", "slack").
+    /// Ignored when `deliver_only` is false.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub deliver_to: Option<String>,
+    /// Extra delivery config (e.g. `{"chat_id": "123"}` for Telegram).
+    /// Supports `{dot.notation}` template variables from the payload.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub deliver_extra: Option<serde_json::Value>,
     /// Denormalized delivery count for UI.
     #[serde(default)]
     pub delivery_count: u64,
@@ -117,6 +135,14 @@ pub struct WebhookCreate {
     pub max_body_bytes: usize,
     #[serde(default = "default_rate_limit")]
     pub rate_limit_per_minute: u32,
+    #[serde(default)]
+    pub deliver_only: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub prompt_template: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub deliver_to: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub deliver_extra: Option<serde_json::Value>,
 }
 
 /// Input for patching a webhook.
@@ -155,6 +181,14 @@ pub struct WebhookPatch {
     pub max_body_bytes: Option<usize>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub rate_limit_per_minute: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub deliver_only: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub prompt_template: Option<Option<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub deliver_to: Option<Option<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub deliver_extra: Option<Option<serde_json::Value>>,
 }
 
 // ── Enums ──────────────────────────────────────────────────────────────
@@ -443,6 +477,10 @@ mod tests {
             allowed_cidrs: vec![],
             max_body_bytes: 1_048_576,
             rate_limit_per_minute: 60,
+            deliver_only: false,
+            prompt_template: None,
+            deliver_to: None,
+            deliver_extra: None,
         };
         let json = serde_json::to_value(&create).unwrap();
         let roundtrip: WebhookCreate = serde_json::from_value(json).unwrap();

--- a/crates/webhooks/src/worker.rs
+++ b/crates/webhooks/src/worker.rs
@@ -27,6 +27,20 @@ pub type ExecuteFn = Arc<
         + Sync,
 >;
 
+/// Callback type for direct channel delivery (deliver_only mode).
+pub type DeliverFn = Arc<
+    dyn Fn(DeliverRequest) -> Pin<Box<dyn Future<Output = anyhow::Result<()>> + Send>>
+        + Send
+        + Sync,
+>;
+
+/// Request to deliver a rendered message directly to a channel.
+pub struct DeliverRequest {
+    pub channel: String,
+    pub message: String,
+    pub extra: Option<serde_json::Value>,
+}
+
 /// Request to execute a webhook delivery.
 pub struct ExecuteRequest {
     pub webhook_id: i64,
@@ -43,6 +57,7 @@ pub struct WebhookWorker {
     rx: mpsc::Receiver<i64>,
     store: Arc<dyn WebhookStore>,
     execute_fn: ExecuteFn,
+    deliver_fn: Option<DeliverFn>,
 }
 
 impl WebhookWorker {
@@ -55,7 +70,14 @@ impl WebhookWorker {
             rx,
             store,
             execute_fn,
+            deliver_fn: None,
         }
+    }
+
+    /// Set the channel delivery callback for `deliver_only` mode.
+    pub fn with_deliver_fn(mut self, deliver_fn: DeliverFn) -> Self {
+        self.deliver_fn = Some(deliver_fn);
+        self
     }
 
     /// Run the worker loop, processing deliveries from the channel.
@@ -136,18 +158,107 @@ impl WebhookWorker {
             None => crate::profiles::generic::GenericProfile.normalize_payload(event_type, &body),
         };
 
-        // Build the delivery message
-        let message = crate::normalize::build_delivery_message(
-            &webhook,
-            delivery.event_type.as_deref(),
-            delivery.delivery_key.as_deref(),
-            &delivery.received_at,
-            &normalized.summary,
-        );
+        // Build the delivery message, applying template if configured.
+        let message = if let Some(ref template) = webhook.prompt_template {
+            crate::normalize::render_template(template, &body)
+        } else {
+            crate::normalize::build_delivery_message(
+                &webhook,
+                delivery.event_type.as_deref(),
+                delivery.delivery_key.as_deref(),
+                &delivery.received_at,
+                &normalized.summary,
+            )
+        };
 
         let session_key = build_session_key(&webhook, delivery_id, delivery.entity_key.as_deref());
 
         let start = std::time::Instant::now();
+
+        // deliver_only mode: render template and forward to channel, skip agent.
+        if webhook.deliver_only {
+            let channel = webhook.deliver_to.as_deref().unwrap_or("log");
+            let extra = webhook.deliver_extra.clone().map(|v| {
+                // Render template variables in deliver_extra values too.
+                if let serde_json::Value::Object(map) = &v {
+                    let mut rendered = serde_json::Map::new();
+                    for (k, val) in map {
+                        if let serde_json::Value::String(s) = val {
+                            rendered.insert(
+                                k.clone(),
+                                serde_json::Value::String(crate::normalize::render_template(
+                                    s, &body,
+                                )),
+                            );
+                        } else {
+                            rendered.insert(k.clone(), val.clone());
+                        }
+                    }
+                    serde_json::Value::Object(rendered)
+                } else {
+                    v
+                }
+            });
+
+            let deliver_result = if let Some(ref deliver_fn) = self.deliver_fn {
+                (deliver_fn)(DeliverRequest {
+                    channel: channel.to_string(),
+                    message: message.clone(),
+                    extra,
+                })
+                .await
+            } else if channel == "log" {
+                info!(
+                    webhook = %webhook.name,
+                    delivery_id,
+                    "deliver_only (log): {message}"
+                );
+                Ok(())
+            } else {
+                warn!(
+                    webhook = %webhook.name,
+                    channel,
+                    "deliver_only: no deliver callback configured, dropping message"
+                );
+                Ok(())
+            };
+
+            let duration_ms = start.elapsed().as_millis() as i64;
+            match deliver_result {
+                Ok(()) => {
+                    self.store
+                        .update_delivery_status(
+                            delivery_id,
+                            DeliveryStatus::Completed,
+                            DeliveryUpdate {
+                                session_key: Some(format!("deliver_only:{channel}")),
+                                finished_at: Some(now_iso()),
+                                duration_ms: Some(duration_ms),
+                                ..Default::default()
+                            },
+                        )
+                        .await
+                        .map_err(|e| anyhow::anyhow!("{e}"))?;
+                },
+                Err(e) => {
+                    warn!(delivery_id, error = %e, "deliver_only delivery failed");
+                    self.store
+                        .update_delivery_status(
+                            delivery_id,
+                            DeliveryStatus::Failed,
+                            DeliveryUpdate {
+                                run_error: Some(e.to_string()),
+                                finished_at: Some(now_iso()),
+                                duration_ms: Some(duration_ms),
+                                ..Default::default()
+                            },
+                        )
+                        .await
+                        .map_err(|e| anyhow::anyhow!("{e}"))?;
+                },
+            }
+            return Ok(());
+        }
 
         // Execute via callback
         let result = (self.execute_fn)(ExecuteRequest {
@@ -256,6 +367,10 @@ mod tests {
             last_delivery_at: None,
             created_at: "2026-04-07T00:00:00Z".into(),
             updated_at: "2026-04-07T00:00:00Z".into(),
+            deliver_only: false,
+            prompt_template: None,
+            deliver_to: None,
+            deliver_extra: None,
         }
     }
 

--- a/crates/webhooks/src/worker.rs
+++ b/crates/webhooks/src/worker.rs
@@ -220,7 +220,9 @@ impl WebhookWorker {
                     channel,
                     "deliver_only: no deliver callback configured, dropping message"
                 );
-                Ok(())
+                Err(anyhow::anyhow!(
+                    "deliver_only: no deliver callback configured for channel '{channel}'"
+                ))
             };
 
             let duration_ms = start.elapsed().as_millis() as i64;

--- a/crates/webhooks/tests/ingress_integration.rs
+++ b/crates/webhooks/tests/ingress_integration.rs
@@ -77,6 +77,10 @@ async fn test_github_pr_ingress_full_flow() {
             allowed_cidrs: vec![],
             max_body_bytes: 1_048_576,
             rate_limit_per_minute: 60,
+            deliver_only: false,
+            prompt_template: None,
+            deliver_to: None,
+            deliver_extra: None,
         })
         .await
         .unwrap();
@@ -265,6 +269,10 @@ async fn test_static_header_auth_flow() {
             allowed_cidrs: vec![],
             max_body_bytes: 1_048_576,
             rate_limit_per_minute: 60,
+            deliver_only: false,
+            prompt_template: None,
+            deliver_to: None,
+            deliver_extra: None,
         })
         .await
         .unwrap();
@@ -419,6 +427,10 @@ async fn test_disabled_webhook_lookup() {
             allowed_cidrs: vec![],
             max_body_bytes: 1_048_576,
             rate_limit_per_minute: 60,
+            deliver_only: false,
+            prompt_template: None,
+            deliver_to: None,
+            deliver_extra: None,
         })
         .await
         .unwrap();
@@ -597,6 +609,10 @@ async fn test_crash_recovery_includes_processing_deliveries() {
             allowed_cidrs: vec![],
             max_body_bytes: 1_048_576,
             rate_limit_per_minute: 60,
+            deliver_only: false,
+            prompt_template: None,
+            deliver_to: None,
+            deliver_extra: None,
         })
         .await
         .unwrap();
@@ -715,6 +731,10 @@ fn test_webhook_redacted_hides_secrets() {
         last_delivery_at: None,
         created_at: "2026-04-07T00:00:00Z".into(),
         updated_at: "2026-04-07T00:00:00Z".into(),
+        deliver_only: false,
+        prompt_template: None,
+        deliver_to: None,
+        deliver_extra: None,
     };
 
     let redacted = wh.redacted();
@@ -757,6 +777,10 @@ fn test_webhook_redacted_none_stays_none() {
         last_delivery_at: None,
         created_at: "2026-04-07T00:00:00Z".into(),
         updated_at: "2026-04-07T00:00:00Z".into(),
+        deliver_only: false,
+        prompt_template: None,
+        deliver_to: None,
+        deliver_extra: None,
     };
 
     let redacted = wh.redacted();
@@ -851,6 +875,10 @@ async fn test_source_profile_not_in_patch() {
             allowed_cidrs: vec![],
             max_body_bytes: 1_048_576,
             rate_limit_per_minute: 60,
+            deliver_only: false,
+            prompt_template: None,
+            deliver_to: None,
+            deliver_extra: None,
         })
         .await
         .unwrap();

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -44,6 +44,7 @@
 - [CalDAV (Calendars)](caldav.md)
 - [GraphQL API](graphql.md)
 - [Session State](session-state.md)
+- [Slash Commands](commands.md)
 - [Modes](modes.md)
 - [Session Branching](session-branching.md)
 - [Checkpoints](checkpoints.md)

--- a/docs/src/checkpoints.md
+++ b/docs/src/checkpoints.md
@@ -1,23 +1,41 @@
 # Checkpoints
 
-Moltis now creates automatic checkpoints before built-in file mutations that
-change personal skills or agent memory files.
+Moltis automatically snapshots files before the agent modifies them. If the
+agent breaks something, use [`/rollback`](commands.md#rollback) to restore files
+to their pre-turn state.
 
-## What Gets Checkpointed
+## Automatic Per-Turn Checkpointing
 
-Current built-in checkpoint coverage includes:
+An `AutoCheckpointHook` runs before every file-mutating tool call (`Write`,
+`Edit`, `MultiEdit`) and snapshots the target file. Checkpoints are grouped by
+**turn** (one user message = one turn), so `/rollback 1` undoes all file changes
+from that turn at once.
 
-- `create_skill`
-- `update_skill`
-- `delete_skill`
-- `write_skill_files`
-- `memory_save`
-- `memory_forget`
-- `memory_delete`
+The hook also fires on skill and memory mutations:
+
+- `create_skill`, `update_skill`, `delete_skill`, `write_skill_files`
+- `memory_save`, `memory_forget`, `memory_delete`
 - the silent pre-compaction memory flush
 
 Each mutation creates a manifest-backed snapshot in `~/.moltis/checkpoints/`
 before the write or delete happens.
+
+## /rollback Command
+
+Available in the web UI, all channels (Telegram, Discord, Slack, etc.), and CLI.
+
+```
+/rollback           # list recent turns with file changes
+/rollback 1         # restore all files from turn 1
+/rollback diff 1    # preview which files were changed in turn 1
+```
+
+Turns are session-scoped — you only see checkpoints from your current session.
+
+## Cleanup
+
+When checkpoint count exceeds 500, the oldest 20% are automatically pruned.
+Cleanup runs lazily on each new checkpoint creation.
 
 ## Tool Surface
 

--- a/docs/src/commands.md
+++ b/docs/src/commands.md
@@ -1,0 +1,154 @@
+# Slash Commands
+
+Slash commands are available in the **web UI chat input**, on all **messaging
+channels** (Telegram, Discord, Slack, Matrix, etc.), and where noted, via the
+**CLI**.
+
+Type `/` in the chat input to see the autocomplete popup.
+
+## Session Management
+
+| Command | Description |
+|---------|-------------|
+| `/new` | Start a new session |
+| `/clear` | Clear session history |
+| `/compact` | Summarize conversation to save tokens |
+| `/context` | Show session context and project info |
+| `/sessions` | List and switch sessions (channels only) |
+| `/attach` | Attach an existing session to this channel (channels only) |
+| `/fork [label]` | Fork the current session into a new branch |
+
+### /fork
+
+Creates an independent copy of the current conversation. The new session
+inherits the parent's model, project, mode, and agent. Messages up to the
+current point are copied.
+
+```
+/fork experiment-a
+```
+
+Available in web UI, all channels, and via the `sessions.fork` RPC. See
+[Session Branching](session-branching.md) for details.
+
+## Control
+
+| Command | Description |
+|---------|-------------|
+| `/agent [N]` | Switch session agent |
+| `/mode [N\|name\|none]` | Switch session mode |
+| `/model [N]` | Switch provider/model |
+| `/sandbox [on\|off\|image N]` | Toggle sandbox and choose image |
+| `/sh [on\|off]` | Enter command mode (passthrough to shell) |
+| `/stop` | Abort the current running agent |
+| `/peek` | Show current thinking/tool status |
+| `/update [version]` | Update moltis (owner-only) |
+
+## Quick Actions
+
+| Command | Description |
+|---------|-------------|
+| `/btw <question>` | Quick side question (no tools, not persisted) |
+| `/fast [on\|off\|status]` | Toggle fast/priority mode |
+| `/insights [days]` | Show usage analytics (tokens, providers) |
+| `/steer <text>` | Inject guidance into the current agent run |
+| `/queue <message>` | Queue a message for the next agent turn |
+| `/rollback [N\|diff N]` | List or restore file checkpoints |
+
+### /btw
+
+Ask a quick side question without tools and without persisting the exchange to
+session history. Uses the session's current model and recent context (last 20
+messages) as read-only background.
+
+```
+/btw what's the default port for PostgreSQL?
+```
+
+The response appears inline and is discarded after display.
+
+### /fast
+
+Toggle fast/priority mode for the current session. When enabled, uses
+provider-specific priority processing where supported (Anthropic prompt caching
+priority, OpenAI priority processing).
+
+```
+/fast          # toggle
+/fast on       # enable
+/fast off      # disable
+/fast status   # check current state
+```
+
+Session-scoped — does not persist across gateway restarts.
+
+### /insights
+
+Show usage analytics from the metrics store. Displays LLM completions, token
+counts (input/output), errors, tool executions, and per-provider breakdowns.
+
+```
+/insights       # last 30 days (default)
+/insights 7     # last 7 days
+/insights 90    # last 90 days
+```
+
+In the web UI, `/insights` renders a formatted markdown table inline. The same
+data is available as a dashboard in **Monitoring > Insights** tab, and via the
+REST API at `GET /api/metrics/insights?days=N`.
+
+### /steer
+
+Inject guidance into an active agent run without interrupting it. The text is
+seen by the LLM on its next iteration (after the current tool call completes).
+
+```
+/steer use the staging API, not production
+/steer focus on security issues only
+```
+
+Only works while an agent run is active. If no run is active, returns an error.
+
+### /queue
+
+Queue a message for the next agent turn without interrupting the current one.
+When the active run finishes, the queued message is automatically submitted.
+
+```
+/queue now write tests for what you just built
+```
+
+If no run is active, the message is sent immediately.
+
+### /rollback
+
+List and restore file checkpoints created by the automatic checkpointing
+system. Before every `Write`, `Edit`, or `MultiEdit` tool call, the original
+file is snapshotted.
+
+```
+/rollback           # list recent turns with file changes
+/rollback 1         # restore all files from turn 1
+/rollback diff 1    # preview which files were changed in turn 1
+```
+
+Checkpoints are grouped by **turn** (one user message = one turn). Restoring a
+turn reverts all files that were modified during that turn to their pre-turn
+state.
+
+See [Checkpoints](checkpoints.md) for details on the automatic checkpointing
+system.
+
+## Approval Management
+
+| Command | Description |
+|---------|-------------|
+| `/approvals` | List pending exec approvals |
+| `/approve [N]` | Approve a pending exec request |
+| `/deny [N]` | Deny a pending exec request |
+
+## Help
+
+| Command | Description |
+|---------|-------------|
+| `/help` | Show available commands (handled locally by each channel) |

--- a/docs/src/session-branching.md
+++ b/docs/src/session-branching.md
@@ -5,16 +5,29 @@ conversation at any point. The new session diverges without affecting the
 original — useful for exploring alternative approaches, running "what if"
 scenarios, or preserving a checkpoint before a risky prompt.
 
+## /fork Command
+
+The quickest way to fork — type in the chat input or on any channel:
+
+```
+/fork                    # fork with auto-generated label
+/fork experiment-a       # fork with a custom label
+```
+
+Available in the web UI, Telegram, Discord, Slack, Matrix, and all other
+channels. See [Slash Commands](commands.md) for the full list.
+
 ## Forking from the UI
 
-There are two ways to fork a session in the web UI:
+There are three ways to fork a session:
 
+- **`/fork` command** — type `/fork [label]` in the chat input.
 - **Chat header** — click the **Fork** button in the header bar (next to
   Delete). This is visible for every session except cron sessions.
 - **Sidebar** — hover over a session in the sidebar and click the fork icon
   that appears in the action buttons.
 
-Both create a new session that copies all messages from the current one and
+All three create a new session that copies all messages from the current one and
 immediately switch you to it.
 
 Forked sessions appear **indented** under their parent in the sidebar, with a

--- a/docs/src/webhooks.md
+++ b/docs/src/webhooks.md
@@ -42,10 +42,10 @@ External Service (GitHub, Stripe, …)
 
 ## Setup
 
-Webhooks are configured exclusively from **Settings → Webhooks** in the web UI.
-They are not part of the onboarding flow.
+Webhooks can be created from the **web UI**, the **CLI**, or by the **agent** itself
+using the `webhook` tool. They are not part of the onboarding flow.
 
-### Creating a Webhook
+### Creating a Webhook (Web UI)
 
 1. Navigate to **Settings → Webhooks** and click **Create webhook**.
 2. Choose a **source profile** (GitHub, GitLab, Stripe, or Generic).
@@ -54,6 +54,39 @@ They are not part of the onboarding flow.
 5. Select a **target agent** and optional model override.
 6. Click **Create** — the endpoint URL is displayed with a copy button.
 7. Register this URL in the external service's webhook settings.
+
+### Creating a Webhook (CLI)
+
+```bash
+moltis webhooks create \
+  --name github-pr-review \
+  --source-profile github \
+  --auth-mode github_hmac_sha256 \
+  --events "pull_request.opened,pull_request.synchronize" \
+  --system-prompt "Review this PR for security issues"
+```
+
+For a zero-cost event forwarder (no LLM tokens):
+
+```bash
+moltis webhooks create \
+  --name stripe-payments \
+  --source-profile stripe \
+  --auth-mode stripe_webhook_signature \
+  --deliver-only \
+  --prompt-template "Payment: {data.object.amount} {data.object.currency} from {data.object.customer_email}" \
+  --deliver-to telegram \
+  --events "payment_intent.succeeded"
+```
+
+### Creating a Webhook (Agent Tool)
+
+The agent can create webhooks programmatically using the `webhook` tool:
+
+> "Set up a webhook for GitHub issues on my repo and forward them to my Slack channel"
+
+The agent will use the `webhook` tool with `action: "create"` to set up the endpoint,
+then tell you the URL to register in GitHub's settings.
 
 ### Endpoint URL
 
@@ -452,6 +485,118 @@ A complete example of setting up a webhook that reviews pull requests:
 | `webhooks_response_actions_total` | Counter | Response actions by tool and status |
 | `webhooks_rate_limited_total` | Counter | Rate-limited requests |
 | `webhooks_worker_queue_depth` | Gauge | Pending deliveries in worker queue |
+
+## Deliver-Only Mode (Webhook Proxy)
+
+By default, each webhook delivery triggers an agent run — the LLM processes the
+event, reasons about it, and optionally acts using tools. This costs tokens and
+takes seconds.
+
+**Deliver-only mode** skips the agent entirely. The webhook payload is rendered
+through a template and forwarded directly to a channel. Zero LLM tokens,
+sub-second delivery.
+
+This turns Moltis into a **webhook proxy**: external services POST events, and
+formatted messages appear in your Telegram, Discord, Slack, or any other
+configured channel.
+
+### When to Use Deliver-Only
+
+- **Monitoring alerts**: Datadog/Grafana/Sentry → Discord
+- **Payment notifications**: Stripe → Telegram
+- **CI/CD status**: GitHub Actions → Slack
+- **Inter-service notifications**: any HTTP POST → any channel
+- **High-volume events**: where per-event LLM calls would be wasteful
+
+### Configuration
+
+Set `deliver_only: true` and provide a `prompt_template` with `{dot.notation}`
+variables, plus a `deliver_to` channel target.
+
+**Web UI**: Toggle "Deliver only" in the webhook settings, fill in the template
+and target channel.
+
+**CLI**:
+```bash
+moltis webhooks create \
+  --name deploy-status \
+  --source-profile generic \
+  --auth-mode static_header \
+  --deliver-only \
+  --prompt-template "Deploy {status}: {environment} ({commit_sha})" \
+  --deliver-to slack
+```
+
+**Agent**: The agent can also create deliver-only webhooks using the `webhook` tool.
+
+### How It Works
+
+```
+External Service POSTs event
+        │
+        ▼
+┌──────────────────────────────────┐
+│         Ingress Handler          │
+│  verify → filter → dedup → 202  │
+└──────────────┬───────────────────┘
+               │
+               ▼
+┌──────────────────────────────────┐
+│       Background Worker          │
+│  render template → deliver to    │
+│  channel → mark completed        │
+│  (no agent, no LLM tokens)       │
+└──────────────────────────────────┘
+```
+
+## Template Rendering
+
+Templates use `{dot.notation}` to interpolate values from the webhook JSON payload.
+
+| Syntax | Resolves to |
+|--------|-------------|
+| `{action}` | Top-level field: `payload["action"]` |
+| `{pull_request.title}` | Nested: `payload["pull_request"]["title"]` |
+| `{pull_request.user.login}` | Deep nested: `payload["pull_request"]["user"]["login"]` |
+| `{__raw__}` | Full payload as indented JSON (truncated at 4000 chars) |
+
+- **Missing keys** are left as literal `{key}` in the output (no error).
+- **Objects and arrays** are JSON-serialized (truncated at 2000 chars).
+- **Strings and numbers** are inserted directly.
+
+Templates work in both `prompt_template` (the message body) and `deliver_extra`
+values (channel-specific metadata like chat IDs).
+
+### Example: GitHub Issue → Telegram
+
+```bash
+moltis webhooks create \
+  --name github-issues \
+  --source-profile github \
+  --auth-mode github_hmac_sha256 \
+  --deliver-only \
+  --prompt-template "#{issue.number} {issue.title} ({action} by {sender.login})" \
+  --deliver-to telegram \
+  --events "issues.opened,issues.closed"
+```
+
+When someone opens issue #42 "Fix auth bug", Telegram receives:
+```
+#42 Fix auth bug (opened by alice)
+```
+
+### Example: Stripe Payment → Discord
+
+```bash
+moltis webhooks create \
+  --name stripe-notify \
+  --source-profile stripe \
+  --auth-mode stripe_webhook_signature \
+  --deliver-only \
+  --prompt-template "Payment {data.object.status}: {data.object.amount} cents ({data.object.currency})" \
+  --deliver-to discord \
+  --events "payment_intent.succeeded,payment_intent.payment_failed"
+```
 
 ## Comparison with Channels and Cron
 

--- a/plans/2026-04-29-automatic-checkpoints-and-rollback.md
+++ b/plans/2026-04-29-automatic-checkpoints-and-rollback.md
@@ -1,0 +1,218 @@
+# Automatic Checkpoints and /rollback
+
+Date: 2026-04-29
+
+## Problem
+
+The agent modifies files (code, configs, moltis.toml) and sometimes breaks things.
+Today there's no user-facing way to undo what the agent did. The `CheckpointManager`
+and `checkpoint_restore` tool exist but they're agent-initiated — the user has to
+ask the agent to checkpoint, and then ask it to restore. That defeats the purpose
+when the agent is the one that broke things.
+
+Hermes solves this with automatic per-turn checkpointing and a `/rollback` command.
+
+## Goals
+
+1. Automatic snapshots before every file-mutating tool call — no user action needed
+2. `/rollback` command available on all channels (Telegram, Discord, Slack, web, etc.)
+3. Covers moltis.toml changes so users can revert broken config
+4. Automatic cleanup of old checkpoints to avoid unbounded disk growth
+5. Minimal overhead — don't snapshot unchanged files, don't slow down tool execution
+
+## Design
+
+### Turn-based checkpointing
+
+Group checkpoints by **turn** (one user message = one turn). A turn may trigger
+many tool calls that each modify files, but the user thinks in terms of "undo
+what you just did" — not individual tool calls.
+
+```
+Turn 7:  user says "refactor the auth module"
+  → write_file: src/auth.rs        (checkpoint before)
+  → edit: src/main.rs              (checkpoint before)
+  → write_file: src/auth/mod.rs    (checkpoint before)
+  → edit: moltis.toml              (checkpoint before)
+
+/rollback 7  →  restores all 4 files to their pre-turn-7 state
+```
+
+### What gets checkpointed
+
+Any tool that modifies the filesystem:
+- `write` / `edit` / `multi_edit` — already have `with_checkpoint_manager()` builder
+- `create_skill` / `update_skill` / `delete_skill` — already checkpoint manually
+- `exec` / `shell` — **cannot reliably detect** which files a shell command modifies
+
+For `exec`, we can't know what `rm -rf` or `sed -i` will touch. Two options:
+- **Option A**: Don't checkpoint exec. Accept the gap. `/rollback` covers agent-native
+  file ops but not shell commands. Document this clearly.
+- **Option B**: Snapshot the entire working directory before exec. Too expensive for
+  large repos.
+
+**Recommendation**: Option A. The exec tool already goes through approval gates.
+Shell commands are the user's responsibility. `/rollback` covers the common case
+(agent writes/edits files via its native tools).
+
+### Storage format
+
+Reuse the existing `CheckpointManager` storage:
+
+```
+~/.moltis/checkpoints/
+  {checkpoint-id}/
+    manifest.json        # CheckpointRecord (id, created_at, reason, source_path, existed, backup_path)
+    snapshot/
+      {file-or-dir}      # copy of original content
+```
+
+Add a **turn index** file that groups checkpoint IDs by turn:
+
+```
+~/.moltis/checkpoints/turns.jsonl
+```
+
+Each line:
+```json
+{"turn_id": "run-abc123", "session_key": "main", "created_at": 1714400000, "checkpoint_ids": ["cp-1", "cp-2", "cp-3"]}
+```
+
+### Implementation: automatic checkpointing via HookHandler
+
+The hook system already fires `BeforeToolCall` with `{ tool_name, arguments }` before
+every tool execution. Register a `CheckpointHookHandler` that:
+
+1. Subscribes to `HookEvent::BeforeToolCall`
+2. Checks if the tool is file-mutating (`write`, `edit`, `multi_edit`)
+3. Extracts the target file path from the tool arguments
+4. Calls `CheckpointManager::checkpoint_path()` to snapshot the file
+5. Records the checkpoint ID in the current turn's group
+
+```rust
+pub struct AutoCheckpointHook {
+    manager: Arc<CheckpointManager>,
+    /// Current turn's checkpoint IDs, keyed by session.
+    active_turns: Arc<RwLock<HashMap<String, TurnCheckpoints>>>,
+}
+
+struct TurnCheckpoints {
+    run_id: String,
+    checkpoint_ids: Vec<String>,
+    created_at: i64,
+}
+```
+
+**Registration**: In gateway startup (`prepare_core/post_state.rs`), after creating
+the `CheckpointManager`, register `AutoCheckpointHook` with the `HookRegistry`.
+
+**Turn boundary detection**: A new turn starts when `run_id` changes (each
+`chat.send` generates a unique `run_id`). The `run_id` is available in the
+tool context (`_run_id` field) passed to tool arguments.
+
+### Protecting moltis.toml
+
+The config file lives at `~/.config/moltis/moltis.toml` (or `MOLTIS_CONFIG_DIR`).
+Two scenarios where it gets modified:
+
+1. **Agent edits it** via `write` or `edit` tool — caught by the auto-checkpoint hook
+2. **Web UI settings pages** write it via the config save RPC — need to add a
+   checkpoint call in the config save path (`crates/gateway/src/methods/services/core.rs`
+   or wherever `config.save()` is called)
+
+For case 2, add a direct `CheckpointManager::checkpoint_path()` call before
+any config file write. This doesn't need the hook system — it's a one-line addition
+at the save callsite.
+
+### /rollback command
+
+Register `/rollback` in the channel command registry. Subcommands:
+
+```
+/rollback              — list recent turns with file changes (last 10)
+/rollback <N>          — restore all files from turn N to their pre-turn state
+/rollback diff <N>     — show which files changed in turn N (paths + sizes)
+/rollback <N> <file>   — restore a single file from turn N
+```
+
+**Handler** (`session_handlers.rs` or new `rollback_handler.rs`):
+
+- `/rollback` (no args): Read `turns.jsonl`, show last 10 entries with turn number,
+  timestamp, file count, session key. Format like:
+  ```
+  Recent turns with file changes:
+  1. 2 min ago — 3 files (src/auth.rs, src/main.rs, moltis.toml)
+  2. 15 min ago — 1 file (src/lib.rs)
+  3. 1 hour ago — 5 files (...)
+  ```
+
+- `/rollback <N>`: Load turn N's checkpoint IDs, call `CheckpointManager::restore()`
+  for each. Report what was restored. Broadcast a session event so the web UI
+  can refresh.
+
+- `/rollback diff <N>`: List files from turn N's checkpoints without restoring.
+  Show original size vs current size, or "file did not exist" vs "now exists".
+
+### Automatic cleanup
+
+Old checkpoints must be pruned. Two strategies, both configurable:
+
+```toml
+[tools.checkpoints]
+enabled = true                    # default: true
+max_age_days = 7                  # delete checkpoints older than this
+max_total_size_mb = 500           # delete oldest when total exceeds this
+cleanup_interval_hours = 6        # how often to run cleanup
+```
+
+**Cleanup logic** (runs on a timer in the gateway, or lazily on checkpoint creation):
+
+1. Scan `~/.moltis/checkpoints/` for all checkpoint dirs
+2. Read each `manifest.json` for `created_at`
+3. Delete checkpoints older than `max_age_days`
+4. If total size still exceeds `max_total_size_mb`, delete oldest first until under budget
+5. Remove corresponding entries from `turns.jsonl`
+6. Log cleanup stats at `info!` level
+
+**Lazy cleanup** (simpler, recommended for v1): Run cleanup at the start of each
+checkpoint creation. If the total checkpoint count exceeds a threshold (e.g., 1000),
+prune the oldest 20%. This avoids needing a background timer.
+
+### Files to modify
+
+| File | Change |
+|------|--------|
+| `crates/tools/src/checkpoints.rs` | Add `TurnIndex` (append/read/prune turns.jsonl), add `cleanup()` method |
+| `crates/common/src/hooks.rs` | No changes needed — hook system already supports this |
+| `crates/tools/src/lib.rs` | New `AutoCheckpointHook` struct implementing `HookHandler` |
+| `crates/channels/src/commands.rs` | Register `/rollback` command |
+| `crates/gateway/src/channel_events/commands/dispatch.rs` | Add dispatch arm |
+| `crates/gateway/src/channel_events/commands/session_handlers.rs` | Add `handle_rollback()` |
+| `crates/gateway/src/server/prepare_core/post_state.rs` | Register `AutoCheckpointHook` with `HookRegistry` |
+| `crates/config/src/schema/tools.rs` | Add `CheckpointsConfig` (enabled, max_age_days, max_total_size_mb) |
+| `crates/config/src/validate/schema_map.rs` | Register `[tools.checkpoints]` |
+| `crates/config/src/template.rs` | Document `[tools.checkpoints]` |
+| Config save callsite | Add checkpoint before moltis.toml writes |
+
+### What this does NOT cover
+
+- **Shell command rollback** (`exec` tool): Can't reliably detect which files
+  a shell command modifies. Users who run destructive shell commands through
+  the agent should use git.
+- **Database rollback**: SQLite changes (sessions, memory) are not checkpointed.
+  This is file-level only.
+- **Undo chat history**: Hermes also undoes the chat turn on rollback. We could
+  add this (truncate session JSONL to pre-turn state) but it's a separate concern.
+  Start without it — file rollback is the high-value feature.
+
+### Implementation order
+
+1. **Turn index** — `TurnIndex` struct in `checkpoints.rs` (append, read, prune)
+2. **Auto-checkpoint hook** — `AutoCheckpointHook` implementing `HookHandler`
+3. **Hook registration** — wire into gateway startup
+4. **Cleanup** — lazy cleanup on checkpoint creation
+5. **`/rollback` command** — register + handler + all subcommands
+6. **Config protection** — checkpoint before moltis.toml saves
+7. **Config fields** — `[tools.checkpoints]` section
+
+Estimated scope: ~500-800 lines of new code across 10 files.

--- a/plans/2026-04-29-hermes-feature-parity-analysis.md
+++ b/plans/2026-04-29-hermes-feature-parity-analysis.md
@@ -1,0 +1,79 @@
+# Hermes Feature Parity Analysis
+
+Date: 2026-04-29
+Source: "15 Hermes Agent features you've never touched" article
+
+## Full Comparison Table
+
+| # | Hermes Feature | How Hermes does it | Moltis Status | Verdict | Notes |
+|---|---------------|-------------------|---------------|---------|-------|
+| 1 | **SOUL.md / /personality** | `SOUL.md` in `~/.hermes/` loaded at boot as system prompt slot #1. `/personality` switches named personas mid-session. 14 built-in personalities (kawaii, pirate, shakespeare, etc.) plus custom in `config.yaml`. | Per-agent `SOUL.md` in workspace dirs (`crates/config/src/loader/workspace.rs`). `/mode` overlays with 9+ presets (concise, technical, creative, teacher, plan, build, review, research, elevated). | **Already done** | Moltis SOUL.md + `/mode` system is equivalent. |
+| 2 | **MEMORY.md + USER.md** | Two bounded markdown files (~800 + ~500 tokens). Agent uses `memory` tool with add/replace/remove actions. FTS5 session search across all past conversations. External memory providers (Honcho, Mem0, etc.). MemoryManager orchestrates built-in + one external provider. | Full memory system in `crates/memory/`: file sync, chunking, OpenAI/local embeddings, FTS5 keyword search, hybrid vector+keyword search with reranking. Per-agent scoped memory via `AgentScopedMemoryWriter`. | **Already done** | Moltis memory system is more sophisticated (hybrid search with embeddings). |
+| 3 | **/insights [days]** | `agent/insights.py` (158KB). Reads sessions table, computes token/cost/tool stats, model/platform breakdowns, bar charts. Works across CLI and messaging platforms. | Metrics infrastructure exists in `crates/metrics/` (Prometheus + JSON snapshots + SQLite time-series store). No user-facing `/insights` command. | **Built in this PR** | Added `/insights [days]` command that queries `SqliteMetricsStore` and aggregates completions, tokens, errors, tool usage, per-provider breakdowns. |
+| 4 | **/snapshot** | Archive `~/.hermes/` config+state to `state-snapshots/` dir. Create/restore/prune snapshots. Excludes transient files. | No config snapshot mechanism. | **Skipped** | Low value. Moltis config is in version-controlled `moltis.toml`, state in SQLite with migrations. Git already provides this. |
+| 5 | **/branch (fork)** | `/branch [name]` creates independent copy of current session. New session ID, optional name. Session DB tracks lineage. | `BranchSessionTool` in `crates/tools/src/branch_session.rs`. Fork session at a message index, new session inherits parent's model and project. | **Already done** | |
+| 6 | **/rollback** | Shadow git repos in `~/.hermes/checkpoints/`. Triggered per-turn before file-mutating ops. `/rollback`, `/rollback <N>`, `/rollback diff <N>`, `/rollback <N> <file>`. 30s git timeout, 50K file limit. | `crates/tools/src/checkpoints.rs` — versioned file backups with manifest tracking, filtering by path pattern, listing with timestamps. | **Already done** | |
+| 7 | **/btw** | `/background` (aliases `/bg`, `/btw`). Queues prompt in separate background session. No tools, no persistence to main conversation. Results appear as panel when done. Can run multiple concurrent background sessions. | Not implemented. | **Built in this PR** | Added `/btw <question>` — direct LLM call with last 20 messages as context, no tools, not persisted. Returns inline. |
+| 8 | **/steer and /queue** | Three busy input modes: `interrupt` (default), `queue`, `steer`. `/steer` appends text to last tool result in current turn (after next tool batch). `/queue` queues message for next turn. `/busy` toggles mode. | Not implemented. | **Built in this PR** | `/steer <text>` — injects guidance via `SteerInbox` (Arc<Mutex<Vec<String>>>) polled by a background task, drained between agent loop iterations. `/queue <message>` — delegates to existing `LiveChatService` message queue. |
+| 9 | **/yolo, /fast, /reasoning** | `/yolo` skips dangerous-command approvals (session-scoped). `/fast` toggles OpenAI Priority Processing / Anthropic Fast Mode. `/reasoning [level]` sets reasoning effort (none/minimal/low/medium/high/xhigh). | `ReasoningEffort` enum exists (Low/Medium/High) in `crates/config/src/schema.rs`. No `/yolo` or `/fast`. | **Partially built** | Added `/fast [on|off|status]` toggle. `/reasoning` already works via config. `/yolo` deliberately omitted — security-sensitive, needs careful design. |
+| 10 | **/model --provider --global** | `/model <name>` switches session. `--global` persists to config. `--provider` switches provider. Modal picker if no args. Lists authenticated providers (up to 50 models). | `/model` command in gateway dispatch (`control_handlers.rs`). Switches model per-session. Provider selection via numbered list. | **Already done** | |
+| 11 | **Auxiliary models** | Central auxiliary client router in `auxiliary_client.py`. Auto-detection fallback chains for text tasks (7-step) and vision (7-step). Per-task overrides in `config.yaml` under `auxiliary:`. Credit exhaustion fallback. | All tasks use primary model. `chat.compaction.summary_model` field exists but documented as "not wired yet" (tracked by `moltis-8me`). | **Config built in this PR** | Added `[auxiliary]` config section with `compaction`, `title_generation`, `vision` fields. Schema map + template documented. Provider resolution wiring is the next step. |
+| 12 | **17-platform gateway** | 35 Python files. Telegram, Discord, Slack, WhatsApp, Signal, Email, SMS, Matrix, Mattermost, Feishu, DingTalk, WeChat, WeCom, QQ Bot, Yuanbao, Home Assistant, BlueBubbles, plus API server and webhook. | Discord (`crates/discord/`), Slack (`crates/slack/`), Matrix (`crates/matrix/`), MS Teams (`crates/msteams/`), Telegram (`crates/telegram/`), WhatsApp (`crates/whatsapp/`), Signal (`crates/signal/`), Home Assistant (`crates/home-assistant/`). Channel plugin architecture. | **Already done (keep expanding)** | 8+ platforms with unified `ChannelPlugin` trait. Adding more is incremental. |
+| 13 | **/voice** | CLI push-to-talk (Ctrl+B), Telegram voice, Discord voice channels. STT via multiple backends. TTS playback via sounddevice. Termux/WSL/Docker detection. | Voice config schema in `crates/config/src/schema/voice.rs`. Multi-provider TTS (OpenAI, ElevenLabs, Google, Piper, Coqui) and STT (Whisper, Groq, Deepgram, Google, Mistral, ElevenLabs, sherpa-onnx). | **Already done** | Moltis has more provider options than Hermes. |
+| 14 | **Cron + /webhook-subscriptions** | File-based cron scheduler with fcntl locking. `/cron` command for CRUD. Delivery to 18+ platforms. Dynamic webhook subscriptions in `webhook_subscriptions.json`. HMAC validation, hot-reload. No outgoing HTTP POST to arbitrary URLs. | Full cron in `crates/cron/`. Full webhook system in `crates/webhooks/` with SQLite store, worker, dedup, rate limiting, HMAC validation. Bundled skill for management. | **Already done** | Both cron and webhook subscriptions fully implemented. Neither Hermes nor Moltis has outgoing webhooks to arbitrary URLs (not needed — agent can use `web_fetch` tool). |
+| 15 | **Skills as slash commands** | 102 bundled skills across 25 categories + 73 optional skills. YAML frontmatter, template substitution, inline shell blocks. Registry integration, online publishing, security scanning. `/<skill-name>` invocation. | Skills system in `crates/skills/` with discovery, YAML manifests, enable/trust state, clawHub integration. | **Already done** | |
+
+## Summary
+
+| Category | Count |
+|----------|-------|
+| Already implemented in Moltis | 10 |
+| Built in this PR | 5 commands + auxiliary config |
+| Deliberately skipped | 1 (/snapshot) |
+| Partially done, needs follow-up | 1 (/yolo — security design needed) |
+
+## Implementation Details (this PR)
+
+### /btw — Ephemeral side question
+- **File**: `crates/gateway/src/channel_events/commands/quick_actions.rs`
+- Resolves provider from `GatewayInner.llm_providers` (same pattern as session summary)
+- Reads last 20 messages from session store for context
+- Single `provider.complete()` call with no tools
+- Response returned inline, nothing persisted
+
+### /fast — Fast/priority mode toggle
+- **Files**: `crates/gateway/src/state.rs` (state), `quick_actions.rs` (handler)
+- Session-scoped `HashSet<String>` in `GatewayInner`
+- `ChatRuntime::is_fast_mode()` trait method for downstream consumption
+- Broadcasts state change via WebSocket
+
+### /insights — Session analytics
+- **File**: `quick_actions.rs`, gated on `#[cfg(feature = "metrics")]`
+- Queries `SqliteMetricsStore::load_history()` for the requested time window
+- Computes deltas between consecutive points (metrics are cumulative counters)
+- Aggregates: completions, input/output tokens, errors, tool executions, per-provider breakdown, completions/hour rate
+
+### /steer — Mid-flight agent steering
+- **Files**: `crates/agents/src/runner/mod.rs` (SteerInbox type), `streaming.rs` (drain logic), `crates/chat/src/run_with_tools.rs` (polling task), `crates/chat/src/runtime.rs` (trait method), `crates/gateway/src/chat.rs` (impl), `crates/gateway/src/state.rs` (storage)
+- `SteerInbox = Arc<tokio::sync::Mutex<Vec<String>>>`
+- Background task polls `ChatRuntime::take_steer_text()` every 500ms
+- Agent loop drains inbox between iterations, injects as user message
+- Text format: `[User steering note — adjust your approach accordingly]: {text}`
+
+### /queue — Queue message for next turn
+- **File**: `quick_actions.rs`
+- Delegates to `ChatService::send()` which auto-queues when a run is active
+- Reports whether message was queued or sent immediately
+
+### [auxiliary] config — Auxiliary model assignments
+- **Files**: `crates/config/src/schema/chat.rs` (AuxiliaryModelsConfig), `schema.rs` (field), `validate/schema_map.rs`, `template.rs`
+- Three fields: `compaction`, `title_generation`, `vision`
+- All optional, fall back to session's primary provider when unset
+- Provider resolution wiring tracked by `moltis-8me`
+
+## Follow-up Work
+
+1. **Wire auxiliary model provider resolution** — resolve `auxiliary.compaction` from `ProviderRegistry` and pass to `compact_session()` instead of the primary provider. Same for title generation and vision tasks. Tracked by `moltis-8me`.
+2. **`/yolo` toggle** — skip dangerous-command approvals. Needs security design: hardline blocklist that `/yolo` cannot bypass, session-scoped only, audit logging.
+3. **Web UI for /insights** — the metrics data is already available via `MetricsSnapshot`; could add a dashboard panel.
+4. **Web UI for /fast** — expose the toggle in the session settings panel.


### PR DESCRIPTION
## Summary

Five new slash commands inspired by Hermes Agent feature analysis, plus auxiliary model config scaffolding:

- **`/btw <question>`** — Ephemeral side question. Direct LLM call with last 20 messages as context, no tools, no persistence. For quick gut checks without polluting the session.
- **`/fast [on|off|status]`** — Toggle fast/priority mode per session. Session-scoped flag in `GatewayInner`, broadcast via WebSocket.
- **`/insights [days]`** — Surface metrics from the SQLite metrics store. Aggregates LLM completions, tokens, errors, tool usage, and per-provider breakdowns over the requested window (default: 30 days).
- **`/steer <text>`** — Inject guidance into an active agent run mid-flight. Flows through `GatewayState` → `ChatRuntime` → `SteerInbox` → agent loop, drained between iterations and injected as a user message.
- **`/queue <message>`** — Queue a message for the next agent turn without interrupting the current one. Delegates to existing `LiveChatService` message queue.
- **`[auxiliary]` config** — New `AuxiliaryModelsConfig` with `compaction`, `title_generation`, `vision` fields for routing side tasks to cheaper models. Config + schema map + template wired; provider resolution is next step (tracked by `moltis-8me`).

## Validation

### Completed
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --exclude moltis-web --exclude moltis-cuda-providers -- -D warnings`
- [x] `cargo test --workspace --exclude moltis-web --exclude moltis-cuda-providers` — all tests pass, 0 failures
- [x] `all_registered_commands_have_dispatch_arms` compile-time test passes
- [x] Config schema map updated for `[auxiliary]` section
- [x] Config template documented

### Remaining
- [ ] `./scripts/local-validate.sh` (full CI gate)
- [ ] Wire auxiliary model provider resolution in compaction (tracked by `moltis-8me`)

## Manual QA

1. Start gateway, send `/btw what day is it` in any channel — should get a quick answer without tools
2. Send `/fast` — should toggle and broadcast state change
3. Send `/insights 7` — should show token/provider stats for last 7 days
4. Start a long agent task, send `/steer use the staging API` — agent should see the note on next iteration
5. During active run, send `/queue follow up with tests` — should queue for next turn
6. Add `[auxiliary] compaction = "some-model"` to moltis.toml — should parse without errors