### PR TITLE
fix: replace completion-based model probe with lightweight catalog check

### DIFF
--- a/crates/agents/src/model/stream.rs
+++ b/crates/agents/src/model/stream.rs
@@ -138,10 +138,11 @@ pub trait LlmProvider: Send + Sync {
     /// the first text delta or terminal event arrives. Providers can override
     /// this to use provider-specific low-cost probe requests.
     async fn probe(&self) -> anyhow::Result<()> {
+        let timeout = self.probe_timeout();
         let probe = vec![ChatMessage::user("ping")];
         let mut stream = self.stream(probe);
 
-        let result = tokio::time::timeout(Duration::from_secs(30), async {
+        let result = tokio::time::timeout(timeout, async {
             while let Some(event) = stream.next().await {
                 match event {
                     StreamEvent::Delta(_) | StreamEvent::Done(_) => return Ok(()),
@@ -157,8 +158,33 @@ pub trait LlmProvider: Send + Sync {
 
         match result {
             Ok(inner) => inner,
-            Err(_) => Err(anyhow::anyhow!("Connection timed out after 30 seconds")),
+            Err(_) => Err(anyhow::anyhow!(
+                "Connection timed out after {} seconds",
+                timeout.as_secs()
+            )),
         }
+    }
+
+    /// Timeout for the completion-based `probe()` fallback.
+    ///
+    /// Providers with slow model loading (e.g. local LLM servers) should
+    /// override this with a longer duration. The default is 30 seconds.
+    fn probe_timeout(&self) -> Duration {
+        Duration::from_secs(30)
+    }
+
+    /// Check whether the provider is reachable and knows about this model.
+    ///
+    /// Unlike [`probe()`](Self::probe), this does **not** require the model to
+    /// generate output. It uses lightweight endpoints such as `GET /v1/models`
+    /// or `POST /api/show` to verify model availability without triggering
+    /// model loading.
+    ///
+    /// The default implementation falls back to [`probe()`](Self::probe).
+    /// Providers should override this with a catalog/listing check whenever
+    /// the server supports one.
+    async fn check_availability(&self) -> anyhow::Result<()> {
+        self.probe().await
     }
 
     /// Fetch runtime model metadata from the provider API.

--- a/crates/chat/src/models.rs
+++ b/crates/chat/src/models.rs
@@ -202,8 +202,8 @@ async fn run_single_probe(
         };
     }
 
-    let completion =
-        tokio::time::timeout(Duration::from_secs(20), provider.check_availability()).await;
+    let probe_timeout = provider.probe_timeout();
+    let completion = tokio::time::timeout(probe_timeout, provider.check_availability()).await;
 
     match completion {
         Ok(Ok(_)) => {
@@ -280,7 +280,7 @@ async fn run_single_probe(
             display_name,
             provider_name,
             status: ProbeStatus::Error {
-                message: "probe timeout after 20s".to_string(),
+                message: format!("probe timeout after {}s", probe_timeout.as_secs()),
             },
         },
     }

--- a/crates/chat/src/models.rs
+++ b/crates/chat/src/models.rs
@@ -202,7 +202,8 @@ async fn run_single_probe(
         };
     }
 
-    let completion = tokio::time::timeout(Duration::from_secs(20), provider.probe()).await;
+    let completion =
+        tokio::time::timeout(Duration::from_secs(20), provider.check_availability()).await;
 
     match completion {
         Ok(Ok(_)) => {
@@ -1138,7 +1139,7 @@ impl ModelService for LiveModelService {
         let started = Instant::now();
         info!(model_id, provider = provider.name(), "model probe started");
 
-        match provider.probe().await {
+        match provider.check_availability().await {
             Ok(()) => {
                 info!(
                     model_id,

--- a/crates/config/src/schema/providers.rs
+++ b/crates/config/src/schema/providers.rs
@@ -282,6 +282,19 @@ pub struct ProviderEntry {
     /// `None` (default) = models stay loaded indefinitely.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub idle_timeout_secs: Option<u64>,
+
+    /// Timeout in seconds for completion-based model probes.
+    ///
+    /// When the lightweight catalog check (`GET /v1/models`) is unavailable,
+    /// probing falls back to sending a completion request. This setting
+    /// controls how long to wait for that fallback.
+    ///
+    /// Increase this for local LLM servers that need time to load large
+    /// models on first request (e.g. llama.cpp with 100B+ models).
+    ///
+    /// `None` (default) uses the built-in 30-second timeout.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub probe_timeout_secs: Option<u64>,
 }
 
 impl std::fmt::Debug for ProviderEntry {
@@ -300,6 +313,7 @@ impl std::fmt::Debug for ProviderEntry {
             .field("strict_tools", &self.strict_tools)
             .field("policy", &self.policy)
             .field("model_overrides", &self.model_overrides)
+            .field("probe_timeout_secs", &self.probe_timeout_secs)
             .finish()
     }
 }
@@ -321,6 +335,7 @@ impl Default for ProviderEntry {
             policy: None,
             model_overrides: HashMap::new(),
             idle_timeout_secs: None,
+            probe_timeout_secs: None,
         }
     }
 }

--- a/crates/config/src/template.rs
+++ b/crates/config/src/template.rs
@@ -124,6 +124,8 @@ port = {port}                           # Port number (auto-generated for this i
 #   strict_tools - Force strict/non-strict tool schemas (default: auto-detect per provider)
 #   policy    - Per-provider tool policy override (allow/deny lists)
 #   model_overrides.<model_id>.context_window - Override context window for a specific model
+#   probe_timeout_secs - Timeout for completion-based model probes (default: 30s).
+#                        Increase for local LLM servers that load large models on first request.
 
 # [providers]
 # offered = ["local-llm", "lmstudio", "github-copilot", "openai-codex", "openai", "anthropic", "openrouter", "ollama", "moonshot", "minimax", "zai"]

--- a/crates/config/src/validate/schema_map.rs
+++ b/crates/config/src/validate/schema_map.rs
@@ -49,6 +49,7 @@ pub(super) fn build_schema_map() -> KnownKeys {
             ("policy", tool_policy_entry()),
             ("model_overrides", Map(Box::new(model_override()))),
             ("idle_timeout_secs", Leaf),
+            ("probe_timeout_secs", Leaf),
         ]))
     };
 

--- a/crates/providers/src/anthropic.rs
+++ b/crates/providers/src/anthropic.rs
@@ -163,6 +163,70 @@ impl AnthropicProvider {
 
         Ok(())
     }
+
+    /// Lightweight availability check via Anthropic's `GET /v1/models` endpoint.
+    ///
+    /// Verifies the API key is valid and the model exists without generating
+    /// any tokens. Falls back to [`probe_request()`] if the models endpoint
+    /// is unavailable.
+    async fn check_model_in_catalog(&self) -> anyhow::Result<()> {
+        let url = format!(
+            "{}{ANTHROPIC_MODELS_ENDPOINT_PATH}/{}",
+            self.base_url.trim_end_matches('/'),
+            self.model,
+        );
+
+        debug!(
+            model = %self.model,
+            url = %url,
+            "checking anthropic model availability via catalog"
+        );
+
+        let resp = self
+            .client
+            .get(&url)
+            .timeout(Duration::from_secs(15))
+            .header("x-api-key", self.api_key.expose_secret())
+            .header("anthropic-version", "2023-06-01")
+            .header("accept", "application/json")
+            .send()
+            .await;
+
+        let resp = match resp {
+            Ok(r) => r,
+            Err(err) => {
+                debug!(
+                    error = %err,
+                    "anthropic catalog unreachable, falling back to completion probe"
+                );
+                return self.probe_request().await;
+            },
+        };
+
+        if resp.status().is_success() {
+            debug!(model = %self.model, "model found in anthropic catalog");
+            return Ok(());
+        }
+
+        // 404 means the model ID doesn't exist — return an error directly
+        // instead of wasting tokens on a completion probe.
+        if resp.status() == reqwest::StatusCode::NOT_FOUND {
+            let body_text = resp.text().await.unwrap_or_default();
+            anyhow::bail!(
+                "Model '{}' not found in Anthropic catalog (HTTP 404: {})",
+                self.model,
+                body_text,
+            );
+        }
+
+        // Other errors (auth, rate-limit) — fall back to the completion probe
+        // which has richer error classification.
+        debug!(
+            status = %resp.status(),
+            "anthropic catalog check failed, falling back to completion probe"
+        );
+        self.probe_request().await
+    }
 }
 
 fn formatted_model_name(model_id: &str) -> String {
@@ -733,6 +797,10 @@ impl LlmProvider for AnthropicProvider {
 
     async fn probe(&self) -> anyhow::Result<()> {
         self.probe_request().await
+    }
+
+    async fn check_availability(&self) -> anyhow::Result<()> {
+        self.check_model_in_catalog().await
     }
 
     #[allow(clippy::collapsible_if)]

--- a/crates/providers/src/anthropic.rs
+++ b/crates/providers/src/anthropic.rs
@@ -211,7 +211,8 @@ impl AnthropicProvider {
         // 404 means the model ID doesn't exist — return an error directly
         // instead of wasting tokens on a completion probe.
         if resp.status() == reqwest::StatusCode::NOT_FOUND {
-            let body_text = resp.text().await.unwrap_or_default();
+            let mut body_text = resp.text().await.unwrap_or_default();
+            body_text.truncate(200);
             anyhow::bail!(
                 "Model '{}' not found in Anthropic catalog (HTTP 404: {})",
                 self.model,

--- a/crates/providers/src/openai/mod.rs
+++ b/crates/providers/src/openai/mod.rs
@@ -40,4 +40,7 @@ pub struct OpenAiProvider {
     /// restrictions handled by sanitization).  Mistral rejects it outright.
     /// Defaults to `true`; set to `false` via `with_supports_user_name(false)`.
     pub(crate) supports_user_name: bool,
+    /// Optional override for the completion-based probe timeout (seconds).
+    /// `None` uses the trait default (30s).
+    probe_timeout_secs: Option<u64>,
 }

--- a/crates/providers/src/openai/provider/completion.rs
+++ b/crates/providers/src/openai/provider/completion.rs
@@ -247,7 +247,7 @@ impl OpenAiProvider {
                     provider = %self.provider_name,
                     "catalog endpoint unreachable, falling back to completion probe"
                 );
-                return self.probe_chat_completions().await;
+                return self.timed_probe_chat_completions().await;
             },
         };
 
@@ -257,7 +257,7 @@ impl OpenAiProvider {
                 provider = %self.provider_name,
                 "catalog endpoint returned error, falling back to completion probe"
             );
-            return self.probe_chat_completions().await;
+            return self.timed_probe_chat_completions().await;
         }
 
         let body: serde_json::Value = match resp.json().await {
@@ -268,7 +268,7 @@ impl OpenAiProvider {
                     provider = %self.provider_name,
                     "catalog response parse failed, falling back to completion probe"
                 );
-                return self.probe_chat_completions().await;
+                return self.timed_probe_chat_completions().await;
             },
         };
 
@@ -293,7 +293,23 @@ impl OpenAiProvider {
             catalog_models = ids.len(),
             "model not found in catalog, falling back to completion probe"
         );
-        self.probe_chat_completions().await
+        self.timed_probe_chat_completions().await
+    }
+
+    /// Run `probe_chat_completions()` with the configured `probe_timeout()`.
+    async fn timed_probe_chat_completions(&self) -> anyhow::Result<()> {
+        let timeout = self.probe_timeout_duration();
+        tokio::time::timeout(timeout, self.probe_chat_completions())
+            .await
+            .map_err(|_| {
+                anyhow::anyhow!("Connection timed out after {} seconds", timeout.as_secs())
+            })?
+    }
+
+    pub(crate) fn probe_timeout_duration(&self) -> Duration {
+        self.probe_timeout_secs
+            .map(|s| Duration::from_secs(s.max(1)))
+            .unwrap_or_else(|| Duration::from_secs(30))
     }
 
     /// Non-streaming completion using the Chat Completions API.

--- a/crates/providers/src/openai/provider/completion.rs
+++ b/crates/providers/src/openai/provider/completion.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use secrecy::ExposeSecret;
 
 use tracing::{debug, trace, warn};
@@ -207,6 +209,91 @@ impl OpenAiProvider {
         }
 
         Ok(())
+    }
+
+    /// Lightweight availability check via `GET /v1/models`.
+    ///
+    /// Verifies the provider is reachable and lists this model without
+    /// triggering model loading or token generation. Falls back to
+    /// [`probe()`](Self::probe_chat_completions) if the models endpoint
+    /// is unavailable or does not list the model.
+    pub(super) async fn check_model_in_catalog(&self) -> anyhow::Result<()> {
+        let url = format!("{}/models", self.base_url.trim_end_matches('/'));
+
+        debug!(
+            model = %self.model,
+            provider = %self.provider_name,
+            url = %url,
+            "checking model availability via catalog endpoint"
+        );
+
+        let resp = self
+            .client
+            .get(&url)
+            .timeout(Duration::from_secs(15))
+            .header(
+                "Authorization",
+                format!("Bearer {}", self.api_key.expose_secret()),
+            )
+            .header("Accept", "application/json")
+            .send()
+            .await;
+
+        let resp = match resp {
+            Ok(r) => r,
+            Err(err) => {
+                debug!(
+                    error = %err,
+                    provider = %self.provider_name,
+                    "catalog endpoint unreachable, falling back to completion probe"
+                );
+                return self.probe_chat_completions().await;
+            },
+        };
+
+        if !resp.status().is_success() {
+            debug!(
+                status = %resp.status(),
+                provider = %self.provider_name,
+                "catalog endpoint returned error, falling back to completion probe"
+            );
+            return self.probe_chat_completions().await;
+        }
+
+        let body: serde_json::Value = match resp.json().await {
+            Ok(v) => v,
+            Err(err) => {
+                debug!(
+                    error = %err,
+                    provider = %self.provider_name,
+                    "catalog response parse failed, falling back to completion probe"
+                );
+                return self.probe_chat_completions().await;
+            },
+        };
+
+        // Walk the response looking for model IDs in standard locations.
+        let mut ids = Vec::new();
+        collect_model_ids(&body, &mut ids);
+
+        if ids.iter().any(|id| id == &self.model) {
+            debug!(
+                model = %self.model,
+                provider = %self.provider_name,
+                "model found in catalog"
+            );
+            return Ok(());
+        }
+
+        // Model not listed — could mean the endpoint doesn't list all models
+        // (e.g. some servers only list loaded models). Fall back to probe.
+        debug!(
+            model = %self.model,
+            provider = %self.provider_name,
+            catalog_models = ids.len(),
+            "model not found in catalog, falling back to completion probe"
+        );
+        self.probe_chat_completions().await
     }
 
     /// Non-streaming completion using the Chat Completions API.
@@ -470,5 +557,29 @@ impl OpenAiProvider {
                 cache_write_tokens,
             },
         })
+    }
+}
+
+/// Extract model IDs from a `/models` JSON response.
+///
+/// Walks standard locations: top-level `data` array (OpenAI), `models` array,
+/// or the root if it is an array. Collects all `"id"` string fields found.
+fn collect_model_ids<'a>(value: &'a serde_json::Value, out: &mut Vec<&'a str>) {
+    let items = match value {
+        serde_json::Value::Array(arr) => arr.as_slice(),
+        serde_json::Value::Object(map) => {
+            for key in ["data", "models", "items", "results"] {
+                if let Some(nested) = map.get(key) {
+                    collect_model_ids(nested, out);
+                }
+            }
+            return;
+        },
+        _ => return,
+    };
+    for entry in items {
+        if let Some(id) = entry.get("id").and_then(serde_json::Value::as_str) {
+            out.push(id);
+        }
     }
 }

--- a/crates/providers/src/openai/provider/core.rs
+++ b/crates/providers/src/openai/provider/core.rs
@@ -328,9 +328,7 @@ impl LlmProvider for OpenAiProvider {
     }
 
     fn probe_timeout(&self) -> std::time::Duration {
-        self.probe_timeout_secs
-            .map(|s| std::time::Duration::from_secs(s.max(1)))
-            .unwrap_or_else(|| std::time::Duration::from_secs(30))
+        self.probe_timeout_duration()
     }
 
     async fn check_availability(&self) -> anyhow::Result<()> {

--- a/crates/providers/src/openai/provider/core.rs
+++ b/crates/providers/src/openai/provider/core.rs
@@ -38,6 +38,7 @@ impl OpenAiProvider {
             context_window_global: std::collections::HashMap::new(),
             context_window_provider: std::collections::HashMap::new(),
             supports_user_name: true,
+            probe_timeout_secs: None,
         }
     }
 
@@ -66,6 +67,7 @@ impl OpenAiProvider {
             context_window_global: std::collections::HashMap::new(),
             context_window_provider: std::collections::HashMap::new(),
             supports_user_name,
+            probe_timeout_secs: None,
         }
     }
 
@@ -111,6 +113,13 @@ impl OpenAiProvider {
     #[must_use]
     pub fn with_supports_user_name(mut self, supported: bool) -> Self {
         self.supports_user_name = supported;
+        self
+    }
+
+    /// Set the completion-based probe timeout override (seconds).
+    #[must_use]
+    pub fn with_probe_timeout_secs(mut self, secs: Option<u64>) -> Self {
+        self.probe_timeout_secs = secs;
         self
     }
 
@@ -213,6 +222,7 @@ impl LlmProvider for OpenAiProvider {
             strict_tools_override: self.strict_tools_override,
             reasoning_content_override: self.reasoning_content_override,
             supports_user_name: self.supports_user_name,
+            probe_timeout_secs: self.probe_timeout_secs,
         }))
     }
 
@@ -315,6 +325,16 @@ impl LlmProvider for OpenAiProvider {
             WireApi::Responses => self.probe_responses().await,
             WireApi::ChatCompletions => self.probe_chat_completions().await,
         }
+    }
+
+    fn probe_timeout(&self) -> std::time::Duration {
+        self.probe_timeout_secs
+            .map(|s| std::time::Duration::from_secs(s.max(1)))
+            .unwrap_or_else(|| std::time::Duration::from_secs(30))
+    }
+
+    async fn check_availability(&self) -> anyhow::Result<()> {
+        self.check_model_in_catalog().await
     }
 
     #[allow(clippy::collapsible_if)]

--- a/crates/providers/src/registry/registration.rs
+++ b/crates/providers/src/registry/registration.rs
@@ -224,6 +224,12 @@ impl ProviderRegistry {
                 if let Some(strict) = config.get(def.config_name).and_then(|e| e.strict_tools) {
                     oai = oai.with_strict_tools(strict);
                 }
+                if let Some(timeout) = config
+                    .get(def.config_name)
+                    .and_then(|e| e.probe_timeout_secs)
+                {
+                    oai = oai.with_probe_timeout_secs(Some(timeout));
+                }
 
                 self.register(
                     ModelInfo {
@@ -948,6 +954,13 @@ impl ProviderRegistry {
                     oai = oai.with_strict_tools(strict);
                 }
 
+                if let Some(timeout) = config
+                    .get(def.config_name)
+                    .and_then(|e| e.probe_timeout_secs)
+                {
+                    oai = oai.with_probe_timeout_secs(Some(timeout));
+                }
+
                 // Fireworks Fire Pass router models for Kimi route to
                 // Moonshot, which rejects strict-mode schemas and requires
                 // reasoning_content on tool-call messages (issue #810).
@@ -1058,6 +1071,7 @@ impl ProviderRegistry {
                 if let Some(strict) = entry.strict_tools {
                     oai = oai.with_strict_tools(strict);
                 }
+                oai = oai.with_probe_timeout_secs(entry.probe_timeout_secs);
                 let provider = Arc::new(oai);
                 self.register(
                     ModelInfo {


### PR DESCRIPTION
## Summary

Fixes #919 — model discovery fails for local LLM providers (llama.cpp, vllm) with large models (100B+) because the probe sends a completion request that requires the model to be fully loaded, exceeding the hardcoded 30-second timeout.

- Add `check_availability()` method to `LlmProvider` trait that uses lightweight catalog endpoints (`GET /v1/models`) instead of requiring token generation
- Override in `OpenAiProvider` (covers all `custom-*` and table-driven OpenAI-compatible providers including llama.cpp, vllm, lmstudio, ollama) and `AnthropicProvider`
- Both implementations fall back gracefully to completion-based `probe()` when the catalog endpoint is unavailable or doesn't list the model
- Wire `check_availability()` into `run_single_probe()` (batch "Detect all models") and `models.test` (individual "Test model" button)
- Add `probe_timeout()` trait method so providers can override the default 30s streaming probe timeout
- Add `probe_timeout_secs` config field on `ProviderEntry` so users can increase the fallback timeout for slow local servers

## Validation

### Completed
- [x] `cargo check` passes for all modified crates
- [x] `just format-check` passes
- [x] `cargo clippy -p moltis-agents -p moltis-providers -p moltis-chat -p moltis-config -p moltis-gateway -- -D warnings` passes (zero warnings)
- [x] `cargo test -p moltis-agents -p moltis-providers -p moltis-chat -p moltis-config -p moltis-gateway` — 1,537 tests pass, 0 failures
- [x] All files under 1,500 line limit

### Remaining
- [ ] `./scripts/local-validate.sh` (full CI validation)

## Manual QA

1. Configure a custom provider pointing to a local llama.cpp server with a large model
2. In web UI, go to Settings → Models → click "Test" on a model — should succeed via catalog check without loading the model
3. Click "Detect all models" — should find models via `/v1/models` without triggering model loading
4. Verify cloud providers (Anthropic, OpenAI) still detect models correctly
5. Test with `probe_timeout_secs = 300` in config for a custom provider that lacks a `/v1/models` endpoint — verify the extended timeout is respected