### PR TITLE
feat(providers): add Zen (opencode.ai) multi-protocol provider

### DIFF
--- a/crates/config/src/schema/providers.rs
+++ b/crates/config/src/schema/providers.rs
@@ -48,6 +48,8 @@ pub const KNOWN_PROVIDER_NAMES: &[&str] = &[
     // Providers registered via genai/async-openai backends
     "groq",
     "xai",
+    // Multi-protocol proxy (opencode.ai)
+    "zen",
 ];
 
 /// OAuth provider configuration (e.g. openai-codex).

--- a/crates/config/src/schema/providers.rs
+++ b/crates/config/src/schema/providers.rs
@@ -49,7 +49,7 @@ pub const KNOWN_PROVIDER_NAMES: &[&str] = &[
     "groq",
     "xai",
     // Multi-protocol proxy (opencode.ai)
-    "zen",
+    "opencode-zen",
 ];
 
 /// OAuth provider configuration (e.g. openai-codex).

--- a/crates/provider-setup/src/known_providers.rs
+++ b/crates/provider-setup/src/known_providers.rs
@@ -257,6 +257,16 @@ pub fn known_providers() -> Vec<KnownProvider> {
             key_optional: false,
             local_only: false,
         },
+        KnownProvider {
+            name: "zen",
+            display_name: "Zen (opencode.ai)",
+            auth_type: AuthType::ApiKey,
+            env_key: Some("ZEN_API_KEY"),
+            default_base_url: Some("https://opencode.ai/zen/v1"),
+            requires_model: false,
+            key_optional: false,
+            local_only: false,
+        },
     ];
 
     // Add local-llm provider when the local-llm feature is enabled

--- a/crates/provider-setup/src/known_providers.rs
+++ b/crates/provider-setup/src/known_providers.rs
@@ -258,10 +258,10 @@ pub fn known_providers() -> Vec<KnownProvider> {
             local_only: false,
         },
         KnownProvider {
-            name: "zen",
-            display_name: "Zen (opencode.ai)",
+            name: "opencode-zen",
+            display_name: "OpenCode Zen",
             auth_type: AuthType::ApiKey,
-            env_key: Some("ZEN_API_KEY"),
+            env_key: Some("OPENCODE_ZEN_API_KEY"),
             default_base_url: Some("https://opencode.ai/zen/v1"),
             requires_model: false,
             key_optional: false,

--- a/crates/providers/src/lib.rs
+++ b/crates/providers/src/lib.rs
@@ -25,9 +25,9 @@ pub mod openai;
 #[cfg(feature = "provider-openai-codex")]
 pub mod openai_codex;
 pub mod openai_compat;
+pub mod opencode_zen;
 pub mod registry;
 pub mod ws_pool;
-pub mod opencode_zen;
 
 #[cfg(test)]
 pub mod contract;

--- a/crates/providers/src/lib.rs
+++ b/crates/providers/src/lib.rs
@@ -27,6 +27,7 @@ pub mod openai_codex;
 pub mod openai_compat;
 pub mod registry;
 pub mod ws_pool;
+pub mod zen;
 
 #[cfg(test)]
 pub mod contract;

--- a/crates/providers/src/lib.rs
+++ b/crates/providers/src/lib.rs
@@ -27,7 +27,7 @@ pub mod openai_codex;
 pub mod openai_compat;
 pub mod registry;
 pub mod ws_pool;
-pub mod zen;
+pub mod opencode_zen;
 
 #[cfg(test)]
 pub mod contract;

--- a/crates/providers/src/opencode_zen.rs
+++ b/crates/providers/src/opencode_zen.rs
@@ -33,10 +33,19 @@ pub(crate) const OPENCODE_ZEN_MODELS: &[(&str, &str)] = &[
     // Anthropic (Messages API)
     ("claude-opus-4-6", "Claude Opus 4.6 (OpenCode Zen)"),
     ("claude-sonnet-4-6", "Claude Sonnet 4.6 (OpenCode Zen)"),
-    ("claude-haiku-4-5-20251001", "Claude Haiku 4.5 (OpenCode Zen)"),
+    (
+        "claude-haiku-4-5-20251001",
+        "Claude Haiku 4.5 (OpenCode Zen)",
+    ),
     // Gemini (ChatCompletions fallback)
-    ("gemini-2.5-pro-preview-05-06", "Gemini 2.5 Pro (OpenCode Zen)"),
-    ("gemini-2.5-flash-preview-05-20", "Gemini 2.5 Flash (OpenCode Zen)"),
+    (
+        "gemini-2.5-pro-preview-05-06",
+        "Gemini 2.5 Pro (OpenCode Zen)",
+    ),
+    (
+        "gemini-2.5-flash-preview-05-20",
+        "Gemini 2.5 Flash (OpenCode Zen)",
+    ),
 ];
 
 /// Wire format to use for a given model, determined by model ID prefix.
@@ -52,7 +61,10 @@ enum ZenWireFormat {
 fn classify_model(model_id: &str) -> ZenWireFormat {
     // Normalize "provider/model-id" → "model-id" so prefix matching works
     // even if Zen's /models endpoint returns fully-qualified IDs.
-    let bare = model_id.rsplit_once('/').map(|(_, id)| id).unwrap_or(model_id);
+    let bare = model_id
+        .rsplit_once('/')
+        .map(|(_, id)| id)
+        .unwrap_or(model_id);
     if bare.starts_with("gpt-") {
         ZenWireFormat::OpenAiResponses
     } else if bare.starts_with("claude-") {

--- a/crates/providers/src/opencode_zen.rs
+++ b/crates/providers/src/opencode_zen.rs
@@ -1,11 +1,11 @@
-//! Zen provider — opencode.ai's curated multi-protocol model proxy.
+//! OpenCode Zen provider — opencode.ai's curated multi-protocol model proxy.
 //!
 //! Zen routes requests to different wire formats based on model family:
 //! - `claude-*`  → Anthropic Messages API (`/zen/v1/messages`)
 //! - `gpt-*`     → OpenAI Responses API   (`/zen/v1/responses`)
 //! - everything  → OpenAI ChatCompletions  (`/zen/v1/chat/completions`)
 //!
-//! All three paths share a single `ZEN_API_KEY` and base URL.
+//! All three paths share a single `OPENCODE_ZEN_API_KEY` and base URL.
 
 use std::{collections::HashMap, pin::Pin, sync::Arc, time::Duration};
 
@@ -21,22 +21,22 @@ use {
 
 use crate::{anthropic::AnthropicProvider, openai::OpenAiProvider};
 
-pub const ZEN_DEFAULT_BASE_URL: &str = "https://opencode.ai/zen/v1";
+pub const OPENCODE_ZEN_DEFAULT_BASE_URL: &str = "https://opencode.ai/zen/v1";
 
 /// Static fallback model catalog for when live discovery is unavailable.
 /// Model IDs must match what the Zen API accepts — they are the same IDs the
 /// underlying provider expects (no `opencode/` prefix).
-pub(crate) const ZEN_MODELS: &[(&str, &str)] = &[
+pub(crate) const OPENCODE_ZEN_MODELS: &[(&str, &str)] = &[
     // OpenAI (Responses API)
-    ("gpt-4o", "GPT-4o (Zen)"),
-    ("gpt-4.1", "GPT-4.1 (Zen)"),
+    ("gpt-4o", "GPT-4o (OpenCode Zen)"),
+    ("gpt-4.1", "GPT-4.1 (OpenCode Zen)"),
     // Anthropic (Messages API)
-    ("claude-opus-4-6", "Claude Opus 4.6 (Zen)"),
-    ("claude-sonnet-4-6", "Claude Sonnet 4.6 (Zen)"),
-    ("claude-haiku-4-5-20251001", "Claude Haiku 4.5 (Zen)"),
+    ("claude-opus-4-6", "Claude Opus 4.6 (OpenCode Zen)"),
+    ("claude-sonnet-4-6", "Claude Sonnet 4.6 (OpenCode Zen)"),
+    ("claude-haiku-4-5-20251001", "Claude Haiku 4.5 (OpenCode Zen)"),
     // Gemini (ChatCompletions fallback)
-    ("gemini-2.5-pro-preview-05-06", "Gemini 2.5 Pro (Zen)"),
-    ("gemini-2.5-flash-preview-05-20", "Gemini 2.5 Flash (Zen)"),
+    ("gemini-2.5-pro-preview-05-06", "Gemini 2.5 Pro (OpenCode Zen)"),
+    ("gemini-2.5-flash-preview-05-20", "Gemini 2.5 Flash (OpenCode Zen)"),
 ];
 
 /// Wire format to use for a given model, determined by model ID prefix.
@@ -59,7 +59,7 @@ fn classify_model(model_id: &str) -> ZenWireFormat {
     }
 }
 
-/// A Zen (opencode.ai) provider that dispatches to the correct wire format.
+/// An OpenCode Zen (opencode.ai) provider that dispatches to the correct wire format.
 ///
 /// The inner provider is selected once at construction time based on the model
 /// ID prefix, so all hot-path method calls are simple `Arc<dyn LlmProvider>`
@@ -77,7 +77,7 @@ impl ZenProvider {
     /// appends `/v1/messages` internally.
     ///
     /// `global_cw` and `provider_cw` are the context-window override maps from
-    /// `[models.<id>]` and `[providers.zen.model_overrides]` config respectively.
+    /// `[models.<id>]` and `[providers.opencode-zen.model_overrides]` config respectively.
     pub fn new(
         api_key: Secret<String>,
         model_id: String,
@@ -87,9 +87,14 @@ impl ZenProvider {
     ) -> Self {
         let inner: Arc<dyn LlmProvider> = match classify_model(&model_id) {
             ZenWireFormat::OpenAiResponses => Arc::new(
-                OpenAiProvider::new_with_name(api_key, model_id.clone(), base_url, "zen".into())
-                    .with_wire_api(WireApi::Responses)
-                    .with_context_window_overrides(global_cw, provider_cw),
+                OpenAiProvider::new_with_name(
+                    api_key,
+                    model_id.clone(),
+                    base_url,
+                    "opencode-zen".into(),
+                )
+                .with_wire_api(WireApi::Responses)
+                .with_context_window_overrides(global_cw, provider_cw),
             ),
             ZenWireFormat::Anthropic => {
                 // AnthropicProvider appends `/v1/messages` to its base_url, so
@@ -104,14 +109,19 @@ impl ZenProvider {
                         api_key,
                         model_id.clone(),
                         anthropic_base,
-                        Some("zen".into()),
+                        Some("opencode-zen".into()),
                     )
                     .with_context_window_overrides(global_cw, provider_cw),
                 )
             },
             ZenWireFormat::ChatCompletions => Arc::new(
-                OpenAiProvider::new_with_name(api_key, model_id.clone(), base_url, "zen".into())
-                    .with_context_window_overrides(global_cw, provider_cw),
+                OpenAiProvider::new_with_name(
+                    api_key,
+                    model_id.clone(),
+                    base_url,
+                    "opencode-zen".into(),
+                )
+                .with_context_window_overrides(global_cw, provider_cw),
             ),
         };
         Self { model_id, inner }
@@ -121,7 +131,7 @@ impl ZenProvider {
 #[async_trait]
 impl LlmProvider for ZenProvider {
     fn name(&self) -> &str {
-        "zen"
+        "opencode-zen"
     }
 
     fn id(&self) -> &str {
@@ -200,17 +210,17 @@ mod tests {
     use super::*;
 
     #[test]
-    fn zen_models_not_empty() {
-        assert!(!ZEN_MODELS.is_empty());
+    fn opencode_zen_models_not_empty() {
+        assert!(!OPENCODE_ZEN_MODELS.is_empty());
     }
 
     #[test]
-    fn zen_models_have_unique_ids() {
-        let mut ids: Vec<&str> = ZEN_MODELS.iter().map(|(id, _)| *id).collect();
+    fn opencode_zen_models_have_unique_ids() {
+        let mut ids: Vec<&str> = OPENCODE_ZEN_MODELS.iter().map(|(id, _)| *id).collect();
         ids.sort();
         let before = ids.len();
         ids.dedup();
-        assert_eq!(before, ids.len(), "duplicate ZEN_MODELS IDs");
+        assert_eq!(before, ids.len(), "duplicate OPENCODE_ZEN_MODELS IDs");
     }
 
     #[test]
@@ -254,7 +264,7 @@ mod tests {
     }
 
     #[test]
-    fn zen_provider_name_is_zen_for_all_wire_formats() {
+    fn zen_provider_name_is_opencode_zen_for_all_wire_formats() {
         let base = "https://opencode.ai/zen/v1".to_string();
         for model_id in &[
             "gpt-4o",
@@ -268,7 +278,11 @@ mod tests {
                 HashMap::new(),
                 HashMap::new(),
             );
-            assert_eq!(p.name(), "zen", "name() should be 'zen' for {model_id}");
+            assert_eq!(
+                p.name(),
+                "opencode-zen",
+                "name() should be 'opencode-zen' for {model_id}"
+            );
         }
     }
 
@@ -325,7 +339,7 @@ mod tests {
             HashMap::new(),
             HashMap::new(),
         );
-        assert_eq!(p.name(), "zen");
+        assert_eq!(p.name(), "opencode-zen");
     }
 
     #[test]

--- a/crates/providers/src/opencode_zen.rs
+++ b/crates/providers/src/opencode_zen.rs
@@ -3,6 +3,7 @@
 //! Zen routes requests to different wire formats based on model family:
 //! - `claude-*`  → Anthropic Messages API (`/zen/v1/messages`)
 //! - `gpt-*`     → OpenAI Responses API   (`/zen/v1/responses`)
+//! - `gemini-*`  → OpenAI ChatCompletions  (`/zen/v1/chat/completions`) (no Google wire format)
 //! - everything  → OpenAI ChatCompletions  (`/zen/v1/chat/completions`)
 //!
 //! All three paths share a single `OPENCODE_ZEN_API_KEY` and base URL.
@@ -24,28 +25,28 @@ use crate::{anthropic::AnthropicProvider, openai::OpenAiProvider};
 pub const OPENCODE_ZEN_DEFAULT_BASE_URL: &str = "https://opencode.ai/zen/v1";
 
 /// Static fallback model catalog for when live discovery is unavailable.
-/// Model IDs must match what the Zen API accepts — they are the same IDs the
-/// underlying provider expects (no `opencode/` prefix).
+///
+/// Only lists the latest version of each model family; older versions are
+/// discovered via the live `/zen/v1/models` endpoint. Free-tier models are
+/// omitted. Model IDs match what the Zen API accepts (no `opencode/` prefix).
+/// Keep in sync with `GET https://opencode.ai/zen/v1/models`.
 pub(crate) const OPENCODE_ZEN_MODELS: &[(&str, &str)] = &[
     // OpenAI (Responses API)
-    ("gpt-4o", "GPT-4o (OpenCode Zen)"),
-    ("gpt-4.1", "GPT-4.1 (OpenCode Zen)"),
+    ("gpt-5.5", "GPT-5.5 (OpenCode Zen)"),
+    ("gpt-5.5-pro", "GPT-5.5 Pro (OpenCode Zen)"),
     // Anthropic (Messages API)
-    ("claude-opus-4-6", "Claude Opus 4.6 (OpenCode Zen)"),
+    ("claude-opus-4-7", "Claude Opus 4.7 (OpenCode Zen)"),
     ("claude-sonnet-4-6", "Claude Sonnet 4.6 (OpenCode Zen)"),
-    (
-        "claude-haiku-4-5-20251001",
-        "Claude Haiku 4.5 (OpenCode Zen)",
-    ),
-    // Gemini (ChatCompletions fallback)
-    (
-        "gemini-2.5-pro-preview-05-06",
-        "Gemini 2.5 Pro (OpenCode Zen)",
-    ),
-    (
-        "gemini-2.5-flash-preview-05-20",
-        "Gemini 2.5 Flash (OpenCode Zen)",
-    ),
+    ("claude-haiku-4-5", "Claude Haiku 4.5 (OpenCode Zen)"),
+    // Gemini — Zen docs show a dedicated /zen/v1/models/gemini-* endpoint,
+    // but we lack a Google-native wire format. ChatCompletions works as a fallback.
+    ("gemini-3.1-pro", "Gemini 3.1 Pro (OpenCode Zen)"),
+    ("gemini-3-flash", "Gemini 3 Flash (OpenCode Zen)"),
+    // ChatCompletions models
+    ("glm-5.1", "GLM 5.1 (OpenCode Zen)"),
+    ("minimax-m2.7", "MiniMax M2.7 (OpenCode Zen)"),
+    ("kimi-k2.6", "Kimi K2.6 (OpenCode Zen)"),
+    ("qwen3.6-plus", "Qwen 3.6 Plus (OpenCode Zen)"),
 ];
 
 /// Wire format to use for a given model, determined by model ID prefix.
@@ -59,8 +60,6 @@ enum ZenWireFormat {
 }
 
 fn classify_model(model_id: &str) -> ZenWireFormat {
-    // Normalize "provider/model-id" → "model-id" so prefix matching works
-    // even if Zen's /models endpoint returns fully-qualified IDs.
     let bare = model_id
         .rsplit_once('/')
         .map(|(_, id)| id)
@@ -239,39 +238,74 @@ mod tests {
     }
 
     #[test]
+    fn opencode_zen_models_all_classify_correctly() {
+        for (id, _label) in OPENCODE_ZEN_MODELS {
+            let fmt = classify_model(id);
+            let expected = if id.starts_with("gpt-") {
+                "OpenAiResponses"
+            } else if id.starts_with("claude-") {
+                "Anthropic"
+            } else {
+                "ChatCompletions"
+            };
+            let actual = match fmt {
+                ZenWireFormat::OpenAiResponses => "OpenAiResponses",
+                ZenWireFormat::Anthropic => "Anthropic",
+                ZenWireFormat::ChatCompletions => "ChatCompletions",
+            };
+            assert_eq!(
+                actual, expected,
+                "model {id} classified as {actual}, expected {expected}"
+            );
+        }
+    }
+
+    #[test]
     fn classify_gpt_uses_responses() {
-        assert!(matches!(
-            classify_model("gpt-4o"),
-            ZenWireFormat::OpenAiResponses
-        ));
-        assert!(matches!(
-            classify_model("gpt-4.1"),
-            ZenWireFormat::OpenAiResponses
-        ));
+        let gpt_models = [
+            "gpt-5.5", "gpt-5.5-pro", "gpt-5.4", "gpt-5.4-pro", "gpt-5.4-mini",
+            "gpt-5.4-nano", "gpt-5.3-codex", "gpt-5.3-codex-spark", "gpt-5.2",
+            "gpt-5.2-codex", "gpt-5.1", "gpt-5.1-codex", "gpt-5.1-codex-max",
+            "gpt-5.1-codex-mini", "gpt-5", "gpt-5-codex", "gpt-5-nano",
+        ];
+        for id in &gpt_models {
+            assert!(
+                matches!(classify_model(id), ZenWireFormat::OpenAiResponses),
+                "{id} should classify as OpenAiResponses"
+            );
+        }
     }
 
     #[test]
     fn classify_claude_uses_anthropic() {
-        assert!(matches!(
-            classify_model("claude-sonnet-4-6"),
-            ZenWireFormat::Anthropic
-        ));
-        assert!(matches!(
-            classify_model("claude-opus-4-6"),
-            ZenWireFormat::Anthropic
-        ));
+        let claude_models = [
+            "claude-opus-4-7", "claude-opus-4-6", "claude-opus-4-5", "claude-opus-4-1",
+            "claude-sonnet-4-6", "claude-sonnet-4-5", "claude-sonnet-4",
+            "claude-haiku-4-5",
+        ];
+        for id in &claude_models {
+            assert!(
+                matches!(classify_model(id), ZenWireFormat::Anthropic),
+                "{id} should classify as Anthropic"
+            );
+        }
     }
 
     #[test]
     fn classify_other_uses_chat_completions() {
-        assert!(matches!(
-            classify_model("gemini-2.5-pro-preview-05-06"),
-            ZenWireFormat::ChatCompletions
-        ));
-        assert!(matches!(
-            classify_model("qwen3-max"),
-            ZenWireFormat::ChatCompletions
-        ));
+        let other_models = [
+            "gemini-3.1-pro", "gemini-3-flash", "glm-5.1", "glm-5",
+            "minimax-m2.7", "minimax-m2.5", "minimax-m2.5-free",
+            "kimi-k2.6", "kimi-k2.5", "qwen3.6-plus", "qwen3.5-plus",
+            "big-pickle", "hy3-preview-free", "ling-2.6-flash-free",
+            "trinity-large-preview-free", "nemotron-3-super-free",
+        ];
+        for id in &other_models {
+            assert!(
+                matches!(classify_model(id), ZenWireFormat::ChatCompletions),
+                "{id} should classify as ChatCompletions"
+            );
+        }
     }
 
     fn dummy_key() -> Secret<String> {
@@ -281,11 +315,7 @@ mod tests {
     #[test]
     fn zen_provider_name_is_opencode_zen_for_all_wire_formats() {
         let base = "https://opencode.ai/zen/v1".to_string();
-        for model_id in &[
-            "gpt-4o",
-            "claude-sonnet-4-6",
-            "gemini-2.5-pro-preview-05-06",
-        ] {
+        for model_id in &["gpt-5.5", "claude-opus-4-7", "gemini-3.1-pro", "kimi-k2.6"] {
             let p = ZenProvider::new(
                 dummy_key(),
                 model_id.to_string(),
@@ -318,10 +348,10 @@ mod tests {
     #[test]
     fn context_window_overrides_applied_to_openai_inner() {
         let mut global_cw = HashMap::new();
-        global_cw.insert("gpt-4o".to_string(), 64_000u32);
+        global_cw.insert("gpt-5.5".to_string(), 64_000u32);
         let p = ZenProvider::new(
             dummy_key(),
-            "gpt-4o".into(),
+            "gpt-5.5".into(),
             "https://opencode.ai/zen/v1".into(),
             global_cw,
             HashMap::new(),
@@ -332,10 +362,10 @@ mod tests {
     #[test]
     fn context_window_overrides_applied_to_chat_completions_inner() {
         let mut provider_cw = HashMap::new();
-        provider_cw.insert("gemini-2.5-flash-preview-05-20".to_string(), 32_000u32);
+        provider_cw.insert("gemini-3.1-pro".to_string(), 32_000u32);
         let p = ZenProvider::new(
             dummy_key(),
-            "gemini-2.5-flash-preview-05-20".into(),
+            "gemini-3.1-pro".into(),
             "https://opencode.ai/zen/v1".into(),
             HashMap::new(),
             provider_cw,
@@ -366,7 +396,7 @@ mod tests {
             ZenWireFormat::Anthropic
         ));
         assert!(matches!(
-            classify_model("openai/gpt-4o"),
+            classify_model("openai/gpt-5.5"),
             ZenWireFormat::OpenAiResponses
         ));
         assert!(matches!(

--- a/crates/providers/src/opencode_zen.rs
+++ b/crates/providers/src/opencode_zen.rs
@@ -50,9 +50,12 @@ enum ZenWireFormat {
 }
 
 fn classify_model(model_id: &str) -> ZenWireFormat {
-    if model_id.starts_with("gpt-") {
+    // Normalize "provider/model-id" → "model-id" so prefix matching works
+    // even if Zen's /models endpoint returns fully-qualified IDs.
+    let bare = model_id.rsplit_once('/').map(|(_, id)| id).unwrap_or(model_id);
+    if bare.starts_with("gpt-") {
         ZenWireFormat::OpenAiResponses
-    } else if model_id.starts_with("claude-") {
+    } else if bare.starts_with("claude-") {
         ZenWireFormat::Anthropic
     } else {
         ZenWireFormat::ChatCompletions
@@ -343,17 +346,19 @@ mod tests {
     }
 
     #[test]
-    fn prefixed_model_ids_fall_through_to_chat_completions() {
-        // If Zen's /models endpoint returns "anthropic/claude-..." or "openai/gpt-..." style IDs,
-        // classify_model will not match the gpt-/claude- prefixes and will route via ChatCompletions.
-        // This is the known risk documented in the code review. If that happens in practice, add
-        // prefix-stripping normalization here and in fetch_models_from_api.
+    fn prefixed_model_ids_are_normalized_before_classification() {
+        // Zen's /models endpoint may return "provider/model-id" style IDs.
+        // classify_model strips the prefix so routing is still correct.
         assert!(matches!(
             classify_model("anthropic/claude-sonnet-4-6"),
-            ZenWireFormat::ChatCompletions
+            ZenWireFormat::Anthropic
         ));
         assert!(matches!(
             classify_model("openai/gpt-4o"),
+            ZenWireFormat::OpenAiResponses
+        ));
+        assert!(matches!(
+            classify_model("google/gemini-2.5-pro"),
             ZenWireFormat::ChatCompletions
         ));
     }

--- a/crates/providers/src/registry/core.rs
+++ b/crates/providers/src/registry/core.rs
@@ -250,21 +250,22 @@ pub async fn fetch_discoverable_models(
         }
     }
 
-    // ── Zen (opencode.ai) ─────────────────────────────────────────────
-    if filter_matches("zen")
-        && config.is_enabled("zen")
+    // ── OpenCode Zen (opencode.ai) ────────────────────────────────────
+    if filter_matches("opencode-zen")
+        && config.is_enabled("opencode-zen")
         && !cfg!(test)
-        && let Some(key) = resolve_api_key(config, "zen", "ZEN_API_KEY", env_overrides)
-        && should_fetch_models(config, "zen")
+        && let Some(key) =
+            resolve_api_key(config, "opencode-zen", "OPENCODE_ZEN_API_KEY", env_overrides)
+        && should_fetch_models(config, "opencode-zen")
     {
         let base_url = config
-            .get("zen")
+            .get("opencode-zen")
             .and_then(|e| e.base_url.clone())
-            .or_else(|| env_value(env_overrides, "ZEN_BASE_URL"))
-            .unwrap_or_else(|| crate::zen::ZEN_DEFAULT_BASE_URL.into());
+            .or_else(|| env_value(env_overrides, "OPENCODE_ZEN_BASE_URL"))
+            .unwrap_or_else(|| crate::opencode_zen::OPENCODE_ZEN_DEFAULT_BASE_URL.into());
         // Zen exposes an OpenAI-compatible /models endpoint.
         tasks.push((
-            "zen".into(),
+            "opencode-zen".into(),
             Box::pin(openai::fetch_models_from_api(key, base_url)),
         ));
     }
@@ -880,7 +881,7 @@ impl ProviderRegistry {
             reg.register_kimi_code_providers(config, env_overrides);
         }
 
-        reg.register_zen_providers(config, env_overrides, prefetched);
+        reg.register_opencode_zen_providers(config, env_overrides, prefetched);
 
         // Local GGUF providers (no API key needed, model runs locally)
         #[cfg(feature = "local-llm")]
@@ -1021,19 +1022,23 @@ impl ProviderRegistry {
             }
         }
 
-        // ── Zen (opencode.ai) ────────────────────────────────────────────
-        if config.is_enabled("zen")
+        // ── OpenCode Zen (opencode.ai) ───────────────────────────────────
+        if config.is_enabled("opencode-zen")
             && !cfg!(test)
-            && let Some(key) = resolve_api_key(config, "zen", "ZEN_API_KEY", env_overrides)
-            && should_fetch_models(config, "zen")
+            && let Some(key) =
+                resolve_api_key(config, "opencode-zen", "OPENCODE_ZEN_API_KEY", env_overrides)
+            && should_fetch_models(config, "opencode-zen")
         {
             let base_url = config
-                .get("zen")
+                .get("opencode-zen")
                 .and_then(|e| e.base_url.clone())
-                .or_else(|| env_value(env_overrides, "ZEN_BASE_URL"))
-                .unwrap_or_else(|| crate::zen::ZEN_DEFAULT_BASE_URL.into());
+                .or_else(|| env_value(env_overrides, "OPENCODE_ZEN_BASE_URL"))
+                .unwrap_or_else(|| crate::opencode_zen::OPENCODE_ZEN_DEFAULT_BASE_URL.into());
             // Zen exposes an OpenAI-compatible /models endpoint.
-            pending.push(("zen".into(), openai::start_model_discovery(key, base_url)));
+            pending.push((
+                "opencode-zen".into(),
+                openai::start_model_discovery(key, base_url),
+            ));
         }
 
         // ── OpenAI Codex ─────────────────────────────────────────────────

--- a/crates/providers/src/registry/core.rs
+++ b/crates/providers/src/registry/core.rs
@@ -262,9 +262,10 @@ pub async fn fetch_discoverable_models(
             .and_then(|e| e.base_url.clone())
             .or_else(|| env_value(env_overrides, "ZEN_BASE_URL"))
             .unwrap_or_else(|| crate::zen::ZEN_DEFAULT_BASE_URL.into());
+        // Zen exposes an OpenAI-compatible /models endpoint.
         tasks.push((
             "zen".into(),
-            Box::pin(crate::zen::fetch_models_from_api(key, base_url)),
+            Box::pin(openai::fetch_models_from_api(key, base_url)),
         ));
     }
 
@@ -1031,10 +1032,8 @@ impl ProviderRegistry {
                 .and_then(|e| e.base_url.clone())
                 .or_else(|| env_value(env_overrides, "ZEN_BASE_URL"))
                 .unwrap_or_else(|| crate::zen::ZEN_DEFAULT_BASE_URL.into());
-            pending.push((
-                "zen".into(),
-                crate::zen::start_model_discovery(key, base_url),
-            ));
+            // Zen exposes an OpenAI-compatible /models endpoint.
+            pending.push(("zen".into(), openai::start_model_discovery(key, base_url)));
         }
 
         // ── OpenAI Codex ─────────────────────────────────────────────────

--- a/crates/providers/src/registry/core.rs
+++ b/crates/providers/src/registry/core.rs
@@ -250,6 +250,24 @@ pub async fn fetch_discoverable_models(
         }
     }
 
+    // ── Zen (opencode.ai) ─────────────────────────────────────────────
+    if filter_matches("zen")
+        && config.is_enabled("zen")
+        && !cfg!(test)
+        && let Some(key) = resolve_api_key(config, "zen", "ZEN_API_KEY", env_overrides)
+        && should_fetch_models(config, "zen")
+    {
+        let base_url = config
+            .get("zen")
+            .and_then(|e| e.base_url.clone())
+            .or_else(|| env_value(env_overrides, "ZEN_BASE_URL"))
+            .unwrap_or_else(|| crate::zen::ZEN_DEFAULT_BASE_URL.into());
+        tasks.push((
+            "zen".into(),
+            Box::pin(crate::zen::fetch_models_from_api(key, base_url)),
+        ));
+    }
+
     // ── Custom providers ──────────────────────────────────────────────
     for (name, entry) in &config.providers {
         if !name.starts_with("custom-") || !entry.enabled {
@@ -861,6 +879,8 @@ impl ProviderRegistry {
             reg.register_kimi_code_providers(config, env_overrides);
         }
 
+        reg.register_zen_providers(config, env_overrides, prefetched);
+
         // Local GGUF providers (no API key needed, model runs locally)
         #[cfg(feature = "local-llm")]
         {
@@ -998,6 +1018,23 @@ impl ProviderRegistry {
                     openai::start_model_discovery(api_key.clone(), base_url.clone()),
                 ));
             }
+        }
+
+        // ── Zen (opencode.ai) ────────────────────────────────────────────
+        if config.is_enabled("zen")
+            && !cfg!(test)
+            && let Some(key) = resolve_api_key(config, "zen", "ZEN_API_KEY", env_overrides)
+            && should_fetch_models(config, "zen")
+        {
+            let base_url = config
+                .get("zen")
+                .and_then(|e| e.base_url.clone())
+                .or_else(|| env_value(env_overrides, "ZEN_BASE_URL"))
+                .unwrap_or_else(|| crate::zen::ZEN_DEFAULT_BASE_URL.into());
+            pending.push((
+                "zen".into(),
+                crate::zen::start_model_discovery(key, base_url),
+            ));
         }
 
         // ── OpenAI Codex ─────────────────────────────────────────────────

--- a/crates/providers/src/registry/core.rs
+++ b/crates/providers/src/registry/core.rs
@@ -254,8 +254,12 @@ pub async fn fetch_discoverable_models(
     if filter_matches("opencode-zen")
         && config.is_enabled("opencode-zen")
         && !cfg!(test)
-        && let Some(key) =
-            resolve_api_key(config, "opencode-zen", "OPENCODE_ZEN_API_KEY", env_overrides)
+        && let Some(key) = resolve_api_key(
+            config,
+            "opencode-zen",
+            "OPENCODE_ZEN_API_KEY",
+            env_overrides,
+        )
         && should_fetch_models(config, "opencode-zen")
     {
         let base_url = config
@@ -1025,8 +1029,12 @@ impl ProviderRegistry {
         // ── OpenCode Zen (opencode.ai) ───────────────────────────────────
         if config.is_enabled("opencode-zen")
             && !cfg!(test)
-            && let Some(key) =
-                resolve_api_key(config, "opencode-zen", "OPENCODE_ZEN_API_KEY", env_overrides)
+            && let Some(key) = resolve_api_key(
+                config,
+                "opencode-zen",
+                "OPENCODE_ZEN_API_KEY",
+                env_overrides,
+            )
             && should_fetch_models(config, "opencode-zen")
         {
             let base_url = config

--- a/crates/providers/src/registry/registration.rs
+++ b/crates/providers/src/registry/registration.rs
@@ -30,7 +30,7 @@ use crate::openai_codex;
 #[allow(unused_imports)]
 use crate::{
     anthropic, async_openai_provider, config_helpers::*, discovered_model::*, genai_provider,
-    model_capabilities::*, model_catalogs::*, model_id::*, ollama::*, openai, zen,
+    model_capabilities::*, model_catalogs::*, model_id::*, ollama::*, openai, opencode_zen,
 };
 impl ProviderRegistry {
     /// Register models from a [`RediscoveryResult`], skipping those already
@@ -1093,52 +1093,56 @@ impl ProviderRegistry {
         }
     }
 
-    pub(crate) fn register_zen_providers(
+    pub(crate) fn register_opencode_zen_providers(
         &mut self,
         config: &ProvidersConfig,
         env_overrides: &HashMap<String, String>,
         prefetched: &HashMap<String, Vec<DiscoveredModel>>,
     ) {
-        if !config.is_enabled("zen") {
+        if !config.is_enabled("opencode-zen") {
             return;
         }
-        let Some(key) = resolve_api_key(config, "zen", "ZEN_API_KEY", env_overrides) else {
+        let Some(key) =
+            resolve_api_key(config, "opencode-zen", "OPENCODE_ZEN_API_KEY", env_overrides)
+        else {
             return;
         };
 
         let base_url = config
-            .get("zen")
+            .get("opencode-zen")
             .and_then(|e| e.base_url.clone())
-            .or_else(|| env_value(env_overrides, "ZEN_BASE_URL"))
-            .unwrap_or_else(|| zen::ZEN_DEFAULT_BASE_URL.into());
+            .or_else(|| env_value(env_overrides, "OPENCODE_ZEN_BASE_URL"))
+            .unwrap_or_else(|| opencode_zen::OPENCODE_ZEN_DEFAULT_BASE_URL.into());
 
-        let alias = config.get("zen").and_then(|e| e.alias.clone());
-        let provider_label = alias.unwrap_or_else(|| "zen".into());
+        let alias = config.get("opencode-zen").and_then(|e| e.alias.clone());
+        let provider_label = alias.unwrap_or_else(|| "opencode-zen".into());
 
-        let preferred = configured_models_for_provider(config, "zen");
-        let discovered = if should_fetch_models(config, "zen") {
-            match prefetched.get("zen") {
+        let preferred = configured_models_for_provider(config, "opencode-zen");
+        let discovered = if should_fetch_models(config, "opencode-zen") {
+            match prefetched.get("opencode-zen") {
                 Some(live) => live.clone(),
                 // Live fetch was requested but produced no result — fall back to
                 // the static catalog so the provider is still usable.
-                None => catalog_to_discovered(zen::ZEN_MODELS, 2),
+                None => catalog_to_discovered(opencode_zen::OPENCODE_ZEN_MODELS, 2),
             }
         } else {
             // Discovery explicitly disabled: only register models the user
-            // pinned in [providers.zen] models = [...]. Consistent with how
-            // other built-in providers behave when fetch_models = false.
+            // pinned in [providers.opencode-zen] models = [...]. Consistent with
+            // how other built-in providers behave when fetch_models = false.
             Vec::new()
         };
         let models = merge_preferred_and_discovered_models(preferred, discovered);
 
         if models.is_empty() {
-            tracing::debug!("zen: no models to register (discovery disabled and no pinned models)");
+            tracing::debug!(
+                "opencode-zen: no models to register (discovery disabled and no pinned models)"
+            );
             return;
         }
 
         let global_cw = self.global_cw_overrides.clone();
         let provider_cw = config
-            .get("zen")
+            .get("opencode-zen")
             .map(|e| extract_cw_overrides(&e.model_overrides))
             .unwrap_or_default();
 
@@ -1147,7 +1151,7 @@ impl ProviderRegistry {
             if self.has_provider_model(&provider_label, &model.id) {
                 continue;
             }
-            let provider: Arc<dyn LlmProvider> = Arc::new(zen::ZenProvider::new(
+            let provider: Arc<dyn LlmProvider> = Arc::new(opencode_zen::ZenProvider::new(
                 key.clone(),
                 model.id.clone(),
                 base_url.clone(),
@@ -1170,7 +1174,7 @@ impl ProviderRegistry {
             added += 1;
         }
 
-        tracing::info!(model_count = added, "registered Zen (opencode.ai) provider");
+        tracing::info!(model_count = added, "registered OpenCode Zen provider");
     }
 
     pub fn get(&self, model_id: &str) -> Option<Arc<dyn LlmProvider>> {

--- a/crates/providers/src/registry/registration.rs
+++ b/crates/providers/src/registry/registration.rs
@@ -1174,7 +1174,9 @@ impl ProviderRegistry {
             added += 1;
         }
 
-        tracing::info!(model_count = added, "registered OpenCode Zen provider");
+        if added > 0 {
+            tracing::info!(model_count = added, "registered OpenCode Zen provider");
+        }
     }
 
     pub fn get(&self, model_id: &str) -> Option<Arc<dyn LlmProvider>> {

--- a/crates/providers/src/registry/registration.rs
+++ b/crates/providers/src/registry/registration.rs
@@ -30,7 +30,7 @@ use crate::openai_codex;
 #[allow(unused_imports)]
 use crate::{
     anthropic, async_openai_provider, config_helpers::*, discovered_model::*, genai_provider,
-    model_capabilities::*, model_catalogs::*, model_id::*, ollama::*, openai,
+    model_capabilities::*, model_catalogs::*, model_id::*, ollama::*, openai, zen,
 };
 impl ProviderRegistry {
     /// Register models from a [`RediscoveryResult`], skipping those already
@@ -1089,6 +1089,64 @@ impl ProviderRegistry {
             tracing::info!(
                 provider = %name,
                 "registered custom OpenAI-compatible provider"
+            );
+        }
+    }
+
+    pub(crate) fn register_zen_providers(
+        &mut self,
+        config: &ProvidersConfig,
+        env_overrides: &HashMap<String, String>,
+        prefetched: &HashMap<String, Vec<DiscoveredModel>>,
+    ) {
+        if !config.is_enabled("zen") {
+            return;
+        }
+        let Some(key) = resolve_api_key(config, "zen", "ZEN_API_KEY", env_overrides) else {
+            return;
+        };
+
+        let base_url = config
+            .get("zen")
+            .and_then(|e| e.base_url.clone())
+            .or_else(|| env_value(env_overrides, "ZEN_BASE_URL"))
+            .unwrap_or_else(|| zen::ZEN_DEFAULT_BASE_URL.into());
+
+        let alias = config.get("zen").and_then(|e| e.alias.clone());
+        let provider_label = alias.unwrap_or_else(|| "zen".into());
+
+        let preferred = configured_models_for_provider(config, "zen");
+        let discovered = if should_fetch_models(config, "zen") {
+            match prefetched.get("zen") {
+                Some(live) => live.clone(),
+                None => catalog_to_discovered(zen::ZEN_MODELS, 2),
+            }
+        } else {
+            catalog_to_discovered(zen::ZEN_MODELS, 2)
+        };
+        let models = merge_preferred_and_discovered_models(preferred, discovered);
+
+        for model in models {
+            if self.has_provider_model(&provider_label, &model.id) {
+                continue;
+            }
+            let provider: Arc<dyn LlmProvider> = Arc::new(zen::ZenProvider::new(
+                key.clone(),
+                model.id.clone(),
+                base_url.clone(),
+            ));
+            self.register(
+                ModelInfo {
+                    id: model.id.clone(),
+                    provider: provider_label.clone(),
+                    display_name: model.display_name.clone(),
+                    created_at: model.created_at,
+                    recommended: model.recommended,
+                    capabilities: model
+                        .capabilities
+                        .unwrap_or_else(|| ModelCapabilities::infer(&model.id)),
+                },
+                provider,
             );
         }
     }

--- a/crates/providers/src/registry/registration.rs
+++ b/crates/providers/src/registry/registration.rs
@@ -1119,12 +1119,22 @@ impl ProviderRegistry {
         let discovered = if should_fetch_models(config, "zen") {
             match prefetched.get("zen") {
                 Some(live) => live.clone(),
+                // Live fetch was requested but produced no result — fall back to
+                // the static catalog so the provider is still usable.
                 None => catalog_to_discovered(zen::ZEN_MODELS, 2),
             }
         } else {
-            catalog_to_discovered(zen::ZEN_MODELS, 2)
+            // Discovery explicitly disabled: only register models the user
+            // pinned in [providers.zen] models = [...]. Consistent with how
+            // other built-in providers behave when fetch_models = false.
+            Vec::new()
         };
         let models = merge_preferred_and_discovered_models(preferred, discovered);
+
+        if models.is_empty() {
+            tracing::debug!("zen: no models to register (discovery disabled and no pinned models)");
+            return;
+        }
 
         let global_cw = self.global_cw_overrides.clone();
         let provider_cw = config
@@ -1132,6 +1142,7 @@ impl ProviderRegistry {
             .map(|e| extract_cw_overrides(&e.model_overrides))
             .unwrap_or_default();
 
+        let mut added = 0usize;
         for model in models {
             if self.has_provider_model(&provider_label, &model.id) {
                 continue;
@@ -1156,7 +1167,10 @@ impl ProviderRegistry {
                 },
                 provider,
             );
+            added += 1;
         }
+
+        tracing::info!(model_count = added, "registered Zen (opencode.ai) provider");
     }
 
     pub fn get(&self, model_id: &str) -> Option<Arc<dyn LlmProvider>> {

--- a/crates/providers/src/registry/registration.rs
+++ b/crates/providers/src/registry/registration.rs
@@ -135,6 +135,58 @@ impl ProviderRegistry {
             }
         }
 
+        // ── OpenCode Zen builtin ──────────────────────────────────────
+        if let Some(models) = fetched.get("opencode-zen")
+            && config.is_enabled("opencode-zen")
+            && let Some(key) = resolve_api_key(
+                config,
+                "opencode-zen",
+                "OPENCODE_ZEN_API_KEY",
+                env_overrides,
+            )
+        {
+            let base_url = config
+                .get("opencode-zen")
+                .and_then(|e| e.base_url.clone())
+                .or_else(|| env_value(env_overrides, "OPENCODE_ZEN_BASE_URL"))
+                .unwrap_or_else(|| opencode_zen::OPENCODE_ZEN_DEFAULT_BASE_URL.into());
+            let alias = config.get("opencode-zen").and_then(|e| e.alias.clone());
+            let provider_label = alias.unwrap_or_else(|| "opencode-zen".into());
+            let global_cw = self.global_cw_overrides.clone();
+            let provider_cw = config
+                .get("opencode-zen")
+                .map(|e| extract_cw_overrides(&e.model_overrides))
+                .unwrap_or_default();
+
+            for model in models {
+                if self.has_provider_model(&provider_label, &model.id) {
+                    continue;
+                }
+                let provider: Arc<dyn LlmProvider> =
+                    Arc::new(opencode_zen::ZenProvider::new(
+                        key.clone(),
+                        model.id.clone(),
+                        base_url.clone(),
+                        global_cw.clone(),
+                        provider_cw.clone(),
+                    ));
+                self.register(
+                    ModelInfo {
+                        id: model.id.clone(),
+                        provider: provider_label.clone(),
+                        display_name: model.display_name.clone(),
+                        created_at: model.created_at,
+                        recommended: model.recommended,
+                        capabilities: model
+                            .capabilities
+                            .unwrap_or_else(|| ModelCapabilities::infer(&model.id)),
+                    },
+                    provider,
+                );
+                added += 1;
+            }
+        }
+
         // ── OpenAI-compatible providers ───────────────────────────────
         for def in OPENAI_COMPAT_PROVIDERS {
             let Some(models) = fetched.get(def.config_name) else {

--- a/crates/providers/src/registry/registration.rs
+++ b/crates/providers/src/registry/registration.rs
@@ -1126,6 +1126,12 @@ impl ProviderRegistry {
         };
         let models = merge_preferred_and_discovered_models(preferred, discovered);
 
+        let global_cw = self.global_cw_overrides.clone();
+        let provider_cw = config
+            .get("zen")
+            .map(|e| extract_cw_overrides(&e.model_overrides))
+            .unwrap_or_default();
+
         for model in models {
             if self.has_provider_model(&provider_label, &model.id) {
                 continue;
@@ -1134,6 +1140,8 @@ impl ProviderRegistry {
                 key.clone(),
                 model.id.clone(),
                 base_url.clone(),
+                global_cw.clone(),
+                provider_cw.clone(),
             ));
             self.register(
                 ModelInfo {

--- a/crates/providers/src/registry/registration.rs
+++ b/crates/providers/src/registry/registration.rs
@@ -1102,9 +1102,12 @@ impl ProviderRegistry {
         if !config.is_enabled("opencode-zen") {
             return;
         }
-        let Some(key) =
-            resolve_api_key(config, "opencode-zen", "OPENCODE_ZEN_API_KEY", env_overrides)
-        else {
+        let Some(key) = resolve_api_key(
+            config,
+            "opencode-zen",
+            "OPENCODE_ZEN_API_KEY",
+            env_overrides,
+        ) else {
             return;
         };
 

--- a/crates/providers/src/zen.rs
+++ b/crates/providers/src/zen.rs
@@ -1,0 +1,283 @@
+//! Zen provider — opencode.ai's curated multi-protocol model proxy.
+//!
+//! Zen routes requests to different wire formats based on model family:
+//! - `claude-*`  → Anthropic Messages API (`/zen/v1/messages`)
+//! - `gpt-*`     → OpenAI Responses API   (`/zen/v1/responses`)
+//! - everything  → OpenAI ChatCompletions  (`/zen/v1/chat/completions`)
+//!
+//! All three paths share a single `ZEN_API_KEY` and base URL.
+
+use std::{pin::Pin, sync::Arc, time::Duration};
+
+use {
+    async_trait::async_trait,
+    moltis_agents::model::{
+        ChatMessage, CompletionResponse, LlmProvider, ModelMetadata, ReasoningEffort, StreamEvent,
+    },
+    moltis_config::WireApi,
+    secrecy::Secret,
+    tokio_stream::Stream,
+};
+
+use crate::{
+    anthropic::AnthropicProvider,
+    discovered_model::DiscoveredModel,
+    openai::{self, OpenAiProvider},
+};
+
+pub const ZEN_DEFAULT_BASE_URL: &str = "https://opencode.ai/zen/v1";
+
+/// Static fallback model catalog for when live discovery is unavailable.
+/// Model IDs must match what the Zen API accepts — they are the same IDs the
+/// underlying provider expects (no `opencode/` prefix).
+pub(crate) const ZEN_MODELS: &[(&str, &str)] = &[
+    // OpenAI (Responses API)
+    ("gpt-4o", "GPT-4o (Zen)"),
+    ("gpt-4.1", "GPT-4.1 (Zen)"),
+    // Anthropic (Messages API)
+    ("claude-opus-4-6", "Claude Opus 4.6 (Zen)"),
+    ("claude-sonnet-4-6", "Claude Sonnet 4.6 (Zen)"),
+    ("claude-haiku-4-5-20251001", "Claude Haiku 4.5 (Zen)"),
+    // Gemini (ChatCompletions fallback)
+    ("gemini-2.5-pro-preview-05-06", "Gemini 2.5 Pro (Zen)"),
+    ("gemini-2.5-flash-preview-05-20", "Gemini 2.5 Flash (Zen)"),
+];
+
+/// Wire format to use for a given model, determined by model ID prefix.
+enum ZenWireFormat {
+    /// OpenAI Responses API — `gpt-*` models.
+    OpenAiResponses,
+    /// Anthropic Messages API — `claude-*` models.
+    Anthropic,
+    /// OpenAI ChatCompletions — everything else (Gemini, etc.).
+    ChatCompletions,
+}
+
+fn classify_model(model_id: &str) -> ZenWireFormat {
+    if model_id.starts_with("gpt-") {
+        ZenWireFormat::OpenAiResponses
+    } else if model_id.starts_with("claude-") {
+        ZenWireFormat::Anthropic
+    } else {
+        ZenWireFormat::ChatCompletions
+    }
+}
+
+/// A Zen (opencode.ai) provider that dispatches to the correct wire format.
+///
+/// The inner provider is selected once at construction time based on the model
+/// ID prefix, so all hot-path method calls are simple `Arc<dyn LlmProvider>`
+/// delegate calls with no branching.
+pub struct ZenProvider {
+    model_id: String,
+    inner: Arc<dyn LlmProvider>,
+}
+
+impl ZenProvider {
+    /// Construct a `ZenProvider` for `model_id`.
+    ///
+    /// `base_url` should be the `v1` prefix, e.g. `https://opencode.ai/zen/v1`.
+    /// Anthropic routing strips the trailing `/v1` because `AnthropicProvider`
+    /// appends `/v1/messages` internally.
+    pub fn new(api_key: Secret<String>, model_id: String, base_url: String) -> Self {
+        let inner: Arc<dyn LlmProvider> = match classify_model(&model_id) {
+            ZenWireFormat::OpenAiResponses => Arc::new(
+                OpenAiProvider::new_with_name(api_key, model_id.clone(), base_url, "zen".into())
+                    .with_wire_api(WireApi::Responses),
+            ),
+            ZenWireFormat::Anthropic => {
+                // AnthropicProvider appends `/v1/messages` to its base_url, so
+                // strip the trailing `/v1` from the Zen base URL.
+                let anthropic_base = base_url
+                    .trim_end_matches('/')
+                    .strip_suffix("/v1")
+                    .map(str::to_string)
+                    .unwrap_or(base_url);
+                Arc::new(AnthropicProvider::with_alias(
+                    api_key,
+                    model_id.clone(),
+                    anthropic_base,
+                    Some("zen".into()),
+                ))
+            },
+            ZenWireFormat::ChatCompletions => Arc::new(OpenAiProvider::new_with_name(
+                api_key,
+                model_id.clone(),
+                base_url,
+                "zen".into(),
+            )),
+        };
+        Self { model_id, inner }
+    }
+}
+
+#[async_trait]
+impl LlmProvider for ZenProvider {
+    fn name(&self) -> &str {
+        "zen"
+    }
+
+    fn id(&self) -> &str {
+        &self.model_id
+    }
+
+    async fn complete(
+        &self,
+        messages: &[ChatMessage],
+        tools: &[serde_json::Value],
+    ) -> anyhow::Result<CompletionResponse> {
+        self.inner.complete(messages, tools).await
+    }
+
+    fn supports_tools(&self) -> bool {
+        self.inner.supports_tools()
+    }
+
+    fn context_window(&self) -> u32 {
+        self.inner.context_window()
+    }
+
+    fn supports_vision(&self) -> bool {
+        self.inner.supports_vision()
+    }
+
+    fn tool_mode(&self) -> Option<moltis_config::ToolMode> {
+        self.inner.tool_mode()
+    }
+
+    fn stream(
+        &self,
+        messages: Vec<ChatMessage>,
+    ) -> Pin<Box<dyn Stream<Item = StreamEvent> + Send + '_>> {
+        self.inner.stream(messages)
+    }
+
+    fn stream_with_tools(
+        &self,
+        messages: Vec<ChatMessage>,
+        tools: Vec<serde_json::Value>,
+    ) -> Pin<Box<dyn Stream<Item = StreamEvent> + Send + '_>> {
+        self.inner.stream_with_tools(messages, tools)
+    }
+
+    fn reasoning_effort(&self) -> Option<ReasoningEffort> {
+        self.inner.reasoning_effort()
+    }
+
+    fn with_reasoning_effort(
+        self: Arc<Self>,
+        effort: ReasoningEffort,
+    ) -> Option<Arc<dyn LlmProvider>> {
+        let new_inner = Arc::clone(&self.inner).with_reasoning_effort(effort)?;
+        Some(Arc::new(ZenProvider {
+            model_id: self.model_id.clone(),
+            inner: new_inner,
+        }))
+    }
+
+    fn probe_timeout(&self) -> Duration {
+        self.inner.probe_timeout()
+    }
+
+    async fn check_availability(&self) -> anyhow::Result<()> {
+        self.inner.check_availability().await
+    }
+
+    async fn model_metadata(&self) -> anyhow::Result<ModelMetadata> {
+        self.inner.model_metadata().await
+    }
+}
+
+/// Fetch live models from `GET /zen/v1/models` (OpenAI-compatible endpoint).
+pub async fn fetch_models_from_api(
+    api_key: Secret<String>,
+    base_url: String,
+) -> anyhow::Result<Vec<DiscoveredModel>> {
+    openai::fetch_models_from_api(api_key, base_url).await
+}
+
+/// Spawn a background thread to fetch Zen models and return a receiver.
+pub fn start_model_discovery(
+    api_key: Secret<String>,
+    base_url: String,
+) -> std::sync::mpsc::Receiver<anyhow::Result<Vec<DiscoveredModel>>> {
+    openai::start_model_discovery(api_key, base_url)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn zen_models_not_empty() {
+        assert!(!ZEN_MODELS.is_empty());
+    }
+
+    #[test]
+    fn zen_models_have_unique_ids() {
+        let mut ids: Vec<&str> = ZEN_MODELS.iter().map(|(id, _)| *id).collect();
+        ids.sort();
+        let before = ids.len();
+        ids.dedup();
+        assert_eq!(before, ids.len(), "duplicate ZEN_MODELS IDs");
+    }
+
+    #[test]
+    fn classify_gpt_uses_responses() {
+        assert!(matches!(
+            classify_model("gpt-4o"),
+            ZenWireFormat::OpenAiResponses
+        ));
+        assert!(matches!(
+            classify_model("gpt-4.1"),
+            ZenWireFormat::OpenAiResponses
+        ));
+    }
+
+    #[test]
+    fn classify_claude_uses_anthropic() {
+        assert!(matches!(
+            classify_model("claude-sonnet-4-6"),
+            ZenWireFormat::Anthropic
+        ));
+        assert!(matches!(
+            classify_model("claude-opus-4-6"),
+            ZenWireFormat::Anthropic
+        ));
+    }
+
+    #[test]
+    fn classify_other_uses_chat_completions() {
+        assert!(matches!(
+            classify_model("gemini-2.5-pro-preview-05-06"),
+            ZenWireFormat::ChatCompletions
+        ));
+        assert!(matches!(
+            classify_model("qwen3-max"),
+            ZenWireFormat::ChatCompletions
+        ));
+    }
+
+    #[test]
+    fn anthropic_base_url_strip() {
+        // Simulate what new() does: strip /v1 for AnthropicProvider
+        let base = "https://opencode.ai/zen/v1";
+        let stripped = base
+            .trim_end_matches('/')
+            .strip_suffix("/v1")
+            .map(str::to_string)
+            .unwrap_or_else(|| base.to_string());
+        assert_eq!(stripped, "https://opencode.ai/zen");
+    }
+
+    #[test]
+    fn anthropic_base_url_strip_trailing_slash() {
+        let base = "https://opencode.ai/zen/v1/";
+        let stripped = base
+            .trim_end_matches('/')
+            .strip_suffix("/v1")
+            .map(str::to_string)
+            .unwrap_or_else(|| base.to_string());
+        assert_eq!(stripped, "https://opencode.ai/zen");
+    }
+}

--- a/crates/providers/src/zen.rs
+++ b/crates/providers/src/zen.rs
@@ -19,11 +19,7 @@ use {
     tokio_stream::Stream,
 };
 
-use crate::{
-    anthropic::AnthropicProvider,
-    discovered_model::DiscoveredModel,
-    openai::{self, OpenAiProvider},
-};
+use crate::{anthropic::AnthropicProvider, openai::OpenAiProvider};
 
 pub const ZEN_DEFAULT_BASE_URL: &str = "https://opencode.ai/zen/v1";
 
@@ -197,22 +193,6 @@ impl LlmProvider for ZenProvider {
     async fn model_metadata(&self) -> anyhow::Result<ModelMetadata> {
         self.inner.model_metadata().await
     }
-}
-
-/// Fetch live models from `GET /zen/v1/models` (OpenAI-compatible endpoint).
-pub async fn fetch_models_from_api(
-    api_key: Secret<String>,
-    base_url: String,
-) -> anyhow::Result<Vec<DiscoveredModel>> {
-    openai::fetch_models_from_api(api_key, base_url).await
-}
-
-/// Spawn a background thread to fetch Zen models and return a receiver.
-pub fn start_model_discovery(
-    api_key: Secret<String>,
-    base_url: String,
-) -> std::sync::mpsc::Receiver<anyhow::Result<Vec<DiscoveredModel>>> {
-    openai::start_model_discovery(api_key, base_url)
 }
 
 #[cfg(test)]

--- a/crates/providers/src/zen.rs
+++ b/crates/providers/src/zen.rs
@@ -7,7 +7,7 @@
 //!
 //! All three paths share a single `ZEN_API_KEY` and base URL.
 
-use std::{pin::Pin, sync::Arc, time::Duration};
+use std::{collections::HashMap, pin::Pin, sync::Arc, time::Duration};
 
 use {
     async_trait::async_trait,
@@ -79,11 +79,21 @@ impl ZenProvider {
     /// `base_url` should be the `v1` prefix, e.g. `https://opencode.ai/zen/v1`.
     /// Anthropic routing strips the trailing `/v1` because `AnthropicProvider`
     /// appends `/v1/messages` internally.
-    pub fn new(api_key: Secret<String>, model_id: String, base_url: String) -> Self {
+    ///
+    /// `global_cw` and `provider_cw` are the context-window override maps from
+    /// `[models.<id>]` and `[providers.zen.model_overrides]` config respectively.
+    pub fn new(
+        api_key: Secret<String>,
+        model_id: String,
+        base_url: String,
+        global_cw: HashMap<String, u32>,
+        provider_cw: HashMap<String, u32>,
+    ) -> Self {
         let inner: Arc<dyn LlmProvider> = match classify_model(&model_id) {
             ZenWireFormat::OpenAiResponses => Arc::new(
                 OpenAiProvider::new_with_name(api_key, model_id.clone(), base_url, "zen".into())
-                    .with_wire_api(WireApi::Responses),
+                    .with_wire_api(WireApi::Responses)
+                    .with_context_window_overrides(global_cw, provider_cw),
             ),
             ZenWireFormat::Anthropic => {
                 // AnthropicProvider appends `/v1/messages` to its base_url, so
@@ -93,19 +103,20 @@ impl ZenProvider {
                     .strip_suffix("/v1")
                     .map(str::to_string)
                     .unwrap_or(base_url);
-                Arc::new(AnthropicProvider::with_alias(
-                    api_key,
-                    model_id.clone(),
-                    anthropic_base,
-                    Some("zen".into()),
-                ))
+                Arc::new(
+                    AnthropicProvider::with_alias(
+                        api_key,
+                        model_id.clone(),
+                        anthropic_base,
+                        Some("zen".into()),
+                    )
+                    .with_context_window_overrides(global_cw, provider_cw),
+                )
             },
-            ZenWireFormat::ChatCompletions => Arc::new(OpenAiProvider::new_with_name(
-                api_key,
-                model_id.clone(),
-                base_url,
-                "zen".into(),
-            )),
+            ZenWireFormat::ChatCompletions => Arc::new(
+                OpenAiProvider::new_with_name(api_key, model_id.clone(), base_url, "zen".into())
+                    .with_context_window_overrides(global_cw, provider_cw),
+            ),
         };
         Self { model_id, inner }
     }
@@ -258,26 +269,98 @@ mod tests {
         ));
     }
 
-    #[test]
-    fn anthropic_base_url_strip() {
-        // Simulate what new() does: strip /v1 for AnthropicProvider
-        let base = "https://opencode.ai/zen/v1";
-        let stripped = base
-            .trim_end_matches('/')
-            .strip_suffix("/v1")
-            .map(str::to_string)
-            .unwrap_or_else(|| base.to_string());
-        assert_eq!(stripped, "https://opencode.ai/zen");
+    fn dummy_key() -> Secret<String> {
+        Secret::new("test-key".into())
     }
 
     #[test]
-    fn anthropic_base_url_strip_trailing_slash() {
-        let base = "https://opencode.ai/zen/v1/";
-        let stripped = base
-            .trim_end_matches('/')
-            .strip_suffix("/v1")
-            .map(str::to_string)
-            .unwrap_or_else(|| base.to_string());
-        assert_eq!(stripped, "https://opencode.ai/zen");
+    fn zen_provider_name_is_zen_for_all_wire_formats() {
+        let base = "https://opencode.ai/zen/v1".to_string();
+        for model_id in &[
+            "gpt-4o",
+            "claude-sonnet-4-6",
+            "gemini-2.5-pro-preview-05-06",
+        ] {
+            let p = ZenProvider::new(
+                dummy_key(),
+                model_id.to_string(),
+                base.clone(),
+                HashMap::new(),
+                HashMap::new(),
+            );
+            assert_eq!(p.name(), "zen", "name() should be 'zen' for {model_id}");
+        }
+    }
+
+    #[test]
+    fn context_window_overrides_applied_to_anthropic_inner() {
+        let mut provider_cw = HashMap::new();
+        provider_cw.insert("claude-sonnet-4-6".to_string(), 50_000u32);
+        let p = ZenProvider::new(
+            dummy_key(),
+            "claude-sonnet-4-6".into(),
+            "https://opencode.ai/zen/v1".into(),
+            HashMap::new(),
+            provider_cw,
+        );
+        assert_eq!(p.context_window(), 50_000);
+    }
+
+    #[test]
+    fn context_window_overrides_applied_to_openai_inner() {
+        let mut global_cw = HashMap::new();
+        global_cw.insert("gpt-4o".to_string(), 64_000u32);
+        let p = ZenProvider::new(
+            dummy_key(),
+            "gpt-4o".into(),
+            "https://opencode.ai/zen/v1".into(),
+            global_cw,
+            HashMap::new(),
+        );
+        assert_eq!(p.context_window(), 64_000);
+    }
+
+    #[test]
+    fn context_window_overrides_applied_to_chat_completions_inner() {
+        let mut provider_cw = HashMap::new();
+        provider_cw.insert("gemini-2.5-flash-preview-05-20".to_string(), 32_000u32);
+        let p = ZenProvider::new(
+            dummy_key(),
+            "gemini-2.5-flash-preview-05-20".into(),
+            "https://opencode.ai/zen/v1".into(),
+            HashMap::new(),
+            provider_cw,
+        );
+        assert_eq!(p.context_window(), 32_000);
+    }
+
+    #[test]
+    fn anthropic_routing_with_trailing_slash_base_url() {
+        // Verify construction succeeds and name is correct when base URL has trailing slash.
+        // The /v1/ suffix must be stripped before AnthropicProvider appends /v1/messages.
+        let p = ZenProvider::new(
+            dummy_key(),
+            "claude-opus-4-6".into(),
+            "https://opencode.ai/zen/v1/".into(),
+            HashMap::new(),
+            HashMap::new(),
+        );
+        assert_eq!(p.name(), "zen");
+    }
+
+    #[test]
+    fn prefixed_model_ids_fall_through_to_chat_completions() {
+        // If Zen's /models endpoint returns "anthropic/claude-..." or "openai/gpt-..." style IDs,
+        // classify_model will not match the gpt-/claude- prefixes and will route via ChatCompletions.
+        // This is the known risk documented in the code review. If that happens in practice, add
+        // prefix-stripping normalization here and in fetch_models_from_api.
+        assert!(matches!(
+            classify_model("anthropic/claude-sonnet-4-6"),
+            ZenWireFormat::ChatCompletions
+        ));
+        assert!(matches!(
+            classify_model("openai/gpt-4o"),
+            ZenWireFormat::ChatCompletions
+        ));
     }
 }


### PR DESCRIPTION
## Summary

Adds [OpenCode Zen](https://opencode.ai/docs/zen/) as a provider. Zen is opencode.ai's curated model proxy — a single API key gives access to GPT, Claude, Gemini, and other models at competitive per-token pricing with a zero-retention policy.

When trying to add Zen as OpenAI compatible provider we get an error:
<img width="482" height="470" alt="Screenshot 2026-04-30 at 7 34 20 PM" src="https://github.com/user-attachments/assets/9c1e8c7f-c84e-4a13-8967-a24041110e8c" />

Zen routes requests to different wire formats depending on model family, so a single provider entry covers all supported models:

| Model prefix | Wire format | Endpoint |
|---|---|---|
| `claude-*` | Anthropic Messages API | `/zen/v1/messages` |
| `gpt-*` | OpenAI Responses API | `/zen/v1/responses` |
| `gemini-*` / everything else | OpenAI ChatCompletions | `/zen/v1/chat/completions` |

`ZenProvider` selects the correct inner provider (`AnthropicProvider` or `OpenAiProvider`) at construction time based on model ID prefix, so hot-path calls are zero-branch delegates. Context-window overrides from `[models.<id>]` and `[providers.opencode-zen.model_overrides]` config are propagated to inner providers.

**Config:**
```toml
[providers.opencode-zen]
api_key = "..."  # or OPENCODE_ZEN_API_KEY env var
```

Live model discovery via `GET /zen/v1/models` (OpenAI-compatible); falls back to a static catalog of current-generation models (GPT-5.5/5.5 Pro, Claude Opus 4.7/Sonnet 4.6/Haiku 4.5, Gemini 3.1 Pro/3 Flash) when unavailable. Free-tier models are omitted from the static catalog — live discovery covers the full list.

## Changes

- Provider registered as `opencode-zen` (env var `OPENCODE_ZEN_API_KEY`, base URL env `OPENCODE_ZEN_BASE_URL`)
- Display name: **OpenCode Zen**
- `classify_model` normalizes `provider/model-id` prefixes (e.g. `anthropic/claude-*`, `openai/gpt-*`) before wire-format matching, so live discovery results in fully-qualified ID format route correctly instead of silently falling through to ChatCompletions
- `tracing::info!` registration log is now guarded by `added > 0` — re-registration passes no longer emit a misleading `model_count = 0` info message
- Static catalog updated to current Zen API models; Gemini routes via ChatCompletions (Zen has a dedicated Gemini endpoint but uses OpenAI wire format, not Google)

## Validation

### Completed
- [x] `cargo check -p moltis-providers` passes
- [x] `cargo test -p moltis-providers` passes (including `opencode_zen_models_all_classify_correctly` and expanded per-family classification tests)
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo test -p moltis-config -p moltis-provider-setup` passes
- [x] `KNOWN_PROVIDER_NAMES` updated
- [x] `KnownProvider` entry added
- [x] CW overrides propagated to all three inner wire formats
- [x] Catalog fallback consistent with other built-in providers
- [x] Prefixed model ID normalization in `classify_model`
- [x] Info log guarded by `added > 0`
- [x] Static catalog synced to current live Zen API models
- [x] Live smoke test: models endpoint returns 41 bare IDs (no `provider/` prefixes — catalog format correct)
- [x] Live smoke test: `gpt-5.5` via ChatCompletions → HTTP 200 ✅
- [x] Live smoke test: `gpt-5.5` via Responses API → HTTP 200 ✅
- [x] Live smoke test: `claude-haiku-4-5` via Messages API (`x-api-key` header) → HTTP 200 ✅

### Remaining
- [ ] Live smoke test: Gemini via ChatCompletions — currently returns GCP `OVERLOADED_CREDENTIALS` (Zen backend bug: proxy forwards Bearer token to GCP on top of its own service account). Code and wire format are correct; blocked on Zen fixing their GCP routing.
- [ ] Integration test against live Zen API (requires `OPENCODE_ZEN_API_KEY`)

## Manual QA

1. Set `OPENCODE_ZEN_API_KEY=<key>` and add `[providers.opencode-zen]` to `moltis.toml`
2. Start moltis — Zen models should appear in model picker
3. Send a message with a `claude-*` model and verify it routes through Anthropic format
4. Send a message with a `gpt-*` model and verify it routes through Responses API
5. Send a message with a `gemini-*` model and verify it routes through ChatCompletions

cc @thdxr