### PR TITLE
fix(web-ui): system-notice text overflows excessively rounded container

### DIFF
--- a/crates/web/src/assets/css/chat.css
+++ b/crates/web/src/assets/css/chat.css
@@ -143,11 +143,11 @@
   background: color-mix(in srgb, var(--surface2) 85%, transparent);
   border: 1px solid var(--border);
   border-color: color-mix(in srgb, var(--border-strong) 65%, transparent);
-  border-radius: 999px;
+  border-radius: 12px;
   align-items: center;
   gap: 6px;
   max-width: min(88%, 640px);
-  padding: 5px 10px;
+  padding: 6px 14px;
   white-space: normal;
   display: inline-flex;
 }


### PR DESCRIPTION
## Summary

- Reduce `.system-notice` border-radius from `999px` (pill) to `12px` (rounded rect) so multi-line content like the `/mode` list doesn't overflow the container corners
- Slightly increase horizontal padding (`10px` → `14px`) to keep text visually clear of the rounded edges

Fixes #938

## Validation

### Completed
- [x] Visual inspection of the CSS change

### Remaining
- [ ] `cd crates/web/ui && npm run build:css` (Tailwind rebuild — this file is plain CSS, not Tailwind-generated, so no rebuild needed)
- [ ] Manual QA: open chat, run `/mode`, verify text stays inside the notice box
- [ ] Manual QA: verify short single-line notices (sandbox enabled/disabled) still look good

## Manual QA

1. Open the web UI chat
2. Type `/mode` — the mode list should render inside a rounded rectangle without text clipping
3. Trigger a sandbox notice — the short pill-like appearance should still look clean with `12px` radius