### PR TITLE
feat: add DeepInfra provider, sandbox GPU passthrough, strict model selection

### DIFF
--- a/crates/chat/src/service/chat_impl/send.rs
+++ b/crates/chat/src/service/chat_impl/send.rs
@@ -513,7 +513,15 @@ impl LiveChatService {
                     .ok_or_else(|| "no LLM providers configured".to_string())?
             };
 
-            if self.failover_config.enabled {
+            // When exact_model is set and the user explicitly selected a model,
+            // skip failover — use the chosen model or fail.
+            let user_selected = model_id.is_some();
+            let skip_failover = !self.failover_config.enabled
+                || (self.failover_config.exact_model && user_selected);
+
+            if skip_failover {
+                primary
+            } else {
                 let fallbacks = if self.failover_config.fallback_models.is_empty() {
                     // Auto-build: same model on other providers first, then same
                     // provider's other models, then everything else.
@@ -528,8 +536,6 @@ impl LiveChatService {
                     chain.extend(fallbacks);
                     Arc::new(moltis_agents::provider_chain::ProviderChain::new(chain))
                 }
-            } else {
-                primary
             }
         };
 

--- a/crates/config/src/schema/providers.rs
+++ b/crates/config/src/schema/providers.rs
@@ -26,6 +26,7 @@ pub const KNOWN_PROVIDER_NAMES: &[&str] = &[
     // OpenAI-compatible providers (table-driven)
     "alibaba-coding",
     "cerebras",
+    "deepinfra",
     "deepseek",
     "fireworks",
     "gemini",

--- a/crates/config/src/schema/system.rs
+++ b/crates/config/src/schema/system.rs
@@ -139,6 +139,12 @@ pub struct NgrokConfig {
 pub struct FailoverConfig {
     /// Whether failover is enabled. Defaults to true.
     pub enabled: bool,
+    /// Treat user-selected models as exact choices. When true and a model
+    /// is explicitly selected (per-session or per-request), failover is
+    /// suppressed for that request — the selected model is used or the
+    /// request fails. Defaults to false.
+    #[serde(default)]
+    pub exact_model: bool,
     /// Ordered list of fallback model IDs to try when the primary fails.
     /// If empty, the chain is built from all registered models.
     #[serde(default)]
@@ -149,6 +155,7 @@ impl Default for FailoverConfig {
     fn default() -> Self {
         Self {
             enabled: true,
+            exact_model: false,
             fallback_models: Vec::new(),
         }
     }

--- a/crates/config/src/schema/tools.rs
+++ b/crates/config/src/schema/tools.rs
@@ -692,6 +692,11 @@ pub struct SandboxConfig {
     /// execution.
     pub backend: String,
     pub resource_limits: ResourceLimitsConfig,
+    /// GPU device passthrough for Docker/Podman backends.
+    /// Examples: "all", "device=0", "device=0,1".
+    /// Ignored for Apple Container and WASM backends.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub gpus: Option<String>,
     /// Packages to install via `apt-get` in the sandbox image.
     /// Set to an empty list to skip provisioning.
     #[serde(default = "default_sandbox_packages")]
@@ -899,6 +904,7 @@ impl Default for SandboxConfig {
             trusted_domains: Vec::new(),
             backend: "auto".into(),
             resource_limits: ResourceLimitsConfig::default(),
+            gpus: None,
             packages: default_sandbox_packages(),
             wasm_fuel_limit: None,
             wasm_epoch_interval_ms: None,

--- a/crates/config/src/template.rs
+++ b/crates/config/src/template.rs
@@ -132,8 +132,8 @@ port = {port}                           # Port number (auto-generated for this i
                                     # Enabled providers and those shown in onboarding/picker UI ([] = enable/show all)
 # show_legacy_models = true         # Show models older than 1 year in the chat model selector (they always appear in Settings)
 # All available providers (canonical list in schema/providers.rs):
-#   "anthropic", "openai", "gemini", "groq", "xai", "deepseek",
-#   "fireworks", "mistral", "openrouter", "cerebras", "minimax",
+#   "anthropic", "openai", "gemini", "groq", "xai", "deepinfra",
+#   "deepseek", "fireworks", "mistral", "openrouter", "cerebras", "minimax",
 #   "moonshot", "zai", "zai-code", "venice", "alibaba-coding",
 #   "ollama", "lmstudio", "local-llm", "openai-codex",
 #   "github-copilot", "kimi-code"
@@ -177,6 +177,14 @@ port = {port}                           # Port number (auto-generated for this i
 # api_key = "..."                             # Or set GROQ_API_KEY env var
 # models = ["llama-3.3-70b-versatile"]
 # alias = "groq"
+
+# ── DeepInfra ─────────────────────────────────────────────────
+# [providers.deepinfra]
+# enabled = true
+# api_key = "..."                             # Or set DEEPINFRA_API_KEY env var
+# models = ["meta-llama/Llama-4-Maverick-17B-128E-Instruct"]
+# base_url = "https://api.deepinfra.com/v1/openai"
+# alias = "deepinfra"
 
 # ── DeepSeek ──────────────────────────────────────────────────
 # [providers.deepseek]
@@ -386,6 +394,8 @@ port = {port}                           # Port number (auto-generated for this i
 # no_network = true                 # Disable network access in sandbox
 # image = "custom-image:tag"        # Custom Docker image (default: auto-built)
 # packages = [...]                  # Packages installed in sandbox containers
+# gpus = "all"                      # GPU passthrough: "all", "device=0", "device=0,1"
+                                    # (Docker/Podman only, ignored for other backends)
 
 # [tools.exec.sandbox.resource_limits]
 # memory_limit = "512M"             # Memory limit (e.g., "512M", "1G")
@@ -520,6 +530,7 @@ port = {port}                           # Port number (auto-generated for this i
 
 # [failover]
 # enabled = true                    # Enable automatic failover
+# exact_model = false               # When true, user-selected models are exact — no fallback
 # fallback_models = []              # Ordered list of fallback models
 
 # ══════════════════════════════════════════════════════════════════════════════

--- a/crates/config/src/validate/schema_map.rs
+++ b/crates/config/src/validate/schema_map.rs
@@ -86,6 +86,7 @@ pub(super) fn build_schema_map() -> KnownKeys {
             ("trusted_domains", Array(Box::new(Leaf))),
             ("backend", Leaf),
             ("resource_limits", resource_limits()),
+            ("gpus", Leaf),
             ("packages", Leaf),
             ("wasm_fuel_limit", Leaf),
             ("wasm_epoch_interval_ms", Leaf),
@@ -523,6 +524,7 @@ pub(super) fn build_schema_map() -> KnownKeys {
             "failover",
             Struct(HashMap::from([
                 ("enabled", Leaf),
+                ("exact_model", Leaf),
                 ("fallback_models", Leaf),
             ])),
         ),

--- a/crates/config/src/validate/semantic.rs
+++ b/crates/config/src/validate/semantic.rs
@@ -563,6 +563,23 @@ pub(super) fn check_semantic_warnings(config: &MoltisConfig, diagnostics: &mut V
         }
     }
 
+    // Sandbox GPU passthrough validation
+    if let Some(ref gpus) = config.tools.exec.sandbox.gpus {
+        let valid = gpus == "all"
+            || gpus.starts_with("device=")
+            || gpus.chars().all(|c| c.is_ascii_digit() || c == ',');
+        if !valid {
+            diagnostics.push(Diagnostic {
+                severity: Severity::Warning,
+                category: "unknown-field",
+                path: "tools.exec.sandbox.gpus".into(),
+                message: format!(
+                    "unrecognized gpus value \"{gpus}\"; expected \"all\", \"device=0\", \"device=0,1\", or a device index",
+                ),
+            });
+        }
+    }
+
     // Unknown CalDAV provider
     let valid_caldav_providers = ["fastmail", "icloud", "generic"];
     for (name, account) in &config.caldav.accounts {

--- a/crates/providers/src/model_catalogs.rs
+++ b/crates/providers/src/model_catalogs.rs
@@ -110,6 +110,25 @@ pub(crate) const ALIBABA_CODING_MODELS: &[(&str, &str)] = &[
     ("glm-4.7", "GLM-4.7"),
 ];
 
+/// Known DeepInfra models.
+/// See: <https://deepinfra.com/models>
+pub(crate) const DEEPINFRA_MODELS: &[(&str, &str)] = &[
+    (
+        "meta-llama/Llama-4-Maverick-17B-128E-Instruct",
+        "Llama 4 Maverick",
+    ),
+    ("meta-llama/Llama-4-Scout-17B-16E-Instruct", "Llama 4 Scout"),
+    ("deepseek-ai/DeepSeek-V3-0324", "DeepSeek V3"),
+    ("deepseek-ai/DeepSeek-R1", "DeepSeek R1"),
+    ("Qwen/Qwen3-235B-A22B", "Qwen3 235B"),
+    ("Qwen/Qwen3-32B", "Qwen3 32B"),
+    (
+        "mistralai/Mistral-Small-24B-Instruct-2501",
+        "Mistral Small 24B",
+    ),
+    ("google/gemma-3-27b-it", "Gemma 3 27B"),
+];
+
 /// Known DeepSeek models.
 pub(crate) const DEEPSEEK_MODELS: &[(&str, &str)] = &[
     ("deepseek-chat", "DeepSeek Chat"),
@@ -241,6 +260,16 @@ pub(crate) const OPENAI_COMPAT_PROVIDERS: &[OpenAiCompatDef] = &[
         local_only: false,
     },
     OpenAiCompatDef {
+        config_name: "deepinfra",
+        env_key: "DEEPINFRA_API_KEY",
+        env_base_url_key: "DEEPINFRA_BASE_URL",
+        default_base_url: "https://api.deepinfra.com/v1/openai",
+        models: DEEPINFRA_MODELS,
+        supports_model_discovery: true,
+        requires_api_key: true,
+        local_only: false,
+    },
+    OpenAiCompatDef {
         config_name: "deepseek",
         env_key: "DEEPSEEK_API_KEY",
         env_base_url_key: "DEEPSEEK_BASE_URL",
@@ -315,6 +344,7 @@ mod tests {
         assert!(!CEREBRAS_MODELS.is_empty());
         assert!(!MINIMAX_MODELS.is_empty());
         assert!(!ZAI_MODELS.is_empty());
+        assert!(!DEEPINFRA_MODELS.is_empty());
         assert!(!MOONSHOT_MODELS.is_empty());
         assert!(!GEMINI_MODELS.is_empty());
     }
@@ -335,6 +365,7 @@ mod tests {
             ANTHROPIC_MODELS,
             MISTRAL_MODELS,
             CEREBRAS_MODELS,
+            DEEPINFRA_MODELS,
             MINIMAX_MODELS,
             ZAI_MODELS,
             MOONSHOT_MODELS,

--- a/crates/providers/src/model_catalogs.rs
+++ b/crates/providers/src/model_catalogs.rs
@@ -118,7 +118,7 @@ pub(crate) const DEEPINFRA_MODELS: &[(&str, &str)] = &[
         "Llama 4 Maverick",
     ),
     ("meta-llama/Llama-4-Scout-17B-16E-Instruct", "Llama 4 Scout"),
-    ("deepseek-ai/DeepSeek-V3-0324", "DeepSeek V3"),
+    ("deepseek-ai/DeepSeek-V3", "DeepSeek V3"),
     ("deepseek-ai/DeepSeek-R1", "DeepSeek R1"),
     ("Qwen/Qwen3-235B-A22B", "Qwen3 235B"),
     ("Qwen/Qwen3-32B", "Qwen3 32B"),

--- a/crates/tools/src/sandbox/docker.rs
+++ b/crates/tools/src/sandbox/docker.rs
@@ -128,6 +128,9 @@ impl DockerSandbox {
         if let Some(pids) = limits.pids_max {
             args.extend(["--pids-limit".to_string(), pids.to_string()]);
         }
+        if let Some(ref gpus) = self.config.gpus {
+            args.extend(["--gpus".to_string(), gpus.clone()]);
+        }
         args
     }
 

--- a/crates/tools/src/sandbox/types.rs
+++ b/crates/tools/src/sandbox/types.rs
@@ -175,6 +175,8 @@ pub struct SandboxConfig {
     /// `"auto"` prefers Apple Container on macOS, then Podman, then Docker, then restricted-host.
     pub backend: String,
     pub resource_limits: ResourceLimits,
+    /// GPU device passthrough for Docker/Podman backends (e.g. "all", "device=0").
+    pub gpus: Option<String>,
     /// Packages to install via `apt-get` after container creation.
     /// Set to an empty list to skip provisioning.
     pub packages: Vec<String>,
@@ -204,6 +206,7 @@ impl Default for SandboxConfig {
             trusted_domains: Vec::new(),
             backend: "auto".into(),
             resource_limits: ResourceLimits::default(),
+            gpus: None,
             packages: Vec::new(),
             timezone: None,
             wasm_fuel_limit: None,
@@ -263,6 +266,7 @@ impl From<&moltis_config::schema::SandboxConfig> for SandboxConfig {
                 cpu_quota: cfg.resource_limits.cpu_quota,
                 pids_max: cfg.resource_limits.pids_max,
             },
+            gpus: cfg.gpus.clone(),
             packages: cfg.packages.clone(),
             timezone: None, // Set by gateway from user profile
             wasm_fuel_limit: cfg.wasm_fuel_limit,


### PR DESCRIPTION
## Summary

Three features ported from OpenClaw v2026.4.27:

- **DeepInfra provider** — table-driven OpenAI-compatible entry with 8-model static catalog (Llama 4 Maverick/Scout, DeepSeek V3/R1, Qwen3, Mistral Small 24B, Gemma 3 27B), `/models` discovery enabled
- **Sandbox GPU passthrough** — `gpus` field on `SandboxConfig` (e.g. `"all"`, `"device=0"`) wired to `--gpus` in Docker/Podman command building; ignored for Apple Container and WASM backends
- **Strict model selection** — `failover.exact_model` config flag: when true and a model is user-selected (per-session or per-request), the fallback chain is suppressed — the chosen model is used or the request fails

## Validation

### Completed
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p moltis-config -p moltis-providers -p moltis-tools -p moltis-chat -- -D warnings` (0 warnings)
- [x] `cargo test -p moltis-config -p moltis-providers -p moltis-tools` (967 passed)
- [x] `cargo test -p moltis-chat` (110 passed)
- [x] Schema map updated for new fields (`gpus`, `exact_model`)
- [x] Config template updated with documentation for all three features
- [x] `KNOWN_PROVIDER_NAMES` updated for `deepinfra`

### Remaining
- [ ] `./scripts/local-validate.sh` (full CI suite)

## Manual QA

1. **DeepInfra**: Set `DEEPINFRA_API_KEY`, verify models appear in Settings > Models, send a chat message routed to DeepInfra
2. **GPU passthrough**: Set `[tools.exec.sandbox] gpus = "all"` in `moltis.toml`, verify `docker inspect` shows GPU device on created containers
3. **Strict model selection**: Set `[failover] exact_model = true`, select a specific model in a session, kill that provider — verify the request fails instead of falling back to another model