### PR TITLE
feat(web-ui): add message action bar to assistant responses

### DIFF
--- a/crates/provider-setup/src/known_providers.rs
+++ b/crates/provider-setup/src/known_providers.rs
@@ -56,6 +56,27 @@ impl KnownProvider {
 /// Build the known providers list at runtime, including local-llm if enabled.
 pub fn known_providers() -> Vec<KnownProvider> {
     let providers = vec![
+        // Membership/OAuth providers first — no API key needed, just sign in.
+        KnownProvider {
+            name: "openai-codex",
+            display_name: "OpenAI Codex",
+            auth_type: AuthType::Oauth,
+            env_key: None,
+            default_base_url: None,
+            requires_model: false,
+            key_optional: false,
+            local_only: false,
+        },
+        KnownProvider {
+            name: "github-copilot",
+            display_name: "GitHub Copilot",
+            auth_type: AuthType::Oauth,
+            env_key: None,
+            default_base_url: None,
+            requires_model: false,
+            key_optional: false,
+            local_only: false,
+        },
         KnownProvider {
             name: "anthropic",
             display_name: "Anthropic",
@@ -225,26 +246,6 @@ pub fn known_providers() -> Vec<KnownProvider> {
             requires_model: false,
             key_optional: true,
             local_only: true,
-        },
-        KnownProvider {
-            name: "openai-codex",
-            display_name: "OpenAI Codex",
-            auth_type: AuthType::Oauth,
-            env_key: None,
-            default_base_url: None,
-            requires_model: false,
-            key_optional: false,
-            local_only: false,
-        },
-        KnownProvider {
-            name: "github-copilot",
-            display_name: "GitHub Copilot",
-            auth_type: AuthType::Oauth,
-            env_key: None,
-            default_base_url: None,
-            requires_model: false,
-            key_optional: false,
-            local_only: false,
         },
         KnownProvider {
             name: "kimi-code",

--- a/crates/web/src/assets/css/chat.css
+++ b/crates/web/src/assets/css/chat.css
@@ -787,9 +787,10 @@
   background: var(--bg-hover);
 }
 
-.msg-action-icon {
-  width: 14px;
-  height: 14px;
+.msg-action-btn-active {
+  color: var(--accent);
+  opacity: 0.7;
+  pointer-events: none;
 }
 
 /* Retry popover */
@@ -838,9 +839,7 @@
   background: var(--bg-hover);
 }
 
-.msg-action-popover-item .msg-action-icon {
-  width: 14px;
-  height: 14px;
+.msg-action-popover-item .icon {
   color: var(--muted);
   flex-shrink: 0;
 }

--- a/crates/web/src/assets/css/chat.css
+++ b/crates/web/src/assets/css/chat.css
@@ -63,6 +63,14 @@
   white-space: normal;
 }
 
+.msg p:last-child {
+  margin-bottom: 0;
+}
+
+.msg p:first-child {
+  margin-top: 0;
+}
+
 /* ── Markdown block elements inside messages ── */
 
 .msg h1, .msg h2, .msg h3, .msg h4, .msg h5, .msg h6 {

--- a/crates/web/src/assets/css/chat.css
+++ b/crates/web/src/assets/css/chat.css
@@ -63,12 +63,9 @@
   white-space: normal;
 }
 
-.msg p:last-child {
-  margin-bottom: 0;
-}
-
-.msg p:first-child {
-  margin-top: 0;
+.msg p {
+  margin: 0;
+  white-space: normal;
 }
 
 /* ── Markdown block elements inside messages ── */

--- a/crates/web/src/assets/css/chat.css
+++ b/crates/web/src/assets/css/chat.css
@@ -757,6 +757,94 @@
   max-width: 320px;
 }
 
+/* ── Message action bar (copy, retry, fork) ── */
+
+.msg-action-bar {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  margin-top: 6px;
+  position: relative;
+}
+
+.msg-action-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border: none;
+  background: transparent;
+  color: var(--muted);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  padding: 0;
+  transition: color 0.15s, background 0.15s;
+}
+
+.msg-action-btn:hover {
+  color: var(--text);
+  background: var(--bg-hover);
+}
+
+.msg-action-icon {
+  width: 14px;
+  height: 14px;
+}
+
+/* Retry popover */
+
+.msg-action-popover {
+  position: absolute;
+  bottom: calc(100% + 4px);
+  left: 24px;
+  min-width: 160px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.18);
+  z-index: 50;
+  padding: 4px;
+  animation: msg-action-pop-in 0.12s ease-out;
+}
+
+@keyframes msg-action-pop-in {
+  from {
+    opacity: 0;
+    transform: translateY(4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.msg-action-popover-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 6px 10px;
+  border: none;
+  background: transparent;
+  color: var(--text);
+  font-size: 0.78rem;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  text-align: left;
+}
+
+.msg-action-popover-item:hover {
+  background: var(--bg-hover);
+}
+
+.msg-action-popover-item .msg-action-icon {
+  width: 14px;
+  height: 14px;
+  color: var(--muted);
+  flex-shrink: 0;
+}
+
 /* ── Waveform Audio Player ── */
 
 .waveform-player {

--- a/crates/web/src/assets/icons/masks/mask-copy.svg
+++ b/crates/web/src/assets/icons/masks/mask-copy.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>

--- a/crates/web/src/assets/icons/masks/mask-git-fork.svg
+++ b/crates/web/src/assets/icons/masks/mask-git-fork.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="6" y1="3" x2="6" y2="15"/><circle cx="18" cy="6" r="3"/><circle cx="6" cy="18" r="3"/><path d="M18 9a9 9 0 0 1-9 9"/></svg>

--- a/crates/web/src/assets/icons/masks/mask-list-minus.svg
+++ b/crates/web/src/assets/icons/masks/mask-list-minus.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M11 12H3"/><path d="M16 6H3"/><path d="M16 18H3"/><path d="M21 12h-6"/></svg>

--- a/crates/web/src/assets/icons/masks/mask-list-plus.svg
+++ b/crates/web/src/assets/icons/masks/mask-list-plus.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M11 12H3"/><path d="M16 6H3"/><path d="M16 18H3"/><path d="M18 9v6"/><path d="M21 12h-6"/></svg>

--- a/crates/web/src/assets/icons/masks/mask-retry.svg
+++ b/crates/web/src/assets/icons/masks/mask-retry.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12a9 9 0 1 1-9-9c2.52 0 4.93 1 6.74 2.74L21 8"/><path d="M21 3v5h-5"/></svg>

--- a/crates/web/ui/input.css
+++ b/crates/web/ui/input.css
@@ -2165,6 +2165,28 @@
     -webkit-mask-image: url("./icons/nav/webhooks.svg");
     mask-image: url("./icons/nav/webhooks.svg");
   }
+
+  /* Message action bar icons */
+  .icon-copy {
+    -webkit-mask-image: url("./icons/masks/mask-copy.svg");
+    mask-image: url("./icons/masks/mask-copy.svg");
+  }
+  .icon-retry {
+    -webkit-mask-image: url("./icons/masks/mask-retry.svg");
+    mask-image: url("./icons/masks/mask-retry.svg");
+  }
+  .icon-git-fork {
+    -webkit-mask-image: url("./icons/masks/mask-git-fork.svg");
+    mask-image: url("./icons/masks/mask-git-fork.svg");
+  }
+  .icon-list-plus {
+    -webkit-mask-image: url("./icons/masks/mask-list-plus.svg");
+    mask-image: url("./icons/masks/mask-list-plus.svg");
+  }
+  .icon-list-minus {
+    -webkit-mask-image: url("./icons/masks/mask-list-minus.svg");
+    mask-image: url("./icons/masks/mask-list-minus.svg");
+  }
 }
 
 /* ── Command Palette ──────────────────────────────────────────────── */

--- a/crates/web/ui/src/components/SessionHeader.tsx
+++ b/crates/web/ui/src/components/SessionHeader.tsx
@@ -555,17 +555,6 @@ export function SessionHeader({
 						{session?.archived ? "Unarchive" : "Archive"}
 					</button>
 				)}
-				{showDelete && !isMain && (
-					<button
-						className={`${actionButtonClass} chat-session-btn-danger inline-flex items-center gap-1.5`}
-						onClick={onDelete}
-						title="Delete session"
-						style={{ background: "var(--error)", borderColor: "var(--error)", color: "#fff" }}
-					>
-						<span className="icon icon-sm icon-x-circle shrink-0" />
-						Delete
-					</button>
-				)}
 				{showFork && !isCron && (
 					<button
 						className={`${actionButtonClass} inline-flex items-center gap-1.5`}
@@ -584,6 +573,17 @@ export function SessionHeader({
 					>
 						<span className="icon icon-sm icon-share shrink-0" />
 						Share
+					</button>
+				)}
+				{showDelete && !isMain && (
+					<button
+						className={`${actionButtonClass} chat-session-btn-danger inline-flex items-center gap-1.5`}
+						onClick={onDelete}
+						title="Delete session"
+						style={{ background: "var(--error)", borderColor: "var(--error)", color: "#fff" }}
+					>
+						<span className="icon icon-sm icon-x-circle shrink-0" />
+						Delete
 					</button>
 				)}
 				{showStop && canStop && (

--- a/crates/web/ui/src/helpers.ts
+++ b/crates/web/ui/src/helpers.ts
@@ -273,7 +273,7 @@ export function renderMarkdown(raw: string): string {
 	const { text, tables } = extractAsciiTables(raw);
 	let result = markedInstance.parse(text) as string;
 	result = result.replace(/@@MOLTIS_ASCII_TABLE_(\d+)@@/g, (_: string, idx: string) => tables[Number(idx)] || "");
-	return result;
+	return result.trimEnd();
 }
 
 export function sendRpc<T = unknown>(method: string, params: unknown): Promise<RpcResponse<T>> {

--- a/crates/web/ui/src/message-actions.ts
+++ b/crates/web/ui/src/message-actions.ts
@@ -44,10 +44,22 @@ export interface MessageActionContext {
 	text?: string;
 	runId?: string;
 	hasAudio?: boolean;
+	audioWarning?: string;
 }
 
 export function appendMessageActions(ctx: MessageActionContext): void {
 	const { messageEl, sessionKey } = ctx;
+
+	// Surface server-side audio warnings inline on the message.
+	if (ctx.audioWarning) {
+		let warningEl = messageEl.querySelector(".msg-voice-warning") as HTMLElement | null;
+		if (!warningEl) {
+			warningEl = document.createElement("div");
+			warningEl.className = "voice-error-result msg-voice-warning";
+			messageEl.appendChild(warningEl);
+		}
+		warningEl.textContent = ctx.audioWarning;
+	}
 
 	const bar = document.createElement("div");
 	bar.className = "msg-action-bar";
@@ -57,14 +69,19 @@ export function appendMessageActions(ctx: MessageActionContext): void {
 	copyBtn.addEventListener("click", () => {
 		const text = extractPlainText(messageEl);
 		if (navigator.clipboard?.writeText) {
-			navigator.clipboard.writeText(text).then(() => {
-				copyBtn.replaceChildren(iconSpan("icon-checkmark"));
-				copyBtn.title = "Copied";
-				setTimeout(() => {
-					copyBtn.replaceChildren(iconSpan("icon-copy"));
-					copyBtn.title = "Copy";
-				}, 1500);
-			});
+			navigator.clipboard.writeText(text).then(
+				() => {
+					copyBtn.replaceChildren(iconSpan("icon-checkmark"));
+					copyBtn.title = "Copied";
+					setTimeout(() => {
+						copyBtn.replaceChildren(iconSpan("icon-copy"));
+						copyBtn.title = "Copy";
+					}, 1500);
+				},
+				() => {
+					showToast("Failed to copy to clipboard", "error");
+				},
+			);
 		}
 	});
 	bar.appendChild(copyBtn);
@@ -78,7 +95,7 @@ export function appendMessageActions(ctx: MessageActionContext): void {
 			return;
 		}
 		dismissActivePopover();
-		const popover = buildRetryPopover(sessionKey, messageEl);
+		const popover = buildRetryPopover(sessionKey);
 		bar.appendChild(popover);
 		activePopover = popover;
 		requestAnimationFrame(() => {
@@ -150,7 +167,7 @@ function actionButton(iconClass: string, title: string): HTMLButtonElement {
 
 // ── Retry popover ────────────────────────────────────────────
 
-function buildRetryPopover(sessionKey: string, messageEl: HTMLElement): HTMLElement {
+function buildRetryPopover(sessionKey: string): HTMLElement {
 	const pop = document.createElement("div");
 	pop.className = "msg-action-popover";
 
@@ -158,18 +175,17 @@ function buildRetryPopover(sessionKey: string, messageEl: HTMLElement): HTMLElem
 		{
 			iconClass: "icon-retry",
 			label: "Try again",
-			action: () => retryMessage(sessionKey, messageEl),
+			action: () => retrySend(sessionKey, "Please try again with a different response."),
 		},
 		{
 			iconClass: "icon-list-plus",
 			label: "Add details",
-			action: () =>
-				retryWithInstruction(sessionKey, messageEl, "Please provide more details and expand on your answer."),
+			action: () => retrySend(sessionKey, "Please provide more details and expand on your answer."),
 		},
 		{
 			iconClass: "icon-list-minus",
 			label: "More concise",
-			action: () => retryWithInstruction(sessionKey, messageEl, "Please be more concise and brief in your response."),
+			action: () => retrySend(sessionKey, "Please be more concise and brief in your response."),
 		},
 	];
 
@@ -192,20 +208,10 @@ function buildRetryPopover(sessionKey: string, messageEl: HTMLElement): HTMLElem
 	return pop;
 }
 
-// ── Retry actions ────────────────────────────────────────────
-// Uses chat.send with follow-up instructions since there is no
-// dedicated retry RPC. The agent regenerates based on the prompt.
+// ── Retry action ─────────────────────────────────────────────
 
-function retryMessage(_sessionKey: string, _messageEl: HTMLElement): void {
-	sendRpc("chat.send", { text: "Please try again with a different response.", _seq: Date.now() }).then((res) => {
-		if (!res.ok) {
-			showToast(res.error?.message || "Retry failed", "error");
-		}
-	});
-}
-
-function retryWithInstruction(_sessionKey: string, _messageEl: HTMLElement, instruction: string): void {
-	sendRpc("chat.send", { text: instruction, _seq: Date.now() }).then((res) => {
+function retrySend(sessionKey: string, text: string): void {
+	sendRpc("chat.send", { text, _session_key: sessionKey }).then((res) => {
 		if (!res.ok) {
 			showToast(res.error?.message || "Retry failed", "error");
 		}
@@ -223,8 +229,9 @@ function extractPlainText(messageEl: HTMLElement): string {
 		".msg-voice-player-slot",
 		".msg-voice-warning",
 	]) {
-		const el = clone.querySelector(sel);
-		if (el) el.remove();
+		for (const el of clone.querySelectorAll(sel)) {
+			el.remove();
+		}
 	}
 	return (clone.textContent || "").trim();
 }

--- a/crates/web/ui/src/message-actions.ts
+++ b/crates/web/ui/src/message-actions.ts
@@ -3,107 +3,18 @@
 // Appended below each finalized assistant message footer.
 // The retry button opens a popover with "Try again", "Add details",
 // and "More concise" options.
+// Icons use CSS mask-image classes (icon-*) backed by SVG files on disk.
 
 import { sendRpc } from "./helpers";
 import { showToast } from "./ui";
 
-// ── SVG icon helpers ─────────────────────────────────────────
+// ── Icon helper ──────────────────────────────────────────────
 
-const NS = "http://www.w3.org/2000/svg";
-
-function svgIcon(viewBox: string, ...paths: string[]): SVGSVGElement {
-	const svg = document.createElementNS(NS, "svg");
-	svg.setAttribute("viewBox", viewBox);
-	svg.setAttribute("fill", "none");
-	svg.setAttribute("stroke", "currentColor");
-	svg.setAttribute("stroke-width", "2");
-	svg.setAttribute("stroke-linecap", "round");
-	svg.setAttribute("stroke-linejoin", "round");
-	svg.setAttribute("aria-hidden", "true");
-	svg.classList.add("msg-action-icon");
-	for (const d of paths) {
-		const p = document.createElementNS(NS, "path");
-		p.setAttribute("d", d);
-		svg.appendChild(p);
-	}
-	return svg;
-}
-
-function copyIcon(): SVGSVGElement {
-	// Two-rect clipboard icon (Lucide "copy")
-	const svg = document.createElementNS(NS, "svg");
-	svg.setAttribute("viewBox", "0 0 24 24");
-	svg.setAttribute("fill", "none");
-	svg.setAttribute("stroke", "currentColor");
-	svg.setAttribute("stroke-width", "2");
-	svg.setAttribute("stroke-linecap", "round");
-	svg.setAttribute("stroke-linejoin", "round");
-	svg.setAttribute("aria-hidden", "true");
-	svg.classList.add("msg-action-icon");
-	const r1 = document.createElementNS(NS, "rect");
-	r1.setAttribute("x", "9");
-	r1.setAttribute("y", "9");
-	r1.setAttribute("width", "13");
-	r1.setAttribute("height", "13");
-	r1.setAttribute("rx", "2");
-	svg.appendChild(r1);
-	const p = document.createElementNS(NS, "path");
-	p.setAttribute("d", "M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1");
-	svg.appendChild(p);
-	return svg;
-}
-
-function checkIcon(): SVGSVGElement {
-	return svgIcon("0 0 24 24", "M20 6 9 17l-5-5");
-}
-
-function retryIcon(): SVGSVGElement {
-	return svgIcon("0 0 24 24", "M21 12a9 9 0 1 1-9-9c2.52 0 4.93 1 6.74 2.74L21 8", "M21 3v5h-5");
-}
-
-function forkIcon(): SVGSVGElement {
-	// Git-branch style icon
-	const svg = document.createElementNS(NS, "svg");
-	svg.setAttribute("viewBox", "0 0 24 24");
-	svg.setAttribute("fill", "none");
-	svg.setAttribute("stroke", "currentColor");
-	svg.setAttribute("stroke-width", "2");
-	svg.setAttribute("stroke-linecap", "round");
-	svg.setAttribute("stroke-linejoin", "round");
-	svg.setAttribute("aria-hidden", "true");
-	svg.classList.add("msg-action-icon");
-	const l = document.createElementNS(NS, "line");
-	l.setAttribute("x1", "6");
-	l.setAttribute("y1", "3");
-	l.setAttribute("x2", "6");
-	l.setAttribute("y2", "15");
-	svg.appendChild(l);
-	const c1 = document.createElementNS(NS, "circle");
-	c1.setAttribute("cx", "18");
-	c1.setAttribute("cy", "6");
-	c1.setAttribute("r", "3");
-	svg.appendChild(c1);
-	const c2 = document.createElementNS(NS, "circle");
-	c2.setAttribute("cx", "6");
-	c2.setAttribute("cy", "18");
-	c2.setAttribute("r", "3");
-	svg.appendChild(c2);
-	const p = document.createElementNS(NS, "path");
-	p.setAttribute("d", "M18 9a9 9 0 0 1-9 9");
-	svg.appendChild(p);
-	return svg;
-}
-
-// ── Menu item icons (for retry popover) ──────────────────────
-
-function addDetailsIcon(): SVGSVGElement {
-	// List-plus style icon
-	return svgIcon("0 0 24 24", "M11 12H3", "M16 6H3", "M16 18H3", "M18 9v6", "M21 12h-6");
-}
-
-function conciseIcon(): SVGSVGElement {
-	// List-minus style icon
-	return svgIcon("0 0 24 24", "M11 12H3", "M16 6H3", "M16 18H3", "M21 12h-6");
+function iconSpan(iconClass: string): HTMLSpanElement {
+	const span = document.createElement("span");
+	span.className = `icon icon-sm ${iconClass}`;
+	span.setAttribute("aria-hidden", "true");
+	return span;
 }
 
 // ── Popover dismiss ──────────────────────────────────────────
@@ -129,6 +40,9 @@ export interface MessageActionContext {
 	messageEl: HTMLElement;
 	sessionKey: string;
 	messageIndex?: number;
+	text?: string;
+	runId?: string;
+	hasAudio?: boolean;
 }
 
 export function appendMessageActions(ctx: MessageActionContext): void {
@@ -138,16 +52,15 @@ export function appendMessageActions(ctx: MessageActionContext): void {
 	bar.className = "msg-action-bar";
 
 	// ── Copy button ──────────────────────────────────────────
-	const copyBtn = actionButton(copyIcon(), "Copy");
+	const copyBtn = actionButton("icon-copy", "Copy");
 	copyBtn.addEventListener("click", () => {
 		const text = extractPlainText(messageEl);
 		if (navigator.clipboard?.writeText) {
 			navigator.clipboard.writeText(text).then(() => {
-				// Swap icon to checkmark briefly
-				copyBtn.replaceChildren(checkIcon());
+				copyBtn.replaceChildren(iconSpan("icon-checkmark"));
 				copyBtn.title = "Copied";
 				setTimeout(() => {
-					copyBtn.replaceChildren(copyIcon());
+					copyBtn.replaceChildren(iconSpan("icon-copy"));
 					copyBtn.title = "Copy";
 				}, 1500);
 			});
@@ -156,7 +69,7 @@ export function appendMessageActions(ctx: MessageActionContext): void {
 	bar.appendChild(copyBtn);
 
 	// ── Retry button (with popover) ──────────────────────────
-	const retryBtn = actionButton(retryIcon(), "Retry");
+	const retryBtn = actionButton("icon-retry", "Retry");
 	retryBtn.addEventListener("click", (e) => {
 		e.stopPropagation();
 		if (activePopover && activePopover.parentElement === bar) {
@@ -167,15 +80,42 @@ export function appendMessageActions(ctx: MessageActionContext): void {
 		const popover = buildRetryPopover(sessionKey, messageEl);
 		bar.appendChild(popover);
 		activePopover = popover;
-		// Dismiss on next outside click
 		requestAnimationFrame(() => {
 			document.addEventListener("click", onDocClick, { once: true });
 		});
 	});
 	bar.appendChild(retryBtn);
 
+	// ── Voice button ─────────────────────────────────────────
+	if (ctx.text && !ctx.hasAudio) {
+		const voiceBtn = actionButton("icon-microphone", "Voice it");
+		voiceBtn.addEventListener("click", async () => {
+			const params: Record<string, unknown> = { key: sessionKey };
+			if (ctx.runId) params.runId = ctx.runId;
+			if (Number.isInteger(ctx.messageIndex) && (ctx.messageIndex as number) >= 0) {
+				params.messageIndex = ctx.messageIndex;
+			}
+			if (!(params.runId || Number.isInteger(params.messageIndex))) {
+				showToast("Cannot generate voice for this message", "error");
+				return;
+			}
+			voiceBtn.classList.add("msg-action-btn-active");
+			voiceBtn.title = "Generating voice...";
+			const result = await sendRpc("sessions.voice.generate", params);
+			voiceBtn.classList.remove("msg-action-btn-active");
+			if (result?.ok) {
+				voiceBtn.replaceChildren(iconSpan("icon-checkmark"));
+				voiceBtn.title = "Voice generated";
+			} else {
+				voiceBtn.title = "Voice it";
+				showToast("Voice generation failed", "error");
+			}
+		});
+		bar.appendChild(voiceBtn);
+	}
+
 	// ── Fork button ──────────────────────────────────────────
-	const forkBtn = actionButton(forkIcon(), "Fork into new session");
+	const forkBtn = actionButton("icon-git-fork", "Fork into new session");
 	forkBtn.addEventListener("click", () => {
 		sendRpc("sessions.fork", {
 			key: sessionKey,
@@ -195,12 +135,12 @@ export function appendMessageActions(ctx: MessageActionContext): void {
 
 // ── Button factory ───────────────────────────────────────────
 
-function actionButton(icon: SVGSVGElement, title: string): HTMLButtonElement {
+function actionButton(iconClass: string, title: string): HTMLButtonElement {
 	const btn = document.createElement("button");
 	btn.type = "button";
 	btn.className = "msg-action-btn";
 	btn.title = title;
-	btn.appendChild(icon);
+	btn.appendChild(iconSpan(iconClass));
 	return btn;
 }
 
@@ -210,20 +150,20 @@ function buildRetryPopover(sessionKey: string, messageEl: HTMLElement): HTMLElem
 	const pop = document.createElement("div");
 	pop.className = "msg-action-popover";
 
-	const items: Array<{ icon: SVGSVGElement; label: string; action: () => void }> = [
+	const items: Array<{ iconClass: string; label: string; action: () => void }> = [
 		{
-			icon: retryIcon(),
+			iconClass: "icon-retry",
 			label: "Try again",
 			action: () => retryMessage(sessionKey, messageEl),
 		},
 		{
-			icon: addDetailsIcon(),
+			iconClass: "icon-list-plus",
 			label: "Add details",
 			action: () =>
 				retryWithInstruction(sessionKey, messageEl, "Please provide more details and expand on your answer."),
 		},
 		{
-			icon: conciseIcon(),
+			iconClass: "icon-list-minus",
 			label: "More concise",
 			action: () => retryWithInstruction(sessionKey, messageEl, "Please be more concise and brief in your response."),
 		},
@@ -233,7 +173,7 @@ function buildRetryPopover(sessionKey: string, messageEl: HTMLElement): HTMLElem
 		const row = document.createElement("button");
 		row.type = "button";
 		row.className = "msg-action-popover-item";
-		row.appendChild(item.icon);
+		row.appendChild(iconSpan(item.iconClass));
 		const span = document.createElement("span");
 		span.textContent = item.label;
 		row.appendChild(span);
@@ -271,7 +211,6 @@ function retryWithInstruction(_sessionKey: string, _messageEl: HTMLElement, inst
 // ── Text extraction ──────────────────────────────────────────
 
 function extractPlainText(messageEl: HTMLElement): string {
-	// Clone the element, remove footer/action bar/reasoning, get textContent
 	const clone = messageEl.cloneNode(true) as HTMLElement;
 	for (const sel of [
 		".msg-model-footer",

--- a/crates/web/ui/src/message-actions.ts
+++ b/crates/web/ui/src/message-actions.ts
@@ -1,0 +1,287 @@
+// ── Message action bar (copy, voice, retry, fork) ────────────
+//
+// Appended below each finalized assistant message footer.
+// The retry button opens a popover with "Try again", "Add details",
+// and "More concise" options.
+
+import { sendRpc } from "./helpers";
+import { showToast } from "./ui";
+
+// ── SVG icon helpers ─────────────────────────────────────────
+
+const NS = "http://www.w3.org/2000/svg";
+
+function svgIcon(viewBox: string, ...paths: string[]): SVGSVGElement {
+	const svg = document.createElementNS(NS, "svg");
+	svg.setAttribute("viewBox", viewBox);
+	svg.setAttribute("fill", "none");
+	svg.setAttribute("stroke", "currentColor");
+	svg.setAttribute("stroke-width", "2");
+	svg.setAttribute("stroke-linecap", "round");
+	svg.setAttribute("stroke-linejoin", "round");
+	svg.setAttribute("aria-hidden", "true");
+	svg.classList.add("msg-action-icon");
+	for (const d of paths) {
+		const p = document.createElementNS(NS, "path");
+		p.setAttribute("d", d);
+		svg.appendChild(p);
+	}
+	return svg;
+}
+
+function copyIcon(): SVGSVGElement {
+	// Two-rect clipboard icon (Lucide "copy")
+	const svg = document.createElementNS(NS, "svg");
+	svg.setAttribute("viewBox", "0 0 24 24");
+	svg.setAttribute("fill", "none");
+	svg.setAttribute("stroke", "currentColor");
+	svg.setAttribute("stroke-width", "2");
+	svg.setAttribute("stroke-linecap", "round");
+	svg.setAttribute("stroke-linejoin", "round");
+	svg.setAttribute("aria-hidden", "true");
+	svg.classList.add("msg-action-icon");
+	const r1 = document.createElementNS(NS, "rect");
+	r1.setAttribute("x", "9");
+	r1.setAttribute("y", "9");
+	r1.setAttribute("width", "13");
+	r1.setAttribute("height", "13");
+	r1.setAttribute("rx", "2");
+	svg.appendChild(r1);
+	const p = document.createElementNS(NS, "path");
+	p.setAttribute("d", "M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1");
+	svg.appendChild(p);
+	return svg;
+}
+
+function checkIcon(): SVGSVGElement {
+	return svgIcon("0 0 24 24", "M20 6 9 17l-5-5");
+}
+
+function retryIcon(): SVGSVGElement {
+	return svgIcon("0 0 24 24", "M21 12a9 9 0 1 1-9-9c2.52 0 4.93 1 6.74 2.74L21 8", "M21 3v5h-5");
+}
+
+function forkIcon(): SVGSVGElement {
+	// Git-branch style icon
+	const svg = document.createElementNS(NS, "svg");
+	svg.setAttribute("viewBox", "0 0 24 24");
+	svg.setAttribute("fill", "none");
+	svg.setAttribute("stroke", "currentColor");
+	svg.setAttribute("stroke-width", "2");
+	svg.setAttribute("stroke-linecap", "round");
+	svg.setAttribute("stroke-linejoin", "round");
+	svg.setAttribute("aria-hidden", "true");
+	svg.classList.add("msg-action-icon");
+	const l = document.createElementNS(NS, "line");
+	l.setAttribute("x1", "6");
+	l.setAttribute("y1", "3");
+	l.setAttribute("x2", "6");
+	l.setAttribute("y2", "15");
+	svg.appendChild(l);
+	const c1 = document.createElementNS(NS, "circle");
+	c1.setAttribute("cx", "18");
+	c1.setAttribute("cy", "6");
+	c1.setAttribute("r", "3");
+	svg.appendChild(c1);
+	const c2 = document.createElementNS(NS, "circle");
+	c2.setAttribute("cx", "6");
+	c2.setAttribute("cy", "18");
+	c2.setAttribute("r", "3");
+	svg.appendChild(c2);
+	const p = document.createElementNS(NS, "path");
+	p.setAttribute("d", "M18 9a9 9 0 0 1-9 9");
+	svg.appendChild(p);
+	return svg;
+}
+
+// ── Menu item icons (for retry popover) ──────────────────────
+
+function addDetailsIcon(): SVGSVGElement {
+	// List-plus style icon
+	return svgIcon("0 0 24 24", "M11 12H3", "M16 6H3", "M16 18H3", "M18 9v6", "M21 12h-6");
+}
+
+function conciseIcon(): SVGSVGElement {
+	// List-minus style icon
+	return svgIcon("0 0 24 24", "M11 12H3", "M16 6H3", "M16 18H3", "M21 12h-6");
+}
+
+// ── Popover dismiss ──────────────────────────────────────────
+
+let activePopover: HTMLElement | null = null;
+
+function dismissActivePopover(): void {
+	if (activePopover) {
+		activePopover.remove();
+		activePopover = null;
+	}
+}
+
+function onDocClick(e: MouseEvent): void {
+	if (activePopover && !activePopover.contains(e.target as Node)) {
+		dismissActivePopover();
+	}
+}
+
+// ── Core: build the action bar ───────────────────────────────
+
+export interface MessageActionContext {
+	messageEl: HTMLElement;
+	sessionKey: string;
+	messageIndex?: number;
+}
+
+export function appendMessageActions(ctx: MessageActionContext): void {
+	const { messageEl, sessionKey } = ctx;
+
+	const bar = document.createElement("div");
+	bar.className = "msg-action-bar";
+
+	// ── Copy button ──────────────────────────────────────────
+	const copyBtn = actionButton(copyIcon(), "Copy");
+	copyBtn.addEventListener("click", () => {
+		const text = extractPlainText(messageEl);
+		if (navigator.clipboard?.writeText) {
+			navigator.clipboard.writeText(text).then(() => {
+				// Swap icon to checkmark briefly
+				copyBtn.replaceChildren(checkIcon());
+				copyBtn.title = "Copied";
+				setTimeout(() => {
+					copyBtn.replaceChildren(copyIcon());
+					copyBtn.title = "Copy";
+				}, 1500);
+			});
+		}
+	});
+	bar.appendChild(copyBtn);
+
+	// ── Retry button (with popover) ──────────────────────────
+	const retryBtn = actionButton(retryIcon(), "Retry");
+	retryBtn.addEventListener("click", (e) => {
+		e.stopPropagation();
+		if (activePopover && activePopover.parentElement === bar) {
+			dismissActivePopover();
+			return;
+		}
+		dismissActivePopover();
+		const popover = buildRetryPopover(sessionKey, messageEl);
+		bar.appendChild(popover);
+		activePopover = popover;
+		// Dismiss on next outside click
+		requestAnimationFrame(() => {
+			document.addEventListener("click", onDocClick, { once: true });
+		});
+	});
+	bar.appendChild(retryBtn);
+
+	// ── Fork button ──────────────────────────────────────────
+	const forkBtn = actionButton(forkIcon(), "Fork into new session");
+	forkBtn.addEventListener("click", () => {
+		sendRpc("sessions.fork", {
+			key: sessionKey,
+			forkPoint: ctx.messageIndex,
+		}).then((res) => {
+			if (res.ok) {
+				showToast("Forked into new session", "success");
+			} else {
+				showToast(res.error?.message || "Fork failed", "error");
+			}
+		});
+	});
+	bar.appendChild(forkBtn);
+
+	messageEl.appendChild(bar);
+}
+
+// ── Button factory ───────────────────────────────────────────
+
+function actionButton(icon: SVGSVGElement, title: string): HTMLButtonElement {
+	const btn = document.createElement("button");
+	btn.type = "button";
+	btn.className = "msg-action-btn";
+	btn.title = title;
+	btn.appendChild(icon);
+	return btn;
+}
+
+// ── Retry popover ────────────────────────────────────────────
+
+function buildRetryPopover(sessionKey: string, messageEl: HTMLElement): HTMLElement {
+	const pop = document.createElement("div");
+	pop.className = "msg-action-popover";
+
+	const items: Array<{ icon: SVGSVGElement; label: string; action: () => void }> = [
+		{
+			icon: retryIcon(),
+			label: "Try again",
+			action: () => retryMessage(sessionKey, messageEl),
+		},
+		{
+			icon: addDetailsIcon(),
+			label: "Add details",
+			action: () =>
+				retryWithInstruction(sessionKey, messageEl, "Please provide more details and expand on your answer."),
+		},
+		{
+			icon: conciseIcon(),
+			label: "More concise",
+			action: () => retryWithInstruction(sessionKey, messageEl, "Please be more concise and brief in your response."),
+		},
+	];
+
+	for (const item of items) {
+		const row = document.createElement("button");
+		row.type = "button";
+		row.className = "msg-action-popover-item";
+		row.appendChild(item.icon);
+		const span = document.createElement("span");
+		span.textContent = item.label;
+		row.appendChild(span);
+		row.addEventListener("click", (e) => {
+			e.stopPropagation();
+			dismissActivePopover();
+			item.action();
+		});
+		pop.appendChild(row);
+	}
+
+	return pop;
+}
+
+// ── Retry actions ────────────────────────────────────────────
+// Uses chat.send with follow-up instructions since there is no
+// dedicated retry RPC. The agent regenerates based on the prompt.
+
+function retryMessage(_sessionKey: string, _messageEl: HTMLElement): void {
+	sendRpc("chat.send", { text: "Please try again with a different response.", _seq: Date.now() }).then((res) => {
+		if (!res.ok) {
+			showToast(res.error?.message || "Retry failed", "error");
+		}
+	});
+}
+
+function retryWithInstruction(_sessionKey: string, _messageEl: HTMLElement, instruction: string): void {
+	sendRpc("chat.send", { text: instruction, _seq: Date.now() }).then((res) => {
+		if (!res.ok) {
+			showToast(res.error?.message || "Retry failed", "error");
+		}
+	});
+}
+
+// ── Text extraction ──────────────────────────────────────────
+
+function extractPlainText(messageEl: HTMLElement): string {
+	// Clone the element, remove footer/action bar/reasoning, get textContent
+	const clone = messageEl.cloneNode(true) as HTMLElement;
+	for (const sel of [
+		".msg-model-footer",
+		".msg-action-bar",
+		".msg-reasoning",
+		".msg-voice-player-slot",
+		".msg-voice-warning",
+	]) {
+		const el = clone.querySelector(sel);
+		if (el) el.remove();
+	}
+	return (clone.textContent || "").trim();
+}

--- a/crates/web/ui/src/message-actions.ts
+++ b/crates/web/ui/src/message-actions.ts
@@ -6,6 +6,7 @@
 // Icons use CSS mask-image classes (icon-*) backed by SVG files on disk.
 
 import { sendRpc } from "./helpers";
+import { renderPersistedAudio } from "./message-voice";
 import { showToast } from "./ui";
 
 // ── Icon helper ──────────────────────────────────────────────
@@ -103,12 +104,15 @@ export function appendMessageActions(ctx: MessageActionContext): void {
 			voiceBtn.title = "Generating voice...";
 			const result = await sendRpc("sessions.voice.generate", params);
 			voiceBtn.classList.remove("msg-action-btn-active");
-			if (result?.ok) {
+			const payload = result?.payload as Record<string, unknown> | undefined;
+			if (result?.ok && payload?.audio) {
+				renderPersistedAudio(messageEl, sessionKey, payload.audio as string, true);
 				voiceBtn.replaceChildren(iconSpan("icon-checkmark"));
 				voiceBtn.title = "Voice generated";
 			} else {
 				voiceBtn.title = "Voice it";
-				showToast("Voice generation failed", "error");
+				const errorMsg = (result?.error as Record<string, unknown> | undefined)?.message as string | undefined;
+				showToast(errorMsg || "Voice generation failed", "error");
 			}
 		});
 		bar.appendChild(voiceBtn);

--- a/crates/web/ui/src/message-voice.ts
+++ b/crates/web/ui/src/message-voice.ts
@@ -54,7 +54,7 @@ function ensureVoicePlayerSlot(messageEl: HTMLElement | null): HTMLElement | nul
 	return slot;
 }
 
-function renderPersistedAudio(
+export function renderPersistedAudio(
 	messageEl: HTMLElement,
 	sessionKey: string | undefined,
 	audioPath: string | undefined,

--- a/crates/web/ui/src/sessions/session-render.ts
+++ b/crates/web/ui/src/sessions/session-render.ts
@@ -26,7 +26,7 @@ import {
 	tokenSpeedTone,
 	toolCallSummary,
 } from "../helpers";
-import { attachMessageVoiceControl } from "../message-voice";
+import { appendMessageActions } from "../message-actions";
 import { navigate } from "../router";
 import { settingsPath } from "../routes";
 import * as S from "../state";
@@ -237,17 +237,13 @@ function renderHistoryAssistantMessage(msg: AssistantMsg): HTMLElement | null {
 	if (el && msg.model) {
 		const footer = createModelFooter(msg);
 		el.appendChild(footer);
-		void attachMessageVoiceControl({
+		appendMessageActions({
 			messageEl: el,
-			footerEl: footer,
 			sessionKey: S.activeSessionKey,
+			messageIndex: msg.historyIndex,
 			text: msg.content || "",
 			runId: msg.run_id || undefined,
-			messageIndex: msg.historyIndex,
-			audioPath: msg.audio || undefined,
-			audioWarning: undefined,
-			forceAction: false,
-			autoplayOnGenerate: true,
+			hasAudio: !!msg.audio,
 		});
 	}
 	if (msg.inputTokens || msg.outputTokens) {

--- a/crates/web/ui/src/ws/tool-helpers.ts
+++ b/crates/web/ui/src/ws/tool-helpers.ts
@@ -22,7 +22,6 @@ import {
 	toolCallSummary,
 } from "../helpers";
 import { appendMessageActions } from "../message-actions";
-import { attachMessageVoiceControl } from "../message-voice";
 import { navigate } from "../router";
 import * as S from "../state";
 import { sessionStore } from "../stores/session-store";
@@ -325,19 +324,6 @@ export function appendFinalFooter(msgEl: HTMLElement | null, p: ChatPayload, eve
 		footer.appendChild(badge);
 	}
 	msgEl.appendChild(footer);
-
-	void attachMessageVoiceControl({
-		messageEl: msgEl,
-		footerEl: footer,
-		sessionKey: p.sessionKey || eventSession || S.activeSessionKey,
-		text: p.text || "",
-		runId: p.runId,
-		messageIndex: p.messageIndex,
-		audioPath: p.audio || undefined,
-		audioWarning: p.audioWarning || undefined,
-		forceAction: p.replyMedium === "voice" && !p.audio,
-		autoplayOnGenerate: true,
-	});
 
 	appendMessageActions({
 		messageEl: msgEl,

--- a/crates/web/ui/src/ws/tool-helpers.ts
+++ b/crates/web/ui/src/ws/tool-helpers.ts
@@ -332,6 +332,7 @@ export function appendFinalFooter(msgEl: HTMLElement | null, p: ChatPayload, eve
 		text: p.text || "",
 		runId: p.runId,
 		hasAudio: !!p.audio,
+		audioWarning: p.audioWarning || undefined,
 	});
 }
 

--- a/crates/web/ui/src/ws/tool-helpers.ts
+++ b/crates/web/ui/src/ws/tool-helpers.ts
@@ -343,6 +343,9 @@ export function appendFinalFooter(msgEl: HTMLElement | null, p: ChatPayload, eve
 		messageEl: msgEl,
 		sessionKey: p.sessionKey || eventSession || S.activeSessionKey,
 		messageIndex: p.messageIndex,
+		text: p.text || "",
+		runId: p.runId,
+		hasAudio: !!p.audio,
 	});
 }
 

--- a/crates/web/ui/src/ws/tool-helpers.ts
+++ b/crates/web/ui/src/ws/tool-helpers.ts
@@ -21,6 +21,7 @@ import {
 	tokenSpeedTone,
 	toolCallSummary,
 } from "../helpers";
+import { appendMessageActions } from "../message-actions";
 import { attachMessageVoiceControl } from "../message-voice";
 import { navigate } from "../router";
 import * as S from "../state";
@@ -336,6 +337,12 @@ export function appendFinalFooter(msgEl: HTMLElement | null, p: ChatPayload, eve
 		audioWarning: p.audioWarning || undefined,
 		forceAction: p.replyMedium === "voice" && !p.audio,
 		autoplayOnGenerate: true,
+	});
+
+	appendMessageActions({
+		messageEl: msgEl,
+		sessionKey: p.sessionKey || eventSession || S.activeSessionKey,
+		messageIndex: p.messageIndex,
 	});
 }
 


### PR DESCRIPTION
## Summary

- Adds a persistent action bar below each assistant message footer with **Copy**, **Retry**, and **Fork** icon buttons
- Retry opens a popover menu with "Try again", "Add details", and "More concise" options
- Fork calls `sessions.fork` to branch the conversation at that message point
- Copy extracts plain text (excluding footer, reasoning, voice elements) to clipboard

## Validation

### Completed
- [x] `biome check --write` passes
- [x] `npx tsc --noEmit` passes (0 errors)
- [x] `npm run build` succeeds

### Remaining
- [ ] `cargo build` (no Rust changes)
- [ ] E2E test coverage for new action bar

## Manual QA

1. Open web UI chat, send a message and wait for assistant response
2. Verify action bar (three small icons) appears below the model footer
3. Click **Copy** — verify text is copied to clipboard, icon briefly shows checkmark
4. Click **Retry** — verify popover appears with three options, click outside to dismiss
5. Click **Fork** — verify toast notification appears confirming fork