### PR TITLE
fix(discord): register slash command arguments and add all thinking levels

### DIFF
--- a/crates/channels/src/commands.rs
+++ b/crates/channels/src/commands.rs
@@ -5,6 +5,22 @@
 //! source of truth. Adding a command here automatically propagates to all
 //! channels.
 
+/// A single argument that a command accepts.
+#[derive(Debug, Clone, Copy)]
+pub struct CommandArg {
+    /// Semantic name for the argument (e.g. `"model"`, `"mode"`, `"id"`).
+    ///
+    /// Used as the Discord option name and shown in platform UIs.
+    pub name: &'static str,
+    /// Short description shown next to the argument in platform UIs.
+    pub description: &'static str,
+    /// Fixed choices the user can pick from (label, value).
+    ///
+    /// Platforms like Discord render these as a dropdown. An empty slice means
+    /// free-form input.
+    pub choices: &'static [(&'static str, &'static str)],
+}
+
 /// A channel command definition.
 #[derive(Debug, Clone, Copy)]
 pub struct CommandDef {
@@ -12,6 +28,8 @@ pub struct CommandDef {
     pub name: &'static str,
     /// Short description shown in help text and platform autocomplete.
     pub description: &'static str,
+    /// If set, the command accepts a single string argument.
+    pub arg: Option<CommandArg>,
 }
 
 /// The single source of truth for all channel commands.
@@ -25,109 +43,208 @@ pub fn all_commands() -> &'static [CommandDef] {
         CommandDef {
             name: "new",
             description: "Start a new session",
+            arg: None,
         },
         CommandDef {
             name: "sessions",
             description: "List and switch sessions",
+            arg: Some(CommandArg {
+                name: "id",
+                description: "Session ID to switch to",
+                choices: &[],
+            }),
         },
         CommandDef {
             name: "attach",
             description: "Attach an existing session here",
+            arg: Some(CommandArg {
+                name: "id",
+                description: "Session ID to attach",
+                choices: &[],
+            }),
         },
         CommandDef {
             name: "fork",
             description: "Fork this session into a new branch",
+            arg: Some(CommandArg {
+                name: "title",
+                description: "Optional title for the fork",
+                choices: &[],
+            }),
         },
         CommandDef {
             name: "clear",
             description: "Clear session history",
+            arg: None,
         },
         CommandDef {
             name: "compact",
             description: "Compact session (summarize)",
+            arg: None,
         },
         CommandDef {
             name: "title",
             description: "Auto-generate session title",
+            arg: None,
         },
         CommandDef {
             name: "context",
             description: "Show session context info",
+            arg: None,
         },
         // Control
         CommandDef {
             name: "approvals",
             description: "List pending exec approvals",
+            arg: None,
         },
         CommandDef {
             name: "approve",
             description: "Approve a pending exec request",
+            arg: Some(CommandArg {
+                name: "id",
+                description: "Approval ID",
+                choices: &[],
+            }),
         },
         CommandDef {
             name: "deny",
             description: "Deny a pending exec request",
+            arg: Some(CommandArg {
+                name: "id",
+                description: "Approval ID",
+                choices: &[],
+            }),
         },
         CommandDef {
             name: "agent",
             description: "Switch session agent",
+            arg: Some(CommandArg {
+                name: "name",
+                description: "Agent name",
+                choices: &[],
+            }),
         },
         CommandDef {
             name: "mode",
             description: "Switch session mode",
+            arg: Some(CommandArg {
+                name: "mode",
+                description: "Mode number or name",
+                choices: &[],
+            }),
         },
         CommandDef {
             name: "model",
             description: "Switch provider/model",
+            arg: Some(CommandArg {
+                name: "model",
+                description: "Model name or provider:model",
+                choices: &[],
+            }),
         },
         CommandDef {
             name: "sandbox",
             description: "Toggle sandbox and choose image",
+            arg: Some(CommandArg {
+                name: "action",
+                description: "Sandbox action",
+                choices: &[("Toggle", "toggle"), ("On", "on"), ("Off", "off")],
+            }),
         },
         CommandDef {
             name: "sh",
             description: "Enable command mode (/sh off to exit)",
+            arg: Some(CommandArg {
+                name: "action",
+                description: "Command mode action",
+                choices: &[
+                    ("On", "on"),
+                    ("Off", "off"),
+                    ("Exit", "exit"),
+                    ("Status", "status"),
+                ],
+            }),
         },
         CommandDef {
             name: "stop",
             description: "Abort the current running agent",
+            arg: None,
         },
         CommandDef {
             name: "peek",
             description: "Show current thinking/tool status",
+            arg: None,
         },
         CommandDef {
             name: "update",
             description: "Update moltis to latest or specified version",
+            arg: Some(CommandArg {
+                name: "version",
+                description: "Version to update to",
+                choices: &[],
+            }),
         },
         CommandDef {
             name: "rollback",
             description: "List or restore file checkpoints",
+            arg: Some(CommandArg {
+                name: "id",
+                description: "Checkpoint ID to restore",
+                choices: &[],
+            }),
         },
         // Quick actions
         CommandDef {
             name: "btw",
             description: "Quick side question (no tools, not persisted)",
+            arg: Some(CommandArg {
+                name: "question",
+                description: "Your question",
+                choices: &[],
+            }),
         },
         CommandDef {
             name: "fast",
             description: "Toggle fast/priority mode",
+            arg: Some(CommandArg {
+                name: "toggle",
+                description: "Enable or disable",
+                choices: &[("On", "on"), ("Off", "off")],
+            }),
         },
         CommandDef {
             name: "insights",
             description: "Show session analytics and usage stats",
+            arg: Some(CommandArg {
+                name: "scope",
+                description: "Scope or filter",
+                choices: &[],
+            }),
         },
         CommandDef {
             name: "steer",
             description: "Inject guidance into the current agent run",
+            arg: Some(CommandArg {
+                name: "guidance",
+                description: "Guidance text",
+                choices: &[],
+            }),
         },
         CommandDef {
             name: "queue",
             description: "Queue a message for the next agent turn",
+            arg: Some(CommandArg {
+                name: "message",
+                description: "Message to queue",
+                choices: &[],
+            }),
         },
         // Meta
         CommandDef {
             name: "help",
             description: "Show available commands",
+            arg: None,
         },
     ]
 }

--- a/crates/channels/src/commands.rs
+++ b/crates/channels/src/commands.rs
@@ -19,6 +19,11 @@ pub struct CommandArg {
     /// Platforms like Discord render these as a dropdown. An empty slice means
     /// free-form input.
     pub choices: &'static [(&'static str, &'static str)],
+    /// Whether the argument must be provided.
+    ///
+    /// When `true`, platforms like Discord enforce the argument at the UI level
+    /// and won't allow bare invocation.
+    pub required: bool,
 }
 
 /// A channel command definition.
@@ -52,6 +57,7 @@ pub fn all_commands() -> &'static [CommandDef] {
                 name: "id",
                 description: "Session ID to switch to",
                 choices: &[],
+                required: false,
             }),
         },
         CommandDef {
@@ -61,6 +67,7 @@ pub fn all_commands() -> &'static [CommandDef] {
                 name: "id",
                 description: "Session ID to attach",
                 choices: &[],
+                required: true,
             }),
         },
         CommandDef {
@@ -70,6 +77,7 @@ pub fn all_commands() -> &'static [CommandDef] {
                 name: "title",
                 description: "Optional title for the fork",
                 choices: &[],
+                required: false,
             }),
         },
         CommandDef {
@@ -105,6 +113,7 @@ pub fn all_commands() -> &'static [CommandDef] {
                 name: "id",
                 description: "Approval ID",
                 choices: &[],
+                required: true,
             }),
         },
         CommandDef {
@@ -114,6 +123,7 @@ pub fn all_commands() -> &'static [CommandDef] {
                 name: "id",
                 description: "Approval ID",
                 choices: &[],
+                required: true,
             }),
         },
         CommandDef {
@@ -123,6 +133,7 @@ pub fn all_commands() -> &'static [CommandDef] {
                 name: "name",
                 description: "Agent name",
                 choices: &[],
+                required: false,
             }),
         },
         CommandDef {
@@ -132,6 +143,7 @@ pub fn all_commands() -> &'static [CommandDef] {
                 name: "mode",
                 description: "Mode number or name",
                 choices: &[],
+                required: false,
             }),
         },
         CommandDef {
@@ -141,6 +153,7 @@ pub fn all_commands() -> &'static [CommandDef] {
                 name: "model",
                 description: "Model name or provider:model",
                 choices: &[],
+                required: false,
             }),
         },
         CommandDef {
@@ -150,6 +163,7 @@ pub fn all_commands() -> &'static [CommandDef] {
                 name: "action",
                 description: "Sandbox action",
                 choices: &[("Toggle", "toggle"), ("On", "on"), ("Off", "off")],
+                required: false,
             }),
         },
         CommandDef {
@@ -164,6 +178,7 @@ pub fn all_commands() -> &'static [CommandDef] {
                     ("Exit", "exit"),
                     ("Status", "status"),
                 ],
+                required: false,
             }),
         },
         CommandDef {
@@ -183,6 +198,7 @@ pub fn all_commands() -> &'static [CommandDef] {
                 name: "version",
                 description: "Version to update to",
                 choices: &[],
+                required: false,
             }),
         },
         CommandDef {
@@ -192,6 +208,7 @@ pub fn all_commands() -> &'static [CommandDef] {
                 name: "id",
                 description: "Checkpoint ID to restore",
                 choices: &[],
+                required: false,
             }),
         },
         // Quick actions
@@ -202,6 +219,7 @@ pub fn all_commands() -> &'static [CommandDef] {
                 name: "question",
                 description: "Your question",
                 choices: &[],
+                required: true,
             }),
         },
         CommandDef {
@@ -211,6 +229,7 @@ pub fn all_commands() -> &'static [CommandDef] {
                 name: "toggle",
                 description: "Enable or disable",
                 choices: &[("On", "on"), ("Off", "off")],
+                required: false,
             }),
         },
         CommandDef {
@@ -220,6 +239,7 @@ pub fn all_commands() -> &'static [CommandDef] {
                 name: "scope",
                 description: "Scope or filter",
                 choices: &[],
+                required: false,
             }),
         },
         CommandDef {
@@ -229,6 +249,7 @@ pub fn all_commands() -> &'static [CommandDef] {
                 name: "guidance",
                 description: "Guidance text",
                 choices: &[],
+                required: true,
             }),
         },
         CommandDef {
@@ -238,6 +259,7 @@ pub fn all_commands() -> &'static [CommandDef] {
                 name: "message",
                 description: "Message to queue",
                 choices: &[],
+                required: true,
             }),
         },
         // Meta

--- a/crates/config/src/schema.rs
+++ b/crates/config/src/schema.rs
@@ -40,15 +40,59 @@ pub use {
 /// Reasoning/thinking effort level for models that support extended thinking.
 ///
 /// Maps to provider-specific parameters:
-/// - **Anthropic**: `thinking.budget_tokens` (low=4096, medium=10240, high=32768)
-/// - **OpenAI**: `reasoning_effort` field on o-series models
+/// - **Anthropic**: `thinking.budget_tokens`
+/// - **OpenAI**: `reasoning_effort` field on o-series / GPT-5 models
+/// - **Gemini**: `thinkingBudget` or `thinkingLevel`
 /// - **Other providers**: ignored if unsupported
+///
+/// Not all providers support every level. Providers map unsupported levels
+/// to their nearest supported equivalent (e.g. `ExtraHigh` → `High` when
+/// the provider caps at `High`).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum ReasoningEffort {
+    Minimal,
     Low,
     Medium,
     High,
+    /// Extra-high reasoning effort. Serializes as `"xhigh"`.
+    #[serde(rename = "xhigh")]
+    ExtraHigh,
+}
+
+impl ReasoningEffort {
+    /// All levels in ascending order.
+    pub const ALL: &[Self] = &[
+        Self::Minimal,
+        Self::Low,
+        Self::Medium,
+        Self::High,
+        Self::ExtraHigh,
+    ];
+
+    /// Wire / serialization name (matches serde output).
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Minimal => "minimal",
+            Self::Low => "low",
+            Self::Medium => "medium",
+            Self::High => "high",
+            Self::ExtraHigh => "xhigh",
+        }
+    }
+
+    /// Human-readable label for UI display.
+    #[must_use]
+    pub const fn label(self) -> &'static str {
+        match self {
+            Self::Minimal => "Minimal",
+            Self::Low => "Low",
+            Self::Medium => "Medium",
+            Self::High => "High",
+            Self::ExtraHigh => "Extra High",
+        }
+    }
 }
 
 /// Agent identity (name, emoji, theme).

--- a/crates/config/src/validate/tests/agents.rs
+++ b/crates/config/src/validate/tests/agents.rs
@@ -2,7 +2,7 @@ use super::*;
 
 #[test]
 fn reasoning_effort_valid_values_no_error() {
-    for effort in &["low", "medium", "high"] {
+    for effort in &["minimal", "low", "medium", "high", "xhigh"] {
         let toml = format!(
             r#"
             [agents.presets.thinker]

--- a/crates/discord/src/commands.rs
+++ b/crates/discord/src/commands.rs
@@ -26,7 +26,8 @@ pub fn build_commands() -> Vec<CreateCommand> {
             let mut cmd = CreateCommand::new(c.name).description(c.description);
             if let Some(arg) = &c.arg {
                 let mut opt =
-                    CreateCommandOption::new(CommandOptionType::String, arg.name, arg.description);
+                    CreateCommandOption::new(CommandOptionType::String, arg.name, arg.description)
+                        .required(arg.required);
                 for &(label, value) in arg.choices {
                     opt = opt.add_string_choice(label, value);
                 }

--- a/crates/discord/src/commands.rs
+++ b/crates/discord/src/commands.rs
@@ -6,7 +6,8 @@
 
 use {
     serenity::all::{
-        Command, CommandInteraction, ComponentInteraction, Context, CreateCommand,
+        Command, CommandDataOption, CommandDataOptionValue, CommandInteraction, CommandOptionType,
+        ComponentInteraction, Context, CreateCommand, CreateCommandOption,
         CreateInteractionResponse, CreateInteractionResponseFollowup, EditInteractionResponse,
         Interaction,
     },
@@ -21,7 +22,18 @@ use crate::state::AccountStateMap;
 pub fn build_commands() -> Vec<CreateCommand> {
     moltis_channels::commands::all_commands()
         .iter()
-        .map(|c| CreateCommand::new(c.name).description(c.description))
+        .map(|c| {
+            let mut cmd = CreateCommand::new(c.name).description(c.description);
+            if let Some(arg) = &c.arg {
+                let mut opt =
+                    CreateCommandOption::new(CommandOptionType::String, arg.name, arg.description);
+                for &(label, value) in arg.choices {
+                    opt = opt.add_string_choice(label, value);
+                }
+                cmd = cmd.add_option(opt);
+            }
+            cmd
+        })
         .collect()
 }
 
@@ -102,8 +114,10 @@ async fn handle_slash_command(
     };
     let sender_id = command.user.id.to_string();
 
+    let command_text = build_command_text(&command.data.name, &command.data.options);
+
     let response_text = match sink
-        .dispatch_command(&command.data.name, reply_to, Some(&sender_id))
+        .dispatch_command(&command_text, reply_to, Some(&sender_id))
         .await
     {
         Ok(response) => response,
@@ -168,6 +182,23 @@ async fn handle_component_interaction(
                 callback_data, "interaction dispatch failed: {e}"
             );
         },
+    }
+}
+
+/// Build the full command string from the slash command name and its options.
+///
+/// Discord slash commands pass arguments as structured options rather than
+/// inline text. This reconstructs the `"name value"` format expected by
+/// `dispatch_command`.
+fn build_command_text(name: &str, options: &[CommandDataOption]) -> String {
+    let arg = options.iter().find_map(|opt| match &opt.value {
+        CommandDataOptionValue::String(s) => Some(s.as_str()),
+        _ => None,
+    });
+
+    match arg {
+        Some(value) if !value.is_empty() => format!("{name} {value}"),
+        _ => name.to_string(),
     }
 }
 
@@ -310,6 +341,199 @@ mod tests {
                     .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_' || c == '-'),
                 "command name contains invalid characters: {name}"
             );
+        }
+    }
+
+    #[test]
+    fn commands_with_arg_have_options() {
+        let commands = build_commands();
+        let registry = moltis_channels::commands::all_commands();
+
+        for reg_cmd in registry {
+            let json = commands
+                .iter()
+                .find_map(|c| {
+                    let v = serde_json::to_value(c).ok()?;
+                    if v["name"].as_str()? == reg_cmd.name {
+                        Some(v)
+                    } else {
+                        None
+                    }
+                })
+                .unwrap_or_else(|| panic!("missing built command: {}", reg_cmd.name));
+
+            let options = json["options"].as_array();
+
+            if let Some(arg) = &reg_cmd.arg {
+                let opts = options.unwrap_or_else(|| {
+                    panic!("command /{} has arg but no Discord options", reg_cmd.name)
+                });
+                assert!(
+                    !opts.is_empty(),
+                    "command /{} has arg but empty options array",
+                    reg_cmd.name
+                );
+                let first = &opts[0];
+                assert_eq!(
+                    first["name"].as_str(),
+                    Some(arg.name),
+                    "command /{} option name should be \"{}\"",
+                    reg_cmd.name,
+                    arg.name,
+                );
+                // CommandOptionType::String == 3
+                assert_eq!(
+                    first["type"].as_u64(),
+                    Some(3),
+                    "command /{} option type should be String (3)",
+                    reg_cmd.name
+                );
+
+                // Verify choices match
+                if !arg.choices.is_empty() {
+                    let json_choices = first["choices"].as_array().unwrap_or_else(|| {
+                        panic!("command /{} has choices but none in JSON", reg_cmd.name)
+                    });
+                    assert_eq!(
+                        json_choices.len(),
+                        arg.choices.len(),
+                        "command /{} choice count mismatch",
+                        reg_cmd.name
+                    );
+                    for (json_choice, &(label, value)) in
+                        json_choices.iter().zip(arg.choices.iter())
+                    {
+                        assert_eq!(json_choice["name"].as_str(), Some(label));
+                        assert_eq!(json_choice["value"].as_str(), Some(value));
+                    }
+                }
+            } else {
+                let is_empty = options.map_or(true, |o| o.is_empty());
+                assert!(
+                    is_empty,
+                    "command /{} has no arg but has Discord options",
+                    reg_cmd.name
+                );
+            }
+        }
+    }
+
+    fn string_option(value: &str) -> CommandDataOption {
+        serde_json::from_value(serde_json::json!({
+            "name": "value",
+            "type": 3,
+            "value": value,
+        }))
+        .expect("valid string option")
+    }
+
+    fn bool_option(value: bool) -> CommandDataOption {
+        serde_json::from_value(serde_json::json!({
+            "name": "value",
+            "type": 5,
+            "value": value,
+        }))
+        .expect("valid bool option")
+    }
+
+    #[test]
+    fn build_command_text_no_options() {
+        let text = build_command_text("new", &[]);
+        assert_eq!(text, "new");
+    }
+
+    #[test]
+    fn build_command_text_with_string_option() {
+        let options = vec![string_option("2")];
+        let text = build_command_text("mode", &options);
+        assert_eq!(text, "mode 2");
+    }
+
+    #[test]
+    fn build_command_text_with_empty_string_option() {
+        let options = vec![string_option("")];
+        let text = build_command_text("mode", &options);
+        assert_eq!(text, "mode");
+    }
+
+    #[test]
+    fn build_command_text_ignores_non_string_options() {
+        let options = vec![bool_option(true)];
+        let text = build_command_text("fast", &options);
+        assert_eq!(text, "fast");
+    }
+
+    #[test]
+    fn build_command_text_with_multi_word_arg() {
+        let options = vec![string_option("provider:openai gpt-4o")];
+        let text = build_command_text("model", &options);
+        assert_eq!(text, "model provider:openai gpt-4o");
+    }
+
+    #[test]
+    fn option_descriptions_within_discord_limit() {
+        // Discord enforces a 100-character limit on option descriptions too.
+        for cmd in moltis_channels::commands::all_commands() {
+            if let Some(arg) = &cmd.arg {
+                assert!(
+                    arg.description.len() <= 100,
+                    "command /{} arg description exceeds 100 chars ({} chars): {}",
+                    cmd.name,
+                    arg.description.len(),
+                    arg.description,
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn arg_names_are_valid_discord_option_names() {
+        // Discord option names: lowercase, 1-32 chars, alphanumeric + hyphens.
+        for cmd in moltis_channels::commands::all_commands() {
+            if let Some(arg) = &cmd.arg {
+                assert!(
+                    !arg.name.is_empty() && arg.name.len() <= 32,
+                    "command /{} arg name length out of range: {}",
+                    cmd.name,
+                    arg.name,
+                );
+                assert!(
+                    arg.name.chars().all(|c| c.is_ascii_lowercase()
+                        || c.is_ascii_digit()
+                        || c == '-'
+                        || c == '_'),
+                    "command /{} arg name has invalid characters: {}",
+                    cmd.name,
+                    arg.name,
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn choices_within_discord_limits() {
+        // Discord allows max 25 choices, each name ≤ 100 chars, each value ≤ 100 chars.
+        for cmd in moltis_channels::commands::all_commands() {
+            if let Some(arg) = &cmd.arg {
+                assert!(
+                    arg.choices.len() <= 25,
+                    "command /{} has {} choices (max 25)",
+                    cmd.name,
+                    arg.choices.len(),
+                );
+                for &(label, value) in arg.choices {
+                    assert!(
+                        label.len() <= 100,
+                        "command /{} choice label too long: {label}",
+                        cmd.name,
+                    );
+                    assert!(
+                        value.len() <= 100,
+                        "command /{} choice value too long: {value}",
+                        cmd.name,
+                    );
+                }
+            }
         }
     }
 }

--- a/crates/msteams/src/plugin.rs
+++ b/crates/msteams/src/plugin.rs
@@ -406,6 +406,54 @@ impl MsTeamsPlugin {
         // Handle slash commands.
         let dispatch_text = text.as_deref().unwrap_or("");
         if let Some(command) = dispatch_text.strip_prefix('/') {
+            let cmd_name = command.split_whitespace().next().unwrap_or("");
+            let is_bare = command.trim() == cmd_name;
+
+            // For bare commands with fixed choices, show an Adaptive Card with
+            // buttons instead of plain text.  Each button uses `imBack` so
+            // clicking it sends "/{cmd} {value}" back as a regular message.
+            if is_bare {
+                if let Some(def) = moltis_channels::commands::all_commands()
+                    .iter()
+                    .find(|c| c.name == cmd_name)
+                    && let Some(arg) = &def.arg
+                    && !arg.choices.is_empty()
+                {
+                    let rows: Vec<moltis_channels::ButtonRow> = arg
+                        .choices
+                        .iter()
+                        .map(|&(label, value)| {
+                            vec![moltis_channels::InteractiveButton {
+                                label: label.to_string(),
+                                callback_data: format!("/{cmd_name} {value}"),
+                                style: moltis_channels::ButtonStyle::Default,
+                            }]
+                        })
+                        .collect();
+                    let card = moltis_channels::InteractiveMessage {
+                        text: format!("/{cmd_name}:"),
+                        button_rows: rows,
+                        replace_message_id: None,
+                    };
+                    if let Err(e) = self
+                        .outbound
+                        .send_interactive(
+                            account_id,
+                            &chat_id,
+                            &card,
+                            reply_to.message_id.as_deref(),
+                        )
+                        .await
+                    {
+                        warn!(
+                            account_id,
+                            chat_id, "failed to send Teams choices card: {e}"
+                        );
+                    }
+                    return Ok(());
+                }
+            }
+
             match sink
                 .dispatch_command(command.trim(), reply_to.clone(), Some(&peer_id))
                 .await

--- a/crates/providers/src/anthropic.rs
+++ b/crates/providers/src/anthropic.rs
@@ -103,9 +103,11 @@ impl AnthropicProvider {
             return;
         };
         let budget_tokens: u64 = match effort {
+            ReasoningEffort::Minimal => 1024,
             ReasoningEffort::Low => 4096,
             ReasoningEffort::Medium => 10240,
             ReasoningEffort::High => 32768,
+            ReasoningEffort::ExtraHigh => 65536,
         };
         body["thinking"] = serde_json::json!({
             "type": "enabled",

--- a/crates/providers/src/model_id.rs
+++ b/crates/providers/src/model_id.rs
@@ -7,7 +7,13 @@ pub(crate) const MODEL_ID_NAMESPACE_SEP: &str = "::";
 pub(crate) const REASONING_SUFFIX_SEP: char = '@';
 
 /// Reasoning effort suffixes appended to model IDs.
+///
+/// Derived from [`ReasoningEffort::ALL`] — one entry per level.
 pub(crate) const REASONING_SUFFIXES: &[(&str, moltis_agents::model::ReasoningEffort)] = &[
+    (
+        "reasoning-minimal",
+        moltis_agents::model::ReasoningEffort::Minimal,
+    ),
     ("reasoning-low", moltis_agents::model::ReasoningEffort::Low),
     (
         "reasoning-medium",
@@ -16,6 +22,10 @@ pub(crate) const REASONING_SUFFIXES: &[(&str, moltis_agents::model::ReasoningEff
     (
         "reasoning-high",
         moltis_agents::model::ReasoningEffort::High,
+    ),
+    (
+        "reasoning-xhigh",
+        moltis_agents::model::ReasoningEffort::ExtraHigh,
     ),
 ];
 
@@ -88,11 +98,31 @@ mod tests {
             split_reasoning_suffix("o3@reasoning-low"),
             ("o3", Some(ReasoningEffort::Low))
         );
+        assert_eq!(
+            split_reasoning_suffix("model@reasoning-minimal"),
+            ("model", Some(ReasoningEffort::Minimal))
+        );
+        assert_eq!(
+            split_reasoning_suffix("gpt-5@reasoning-xhigh"),
+            ("gpt-5", Some(ReasoningEffort::ExtraHigh))
+        );
         assert_eq!(split_reasoning_suffix("gpt-4o"), ("gpt-4o", None));
         assert_eq!(
             split_reasoning_suffix("model@unknown-suffix"),
             ("model@unknown-suffix", None)
         );
+    }
+
+    #[test]
+    fn reasoning_suffixes_covers_all_efforts() {
+        use moltis_agents::model::ReasoningEffort;
+        for effort in ReasoningEffort::ALL {
+            assert!(
+                REASONING_SUFFIXES.iter().any(|(_, e)| e == effort),
+                "REASONING_SUFFIXES missing entry for {:?}",
+                effort
+            );
+        }
     }
 
     #[test]

--- a/crates/providers/src/openai/provider/core.rs
+++ b/crates/providers/src/openai/provider/core.rs
@@ -139,16 +139,29 @@ impl OpenAiProvider {
     }
 
     /// Return the reasoning effort string if configured.
+    ///
+    /// OpenAI accepts `"low"`, `"medium"`, `"high"`. Levels outside that range
+    /// are clamped to the nearest supported value.
     pub(crate) fn reasoning_effort_str(&self) -> Option<&'static str> {
         use moltis_agents::model::ReasoningEffort;
         self.reasoning_effort.map(|e| match e {
-            // OpenAI accepts "low", "medium", "high". Minimal maps to "low",
-            // ExtraHigh maps to "high" (provider caps at high for most models).
-            ReasoningEffort::Minimal => "low",
+            ReasoningEffort::Minimal => {
+                tracing::debug!(
+                    model = %self.model,
+                    "reasoning effort Minimal clamped to \"low\" (OpenAI minimum)"
+                );
+                "low"
+            },
             ReasoningEffort::Low => "low",
             ReasoningEffort::Medium => "medium",
             ReasoningEffort::High => "high",
-            ReasoningEffort::ExtraHigh => "high",
+            ReasoningEffort::ExtraHigh => {
+                tracing::debug!(
+                    model = %self.model,
+                    "reasoning effort ExtraHigh clamped to \"high\" (OpenAI maximum)"
+                );
+                "high"
+            },
         })
     }
 

--- a/crates/providers/src/openai/provider/core.rs
+++ b/crates/providers/src/openai/provider/core.rs
@@ -142,9 +142,13 @@ impl OpenAiProvider {
     pub(crate) fn reasoning_effort_str(&self) -> Option<&'static str> {
         use moltis_agents::model::ReasoningEffort;
         self.reasoning_effort.map(|e| match e {
+            // OpenAI accepts "low", "medium", "high". Minimal maps to "low",
+            // ExtraHigh maps to "high" (provider caps at high for most models).
+            ReasoningEffort::Minimal => "low",
             ReasoningEffort::Low => "low",
             ReasoningEffort::Medium => "medium",
             ReasoningEffort::High => "high",
+            ReasoningEffort::ExtraHigh => "high",
         })
     }
 

--- a/crates/slack/src/commands.rs
+++ b/crates/slack/src/commands.rs
@@ -9,6 +9,8 @@
 pub struct SlackCommandDef {
     pub name: &'static str,
     pub description: &'static str,
+    /// Hint shown in the Slack command input (e.g. `"[model name]"`).
+    pub usage_hint: String,
 }
 
 /// Returns the list of channel control commands.
@@ -17,9 +19,21 @@ pub struct SlackCommandDef {
 pub fn command_definitions() -> Vec<SlackCommandDef> {
     moltis_channels::commands::all_commands()
         .iter()
-        .map(|c| SlackCommandDef {
-            name: c.name,
-            description: c.description,
+        .map(|c| {
+            let usage_hint = match &c.arg {
+                Some(arg) if !arg.choices.is_empty() => {
+                    // Show choices inline: "[on | off | exit | status]"
+                    let options: Vec<&str> = arg.choices.iter().map(|&(_, v)| v).collect();
+                    format!("[{}]", options.join(" | "))
+                },
+                Some(arg) => format!("[{}]", arg.description),
+                None => String::new(),
+            };
+            SlackCommandDef {
+                name: c.name,
+                description: c.description,
+                usage_hint,
+            }
         })
         .collect()
 }
@@ -32,8 +46,8 @@ pub fn generate_manifest_snippet(request_url_base: &str) -> String {
     let mut yaml = String::from("slash_commands:\n");
     for cmd in command_definitions() {
         yaml.push_str(&format!(
-            "  - command: /{}\n    url: {}/api/channels/slack/{{{{account_id}}}}/commands\n    description: \"{}\"\n    usage_hint: \"\"\n    should_escape: false\n",
-            cmd.name, request_url_base, cmd.description,
+            "  - command: /{}\n    url: {}/api/channels/slack/{{{{account_id}}}}/commands\n    description: \"{}\"\n    usage_hint: \"{}\"\n    should_escape: false\n",
+            cmd.name, request_url_base, cmd.description, cmd.usage_hint,
         ));
     }
     yaml
@@ -47,6 +61,7 @@ pub fn command_definitions_json() -> serde_json::Value {
             serde_json::json!({
                 "name": cmd.name,
                 "description": cmd.description,
+                "usage_hint": cmd.usage_hint,
             })
         })
         .collect();
@@ -77,6 +92,31 @@ mod tests {
     }
 
     #[test]
+    fn manifest_snippet_includes_usage_hints() {
+        let snippet = generate_manifest_snippet("https://example.com");
+        // /sh has choices, so usage_hint should list them.
+        assert!(
+            snippet.contains("usage_hint: \"[on | off | exit | status]\""),
+            "manifest should include /sh choices in usage_hint"
+        );
+        // /fast also has choices.
+        assert!(
+            snippet.contains("usage_hint: \"[on | off]\""),
+            "manifest should include /fast choices in usage_hint"
+        );
+        // /model has a free-form arg, so usage_hint should show description.
+        assert!(
+            snippet.contains("usage_hint: \"[Model name or provider:model]\""),
+            "manifest should include /model arg description in usage_hint"
+        );
+        // /new has no arg, so usage_hint should be empty.
+        assert!(
+            snippet.contains("command: /new\n") && snippet.contains("usage_hint: \"\"\n"),
+            "manifest should have empty usage_hint for /new"
+        );
+    }
+
+    #[test]
     fn command_definitions_json_structure() {
         let json = command_definitions_json();
         let arr = json.as_array().unwrap();
@@ -84,6 +124,7 @@ mod tests {
         for item in arr {
             assert!(item.get("name").unwrap().is_string());
             assert!(item.get("description").unwrap().is_string());
+            assert!(item.get("usage_hint").unwrap().is_string());
         }
     }
 }

--- a/crates/telegram/src/handlers/callbacks.rs
+++ b/crates/telegram/src/handlers/callbacks.rs
@@ -288,6 +288,38 @@ pub(super) async fn send_sandbox_keyboard(bot: &Bot, to: &str, text: &str) {
     let _ = req.await;
 }
 
+/// Render a command's fixed choices as an inline keyboard.
+///
+/// Used for commands like `/sh` and `/fast` that have a small set of known
+/// values. The callback data format is `{cmd}_choice:{value}`, handled by
+/// `handle_callback_query` in `implementation.rs`.
+pub(super) async fn send_choices_keyboard(
+    bot: &Bot,
+    to: &str,
+    cmd: &str,
+    choices: &[(&str, &str)],
+) {
+    let (chat, thread_id) = parse_chat_target_lossy(to);
+
+    let buttons: Vec<Vec<InlineKeyboardButton>> = choices
+        .iter()
+        .map(|&(label, value)| {
+            vec![InlineKeyboardButton::callback(
+                label.to_string(),
+                format!("{cmd}_choice:{value}"),
+            )]
+        })
+        .collect();
+
+    let keyboard = InlineKeyboardMarkup::new(buttons);
+    let heading = format!("/{cmd}:");
+    let mut req = bot.send_message(chat, heading).reply_markup(keyboard);
+    if let Some(tid) = thread_id {
+        req = req.message_thread_id(tid);
+    }
+    let _ = req.await;
+}
+
 fn escape_html_simple(s: &str) -> String {
     s.replace('&', "&amp;")
         .replace('<', "&lt;")

--- a/crates/telegram/src/handlers/implementation.rs
+++ b/crates/telegram/src/handlers/implementation.rs
@@ -696,6 +696,35 @@ pub async fn handle_message_direct(
                     return Ok(());
                 }
 
+                // For bare commands with fixed choices (e.g. /sh, /fast),
+                // show an inline keyboard derived from CommandDef.choices.
+                // Commands with custom keyboard handlers (model, agent, etc.)
+                // are handled above and won't reach this point.
+                if cmd_text.trim() == cmd {
+                    let cmd_def = moltis_channels::commands::all_commands()
+                        .iter()
+                        .find(|c| c.name == cmd);
+                    if let Some(def) = cmd_def
+                        && let Some(arg) = &def.arg
+                        && !arg.choices.is_empty()
+                    {
+                        let bot = {
+                            let accts = accounts.read().unwrap_or_else(|e| e.into_inner());
+                            accts.get(account_id).map(|s| s.bot.clone())
+                        };
+                        if let Some(bot) = bot {
+                            send_choices_keyboard(
+                                &bot,
+                                &reply_target.outbound_to(),
+                                cmd,
+                                arg.choices,
+                            )
+                            .await;
+                        }
+                        return Ok(());
+                    }
+                }
+
                 let response = if cmd == "help" {
                     moltis_channels::commands::help_text()
                 } else {
@@ -860,6 +889,10 @@ pub async fn handle_callback_query(
     } else if data.starts_with("model_provider:") {
         // Handled separately below — no simple cmd_text.
         None
+    } else if data.contains("_choice:") {
+        // Generic choice callback: "{cmd}_choice:{value}" → "{cmd} {value}"
+        let (cmd_part, val) = data.split_once("_choice:").unwrap_or(("", ""));
+        Some(format!("{cmd_part} {val}"))
     } else {
         if let Some(ref bot) = bot {
             let _ = bot.answer_callback_query(&query.id).await;

--- a/crates/web/ui/src/locales/en/chat.ts
+++ b/crates/web/ui/src/locales/en/chat.ts
@@ -47,9 +47,11 @@ export default {
 	// ── Reasoning toggle ─────────────────────────────────────
 	reasoningTooltip: "Reasoning effort",
 	reasoningOff: "Off",
+	reasoningMinimal: "Minimal",
 	reasoningLow: "Low",
 	reasoningMedium: "Medium",
 	reasoningHigh: "High",
+	reasoningExtraHigh: "Extra High",
 
 	// ── Debug panel ──────────────────────────────────────────
 	debugTooltip: "Show context debug info",

--- a/crates/web/ui/src/locales/fr/chat.ts
+++ b/crates/web/ui/src/locales/fr/chat.ts
@@ -47,9 +47,11 @@ export default {
 	// ── Reasoning toggle ─────────────────────────────────────
 	reasoningTooltip: "Effort de raisonnement",
 	reasoningOff: "Désactivé",
+	reasoningMinimal: "Minimal",
 	reasoningLow: "Faible",
 	reasoningMedium: "Moyen",
 	reasoningHigh: "Élevé",
+	reasoningExtraHigh: "Très élevé",
 
 	// ── Debug panel ──────────────────────────────────────────
 	debugTooltip: "Show context debug info",

--- a/crates/web/ui/src/locales/zh/chat.ts
+++ b/crates/web/ui/src/locales/zh/chat.ts
@@ -47,9 +47,11 @@ export default {
 	// ── Reasoning toggle ─────────────────────────────────────
 	reasoningTooltip: "推理深度",
 	reasoningOff: "关闭",
+	reasoningMinimal: "最低",
 	reasoningLow: "低",
 	reasoningMedium: "中",
 	reasoningHigh: "高",
+	reasoningExtraHigh: "极高",
 
 	// ── Debug panel ──────────────────────────────────────────
 	debugTooltip: "显示上下文调试信息",

--- a/crates/web/ui/src/reasoning-toggle.ts
+++ b/crates/web/ui/src/reasoning-toggle.ts
@@ -10,7 +10,7 @@ import { effect } from "@preact/signals";
 import { t } from "./i18n";
 import { modelStore } from "./stores/model-store";
 
-const EFFORT_VALUES: string[] = ["", "low", "medium", "high"];
+const EFFORT_VALUES: string[] = ["", "minimal", "low", "medium", "high", "xhigh"];
 
 let reasoningCombo: HTMLElement | null = null;
 let reasoningComboBtn: HTMLElement | null = null;
@@ -22,9 +22,11 @@ let disposeVisibility: (() => void) | null = null;
 function effortLabel(effort: string): string {
 	const map: Record<string, string> = {
 		"": t("chat:reasoningOff"),
+		minimal: t("chat:reasoningMinimal"),
 		low: t("chat:reasoningLow"),
 		medium: t("chat:reasoningMedium"),
 		high: t("chat:reasoningHigh"),
+		xhigh: t("chat:reasoningExtraHigh"),
 	};
 	return map[effort] ?? t("chat:reasoningOff");
 }


### PR DESCRIPTION
## Summary

- **Discord slash commands now accept arguments** — fixes #948 where `/mode 2`, `/model gpt-4o`, etc. were silently ignored
- **Semantic option names** — Discord shows descriptive names (`model`, `mode`, `action`, `id`) instead of generic `value`
- **Dropdown choices** for fixed-value commands (`/sh`, `/sandbox`, `/fast`)
- **5 reasoning levels** — expanded `ReasoningEffort` from 3 (Low/Medium/High) to 5 (Minimal/Low/Medium/High/ExtraHigh) matching Codex, OpenClaw, and Hermes

## Validation

### Completed
- [x] `cargo fmt --all -- --check`
- [x] `cargo check -p moltis-config -p moltis-agents -p moltis-providers -p moltis-discord -p moltis-gateway`
- [x] `cargo test -p moltis-config -p moltis-providers -p moltis-discord --lib` (594 tests pass)
- [x] `biome check --write` on changed TS files
- [x] 15 Discord command tests (8 new: arg registration, text extraction, choices, Discord limits)
- [x] Config validation test covers all 5 effort values
- [x] `reasoning_suffixes_covers_all_efforts` test ensures no level is missed

### Remaining
- [ ] `./scripts/local-validate.sh` (full CI validation)
- [ ] `npx tsc --noEmit` (TypeScript type check — needs `npm install`)

## Manual QA

1. Set up a Discord bot account
2. Verify `/mode` shows a `mode` input field (not just the bare command)
3. Verify `/sh` shows a dropdown with On/Off/Exit/Status choices
4. Verify `/mode 2` dispatches correctly (was broken before)
5. Open web UI → select a reasoning-capable model → verify dropdown shows all 5 levels (Off, Minimal, Low, Medium, High, Extra High)
6. Set `reasoning_effort = "xhigh"` in `moltis.toml` agent preset → verify it parses without error

Closes #948