### PR TITLE
feat(skills): add per-skill usage telemetry to /insights and web UI

### DIFF
--- a/crates/gateway/src/channel_events/commands/quick_actions.rs
+++ b/crates/gateway/src/channel_events/commands/quick_actions.rs
@@ -446,6 +446,44 @@ pub(in crate::channel_events) async fn handle_insights(
             "Based on {data_points} data points over {span_hours:.1} hours."
         ));
 
+        // Skill usage telemetry
+        if let Some(store) = state.skill_usage_store.get() {
+            let usage = store.get_all().await;
+            if !usage.is_empty() {
+                lines.push(String::new());
+                lines.push("Skills:".to_string());
+
+                let total_reads: u64 = usage.values().map(|e| e.read_count).sum();
+                let total_writes: u64 = usage.values().map(|e| e.write_count).sum();
+                lines.push(format!(
+                    "  {total_reads} activations, {total_writes} modifications across {} skills",
+                    usage.len()
+                ));
+
+                // Top 5 most-used skills by read_count
+                let mut by_reads: Vec<_> = usage.iter().collect();
+                by_reads.sort_by(|a, b| b.1.read_count.cmp(&a.1.read_count));
+                if by_reads.iter().any(|(_, e)| e.read_count > 0) {
+                    lines.push("  Most activated:".to_string());
+                    for (name, entry) in by_reads.iter().take(5) {
+                        if entry.read_count == 0 {
+                            break;
+                        }
+                        lines.push(format!(
+                            "    {name}: {} reads, {} writes",
+                            entry.read_count, entry.write_count
+                        ));
+                    }
+                }
+
+                // Skills never read (created but unused)
+                let never_read: Vec<_> = usage.iter().filter(|(_, e)| e.read_count == 0).collect();
+                if !never_read.is_empty() {
+                    lines.push(format!("  Never activated: {}", never_read.len()));
+                }
+            }
+        }
+
         Ok(lines.join("\n"))
     }
 }

--- a/crates/gateway/src/methods/services/system.rs
+++ b/crates/gateway/src/methods/services/system.rs
@@ -15,22 +15,24 @@ pub(super) fn register(reg: &mut MethodRegistry) {
                     .map_err(ErrorShape::from)?;
 
                 // Enrich with per-skill usage telemetry.
+                // Always insert read_count/write_count (defaulting to 0)
+                // so the response schema is consistent for all skills.
                 if let Some(store) = ctx.state.skill_usage_store.get() {
                     let usage = store.get_all().await;
                     if let Some(arr) = result.as_array_mut() {
                         for item in arr.iter_mut() {
-                            let name = item.get("name").and_then(|n| n.as_str());
-                            let entry = name.and_then(|n| usage.get(n));
-                            if let Some((entry, obj)) = entry.zip(item.as_object_mut()) {
+                            if let Some(obj) = item.as_object_mut() {
+                                let name = obj.get("name").and_then(|n| n.as_str()).unwrap_or("");
+                                let entry = usage.get(name);
                                 obj.insert(
                                     "read_count".into(),
-                                    serde_json::json!(entry.read_count),
+                                    serde_json::json!(entry.map_or(0, |e| e.read_count)),
                                 );
                                 obj.insert(
                                     "write_count".into(),
-                                    serde_json::json!(entry.write_count),
+                                    serde_json::json!(entry.map_or(0, |e| e.write_count)),
                                 );
-                                if let Some(ts) = entry.last_read_at {
+                                if let Some(ts) = entry.and_then(|e| e.last_read_at) {
                                     obj.insert("last_read_at".into(), serde_json::json!(ts));
                                 }
                             }

--- a/crates/gateway/src/methods/services/system.rs
+++ b/crates/gateway/src/methods/services/system.rs
@@ -139,17 +139,30 @@ pub(super) fn register(reg: &mut MethodRegistry) {
         Box::new(|ctx| {
             Box::pin(async move {
                 // Capture skill names from the repo before it's removed,
-                // so we can prune the usage store afterwards.
+                // so we can prune the usage store afterwards. Uses
+                // spawn_blocking since ManifestStore::load() is sync I/O.
                 let source = ctx.params.get("source").and_then(|v| v.as_str());
-                let skill_names: Vec<String> = source
-                    .and_then(|s| {
+                let skill_names: Vec<String> = if let Some(s) = source {
+                    let s = s.to_string();
+                    tokio::task::spawn_blocking(move || {
                         let path = moltis_skills::manifest::ManifestStore::default_path().ok()?;
                         let store = moltis_skills::manifest::ManifestStore::new(path);
                         let manifest = store.load().ok()?;
-                        let repo = manifest.find_repo(s)?;
-                        Some(repo.skills.iter().map(|s| s.name.clone()).collect())
+                        let repo = manifest.find_repo(&s)?;
+                        Some(
+                            repo.skills
+                                .iter()
+                                .map(|sk| sk.name.clone())
+                                .collect::<Vec<_>>(),
+                        )
                     })
-                    .unwrap_or_default();
+                    .await
+                    .ok()
+                    .flatten()
+                    .unwrap_or_default()
+                } else {
+                    vec![]
+                };
 
                 let result = ctx
                     .state

--- a/crates/gateway/src/methods/services/system.rs
+++ b/crates/gateway/src/methods/services/system.rs
@@ -6,12 +6,39 @@ pub(super) fn register(reg: &mut MethodRegistry) {
         "skills.list",
         Box::new(|ctx| {
             Box::pin(async move {
-                ctx.state
+                let mut result = ctx
+                    .state
                     .services
                     .skills
                     .list()
                     .await
-                    .map_err(ErrorShape::from)
+                    .map_err(ErrorShape::from)?;
+
+                // Enrich with per-skill usage telemetry.
+                if let Some(store) = ctx.state.skill_usage_store.get() {
+                    let usage = store.get_all().await;
+                    if let Some(arr) = result.as_array_mut() {
+                        for item in arr.iter_mut() {
+                            let name = item.get("name").and_then(|n| n.as_str());
+                            let entry = name.and_then(|n| usage.get(n));
+                            if let Some((entry, obj)) = entry.zip(item.as_object_mut()) {
+                                obj.insert(
+                                    "read_count".into(),
+                                    serde_json::json!(entry.read_count),
+                                );
+                                obj.insert(
+                                    "write_count".into(),
+                                    serde_json::json!(entry.write_count),
+                                );
+                                if let Some(ts) = entry.last_read_at {
+                                    obj.insert("last_read_at".into(), serde_json::json!(ts));
+                                }
+                            }
+                        }
+                    }
+                }
+
+                Ok(result)
             })
         }),
     );

--- a/crates/gateway/src/methods/services/system.rs
+++ b/crates/gateway/src/methods/services/system.rs
@@ -138,12 +138,36 @@ pub(super) fn register(reg: &mut MethodRegistry) {
         "skills.remove",
         Box::new(|ctx| {
             Box::pin(async move {
-                ctx.state
+                // Capture skill names from the repo before it's removed,
+                // so we can prune the usage store afterwards.
+                let source = ctx.params.get("source").and_then(|v| v.as_str());
+                let skill_names: Vec<String> = source
+                    .and_then(|s| {
+                        let path = moltis_skills::manifest::ManifestStore::default_path().ok()?;
+                        let store = moltis_skills::manifest::ManifestStore::new(path);
+                        let manifest = store.load().ok()?;
+                        let repo = manifest.find_repo(s)?;
+                        Some(repo.skills.iter().map(|s| s.name.clone()).collect())
+                    })
+                    .unwrap_or_default();
+
+                let result = ctx
+                    .state
                     .services
                     .skills
                     .remove(ctx.params.clone())
                     .await
-                    .map_err(ErrorShape::from)
+                    .map_err(ErrorShape::from)?;
+
+                // Prune usage entries for removed skills so they don't
+                // linger in /insights aggregates.
+                if let Some(store) = ctx.state.skill_usage_store.get() {
+                    for name in &skill_names {
+                        store.remove(name).await;
+                    }
+                }
+
+                Ok(result)
             })
         }),
     );

--- a/crates/gateway/src/methods/services/system.rs
+++ b/crates/gateway/src/methods/services/system.rs
@@ -32,9 +32,10 @@ pub(super) fn register(reg: &mut MethodRegistry) {
                                     "write_count".into(),
                                     serde_json::json!(entry.map_or(0, |e| e.write_count)),
                                 );
-                                if let Some(ts) = entry.and_then(|e| e.last_read_at) {
-                                    obj.insert("last_read_at".into(), serde_json::json!(ts));
-                                }
+                                obj.insert(
+                                    "last_read_at".into(),
+                                    serde_json::json!(entry.and_then(|e| e.last_read_at)),
+                                );
                             }
                         }
                     }

--- a/crates/gateway/src/server/prepare_core/post_state.rs
+++ b/crates/gateway/src/server/prepare_core/post_state.rs
@@ -1213,7 +1213,7 @@ pub(super) async fn complete_startup(
         {
             use moltis_skills::{discover::FsSkillDiscoverer, usage::SkillUsageStore};
 
-            let skill_usage = SkillUsageStore::new(&data_dir);
+            let skill_usage = SkillUsageStore::open(&data_dir).await;
 
             tool_registry.register(Box::new(
                 moltis_tools::skill_tools::CreateSkillTool::new(data_dir.clone())

--- a/crates/gateway/src/server/prepare_core/post_state.rs
+++ b/crates/gateway/src/server/prepare_core/post_state.rs
@@ -1211,20 +1211,26 @@ pub(super) async fn complete_startup(
         )));
 
         {
-            use moltis_skills::discover::FsSkillDiscoverer;
+            use moltis_skills::{discover::FsSkillDiscoverer, usage::SkillUsageStore};
 
-            tool_registry.register(Box::new(moltis_tools::skill_tools::CreateSkillTool::new(
-                data_dir.clone(),
-            )));
-            tool_registry.register(Box::new(moltis_tools::skill_tools::UpdateSkillTool::new(
-                data_dir.clone(),
-            )));
-            tool_registry.register(Box::new(moltis_tools::skill_tools::PatchSkillTool::new(
-                data_dir.clone(),
-            )));
-            tool_registry.register(Box::new(moltis_tools::skill_tools::DeleteSkillTool::new(
-                data_dir.clone(),
-            )));
+            let skill_usage = SkillUsageStore::new(&data_dir);
+
+            tool_registry.register(Box::new(
+                moltis_tools::skill_tools::CreateSkillTool::new(data_dir.clone())
+                    .with_usage_store(skill_usage.clone()),
+            ));
+            tool_registry.register(Box::new(
+                moltis_tools::skill_tools::UpdateSkillTool::new(data_dir.clone())
+                    .with_usage_store(skill_usage.clone()),
+            ));
+            tool_registry.register(Box::new(
+                moltis_tools::skill_tools::PatchSkillTool::new(data_dir.clone())
+                    .with_usage_store(skill_usage.clone()),
+            ));
+            tool_registry.register(Box::new(
+                moltis_tools::skill_tools::DeleteSkillTool::new(data_dir.clone())
+                    .with_usage_store(skill_usage.clone()),
+            ));
 
             let fs_discoverer =
                 FsSkillDiscoverer::new(FsSkillDiscoverer::default_paths_for(&data_dir));
@@ -1241,15 +1247,17 @@ pub(super) async fn complete_startup(
                     moltis_tools::skill_tools::ReadSkillTool::with_bundled(
                         read_discoverer,
                         bundled_store,
-                    ),
+                    )
+                    .with_usage_store(skill_usage.clone()),
                 ));
             }
             #[cfg(not(feature = "bundled-skills"))]
             {
                 let read_discoverer = Arc::new(fs_discoverer);
-                tool_registry.register(Box::new(moltis_tools::skill_tools::ReadSkillTool::new(
-                    read_discoverer,
-                )));
+                tool_registry.register(Box::new(
+                    moltis_tools::skill_tools::ReadSkillTool::new(read_discoverer)
+                        .with_usage_store(skill_usage.clone()),
+                ));
             }
 
             if config.skills.enable_agent_sidecar_files {
@@ -1257,6 +1265,8 @@ pub(super) async fn complete_startup(
                     moltis_tools::skill_tools::WriteSkillFilesTool::new(data_dir.clone()),
                 ));
             }
+
+            let _ = state.skill_usage_store.set(skill_usage);
         }
 
         tool_registry.register(Box::new(

--- a/crates/gateway/src/state.rs
+++ b/crates/gateway/src/state.rs
@@ -439,6 +439,10 @@ pub struct GatewayState {
     /// Sender for queueing delivery IDs to the webhook worker.
     pub webhook_worker_tx: std::sync::OnceLock<mpsc::Sender<i64>>,
 
+    // ── Skill usage telemetry ─────────────────────────────────────────────
+    /// Late-bound skill usage store for per-skill read/write telemetry.
+    pub skill_usage_store: std::sync::OnceLock<moltis_skills::usage::SkillUsageStore>,
+
     // ── Atomics (lock-free) ─────────────────────────────────────────────────
     pub tts_phrase_counter: AtomicUsize,
     /// Live count of connected nodes.  Shared with `ExecTool` via the
@@ -549,6 +553,7 @@ impl GatewayState {
             webhook_store: std::sync::OnceLock::new(),
             webhook_rate_limiter: moltis_webhooks::rate_limit::WebhookRateLimiter::default(),
             webhook_worker_tx: std::sync::OnceLock::new(),
+            skill_usage_store: std::sync::OnceLock::new(),
             tts_phrase_counter: AtomicUsize::new(0),
             node_count: Arc::new(AtomicUsize::new(0)),
             ssh_target_count: Arc::new(AtomicUsize::new(0)),

--- a/crates/metrics/src/definitions.rs
+++ b/crates/metrics/src/definitions.rs
@@ -448,6 +448,10 @@ pub mod skills {
     /// Prompt generation duration
     pub const PROMPT_GENERATION_DURATION_SECONDS: &str =
         "moltis_skills_prompt_generation_duration_seconds";
+    /// Skill activations (read_skill primary calls)
+    pub const ACTIVATIONS_TOTAL: &str = "moltis_skills_activations_total";
+    /// Skill modifications (create + update + patch)
+    pub const MODIFICATIONS_TOTAL: &str = "moltis_skills_modifications_total";
 }
 
 /// Telegram channel metrics

--- a/crates/skills/src/lib.rs
+++ b/crates/skills/src/lib.rs
@@ -18,6 +18,7 @@ pub mod registry;
 pub mod requirements;
 pub mod safety;
 pub mod types;
+pub mod usage;
 
 #[cfg(feature = "bundled-skills")]
 pub mod bundled;

--- a/crates/skills/src/usage.rs
+++ b/crates/skills/src/usage.rs
@@ -203,7 +203,8 @@ impl SkillUsageStore {
 ///
 /// Serializes data and clears the dirty flag under a single write lock
 /// to avoid a TOCTOU race where a concurrent mutation between snapshot
-/// and flag-clear would be silently lost.
+/// and flag-clear would be silently lost. On I/O failure, re-sets the
+/// dirty flag so the background task will retry.
 async fn flush_to_disk(inner: &RwLock<Inner>, path: &Path) {
     let snapshot = {
         let mut guard = inner.write().await;
@@ -221,17 +222,19 @@ async fn flush_to_disk(inner: &RwLock<Inner>, path: &Path) {
         guard.last_flush_at = now_secs();
         s
     };
-    // I/O proceeds outside the lock.
+    // I/O proceeds outside the lock. On failure, re-mark dirty for retry.
     let tmp = path.with_extension("json.tmp");
     if let Some(parent) = path.parent() {
         let _ = tokio::fs::create_dir_all(parent).await;
     }
     if let Err(e) = tokio::fs::write(&tmp, &snapshot).await {
         tracing::warn!(error = %e, "failed to write skill usage temp file");
+        inner.write().await.dirty = true;
         return;
     }
     if let Err(e) = tokio::fs::rename(&tmp, path).await {
         tracing::warn!(error = %e, "failed to rename skill usage file");
+        inner.write().await.dirty = true;
     }
 }
 

--- a/crates/skills/src/usage.rs
+++ b/crates/skills/src/usage.rs
@@ -2,7 +2,7 @@
 //!
 //! Tracks how often each skill is read (activated) and modified (created,
 //! updated, patched). Data is persisted to `<data_dir>/skills-usage.json`
-//! with atomic writes.
+//! with atomic writes, debounced to avoid excessive I/O.
 
 use std::{
     collections::HashMap,
@@ -13,8 +13,11 @@ use std::{
 
 use {
     serde::{Deserialize, Serialize},
-    tokio::sync::RwLock,
+    tokio::sync::{Notify, RwLock},
 };
+
+/// Minimum interval between disk flushes (seconds).
+const FLUSH_DEBOUNCE_SECS: u64 = 5;
 
 /// Per-skill usage counters and timestamps.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -41,20 +44,32 @@ struct UsageFile {
     skills: HashMap<String, SkillUsageEntry>,
 }
 
+/// Shared interior state.
+struct Inner {
+    data: UsageFile,
+    dirty: bool,
+    last_flush_at: u64,
+}
+
 /// Thread-safe, file-backed skill usage store.
+///
+/// Flushes are debounced: mutations mark the store dirty but only write to
+/// disk when at least [`FLUSH_DEBOUNCE_SECS`] have elapsed since the last
+/// flush. A background notify ensures eventual persistence.
 ///
 /// Clone-friendly via inner `Arc`.
 #[derive(Clone)]
 pub struct SkillUsageStore {
-    inner: Arc<RwLock<UsageFile>>,
+    inner: Arc<RwLock<Inner>>,
     path: PathBuf,
+    flush_notify: Arc<Notify>,
 }
 
 impl SkillUsageStore {
-    /// Create a new store, loading existing data from disk if present.
+    /// Create a new store synchronously (for tests and non-async contexts).
     pub fn new(data_dir: &Path) -> Self {
         let path = data_dir.join("skills-usage.json");
-        let file = if path.exists() {
+        let data = if path.exists() {
             std::fs::read_to_string(&path)
                 .ok()
                 .and_then(|s| serde_json::from_str::<UsageFile>(&s).ok())
@@ -62,10 +77,46 @@ impl SkillUsageStore {
         } else {
             UsageFile::default()
         };
-        Self {
-            inner: Arc::new(RwLock::new(file)),
+        Self::from_data(data, path)
+    }
+
+    /// Create a new store with async I/O (preferred in async contexts).
+    pub async fn open(data_dir: &Path) -> Self {
+        let path = data_dir.join("skills-usage.json");
+        let data = match tokio::fs::read_to_string(&path).await {
+            Ok(s) => serde_json::from_str::<UsageFile>(&s).unwrap_or_default(),
+            Err(_) => UsageFile::default(),
+        };
+        Self::from_data(data, path)
+    }
+
+    fn from_data(data: UsageFile, path: PathBuf) -> Self {
+        let store = Self {
+            inner: Arc::new(RwLock::new(Inner {
+                data,
+                dirty: false,
+                last_flush_at: 0,
+            })),
             path,
-        }
+            flush_notify: Arc::new(Notify::new()),
+        };
+        store.spawn_flush_task();
+        store
+    }
+
+    /// Spawn a background task that flushes dirty data on notification.
+    fn spawn_flush_task(&self) {
+        let inner = Arc::clone(&self.inner);
+        let path = self.path.clone();
+        let notify = Arc::clone(&self.flush_notify);
+        tokio::spawn(async move {
+            loop {
+                notify.notified().await;
+                // Coalesce rapid mutations by sleeping briefly.
+                tokio::time::sleep(tokio::time::Duration::from_secs(FLUSH_DEBOUNCE_SECS)).await;
+                flush_to_disk(&inner, &path).await;
+            }
+        });
     }
 
     /// Record a read (activation) event for a skill.
@@ -74,6 +125,7 @@ impl SkillUsageStore {
         {
             let mut guard = self.inner.write().await;
             let entry = guard
+                .data
                 .skills
                 .entry(name.to_string())
                 .or_insert_with(|| SkillUsageEntry {
@@ -85,8 +137,9 @@ impl SkillUsageStore {
                 });
             entry.read_count += 1;
             entry.last_read_at = Some(now);
+            guard.dirty = true;
         }
-        self.flush().await;
+        self.maybe_flush().await;
     }
 
     /// Record a write (create/update/patch) event for a skill.
@@ -95,6 +148,7 @@ impl SkillUsageStore {
         {
             let mut guard = self.inner.write().await;
             let entry = guard
+                .data
                 .skills
                 .entry(name.to_string())
                 .or_insert_with(|| SkillUsageEntry {
@@ -106,48 +160,73 @@ impl SkillUsageStore {
                 });
             entry.write_count += 1;
             entry.last_write_at = Some(now);
+            guard.dirty = true;
         }
-        self.flush().await;
+        // Writes are less frequent — flush immediately.
+        flush_to_disk(&self.inner, &self.path).await;
     }
 
     /// Remove a skill's usage entry (called on delete).
     pub async fn remove(&self, name: &str) {
         {
             let mut guard = self.inner.write().await;
-            guard.skills.remove(name);
+            guard.data.skills.remove(name);
+            guard.dirty = true;
         }
-        self.flush().await;
+        flush_to_disk(&self.inner, &self.path).await;
     }
 
     /// Return a snapshot of all usage entries.
     pub async fn get_all(&self) -> HashMap<String, SkillUsageEntry> {
-        self.inner.read().await.skills.clone()
+        self.inner.read().await.data.skills.clone()
     }
 
-    /// Persist to disk atomically (temp + rename).
-    async fn flush(&self) {
-        let snapshot = {
+    /// Flush immediately if enough time has elapsed, otherwise notify the
+    /// background task to handle it after the debounce interval.
+    async fn maybe_flush(&self) {
+        let now = now_secs();
+        let should_flush = {
             let guard = self.inner.read().await;
-            match serde_json::to_string_pretty(&*guard) {
-                Ok(s) => s,
-                Err(e) => {
-                    tracing::warn!(error = %e, "failed to serialize skill usage");
-                    return;
-                },
-            }
+            guard.dirty && now.saturating_sub(guard.last_flush_at) >= FLUSH_DEBOUNCE_SECS
         };
-        let tmp = self.path.with_extension("json.tmp");
-        if let Some(parent) = self.path.parent() {
-            let _ = tokio::fs::create_dir_all(parent).await;
-        }
-        if let Err(e) = tokio::fs::write(&tmp, &snapshot).await {
-            tracing::warn!(error = %e, "failed to write skill usage temp file");
-            return;
-        }
-        if let Err(e) = tokio::fs::rename(&tmp, &self.path).await {
-            tracing::warn!(error = %e, "failed to rename skill usage file");
+        if should_flush {
+            flush_to_disk(&self.inner, &self.path).await;
+        } else {
+            self.flush_notify.notify_one();
         }
     }
+}
+
+/// Persist to disk atomically (temp + rename), clearing the dirty flag.
+async fn flush_to_disk(inner: &RwLock<Inner>, path: &Path) {
+    let snapshot = {
+        let guard = inner.read().await;
+        if !guard.dirty {
+            return;
+        }
+        match serde_json::to_string_pretty(&guard.data) {
+            Ok(s) => s,
+            Err(e) => {
+                tracing::warn!(error = %e, "failed to serialize skill usage");
+                return;
+            },
+        }
+    };
+    let tmp = path.with_extension("json.tmp");
+    if let Some(parent) = path.parent() {
+        let _ = tokio::fs::create_dir_all(parent).await;
+    }
+    if let Err(e) = tokio::fs::write(&tmp, &snapshot).await {
+        tracing::warn!(error = %e, "failed to write skill usage temp file");
+        return;
+    }
+    if let Err(e) = tokio::fs::rename(&tmp, path).await {
+        tracing::warn!(error = %e, "failed to rename skill usage file");
+        return;
+    }
+    let mut guard = inner.write().await;
+    guard.dirty = false;
+    guard.last_flush_at = now_secs();
 }
 
 fn now_millis() -> u64 {
@@ -155,6 +234,13 @@ fn now_millis() -> u64 {
         .duration_since(UNIX_EPOCH)
         .unwrap_or_default()
         .as_millis() as u64
+}
+
+fn now_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
 }
 
 #[allow(clippy::unwrap_used, clippy::expect_used)]
@@ -165,7 +251,7 @@ mod tests {
     #[tokio::test]
     async fn test_record_read_increments() {
         let tmp = tempfile::tempdir().unwrap();
-        let store = SkillUsageStore::new(tmp.path());
+        let store = SkillUsageStore::open(tmp.path()).await;
 
         store.record_read("demo").await;
         store.record_read("demo").await;
@@ -181,7 +267,7 @@ mod tests {
     #[tokio::test]
     async fn test_record_write_increments() {
         let tmp = tempfile::tempdir().unwrap();
-        let store = SkillUsageStore::new(tmp.path());
+        let store = SkillUsageStore::open(tmp.path()).await;
 
         store.record_write("demo").await;
 
@@ -195,7 +281,7 @@ mod tests {
     #[tokio::test]
     async fn test_remove_deletes_entry() {
         let tmp = tempfile::tempdir().unwrap();
-        let store = SkillUsageStore::new(tmp.path());
+        let store = SkillUsageStore::open(tmp.path()).await;
 
         store.record_read("demo").await;
         assert!(store.get_all().await.contains_key("demo"));
@@ -209,24 +295,27 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
 
         {
-            let store = SkillUsageStore::new(tmp.path());
-            store.record_read("alpha").await;
+            let store = SkillUsageStore::open(tmp.path()).await;
+            // record_write flushes immediately, so data is on disk.
             store.record_write("alpha").await;
-            store.record_read("beta").await;
+            store.record_read("alpha").await;
+            // Force flush for the read (which may be debounced).
+            flush_to_disk(&store.inner, &store.path).await;
+            store.record_write("beta").await;
         }
 
         // New store instance reads from disk.
-        let store2 = SkillUsageStore::new(tmp.path());
+        let store2 = SkillUsageStore::open(tmp.path()).await;
         let all = store2.get_all().await;
         assert_eq!(all.get("alpha").unwrap().read_count, 1);
         assert_eq!(all.get("alpha").unwrap().write_count, 1);
-        assert_eq!(all.get("beta").unwrap().read_count, 1);
+        assert_eq!(all.get("beta").unwrap().write_count, 1);
     }
 
     #[tokio::test]
     async fn test_created_at_set_on_first_event() {
         let tmp = tempfile::tempdir().unwrap();
-        let store = SkillUsageStore::new(tmp.path());
+        let store = SkillUsageStore::open(tmp.path()).await;
 
         store.record_read("new-skill").await;
         let all = store.get_all().await;
@@ -246,7 +335,15 @@ mod tests {
     #[tokio::test]
     async fn test_missing_file_creates_empty_store() {
         let tmp = tempfile::tempdir().unwrap();
-        let store = SkillUsageStore::new(tmp.path());
+        let store = SkillUsageStore::open(tmp.path()).await;
         assert!(store.get_all().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_sync_constructor_works() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = SkillUsageStore::new(tmp.path());
+        store.record_write("test").await;
+        assert_eq!(store.get_all().await.get("test").unwrap().write_count, 1);
     }
 }

--- a/crates/skills/src/usage.rs
+++ b/crates/skills/src/usage.rs
@@ -183,15 +183,24 @@ impl SkillUsageStore {
         self.inner.read().await.data.skills.clone()
     }
 
+    /// Force-flush any pending dirty data to disk. Call during graceful
+    /// shutdown to ensure debounced read events are not lost.
+    pub async fn shutdown_flush(&self) {
+        flush_to_disk(&self.inner, &self.path).await;
+    }
+
     /// Flush immediately if enough time has elapsed, otherwise notify the
     /// background task to handle it after the debounce interval.
     async fn maybe_flush(&self) {
         let now = now_secs();
-        let should_flush = {
+        let (is_dirty, elapsed) = {
             let guard = self.inner.read().await;
-            guard.dirty && now.saturating_sub(guard.last_flush_at) >= FLUSH_DEBOUNCE_SECS
+            (guard.dirty, now.saturating_sub(guard.last_flush_at))
         };
-        if should_flush {
+        if !is_dirty {
+            return;
+        }
+        if elapsed >= FLUSH_DEBOUNCE_SECS {
             flush_to_disk(&self.inner, &self.path).await;
         } else {
             self.flush_notify.notify_one();

--- a/crates/skills/src/usage.rs
+++ b/crates/skills/src/usage.rs
@@ -1,0 +1,252 @@
+//! Per-skill usage telemetry.
+//!
+//! Tracks how often each skill is read (activated) and modified (created,
+//! updated, patched). Data is persisted to `<data_dir>/skills-usage.json`
+//! with atomic writes.
+
+use std::{
+    collections::HashMap,
+    path::{Path, PathBuf},
+    sync::Arc,
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+use {
+    serde::{Deserialize, Serialize},
+    tokio::sync::RwLock,
+};
+
+/// Per-skill usage counters and timestamps.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SkillUsageEntry {
+    /// Number of times the skill was activated via `read_skill`.
+    pub read_count: u64,
+    /// Number of times the skill was created or modified
+    /// (create_skill + update_skill + patch_skill).
+    pub write_count: u64,
+    /// Unix milliseconds of the last `read_skill` call.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_read_at: Option<u64>,
+    /// Unix milliseconds of the last create/update/patch.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_write_at: Option<u64>,
+    /// Unix milliseconds when this skill first appeared in telemetry.
+    pub created_at: u64,
+}
+
+/// Top-level usage file.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+struct UsageFile {
+    #[serde(default)]
+    skills: HashMap<String, SkillUsageEntry>,
+}
+
+/// Thread-safe, file-backed skill usage store.
+///
+/// Clone-friendly via inner `Arc`.
+#[derive(Clone)]
+pub struct SkillUsageStore {
+    inner: Arc<RwLock<UsageFile>>,
+    path: PathBuf,
+}
+
+impl SkillUsageStore {
+    /// Create a new store, loading existing data from disk if present.
+    pub fn new(data_dir: &Path) -> Self {
+        let path = data_dir.join("skills-usage.json");
+        let file = if path.exists() {
+            std::fs::read_to_string(&path)
+                .ok()
+                .and_then(|s| serde_json::from_str::<UsageFile>(&s).ok())
+                .unwrap_or_default()
+        } else {
+            UsageFile::default()
+        };
+        Self {
+            inner: Arc::new(RwLock::new(file)),
+            path,
+        }
+    }
+
+    /// Record a read (activation) event for a skill.
+    pub async fn record_read(&self, name: &str) {
+        let now = now_millis();
+        {
+            let mut guard = self.inner.write().await;
+            let entry = guard
+                .skills
+                .entry(name.to_string())
+                .or_insert_with(|| SkillUsageEntry {
+                    read_count: 0,
+                    write_count: 0,
+                    last_read_at: None,
+                    last_write_at: None,
+                    created_at: now,
+                });
+            entry.read_count += 1;
+            entry.last_read_at = Some(now);
+        }
+        self.flush().await;
+    }
+
+    /// Record a write (create/update/patch) event for a skill.
+    pub async fn record_write(&self, name: &str) {
+        let now = now_millis();
+        {
+            let mut guard = self.inner.write().await;
+            let entry = guard
+                .skills
+                .entry(name.to_string())
+                .or_insert_with(|| SkillUsageEntry {
+                    read_count: 0,
+                    write_count: 0,
+                    last_read_at: None,
+                    last_write_at: None,
+                    created_at: now,
+                });
+            entry.write_count += 1;
+            entry.last_write_at = Some(now);
+        }
+        self.flush().await;
+    }
+
+    /// Remove a skill's usage entry (called on delete).
+    pub async fn remove(&self, name: &str) {
+        {
+            let mut guard = self.inner.write().await;
+            guard.skills.remove(name);
+        }
+        self.flush().await;
+    }
+
+    /// Return a snapshot of all usage entries.
+    pub async fn get_all(&self) -> HashMap<String, SkillUsageEntry> {
+        self.inner.read().await.skills.clone()
+    }
+
+    /// Persist to disk atomically (temp + rename).
+    async fn flush(&self) {
+        let snapshot = {
+            let guard = self.inner.read().await;
+            match serde_json::to_string_pretty(&*guard) {
+                Ok(s) => s,
+                Err(e) => {
+                    tracing::warn!(error = %e, "failed to serialize skill usage");
+                    return;
+                },
+            }
+        };
+        let tmp = self.path.with_extension("json.tmp");
+        if let Some(parent) = self.path.parent() {
+            let _ = tokio::fs::create_dir_all(parent).await;
+        }
+        if let Err(e) = tokio::fs::write(&tmp, &snapshot).await {
+            tracing::warn!(error = %e, "failed to write skill usage temp file");
+            return;
+        }
+        if let Err(e) = tokio::fs::rename(&tmp, &self.path).await {
+            tracing::warn!(error = %e, "failed to rename skill usage file");
+        }
+    }
+}
+
+fn now_millis() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as u64
+}
+
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_record_read_increments() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = SkillUsageStore::new(tmp.path());
+
+        store.record_read("demo").await;
+        store.record_read("demo").await;
+
+        let all = store.get_all().await;
+        let entry = all.get("demo").unwrap();
+        assert_eq!(entry.read_count, 2);
+        assert_eq!(entry.write_count, 0);
+        assert!(entry.last_read_at.is_some());
+        assert!(entry.last_write_at.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_record_write_increments() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = SkillUsageStore::new(tmp.path());
+
+        store.record_write("demo").await;
+
+        let all = store.get_all().await;
+        let entry = all.get("demo").unwrap();
+        assert_eq!(entry.read_count, 0);
+        assert_eq!(entry.write_count, 1);
+        assert!(entry.last_write_at.is_some());
+    }
+
+    #[tokio::test]
+    async fn test_remove_deletes_entry() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = SkillUsageStore::new(tmp.path());
+
+        store.record_read("demo").await;
+        assert!(store.get_all().await.contains_key("demo"));
+
+        store.remove("demo").await;
+        assert!(!store.get_all().await.contains_key("demo"));
+    }
+
+    #[tokio::test]
+    async fn test_persistence_roundtrip() {
+        let tmp = tempfile::tempdir().unwrap();
+
+        {
+            let store = SkillUsageStore::new(tmp.path());
+            store.record_read("alpha").await;
+            store.record_write("alpha").await;
+            store.record_read("beta").await;
+        }
+
+        // New store instance reads from disk.
+        let store2 = SkillUsageStore::new(tmp.path());
+        let all = store2.get_all().await;
+        assert_eq!(all.get("alpha").unwrap().read_count, 1);
+        assert_eq!(all.get("alpha").unwrap().write_count, 1);
+        assert_eq!(all.get("beta").unwrap().read_count, 1);
+    }
+
+    #[tokio::test]
+    async fn test_created_at_set_on_first_event() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = SkillUsageStore::new(tmp.path());
+
+        store.record_read("new-skill").await;
+        let all = store.get_all().await;
+        let entry = all.get("new-skill").unwrap();
+        assert!(entry.created_at > 0);
+
+        let original = entry.created_at;
+        store.record_read("new-skill").await;
+        let all = store.get_all().await;
+        assert_eq!(
+            all.get("new-skill").unwrap().created_at,
+            original,
+            "created_at must not change on subsequent events"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_missing_file_creates_empty_store() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = SkillUsageStore::new(tmp.path());
+        assert!(store.get_all().await.is_empty());
+    }
+}

--- a/crates/skills/src/usage.rs
+++ b/crates/skills/src/usage.rs
@@ -197,21 +197,29 @@ impl SkillUsageStore {
     }
 }
 
-/// Persist to disk atomically (temp + rename), clearing the dirty flag.
+/// Persist to disk atomically (temp + rename).
+///
+/// Serializes data and clears the dirty flag under a single write lock
+/// to avoid a TOCTOU race where a concurrent mutation between snapshot
+/// and flag-clear would be silently lost.
 async fn flush_to_disk(inner: &RwLock<Inner>, path: &Path) {
     let snapshot = {
-        let guard = inner.read().await;
+        let mut guard = inner.write().await;
         if !guard.dirty {
             return;
         }
-        match serde_json::to_string_pretty(&guard.data) {
+        let s = match serde_json::to_string_pretty(&guard.data) {
             Ok(s) => s,
             Err(e) => {
                 tracing::warn!(error = %e, "failed to serialize skill usage");
                 return;
             },
-        }
+        };
+        guard.dirty = false;
+        guard.last_flush_at = now_secs();
+        s
     };
+    // I/O proceeds outside the lock.
     let tmp = path.with_extension("json.tmp");
     if let Some(parent) = path.parent() {
         let _ = tokio::fs::create_dir_all(parent).await;
@@ -222,11 +230,7 @@ async fn flush_to_disk(inner: &RwLock<Inner>, path: &Path) {
     }
     if let Err(e) = tokio::fs::rename(&tmp, path).await {
         tracing::warn!(error = %e, "failed to rename skill usage file");
-        return;
     }
-    let mut guard = inner.write().await;
-    guard.dirty = false;
-    guard.last_flush_at = now_secs();
 }
 
 fn now_millis() -> u64 {

--- a/crates/skills/src/usage.rs
+++ b/crates/skills/src/usage.rs
@@ -66,7 +66,9 @@ pub struct SkillUsageStore {
 }
 
 impl SkillUsageStore {
-    /// Create a new store synchronously (for tests and non-async contexts).
+    /// Create a new store with synchronous file I/O. Requires an active Tokio
+    /// runtime (spawns a background flush task). Prefer [`open`](Self::open)
+    /// in async contexts.
     pub fn new(data_dir: &Path) -> Self {
         let path = data_dir.join("skills-usage.json");
         let data = if path.exists() {

--- a/crates/tools/src/skill_tools/crud.rs
+++ b/crates/tools/src/skill_tools/crud.rs
@@ -9,6 +9,9 @@ use {
     serde_json::{Value, json},
 };
 
+#[cfg(feature = "metrics")]
+use moltis_metrics::{counter, labels, skills as skills_metrics};
+
 use {
     super::helpers::{build_skill_md, write_skill},
     crate::{checkpoints::CheckpointManager, error::Error},
@@ -130,6 +133,9 @@ impl AgentTool for CreateSkillTool {
         if let Some(ref store) = self.usage_store {
             store.record_write(name).await;
         }
+        #[cfg(feature = "metrics")]
+        counter!(skills_metrics::MODIFICATIONS_TOTAL, labels::TOOL => "create_skill".to_string())
+            .increment(1);
 
         Ok(json!({
             "created": true,
@@ -253,6 +259,9 @@ impl AgentTool for UpdateSkillTool {
         if let Some(ref store) = self.usage_store {
             store.record_write(name).await;
         }
+        #[cfg(feature = "metrics")]
+        counter!(skills_metrics::MODIFICATIONS_TOTAL, labels::TOOL => "update_skill".to_string())
+            .increment(1);
 
         Ok(json!({
             "updated": true,

--- a/crates/tools/src/skill_tools/crud.rs
+++ b/crates/tools/src/skill_tools/crud.rs
@@ -5,6 +5,7 @@ use std::path::PathBuf;
 use {
     async_trait::async_trait,
     moltis_agents::tool_registry::AgentTool,
+    moltis_skills::usage::SkillUsageStore,
     serde_json::{Value, json},
 };
 
@@ -19,6 +20,7 @@ use {
 pub struct CreateSkillTool {
     data_dir: PathBuf,
     checkpoints: CheckpointManager,
+    usage_store: Option<SkillUsageStore>,
 }
 
 impl CreateSkillTool {
@@ -27,7 +29,14 @@ impl CreateSkillTool {
         Self {
             data_dir,
             checkpoints,
+            usage_store: None,
         }
+    }
+
+    #[must_use]
+    pub fn with_usage_store(mut self, store: SkillUsageStore) -> Self {
+        self.usage_store = Some(store);
+        self
     }
 
     fn skills_dir(&self) -> PathBuf {
@@ -118,6 +127,10 @@ impl AgentTool for CreateSkillTool {
         let content = build_skill_md(name, description, body, &allowed_tools);
         write_skill(&skill_dir, &content).await?;
 
+        if let Some(ref store) = self.usage_store {
+            store.record_write(name).await;
+        }
+
         Ok(json!({
             "created": true,
             "path": skill_dir.display().to_string(),
@@ -132,6 +145,7 @@ impl AgentTool for CreateSkillTool {
 pub struct UpdateSkillTool {
     data_dir: PathBuf,
     checkpoints: CheckpointManager,
+    usage_store: Option<SkillUsageStore>,
 }
 
 impl UpdateSkillTool {
@@ -140,7 +154,14 @@ impl UpdateSkillTool {
         Self {
             data_dir,
             checkpoints,
+            usage_store: None,
         }
+    }
+
+    #[must_use]
+    pub fn with_usage_store(mut self, store: SkillUsageStore) -> Self {
+        self.usage_store = Some(store);
+        self
     }
 
     fn skills_dir(&self) -> PathBuf {
@@ -229,6 +250,10 @@ impl AgentTool for UpdateSkillTool {
         let content = build_skill_md(name, description, body, &allowed_tools);
         write_skill(&skill_dir, &content).await?;
 
+        if let Some(ref store) = self.usage_store {
+            store.record_write(name).await;
+        }
+
         Ok(json!({
             "updated": true,
             "path": skill_dir.display().to_string(),
@@ -243,6 +268,7 @@ impl AgentTool for UpdateSkillTool {
 pub struct DeleteSkillTool {
     data_dir: PathBuf,
     checkpoints: CheckpointManager,
+    usage_store: Option<SkillUsageStore>,
 }
 
 impl DeleteSkillTool {
@@ -251,7 +277,14 @@ impl DeleteSkillTool {
         Self {
             data_dir,
             checkpoints,
+            usage_store: None,
         }
+    }
+
+    #[must_use]
+    pub fn with_usage_store(mut self, store: SkillUsageStore) -> Self {
+        self.usage_store = Some(store);
+        self
     }
 
     fn skills_dir(&self) -> PathBuf {
@@ -315,6 +348,10 @@ impl AgentTool for DeleteSkillTool {
             .checkpoint_path(&skill_dir, "delete_skill")
             .await?;
         tokio::fs::remove_dir_all(&skill_dir).await?;
+
+        if let Some(ref store) = self.usage_store {
+            store.remove(name).await;
+        }
 
         Ok(json!({
             "deleted": true,

--- a/crates/tools/src/skill_tools/read_ops.rs
+++ b/crates/tools/src/skill_tools/read_ops.rs
@@ -188,7 +188,8 @@ impl AgentTool for ReadSkillTool {
             store.record_read(name).await;
         }
         #[cfg(feature = "metrics")]
-        counter!(skills_metrics::ACTIVATIONS_TOTAL, labels::TOOL => name.to_string()).increment(1);
+        counter!(skills_metrics::ACTIVATIONS_TOTAL, labels::TOOL => "read_skill".to_string())
+            .increment(1);
 
         Ok(result)
     }

--- a/crates/tools/src/skill_tools/read_ops.rs
+++ b/crates/tools/src/skill_tools/read_ops.rs
@@ -5,7 +5,7 @@ use std::{path::Path, sync::Arc};
 use {
     async_trait::async_trait,
     moltis_agents::tool_registry::AgentTool,
-    moltis_skills::{discover::SkillDiscoverer, types::SkillSource},
+    moltis_skills::{discover::SkillDiscoverer, types::SkillSource, usage::SkillUsageStore},
     serde_json::{Value, json},
 };
 
@@ -30,6 +30,7 @@ const SIDECAR_SUBDIRS: &[&str] = moltis_skills::SIDECAR_SUBDIRS;
 /// filesystem MCP server to load `SKILL.md` by absolute path.
 pub struct ReadSkillTool {
     discoverer: Arc<dyn SkillDiscoverer>,
+    usage_store: Option<SkillUsageStore>,
     #[cfg(feature = "bundled-skills")]
     bundled_store: Option<Arc<moltis_skills::bundled::BundledSkillStore>>,
 }
@@ -40,6 +41,7 @@ impl ReadSkillTool {
     pub fn new(discoverer: Arc<dyn SkillDiscoverer>) -> Self {
         Self {
             discoverer,
+            usage_store: None,
             #[cfg(feature = "bundled-skills")]
             bundled_store: None,
         }
@@ -54,8 +56,16 @@ impl ReadSkillTool {
     ) -> Self {
         Self {
             discoverer,
+            usage_store: None,
             bundled_store: Some(bundled_store),
         }
+    }
+
+    /// Attach a usage telemetry store.
+    #[must_use]
+    pub fn with_usage_store(mut self, store: SkillUsageStore) -> Self {
+        self.usage_store = Some(store);
+        self
     }
 
     /// Convenience constructor that uses default filesystem paths.
@@ -65,6 +75,7 @@ impl ReadSkillTool {
         let discoverer = Arc::new(FsSkillDiscoverer::new(FsSkillDiscoverer::default_paths()));
         Self {
             discoverer,
+            usage_store: None,
             #[cfg(feature = "bundled-skills")]
             bundled_store: None,
         }
@@ -168,6 +179,12 @@ impl AgentTool for ReadSkillTool {
 
         let mut result = read_primary(name, meta).await?;
         inject_install_note(&mut result, &install_note);
+
+        // Record activation (primary reads only, not sidecar reads).
+        if let Some(ref store) = self.usage_store {
+            store.record_read(name).await;
+        }
+
         Ok(result)
     }
 }

--- a/crates/tools/src/skill_tools/read_ops.rs
+++ b/crates/tools/src/skill_tools/read_ops.rs
@@ -9,6 +9,9 @@ use {
     serde_json::{Value, json},
 };
 
+#[cfg(feature = "metrics")]
+use moltis_metrics::{counter, labels, skills as skills_metrics};
+
 use {
     super::{
         MAX_SIDECAR_FILES_PER_CALL, MAX_SIDECAR_FILES_PER_SUBDIR, MAX_SKILL_BODY_BYTES,
@@ -184,6 +187,8 @@ impl AgentTool for ReadSkillTool {
         if let Some(ref store) = self.usage_store {
             store.record_read(name).await;
         }
+        #[cfg(feature = "metrics")]
+        counter!(skills_metrics::ACTIVATIONS_TOTAL, labels::TOOL => name.to_string()).increment(1);
 
         Ok(result)
     }

--- a/crates/tools/src/skill_tools/write_ops.rs
+++ b/crates/tools/src/skill_tools/write_ops.rs
@@ -9,6 +9,9 @@ use {
     serde_json::{Value, json},
 };
 
+#[cfg(feature = "metrics")]
+use moltis_metrics::{counter, labels, skills as skills_metrics};
+
 use {
     super::{
         MAX_SIDECAR_FILES_PER_CALL,
@@ -348,6 +351,9 @@ impl AgentTool for PatchSkillTool {
         if let Some(ref store) = self.usage_store {
             store.record_write(name).await;
         }
+        #[cfg(feature = "metrics")]
+        counter!(skills_metrics::MODIFICATIONS_TOTAL, labels::TOOL => "patch_skill".to_string())
+            .increment(1);
 
         let mut response = json!({
             "patched": true,

--- a/crates/tools/src/skill_tools/write_ops.rs
+++ b/crates/tools/src/skill_tools/write_ops.rs
@@ -5,6 +5,7 @@ use std::path::PathBuf;
 use {
     async_trait::async_trait,
     moltis_agents::tool_registry::AgentTool,
+    moltis_skills::usage::SkillUsageStore,
     serde_json::{Value, json},
 };
 
@@ -142,6 +143,7 @@ const MAX_PATCHES_PER_CALL: usize = 10;
 pub struct PatchSkillTool {
     data_dir: PathBuf,
     checkpoints: CheckpointManager,
+    usage_store: Option<SkillUsageStore>,
 }
 
 impl PatchSkillTool {
@@ -150,7 +152,14 @@ impl PatchSkillTool {
         Self {
             data_dir,
             checkpoints,
+            usage_store: None,
         }
+    }
+
+    #[must_use]
+    pub fn with_usage_store(mut self, store: SkillUsageStore) -> Self {
+        self.usage_store = Some(store);
+        self
     }
 
     fn skills_dir(&self) -> PathBuf {
@@ -335,6 +344,10 @@ impl AgentTool for PatchSkillTool {
         } else {
             None
         };
+
+        if let Some(ref store) = self.usage_store {
+            store.record_write(name).await;
+        }
 
         let mut response = json!({
             "patched": true,


### PR DESCRIPTION
## Summary

- Add per-skill usage telemetry tracking (read counts, write counts, timestamps) persisted to `<data_dir>/skills-usage.json`
- Surface skill usage stats in the `/insights` channel command (top skills, never-activated count)
- Enrich the `skills.list` RPC response with `read_count`, `write_count`, `last_read_at` for web UI consumption
- Emit Prometheus counters: `moltis_skills_activations_total` and `moltis_skills_modifications_total`

Inspired by Hermes Agent's Curator feature — this is the telemetry foundation for future skill lifecycle management (stale detection, consolidation/pruning).

### Architecture

- **`crates/skills/src/usage.rs`** — `SkillUsageStore`: thread-safe, file-backed JSON store with atomic writes. Clone-friendly via inner `Arc<RwLock<...>>`
- **Skill tools** (`ReadSkillTool`, `CreateSkillTool`, `UpdateSkillTool`, `PatchSkillTool`, `DeleteSkillTool`) accept optional store via `.with_usage_store()` builder — existing constructors unchanged
- **Gateway** wires a shared instance into all skill tools at startup via `OnceLock` on `GatewayState`
- **RPC enrichment** happens at the handler layer in `system.rs` — no trait changes needed

### `/insights` output example

```
Skills:
  42 activations, 8 modifications across 12 skills
  Most activated:
    commit: 15 reads, 2 writes
    code-review: 10 reads, 1 writes
  Never activated: 3
```

## Validation

### Completed
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --package moltis-skills --package moltis-tools --package moltis-gateway -- -D warnings` — clean
- [x] `cargo test --package moltis-skills` — 147 passed
- [x] `cargo test --package moltis-tools -- skill` — 87 passed
- [x] `cargo test --package moltis-gateway` — 14 passed (+ 394 doc-tests)

### Remaining
- [ ] `./scripts/local-validate.sh`
- [ ] Manual QA: create/read/patch skills and verify `/insights` output

## Manual QA

1. Start Moltis, create a skill via agent (`create_skill`)
2. Read the skill (`read_skill`) a few times
3. Run `/insights` — verify "Skills:" section appears with correct counts
4. Check `~/.moltis/skills-usage.json` exists with correct data
5. Call `skills.list` RPC — verify `read_count`/`write_count`/`last_read_at` in response