### PR TITLE
feat(gateway): auto-generate session titles from conversation

### DIFF
--- a/crates/agents/src/lib.rs
+++ b/crates/agents/src/lib.rs
@@ -17,6 +17,7 @@ pub mod provider_chain;
 pub mod response_sanitizer;
 pub mod silent_turn;
 pub mod skills;
+pub mod title;
 pub mod tool_arg_validator;
 pub mod tool_loop_detector;
 pub mod tool_registry;

--- a/crates/agents/src/title.rs
+++ b/crates/agents/src/title.rs
@@ -1,0 +1,189 @@
+//! Session title generation via a lightweight LLM call.
+//!
+//! Produces a short descriptive title (3-8 words) from conversation context.
+//! No tools, no history persistence — just a single completion call.
+
+use std::sync::Arc;
+
+use {
+    anyhow::Result,
+    tracing::{debug, info, warn},
+};
+
+#[cfg(feature = "metrics")]
+use std::time::Instant;
+
+#[cfg(feature = "metrics")]
+use moltis_metrics::{counter, histogram, labels, memory as mem_metrics};
+
+use crate::model::{ChatMessage, LlmProvider, UserContent};
+
+const TITLE_SYSTEM_PROMPT: &str = "\
+Generate a short, descriptive title (3-8 words) for the following conversation. \
+The title should capture the main topic or intent. \
+Output ONLY the title text — no quotes, no punctuation at the end, no explanation.";
+
+/// Maximum characters from each message included in the title-generation prompt.
+const MAX_CHARS_PER_MESSAGE: usize = 500;
+
+/// Maximum number of messages to include (first user + assistant exchange is enough).
+const MAX_MESSAGES: usize = 6;
+
+/// Generate a short title from conversation history.
+///
+/// Returns `Ok(title)` on success or an error if the LLM call fails.
+/// The caller is responsible for persisting the title.
+#[tracing::instrument(skip(provider, conversation), fields(messages = conversation.len()))]
+pub async fn generate_title(
+    provider: Arc<dyn LlmProvider>,
+    conversation: &[ChatMessage],
+) -> Result<String> {
+    if conversation.is_empty() {
+        anyhow::bail!("cannot generate title from empty conversation");
+    }
+
+    // Build a compact summary of the conversation for the title prompt.
+    let mut context = String::new();
+    let mut included = 0;
+    for msg in conversation {
+        if included >= MAX_MESSAGES {
+            break;
+        }
+        let (role, content) = match msg {
+            ChatMessage::System { .. } => continue,
+            ChatMessage::User {
+                content: UserContent::Text(t),
+                ..
+            } => ("user", t.as_str()),
+            ChatMessage::User {
+                content: UserContent::Multimodal(_),
+                ..
+            } => ("user", "[multimodal content]"),
+            ChatMessage::Assistant { content, .. } => {
+                ("assistant", content.as_deref().unwrap_or(""))
+            },
+            ChatMessage::Tool { .. } => continue,
+        };
+        let truncated = &content[..content.floor_char_boundary(MAX_CHARS_PER_MESSAGE)];
+        context.push_str(&format!("{role}: {truncated}\n"));
+        included += 1;
+    }
+
+    debug!(context_len = context.len(), "generating session title");
+
+    #[cfg(feature = "metrics")]
+    let start = Instant::now();
+
+    let messages = vec![
+        ChatMessage::system(TITLE_SYSTEM_PROMPT),
+        ChatMessage::user(&context),
+    ];
+    let result = provider.complete(&messages, &[]).await;
+
+    match result {
+        Ok(response) => {
+            #[cfg(feature = "metrics")]
+            {
+                let duration = start.elapsed().as_secs_f64();
+                counter!(
+                    mem_metrics::SILENT_TURNS_TOTAL,
+                    labels::VARIANT => "title-generation",
+                    labels::SUCCESS => "true"
+                )
+                .increment(1);
+                histogram!(
+                    mem_metrics::SILENT_TURN_DURATION_SECONDS,
+                    labels::VARIANT => "title-generation"
+                )
+                .record(duration);
+            }
+            let raw = response.text.unwrap_or_default();
+            let title = clean_title(&raw);
+            if title.is_empty() {
+                anyhow::bail!("LLM returned empty title");
+            }
+            info!(title = %title, "generated session title");
+            Ok(title)
+        },
+        Err(e) => {
+            #[cfg(feature = "metrics")]
+            {
+                let duration = start.elapsed().as_secs_f64();
+                counter!(
+                    mem_metrics::SILENT_TURNS_TOTAL,
+                    labels::VARIANT => "title-generation",
+                    labels::SUCCESS => "false"
+                )
+                .increment(1);
+                histogram!(
+                    mem_metrics::SILENT_TURN_DURATION_SECONDS,
+                    labels::VARIANT => "title-generation"
+                )
+                .record(duration);
+            }
+            warn!(error = %e, "title generation LLM call failed");
+            Err(e)
+        },
+    }
+}
+
+/// Strip quotes, trailing punctuation, and whitespace from LLM output.
+fn clean_title(raw: &str) -> String {
+    let trimmed = raw.trim();
+    // Strip surrounding quotes (single or double).
+    let unquoted = trimmed
+        .strip_prefix('"')
+        .and_then(|s| s.strip_suffix('"'))
+        .or_else(|| {
+            trimmed
+                .strip_prefix('\'')
+                .and_then(|s| s.strip_suffix('\''))
+        })
+        .unwrap_or(trimmed);
+    // Strip trailing period or colon.
+    let cleaned = unquoted.trim_end_matches('.').trim_end_matches(':').trim();
+    // Take only the first line if the model produced multiple.
+    cleaned.lines().next().unwrap_or(cleaned).trim().to_string()
+}
+
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn clean_title_strips_quotes() {
+        assert_eq!(clean_title("\"Fix auth module\""), "Fix auth module");
+        assert_eq!(clean_title("'Fix auth module'"), "Fix auth module");
+    }
+
+    #[test]
+    fn clean_title_strips_trailing_punctuation() {
+        assert_eq!(clean_title("Fix auth module."), "Fix auth module");
+        assert_eq!(clean_title("Fix auth module:"), "Fix auth module");
+    }
+
+    #[test]
+    fn clean_title_takes_first_line() {
+        assert_eq!(
+            clean_title("Fix auth module\nThis is extra"),
+            "Fix auth module"
+        );
+    }
+
+    #[test]
+    fn clean_title_handles_whitespace() {
+        assert_eq!(clean_title("  Fix auth module  "), "Fix auth module");
+    }
+
+    #[test]
+    fn clean_title_handles_empty() {
+        assert_eq!(clean_title(""), "");
+        assert_eq!(clean_title("  "), "");
+    }
+
+    #[test]
+    fn clean_title_quoted_with_trailing_period() {
+        assert_eq!(clean_title("\"Fix auth module.\""), "Fix auth module");
+    }
+}

--- a/crates/agents/src/title.rs
+++ b/crates/agents/src/title.rs
@@ -69,6 +69,10 @@ pub async fn generate_title(
         included += 1;
     }
 
+    if context.is_empty() {
+        anyhow::bail!("no user/assistant content to generate title from");
+    }
+
     debug!(context_len = context.len(), "generating session title");
 
     #[cfg(feature = "metrics")]

--- a/crates/channels/src/commands.rs
+++ b/crates/channels/src/commands.rs
@@ -47,6 +47,10 @@ pub fn all_commands() -> &'static [CommandDef] {
             description: "Compact session (summarize)",
         },
         CommandDef {
+            name: "title",
+            description: "Auto-generate session title",
+        },
+        CommandDef {
             name: "context",
             description: "Show session context info",
         },
@@ -221,6 +225,7 @@ mod tests {
             "fork",
             "clear",
             "compact",
+            "title",
             "context",
             "sessions",
             "attach",

--- a/crates/chat/src/runtime.rs
+++ b/crates/chat/src/runtime.rs
@@ -170,4 +170,10 @@ pub trait ChatRuntime: Send + Sync {
     async fn is_fast_mode(&self, _session_key: &str) -> bool {
         false
     }
+
+    /// Trigger background auto-title generation for a session.
+    ///
+    /// Called after the first assistant response. The gateway implements this
+    /// to spawn a background LLM call; the default is a no-op.
+    async fn trigger_auto_title(&self, _session_key: &str) {}
 }

--- a/crates/chat/src/service/chat_impl/send.rs
+++ b/crates/chat/src/service/chat_impl/send.rs
@@ -1086,6 +1086,7 @@ impl LiveChatService {
             // Capture config values before persona is moved into the agent future.
             let auto_extract_interval = persona.config.memory.auto_extract_interval;
             let extraction_write_mode = persona.config.memory.agent_write_mode;
+            let auto_title_enabled = persona.config.chat.auto_title;
             let agent_fut = async {
                 if stream_only {
                     run_streaming(
@@ -1271,6 +1272,13 @@ impl LiveChatService {
                         }
                     }
                 }
+            }
+
+            // ── Auto-title generation ──────────────────────────────
+            // After the first exchange (2 messages = 1 user + 1 assistant),
+            // trigger background title generation if the session has no label.
+            if auto_title_enabled && let Ok(2) = session_store.count(&session_key_clone).await {
+                state.trigger_auto_title(&session_key_clone).await;
             }
 
             let _ = LiveChatService::wait_for_event_forwarder(

--- a/crates/chat/src/service/chat_impl/send.rs
+++ b/crates/chat/src/service/chat_impl/send.rs
@@ -1275,9 +1275,15 @@ impl LiveChatService {
             }
 
             // ── Auto-title generation ──────────────────────────────
-            // After the first exchange (2 messages = 1 user + 1 assistant),
-            // trigger background title generation if the session has no label.
-            if auto_title_enabled && let Ok(2) = session_store.count(&session_key_clone).await {
+            // After the first completed turn, trigger background title
+            // generation. We check >= 2 (not == 2) because agentic turns
+            // with tool calls produce more than 2 stored messages.
+            // `generate_title_if_needed` guards against duplicate titles.
+            if auto_title_enabled
+                && let Ok(count) = session_store.count(&session_key_clone).await
+                && count >= 2
+                && !queued_replay
+            {
                 state.trigger_auto_title(&session_key_clone).await;
             }
 

--- a/crates/config/src/schema/chat.rs
+++ b/crates/config/src/schema/chat.rs
@@ -4,6 +4,9 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
 pub struct ChatConfig {
+    /// Automatically generate a session title after the first exchange.
+    #[serde(default = "default_auto_title")]
+    pub auto_title: bool,
     /// How to handle messages that arrive while an agent run is active.
     #[serde(default = "default_message_queue_mode")]
     pub message_queue_mode: MessageQueueMode,
@@ -25,6 +28,10 @@ pub struct ChatConfig {
     pub compaction: CompactionConfig,
 }
 
+fn default_auto_title() -> bool {
+    true
+}
+
 fn default_message_queue_mode() -> MessageQueueMode {
     MessageQueueMode::Followup
 }
@@ -40,6 +47,7 @@ fn default_workspace_file_max_chars() -> usize {
 impl Default for ChatConfig {
     fn default() -> Self {
         Self {
+            auto_title: default_auto_title(),
             message_queue_mode: default_message_queue_mode(),
             prompt_memory_mode: default_prompt_memory_mode(),
             workspace_file_max_chars: default_workspace_file_max_chars(),

--- a/crates/config/src/template.rs
+++ b/crates/config/src/template.rs
@@ -244,6 +244,7 @@ port = {port}                           # Port number (auto-generated for this i
 # ══════════════════════════════════════════════════════════════════════════════
 
 # [chat]
+# auto_title = true                   # Auto-generate session title after first exchange
 # message_queue_mode = "followup"   # How to handle messages during an active agent run:
                                     #   "followup" - Queue messages, replay one-by-one after run
                                     #   "collect"  - Buffer messages, concatenate as single message

--- a/crates/config/src/validate/schema_map.rs
+++ b/crates/config/src/validate/schema_map.rs
@@ -355,6 +355,7 @@ pub(super) fn build_schema_map() -> KnownKeys {
         (
             "chat",
             Struct(HashMap::from([
+                ("auto_title", Leaf),
                 ("message_queue_mode", Leaf),
                 ("prompt_memory_mode", Leaf),
                 ("workspace_file_max_chars", Leaf),

--- a/crates/gateway/src/channel_events/commands/dispatch.rs
+++ b/crates/gateway/src/channel_events/commands/dispatch.rs
@@ -73,6 +73,7 @@ pub(in crate::channel_events) async fn dispatch_command(
         "fork" => session_handlers::handle_fork(state, &session_key, args).await,
         "clear" => session_handlers::handle_clear(state, &session_key).await,
         "compact" => session_handlers::handle_compact(state, &session_key).await,
+        "title" => session_handlers::handle_title(state, &session_key).await,
         "context" => session_handlers::handle_context(state, &session_key).await,
         "sessions" => {
             session_handlers::handle_sessions(
@@ -152,6 +153,7 @@ mod tests {
             "fork",
             "clear",
             "compact",
+            "title",
             "context",
             "sessions",
             "attach",

--- a/crates/gateway/src/channel_events/commands/session_handlers.rs
+++ b/crates/gateway/src/channel_events/commands/session_handlers.rs
@@ -178,6 +178,22 @@ pub(in crate::channel_events) async fn handle_new(
     }
 }
 
+pub(in crate::channel_events) async fn handle_title(
+    state: &Arc<GatewayState>,
+    session_key: &str,
+) -> ChannelResult<String> {
+    crate::session::title::generate_title_for_session(state, session_key).await;
+    let label = if let Some(ref meta) = state.services.session_metadata {
+        meta.get(session_key)
+            .await
+            .and_then(|e| e.label)
+            .unwrap_or_else(|| "untitled".to_string())
+    } else {
+        "untitled".to_string()
+    };
+    Ok(format!("Title: {label}"))
+}
+
 pub(in crate::channel_events) async fn handle_fork(
     state: &Arc<GatewayState>,
     session_key: &str,

--- a/crates/gateway/src/chat.rs
+++ b/crates/gateway/src/chat.rs
@@ -259,4 +259,12 @@ impl ChatRuntime for GatewayChatRuntime {
     async fn is_fast_mode(&self, session_key: &str) -> bool {
         self.state.is_fast_mode(session_key).await
     }
+
+    async fn trigger_auto_title(&self, session_key: &str) {
+        let state = Arc::clone(&self.state);
+        let key = session_key.to_string();
+        tokio::spawn(async move {
+            crate::session::title::generate_title_if_needed(&state, &key).await;
+        });
+    }
 }

--- a/crates/gateway/src/methods/services/sessions.rs
+++ b/crates/gateway/src/methods/services/sessions.rs
@@ -314,6 +314,28 @@ pub(super) fn register(reg: &mut MethodRegistry) {
         }),
     );
     reg.register(
+        "sessions.generate_title",
+        Box::new(|ctx| {
+            Box::pin(async move {
+                let key = ctx
+                    .params
+                    .get("key")
+                    .and_then(|v| v.as_str())
+                    .ok_or_else(|| {
+                        ErrorShape::new(error_codes::INVALID_REQUEST, "missing 'key' parameter")
+                    })?
+                    .to_string();
+                crate::session::title::generate_title_for_session(&ctx.state, &key).await;
+                let label = if let Some(ref meta) = ctx.state.services.session_metadata {
+                    meta.get(&key).await.and_then(|e| e.label)
+                } else {
+                    None
+                };
+                Ok(serde_json::json!({ "ok": true, "label": label }))
+            })
+        }),
+    );
+    reg.register(
         "sessions.share.create",
         Box::new(|ctx| {
             Box::pin(async move {

--- a/crates/gateway/src/session.rs
+++ b/crates/gateway/src/session.rs
@@ -857,6 +857,7 @@ mod share;
 pub(crate) mod summary;
 #[cfg(test)]
 mod tests;
+pub(crate) mod title;
 mod voice;
 
 pub use service::LiveSessionService;

--- a/crates/gateway/src/session/title.rs
+++ b/crates/gateway/src/session/title.rs
@@ -1,0 +1,129 @@
+//! Session title auto-generation.
+//!
+//! Uses a lightweight LLM call to produce a short descriptive title from
+//! the first few messages. Runs in the background after the first assistant
+//! response so it never blocks the chat flow.
+
+use std::sync::Arc;
+
+use tracing::{debug, info, warn};
+
+use crate::{
+    broadcast::{BroadcastOpts, broadcast},
+    state::GatewayState,
+};
+
+/// Minimum number of messages before title generation fires (1 user + 1 assistant).
+const MIN_MESSAGES_FOR_TITLE: usize = 2;
+
+/// Generate and persist a session title if the session has no label yet.
+///
+/// Intended to be called from a background task after the first assistant
+/// response. No-ops silently when:
+/// - the session already has a label
+/// - there are too few messages
+/// - no provider is available
+pub(crate) async fn generate_title_if_needed(state: &Arc<GatewayState>, session_key: &str) {
+    let Some(session_metadata) = state.services.session_metadata.as_ref() else {
+        return;
+    };
+    let entry = match session_metadata.get(session_key).await {
+        Some(e) => e,
+        None => return,
+    };
+
+    // Skip if the session already has a user-set label.
+    if entry.label.is_some() {
+        debug!(session = %session_key, "auto-title: session already has label, skipping");
+        return;
+    }
+
+    generate_title_for_session(state, session_key).await;
+}
+
+/// Unconditionally generate and persist a title for the session.
+///
+/// Used by both the auto-trigger (via [`generate_title_if_needed`]) and the
+/// manual `/title` command / RPC endpoint.
+pub(crate) async fn generate_title_for_session(state: &Arc<GatewayState>, session_key: &str) {
+    let Some(session_store) = state.services.session_store.as_ref() else {
+        return;
+    };
+    let Some(session_metadata) = state.services.session_metadata.as_ref() else {
+        return;
+    };
+
+    let history = match session_store.read(session_key).await {
+        Ok(h) if h.len() >= MIN_MESSAGES_FOR_TITLE => h,
+        Ok(_) => {
+            debug!("auto-title: too few messages, skipping");
+            return;
+        },
+        Err(e) => {
+            warn!(error = %e, "auto-title: failed to read session history");
+            return;
+        },
+    };
+
+    // Resolve a provider — prefer auxiliary.title_generation, fall back to session model.
+    let provider: Arc<dyn moltis_agents::model::LlmProvider> = {
+        let inner = state.inner.read().await;
+        let Some(ref registry) = inner.llm_providers else {
+            debug!("auto-title: no provider registry available");
+            return;
+        };
+        let reg = registry.read().await;
+
+        // Try auxiliary title_generation model first.
+        let auxiliary_model = state.config.auxiliary.title_generation.as_deref();
+        let from_auxiliary = auxiliary_model.and_then(|id| reg.get(id));
+
+        // Fall back to the session's own model.
+        let entry = session_metadata.get(session_key).await;
+        let session_model = entry.and_then(|e| e.model);
+        let from_session = session_model.and_then(|id| reg.get(&id));
+
+        match from_auxiliary.or(from_session).or_else(|| reg.first()) {
+            Some(p) => p,
+            None => {
+                debug!("auto-title: no provider available, skipping");
+                return;
+            },
+        }
+    };
+
+    let chat_msgs = moltis_agents::model::values_to_chat_messages(&history);
+    match moltis_agents::title::generate_title(provider, &chat_msgs).await {
+        Ok(title) => {
+            // Persist the title as the session label.
+            if let Err(e) = session_metadata
+                .upsert(session_key, Some(title.clone()))
+                .await
+            {
+                warn!(error = %e, session = %session_key, "auto-title: failed to persist title");
+                return;
+            }
+
+            info!(session = %session_key, title = %title, "auto-title: set session title");
+
+            // Broadcast so the UI updates immediately.
+            let entry = session_metadata.get(session_key).await;
+            let version = entry.map(|e| e.version).unwrap_or(0);
+            broadcast(
+                state,
+                "session",
+                serde_json::json!({
+                    "kind": "patched",
+                    "sessionKey": session_key,
+                    "version": version,
+                    "label": title,
+                }),
+                BroadcastOpts::default(),
+            )
+            .await;
+        },
+        Err(e) => {
+            warn!(error = %e, session = %session_key, "auto-title: generation failed");
+        },
+    }
+}

--- a/crates/gateway/src/session/title.rs
+++ b/crates/gateway/src/session/title.rs
@@ -95,27 +95,28 @@ pub(crate) async fn generate_title_for_session(state: &Arc<GatewayState>, sessio
     let chat_msgs = moltis_agents::model::values_to_chat_messages(&history);
     match moltis_agents::title::generate_title(provider, &chat_msgs).await {
         Ok(title) => {
-            // Persist the title as the session label.
-            if let Err(e) = session_metadata
+            // Persist the title as the session label and read back the
+            // entry atomically so the broadcast version is consistent.
+            let entry = match session_metadata
                 .upsert(session_key, Some(title.clone()))
                 .await
             {
-                warn!(error = %e, session = %session_key, "auto-title: failed to persist title");
-                return;
-            }
+                Ok(e) => e,
+                Err(e) => {
+                    warn!(error = %e, session = %session_key, "auto-title: failed to persist title");
+                    return;
+                },
+            };
 
             info!(session = %session_key, title = %title, "auto-title: set session title");
 
-            // Broadcast so the UI updates immediately.
-            let entry = session_metadata.get(session_key).await;
-            let version = entry.map(|e| e.version).unwrap_or(0);
             broadcast(
                 state,
                 "session",
                 serde_json::json!({
                     "kind": "patched",
                     "sessionKey": session_key,
-                    "version": version,
+                    "version": entry.version,
                     "label": title,
                 }),
                 BroadcastOpts::default(),

--- a/crates/web/ui/src/components/SessionHeader.tsx
+++ b/crates/web/ui/src/components/SessionHeader.tsx
@@ -243,10 +243,11 @@ export function SessionHeader({
 	const [generatingTitle, setGeneratingTitle] = useState(false);
 	const onGenerateTitle = useCallback(() => {
 		setGeneratingTitle(true);
-		sendRpc<{ label?: string }>("sessions.generate_title", { key: currentKey }).then((res) => {
-			setGeneratingTitle(false);
-			if (res?.ok) fetchSessions();
-		});
+		sendRpc<{ label?: string }>("sessions.generate_title", { key: currentKey })
+			.then((res) => {
+				if (res?.ok) fetchSessions();
+			})
+			.finally(() => setGeneratingTitle(false));
 	}, [currentKey]);
 
 	const onFork = useCallback(() => {

--- a/crates/web/ui/src/components/SessionHeader.tsx
+++ b/crates/web/ui/src/components/SessionHeader.tsx
@@ -240,6 +240,15 @@ export function SessionHeader({
 		[commitRename],
 	);
 
+	const [generatingTitle, setGeneratingTitle] = useState(false);
+	const onGenerateTitle = useCallback(() => {
+		setGeneratingTitle(true);
+		sendRpc<{ label?: string }>("sessions.generate_title", { key: currentKey }).then((res) => {
+			setGeneratingTitle(false);
+			if (res?.ok) fetchSessions();
+		});
+	}, [currentKey]);
+
 	const onFork = useCallback(() => {
 		sendRpc<{ sessionKey?: string }>("sessions.fork", { key: currentKey }).then((res) => {
 			if (res?.ok && res.payload?.sessionKey) {
@@ -506,9 +515,19 @@ export function SessionHeader({
 		));
 
 	const renameCta = showName && showRenameButton && canRename && !renaming && (
-		<button className={actionButtonClass} onClick={startRename} title="Rename session">
-			Rename
-		</button>
+		<div className="flex items-center gap-1">
+			<button className={actionButtonClass} onClick={startRename} title="Rename session">
+				Rename
+			</button>
+			<button
+				className={actionButtonClass}
+				onClick={onGenerateTitle}
+				disabled={generatingTitle}
+				title="Auto-generate title from conversation"
+			>
+				{generatingTitle ? "..." : "Auto-title"}
+			</button>
+		</div>
 	);
 
 	return (


### PR DESCRIPTION
## Summary

- Add automatic session title generation using a lightweight LLM call after the first exchange
- Titles are 3-8 words describing the main conversation topic
- Auto-triggers in background after first assistant response; also available via `/title` slash command, `sessions.generate_title` RPC, and "Auto-title" button in the web UI
- Configurable via `chat.auto_title = true` (default on) and `auxiliary.title_generation` model override
- Supersedes the approach in #197 with cleaner architecture (no tool calls, no history persistence, background-only)

### Architecture

| Layer | File | Role |
|-------|------|------|
| Core | `crates/agents/src/title.rs` | Single LLM completion + `clean_title()` post-processing |
| Gateway | `crates/gateway/src/session/title.rs` | Provider resolution, persistence, broadcast |
| Auto-trigger | `crates/chat/src/service/chat_impl/send.rs` | Fires when message count reaches 2 |
| Bridge | `crates/chat/src/runtime.rs` | `ChatRuntime::trigger_auto_title()` trait method |
| RPC | `crates/gateway/src/methods/services/sessions.rs` | `sessions.generate_title` endpoint |
| Slash cmd | `crates/channels/src/commands.rs` + dispatch | `/title` command |
| Web UI | `crates/web/ui/src/components/SessionHeader.tsx` | "Auto-title" button |
| Config | `crates/config/src/schema/chat.rs` | `chat.auto_title` toggle |

## Validation

### Completed

- [x] `cargo check` passes (all modified crates)
- [x] `cargo clippy` passes with `-D warnings` (all modified crates)
- [x] `cargo fmt --check` passes
- [x] `cargo test` passes (all modified crates)
- [x] `biome check` passes (SessionHeader.tsx)
- [x] Unit tests for `clean_title()` (6 tests: quotes, punctuation, multiline, whitespace, empty)
- [x] Command registry tests updated (dispatch + expected_commands_present)

### Remaining

- [ ] E2E test for `/title` slash command
- [ ] E2E test for "Auto-title" button in SessionHeader
- [ ] Full `local-validate.sh` run (blocked by missing web assets in worktree)
- [ ] Manual QA with live LLM provider

## Manual QA

1. Start a new session in Web UI → send a message → wait for response → verify title auto-generates in header and sidebar
2. Click "Auto-title" button → verify it regenerates the title
3. Set `chat.auto_title = false` in `moltis.toml` → new session → verify no auto-title
4. In a channel (Telegram/Discord/Slack) → send `/title` → verify bot replies with generated title
5. Set `auxiliary.title_generation = "some-cheap-model"` → verify that model is used for title generation

Closes #197