### PR TITLE
fix(mcp): preserve auth_state on expired OAuth token so re-auth button shows

### DIFF
--- a/crates/mcp/src/client.rs
+++ b/crates/mcp/src/client.rs
@@ -20,7 +20,7 @@ use crate::{
     transport::StdioTransport,
     types::{
         ClientCapabilities, ClientInfo, InitializeParams, InitializeResult, McpToolDef,
-        PROTOCOL_VERSION, ToolsCallParams, ToolsCallResult, ToolsListResult,
+        McpTransportError, PROTOCOL_VERSION, ToolsCallParams, ToolsCallResult, ToolsListResult,
     },
 };
 
@@ -235,11 +235,20 @@ impl McpClient {
             },
         };
 
-        let resp = self
+        let resp = match self
             .transport
             .request("initialize", Some(serde_json::to_value(&params)?))
             .await
-            .context("MCP initialize request failed")?;
+        {
+            Ok(r) => r,
+            // Preserve 401 so the manager can trigger the OAuth re-auth flow.
+            Err(e @ Error::Transport(McpTransportError::Unauthorized { .. })) => return Err(e),
+            Err(e) => {
+                return Err(Error::message(format!(
+                    "MCP initialize request failed: {e}"
+                )));
+            },
+        };
 
         let result: InitializeResult =
             serde_json::from_value(resp.result.context("MCP initialize returned no result")?)

--- a/crates/mcp/src/manager.rs
+++ b/crates/mcp/src/manager.rs
@@ -234,9 +234,15 @@ impl McpManager {
                                     .handle_unauthorized(www_authenticate.as_deref())
                                     .await?;
 
+                                // Store provider before retry so auth_state is
+                                // visible even if the retry also fails (GH-927).
+                                let mut inner = self.inner.write().await;
+                                inner
+                                    .auth_providers
+                                    .insert(name.to_string(), auth_provider.clone());
+                                drop(inner);
+
                                 if !auth_ok {
-                                    let mut inner = self.inner.write().await;
-                                    inner.auth_providers.insert(name.to_string(), auth_provider);
                                     return Err(McpManagerError::OAuthRequired {
                                         server: name.to_string(),
                                     }
@@ -276,9 +282,15 @@ impl McpManager {
                                     .handle_unauthorized(www_authenticate.as_deref())
                                     .await?;
 
+                                // Store provider before retry so auth_state is
+                                // visible even if the retry also fails (GH-927).
+                                let mut inner = self.inner.write().await;
+                                inner
+                                    .auth_providers
+                                    .insert(name.to_string(), auth_provider.clone());
+                                drop(inner);
+
                                 if !auth_ok {
-                                    let mut inner = self.inner.write().await;
-                                    inner.auth_providers.insert(name.to_string(), auth_provider);
                                     return Err(McpManagerError::OAuthRequired {
                                         server: name.to_string(),
                                     }
@@ -354,9 +366,15 @@ impl McpManager {
                                     .handle_unauthorized(www_authenticate.as_deref())
                                     .await?;
 
+                                // Store provider before retry so auth_state is
+                                // visible even if the retry also fails (GH-927).
+                                let mut inner = self.inner.write().await;
+                                inner
+                                    .auth_providers
+                                    .insert(name.to_string(), auth_provider.clone());
+                                drop(inner);
+
                                 if !auth_ok {
-                                    let mut inner = self.inner.write().await;
-                                    inner.auth_providers.insert(name.to_string(), auth_provider);
                                     return Err(McpManagerError::OAuthRequired {
                                         server: name.to_string(),
                                     }
@@ -395,9 +413,15 @@ impl McpManager {
                                     .handle_unauthorized(www_authenticate.as_deref())
                                     .await?;
 
+                                // Store provider before retry so auth_state is
+                                // visible even if the retry also fails (GH-927).
+                                let mut inner = self.inner.write().await;
+                                inner
+                                    .auth_providers
+                                    .insert(name.to_string(), auth_provider.clone());
+                                drop(inner);
+
                                 if !auth_ok {
-                                    let mut inner = self.inner.write().await;
-                                    inner.auth_providers.insert(name.to_string(), auth_provider);
                                     return Err(McpManagerError::OAuthRequired {
                                         server: name.to_string(),
                                     }
@@ -1002,6 +1026,47 @@ mod tests {
             statuses[0].auth_state,
             Some(McpAuthState::Failed),
             "auth_state must be Failed so the UI can show a Re-authenticate button"
+        );
+    }
+
+    /// Same as the SSE test above but for the StreamableHttp transport path.
+    #[tokio::test]
+    async fn test_start_server_streamable_http_expired_token_preserves_auth_state() {
+        let mut mock_server = mockito::Server::new_async().await;
+        // StreamableHttp POSTs directly to the configured URL.
+        let _post_401 = mock_server
+            .mock("POST", "/mcp")
+            .with_status(401)
+            .with_header("www-authenticate", "Bearer")
+            .create_async()
+            .await;
+
+        let url = format!("{}/mcp", mock_server.url());
+        let mut reg = McpRegistry::new();
+        let config = McpServerConfig {
+            transport: TransportType::StreamableHttp,
+            url: Some(secrecy::Secret::new(url)),
+            enabled: true,
+            oauth: Some(McpOAuthConfig {
+                client_id: "test-client".into(),
+                auth_url: "https://auth.example.com/authorize".into(),
+                token_url: "https://auth.example.com/token".into(),
+                scopes: vec![],
+            }),
+            ..Default::default()
+        };
+        reg.servers.insert("analytics".into(), config.clone());
+        let mgr = McpManager::new(reg);
+
+        let err = mgr.start_server("analytics", &config).await;
+        assert!(err.is_err(), "start_server should fail with 401");
+
+        let statuses = mgr.status_all().await;
+        assert_eq!(statuses.len(), 1);
+        assert_eq!(
+            statuses[0].auth_state,
+            Some(McpAuthState::Failed),
+            "StreamableHttp auth_state must be Failed for re-auth button"
         );
     }
 }

--- a/crates/mcp/src/manager.rs
+++ b/crates/mcp/src/manager.rs
@@ -214,14 +214,48 @@ impl McpManager {
                     config.oauth.is_some(),
                     has_stored_token,
                 ) {
-                    let client = McpClient::connect_legacy_sse_with_auth(
+                    match McpClient::connect_legacy_sse_with_auth(
                         name,
                         &remote,
                         auth_provider.clone(),
                         self.effective_timeout_for(config),
                     )
-                    .await?;
-                    (client, Some(auth_provider))
+                    .await
+                    {
+                        Ok(client) => (client, Some(auth_provider)),
+                        Err(e) => {
+                            if let Error::Transport(McpTransportError::Unauthorized {
+                                www_authenticate,
+                            }) = &e
+                            {
+                                info!(server = %name, "legacy SSE auth failed (token expired?)");
+
+                                let auth_ok = auth_provider
+                                    .handle_unauthorized(www_authenticate.as_deref())
+                                    .await?;
+
+                                if !auth_ok {
+                                    let mut inner = self.inner.write().await;
+                                    inner.auth_providers.insert(name.to_string(), auth_provider);
+                                    return Err(McpManagerError::OAuthRequired {
+                                        server: name.to_string(),
+                                    }
+                                    .into());
+                                }
+
+                                let client = McpClient::connect_legacy_sse_with_auth(
+                                    name,
+                                    &remote,
+                                    auth_provider.clone(),
+                                    self.effective_timeout_for(config),
+                                )
+                                .await?;
+                                (client, Some(auth_provider))
+                            } else {
+                                return Err(e);
+                            }
+                        },
+                    }
                 } else {
                     match McpClient::connect_legacy_sse(
                         name,
@@ -297,14 +331,51 @@ impl McpManager {
                     config.oauth.is_some(),
                     has_stored_token,
                 ) {
-                    let client = McpClient::connect_sse_with_auth(
+                    match McpClient::connect_sse_with_auth(
                         name,
                         &remote,
                         auth_provider.clone(),
                         self.effective_timeout_for(config),
                     )
-                    .await?;
-                    (client, Some(auth_provider))
+                    .await
+                    {
+                        Ok(client) => (client, Some(auth_provider)),
+                        Err(e) => {
+                            if let Error::Transport(McpTransportError::Unauthorized {
+                                www_authenticate,
+                            }) = &e
+                            {
+                                info!(
+                                    server = %name,
+                                    "streamable HTTP auth failed (token expired?)"
+                                );
+
+                                let auth_ok = auth_provider
+                                    .handle_unauthorized(www_authenticate.as_deref())
+                                    .await?;
+
+                                if !auth_ok {
+                                    let mut inner = self.inner.write().await;
+                                    inner.auth_providers.insert(name.to_string(), auth_provider);
+                                    return Err(McpManagerError::OAuthRequired {
+                                        server: name.to_string(),
+                                    }
+                                    .into());
+                                }
+
+                                let client = McpClient::connect_sse_with_auth(
+                                    name,
+                                    &remote,
+                                    auth_provider.clone(),
+                                    self.effective_timeout_for(config),
+                                )
+                                .await?;
+                                (client, Some(auth_provider))
+                            } else {
+                                return Err(e);
+                            }
+                        },
+                    }
                 } else {
                     match McpClient::connect_sse(name, &remote, self.effective_timeout_for(config))
                         .await
@@ -880,5 +951,57 @@ mod tests {
             err,
             Error::Manager(McpManagerError::OAuthStateNotFound)
         ));
+    }
+
+    /// Regression test for GH-927: when an SSE server with OAuth config gets a
+    /// 401 on the authenticated connection path, `start_server` must preserve the
+    /// auth provider (with `Failed` state) so the frontend can show a
+    /// "Re-authenticate" button.
+    ///
+    /// Before the fix, the auth_provider was discarded when
+    /// `connect_legacy_sse_with_auth` failed via `?`, leaving auth_state as `None`.
+    #[tokio::test]
+    async fn test_start_server_with_expired_token_preserves_auth_state() {
+        // Mock server that always returns 401 on the SSE endpoint.
+        let mut mock_server = mockito::Server::new_async().await;
+        let _sse_401 = mock_server
+            .mock("GET", "/sse")
+            .with_status(401)
+            .with_header("www-authenticate", "Bearer")
+            .create_async()
+            .await;
+
+        let url = format!("{}/sse", mock_server.url());
+        let mut reg = McpRegistry::new();
+        let config = McpServerConfig {
+            transport: TransportType::Sse,
+            url: Some(secrecy::Secret::new(url)),
+            enabled: true,
+            // OAuth config makes should_attempt_auth_connection return true,
+            // simulating a server that was previously configured with OAuth.
+            oauth: Some(McpOAuthConfig {
+                client_id: "test-client".into(),
+                auth_url: "https://auth.example.com/authorize".into(),
+                token_url: "https://auth.example.com/token".into(),
+                scopes: vec![],
+            }),
+            ..Default::default()
+        };
+        reg.servers.insert("posthog".into(), config.clone());
+        let mgr = McpManager::new(reg);
+
+        // No pre-seeded auth_providers — simulates a cold restart.
+        // start_server will take the authenticated path (due to oauth config),
+        // get 401, and must store the auth_provider with Failed state.
+        let err = mgr.start_server("posthog", &config).await;
+        assert!(err.is_err(), "start_server should fail with 401");
+
+        let statuses = mgr.status_all().await;
+        assert_eq!(statuses.len(), 1);
+        assert_eq!(
+            statuses[0].auth_state,
+            Some(McpAuthState::Failed),
+            "auth_state must be Failed so the UI can show a Re-authenticate button"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Fixes #927 — MCP settings page now shows a "Re-authenticate" button when an OAuth server has expired tokens.

**Two bugs fixed:**

1. **Error type lost in `initialize()`** (`client.rs`): `.context()` flattened `McpTransportError::Unauthorized` into a generic `Error::Message`, so the manager's error matching could never trigger the OAuth re-auth flow.

2. **Auth provider discarded on authenticated path** (`manager.rs`): When `should_attempt_auth_connection = true` (OAuth config or stored token), `connect_*_with_auth` used bare `?` propagation. On 401, the auth_provider was dropped — `status_all()` returned `auth_state: None` and the frontend's existing re-auth button never rendered. Fixed for both SSE and StreamableHttp transports.

## Validation

### Completed
- [x] `cargo test -p moltis-mcp` — 109 tests pass
- [x] `cargo clippy -p moltis-mcp --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] Regression test `test_start_server_with_expired_token_preserves_auth_state` added and passing
- [x] Test confirmed to fail before fix, pass after

### Remaining
- [ ] `./scripts/local-validate.sh <PR>`
- [ ] Manual QA: add OAuth MCP server, revoke token, restart, verify re-auth button appears

## Manual QA

1. Add a remote MCP server using OAuth (e.g. PostHog at `https://mcp.posthog.com/mcp`)
2. Complete the initial OAuth flow
3. Revoke the token or let it expire
4. Restart Moltis
5. Open MCP settings — verify "Auth failed" badge and "Re-auth" button appear on the server card
6. Click "Re-auth" — verify OAuth flow opens in browser