### PR TITLE
feat(portable): add data import/export for config, databases, and sessions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7168,6 +7168,7 @@ dependencies = [
  "moltis-onboarding",
  "moltis-openclaw-import",
  "moltis-plugins",
+ "moltis-portable",
  "moltis-projects",
  "moltis-sessions",
  "moltis-skills",
@@ -7727,6 +7728,7 @@ dependencies = [
  "moltis-matrix",
  "moltis-metrics",
  "moltis-msteams",
+ "moltis-portable",
  "moltis-protocol",
  "moltis-providers",
  "moltis-service-traits",
@@ -8061,6 +8063,26 @@ dependencies = [
  "tokio",
  "toml 0.8.23",
  "tracing",
+]
+
+[[package]]
+name = "moltis-portable"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "flate2",
+ "hex",
+ "moltis-config",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "sqlx",
+ "tar",
+ "tempfile",
+ "time",
+ "tokio",
+ "tracing",
+ "walkdir",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ default-members = [
   "crates/onboarding",
   "crates/openclaw-import",
   "crates/plugins",
+  "crates/portable",
   "crates/projects",
   "crates/protocol",
   "crates/provider-setup",
@@ -103,6 +104,7 @@ members = [
   "crates/onboarding",
   "crates/openclaw-import",
   "crates/plugins",
+  "crates/portable",
   "crates/projects",
   "crates/protocol",
   "crates/provider-setup",
@@ -376,6 +378,7 @@ moltis-oauth            = { path = "crates/oauth" }
 moltis-onboarding       = { path = "crates/onboarding" }
 moltis-openclaw-import  = { path = "crates/openclaw-import" }
 moltis-plugins          = { path = "crates/plugins" }
+moltis-portable         = { path = "crates/portable" }
 moltis-projects         = { path = "crates/projects" }
 moltis-protocol         = { path = "crates/protocol" }
 moltis-provider-setup   = { path = "crates/provider-setup" }

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -80,6 +80,7 @@ moltis-oauth           = { workspace = true }
 moltis-onboarding      = { workspace = true }
 moltis-openclaw-import = { optional = true, workspace = true }
 moltis-plugins         = { workspace = true }
+moltis-portable        = { workspace = true }
 moltis-projects        = { workspace = true }
 moltis-sessions        = { workspace = true }
 moltis-skills          = { workspace = true }

--- a/crates/cli/src/data_commands.rs
+++ b/crates/cli/src/data_commands.rs
@@ -1,0 +1,193 @@
+//! CLI subcommand for exporting and importing Moltis data archives.
+
+use std::path::PathBuf;
+
+use clap::Subcommand;
+
+#[derive(Subcommand)]
+pub enum DataAction {
+    /// Export config, databases, and sessions to a .tar.gz archive.
+    Export {
+        /// Output file path (default: moltis-backup-<timestamp>.tar.gz in current directory).
+        #[arg(short, long)]
+        output: Option<PathBuf>,
+        /// Include session media files (audio, images). Can make archives large.
+        #[arg(long, default_value_t = false)]
+        include_media: bool,
+        /// Exclude provider API keys from the export.
+        #[arg(long, default_value_t = false)]
+        no_provider_keys: bool,
+    },
+    /// Import data from a .tar.gz archive.
+    Import {
+        /// Path to the archive file.
+        archive: PathBuf,
+        /// Preview what would be imported without writing anything.
+        #[arg(long, default_value_t = false)]
+        dry_run: bool,
+        /// Conflict strategy: skip (default) or overwrite.
+        #[arg(long, default_value = "skip")]
+        conflict: String,
+        /// Emit structured JSON output.
+        #[arg(long, default_value_t = false)]
+        json: bool,
+    },
+    /// Inspect an archive and show its manifest without importing.
+    Inspect {
+        /// Path to the archive file.
+        archive: PathBuf,
+        /// Emit structured JSON output.
+        #[arg(long, default_value_t = false)]
+        json: bool,
+    },
+}
+
+pub async fn handle_data(action: DataAction) -> anyhow::Result<()> {
+    match action {
+        DataAction::Export {
+            output,
+            include_media,
+            no_provider_keys,
+        } => handle_export(output, include_media, no_provider_keys).await,
+        DataAction::Import {
+            archive,
+            dry_run,
+            conflict,
+            json,
+        } => handle_import(archive, dry_run, &conflict, json).await,
+        DataAction::Inspect { archive, json } => handle_inspect(archive, json),
+    }
+}
+
+async fn handle_export(
+    output: Option<PathBuf>,
+    include_media: bool,
+    no_provider_keys: bool,
+) -> anyhow::Result<()> {
+    let config_dir =
+        moltis_config::config_dir().ok_or_else(|| anyhow::anyhow!("config directory not set"))?;
+    let data_dir = moltis_config::data_dir();
+
+    let opts = moltis_portable::ExportOptions {
+        include_provider_keys: !no_provider_keys,
+        include_media,
+    };
+
+    let output_path = output.unwrap_or_else(|| {
+        let now = time::OffsetDateTime::now_utc();
+        PathBuf::from(format!(
+            "moltis-backup-{:04}{:02}{:02}-{:02}{:02}{:02}.tar.gz",
+            now.year(),
+            now.month() as u8,
+            now.day(),
+            now.hour(),
+            now.minute(),
+            now.second(),
+        ))
+    });
+
+    let file = std::fs::File::create(&output_path)?;
+    let manifest = moltis_portable::export_archive(&config_dir, &data_dir, &opts, file).await?;
+
+    println!("Export complete: {}", output_path.display());
+    println!("  Config files: {}", manifest.inventory.config_files.len());
+    println!(
+        "  Workspace files: {}",
+        manifest.inventory.workspace_files.len()
+    );
+    println!("  Sessions: {}", manifest.inventory.session_count());
+    if include_media {
+        println!("  Media files: {}", manifest.inventory.media_count());
+    }
+    println!("  moltis.db: {}", manifest.inventory.has_moltis_db);
+    println!("  memory.db: {}", manifest.inventory.has_memory_db);
+
+    Ok(())
+}
+
+async fn handle_import(
+    archive: PathBuf,
+    dry_run: bool,
+    conflict: &str,
+    json: bool,
+) -> anyhow::Result<()> {
+    let config_dir =
+        moltis_config::config_dir().ok_or_else(|| anyhow::anyhow!("config directory not set"))?;
+    let data_dir = moltis_config::data_dir();
+
+    let conflict_strategy = match conflict {
+        "skip" => moltis_portable::ConflictStrategy::Skip,
+        "overwrite" => moltis_portable::ConflictStrategy::Overwrite,
+        other => anyhow::bail!("unknown conflict strategy: {other} (use 'skip' or 'overwrite')"),
+    };
+
+    let opts = moltis_portable::ImportOptions {
+        conflict: conflict_strategy,
+        dry_run,
+    };
+
+    let file = std::fs::File::open(&archive)?;
+    let result = moltis_portable::import_archive(&config_dir, &data_dir, &opts, file).await?;
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&result)?);
+        return Ok(());
+    }
+
+    if dry_run {
+        println!("Dry run — no changes written.");
+    }
+
+    println!("Imported: {}", result.imported.len());
+    for item in &result.imported {
+        println!("  [{}] {} — {}", item.category, item.path, item.action);
+    }
+
+    if !result.skipped.is_empty() {
+        println!("Skipped: {}", result.skipped.len());
+        for item in &result.skipped {
+            println!("  [{}] {} — {}", item.category, item.path, item.action);
+        }
+    }
+
+    if !result.warnings.is_empty() {
+        println!("Warnings:");
+        for w in &result.warnings {
+            println!("  {w}");
+        }
+    }
+
+    Ok(())
+}
+
+fn handle_inspect(archive: PathBuf, json: bool) -> anyhow::Result<()> {
+    let file = std::fs::File::open(&archive)?;
+    let manifest = moltis_portable::inspect_archive(file)?;
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&manifest)?);
+        return Ok(());
+    }
+
+    println!("Archive format version: {}", manifest.format_version);
+    println!("Moltis version: {}", manifest.moltis_version);
+    println!("Created: {}", manifest.created_at);
+    println!("Contents:");
+    println!("  Config files: {}", manifest.inventory.config_files.len());
+    for f in &manifest.inventory.config_files {
+        println!("    {f}");
+    }
+    println!(
+        "  Workspace files: {}",
+        manifest.inventory.workspace_files.len()
+    );
+    for f in &manifest.inventory.workspace_files {
+        println!("    {f}");
+    }
+    println!("  moltis.db: {}", manifest.inventory.has_moltis_db);
+    println!("  memory.db: {}", manifest.inventory.has_memory_db);
+    println!("  Sessions: {}", manifest.inventory.session_count());
+    println!("  Media files: {}", manifest.inventory.media_count());
+
+    Ok(())
+}

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -28,6 +28,7 @@ mod auth_commands;
 mod browser_commands;
 mod channel_commands;
 mod config_commands;
+mod data_commands;
 mod db_commands;
 mod doctor_commands;
 mod hooks_commands;
@@ -159,6 +160,11 @@ enum Commands {
     Browser {
         #[command(subcommand)]
         action: browser_commands::BrowserAction,
+    },
+    /// Export and import Moltis data archives.
+    Data {
+        #[command(subcommand)]
+        action: data_commands::DataAction,
     },
     /// Database management (reset, clear, migrate).
     Db {
@@ -469,6 +475,7 @@ async fn main() -> anyhow::Result<()> {
         Some(Commands::Auth { action }) => auth_commands::handle_auth(action).await,
         Some(Commands::Sandbox { action }) => sandbox_commands::handle_sandbox(action).await,
         Some(Commands::Browser { action }) => browser_commands::handle_browser(action),
+        Some(Commands::Data { action }) => data_commands::handle_data(action).await,
         Some(Commands::Db { action }) => db_commands::handle_db(action).await,
         Some(Commands::Memory { action }) => memory_commands::handle_memory(action).await,
         Some(Commands::Node { action }) => node_commands::handle_node(action).await,

--- a/crates/httpd/Cargo.toml
+++ b/crates/httpd/Cargo.toml
@@ -31,6 +31,7 @@ moltis-graphql        = { optional = true, workspace = true }
 moltis-matrix         = { optional = true, workspace = true }
 moltis-metrics        = { optional = true, workspace = true }
 moltis-msteams        = { optional = true, workspace = true }
+moltis-portable       = { workspace = true }
 moltis-protocol       = { workspace = true }
 moltis-service-traits = { workspace = true }
 moltis-sessions       = { workspace = true }

--- a/crates/httpd/src/data_routes.rs
+++ b/crates/httpd/src/data_routes.rs
@@ -15,6 +15,7 @@ use {
     },
     moltis_portable::{ConflictStrategy, ExportOptions, ImportOptions},
     serde::Deserialize,
+    tokio_util::io::ReaderStream,
     tracing::warn,
 };
 
@@ -56,6 +57,10 @@ pub fn data_router() -> Router<AppState> {
 }
 
 /// `GET /api/data/export`
+///
+/// Writes the archive to a temporary file, then streams it to the client.
+/// This avoids buffering the entire archive in memory while still allowing
+/// the synchronous `tar`/`flate2` writers to work naturally.
 async fn export_handler(Query(query): Query<ExportQuery>) -> impl IntoResponse {
     let config_dir = match moltis_config::config_dir() {
         Some(d) => d,
@@ -74,37 +79,80 @@ async fn export_handler(Query(query): Query<ExportQuery>) -> impl IntoResponse {
         include_media: query.include_media,
     };
 
-    let mut buf = Vec::new();
-    match moltis_portable::export_archive(&config_dir, &data_dir, &opts, &mut buf).await {
-        Ok(_manifest) => {
-            let now = time::OffsetDateTime::now_utc();
-            let filename = format!(
-                "moltis-backup-{:04}{:02}{:02}-{:02}{:02}{:02}.tar.gz",
-                now.year(),
-                now.month() as u8,
-                now.day(),
-                now.hour(),
-                now.minute(),
-                now.second(),
-            );
-            let headers = [
-                (header::CONTENT_TYPE, "application/gzip".to_owned()),
-                (
-                    header::CONTENT_DISPOSITION,
-                    format!("attachment; filename=\"{filename}\""),
-                ),
-            ];
-            (headers, buf).into_response()
-        },
+    // Write to a temp file so we don't buffer the full archive in memory.
+    let tmp_file = match tempfile::NamedTempFile::new() {
+        Ok(f) => f,
         Err(e) => {
+            warn!(error = %e, "failed to create temp file for export");
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({"ok": false, "error": "failed to create temp file"})),
+            )
+                .into_response();
+        },
+    };
+
+    let tmp_path = tmp_file.path().to_path_buf();
+    {
+        let file = match std::fs::File::create(&tmp_path) {
+            Ok(f) => f,
+            Err(e) => {
+                warn!(error = %e, "failed to open temp file for export");
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(serde_json::json!({"ok": false, "error": "failed to open temp file"})),
+                )
+                    .into_response();
+            },
+        };
+
+        if let Err(e) = moltis_portable::export_archive(&config_dir, &data_dir, &opts, file).await {
             warn!(error = %e, "data export failed");
-            (
+            return (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Json(serde_json::json!({"ok": false, "error": e.to_string()})),
             )
-                .into_response()
-        },
+                .into_response();
+        }
     }
+
+    // Stream the temp file to the client.
+    let async_file = match tokio::fs::File::open(&tmp_path).await {
+        Ok(f) => f,
+        Err(e) => {
+            warn!(error = %e, "failed to reopen temp file for streaming");
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({"ok": false, "error": "failed to read export"})),
+            )
+                .into_response();
+        },
+    };
+
+    // Keep the NamedTempFile alive so it isn't deleted until streaming completes.
+    // The file will be cleaned up when `tmp_file` is dropped after the response.
+    let stream = ReaderStream::new(tokio::io::BufReader::new(async_file));
+    let body = axum::body::Body::from_stream(stream);
+
+    let now = time::OffsetDateTime::now_utc();
+    let filename = format!(
+        "moltis-backup-{:04}{:02}{:02}-{:02}{:02}{:02}.tar.gz",
+        now.year(),
+        now.month() as u8,
+        now.day(),
+        now.hour(),
+        now.minute(),
+        now.second(),
+    );
+
+    let headers = [
+        (header::CONTENT_TYPE, "application/gzip".to_owned()),
+        (
+            header::CONTENT_DISPOSITION,
+            format!("attachment; filename=\"{filename}\""),
+        ),
+    ];
+    (headers, body).into_response()
 }
 
 /// `POST /api/data/import`
@@ -148,7 +196,8 @@ async fn run_import(query: ImportQuery, body: Bytes, dry_run: bool) -> impl Into
 
     let opts = ImportOptions { conflict, dry_run };
 
-    let reader = std::io::Cursor::new(body.to_vec());
+    // Cursor<Bytes> implements Read without copying the data.
+    let reader = std::io::Cursor::new(body);
     match moltis_portable::import_archive(&config_dir, &data_dir, &opts, reader).await {
         Ok(result) => Json(serde_json::json!({
             "ok": true,

--- a/crates/httpd/src/data_routes.rs
+++ b/crates/httpd/src/data_routes.rs
@@ -1,0 +1,170 @@
+//! Export/import Moltis data as `.tar.gz` archives.
+//!
+//! - `GET  /api/data/export` — stream a backup archive
+//! - `POST /api/data/import` — upload and apply an archive
+//! - `POST /api/data/import/preview` — upload and preview without applying
+
+use {
+    axum::{
+        Json, Router,
+        body::Bytes,
+        extract::Query,
+        http::{StatusCode, header},
+        response::IntoResponse,
+        routing::{get, post},
+    },
+    moltis_portable::{ConflictStrategy, ExportOptions, ImportOptions},
+    serde::Deserialize,
+    tracing::warn,
+};
+
+use crate::AppState;
+
+/// Maximum import archive size: 2 GB.
+const MAX_IMPORT_SIZE: usize = 2 * 1024 * 1024 * 1024;
+
+#[derive(Debug, Deserialize, Default)]
+pub struct ExportQuery {
+    #[serde(default = "default_true")]
+    pub include_provider_keys: bool,
+    #[serde(default)]
+    pub include_media: bool,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+#[derive(Debug, Deserialize, Default)]
+pub struct ImportQuery {
+    #[serde(default)]
+    pub conflict: Option<String>,
+}
+
+pub fn data_router() -> Router<AppState> {
+    Router::new()
+        .route("/export", get(export_handler))
+        .route(
+            "/import",
+            post(import_handler).layer(axum::extract::DefaultBodyLimit::max(MAX_IMPORT_SIZE)),
+        )
+        .route(
+            "/import/preview",
+            post(import_preview_handler)
+                .layer(axum::extract::DefaultBodyLimit::max(MAX_IMPORT_SIZE)),
+        )
+}
+
+/// `GET /api/data/export`
+async fn export_handler(Query(query): Query<ExportQuery>) -> impl IntoResponse {
+    let config_dir = match moltis_config::config_dir() {
+        Some(d) => d,
+        None => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({"ok": false, "error": "config directory not set"})),
+            )
+                .into_response();
+        },
+    };
+    let data_dir = moltis_config::data_dir();
+
+    let opts = ExportOptions {
+        include_provider_keys: query.include_provider_keys,
+        include_media: query.include_media,
+    };
+
+    let mut buf = Vec::new();
+    match moltis_portable::export_archive(&config_dir, &data_dir, &opts, &mut buf).await {
+        Ok(_manifest) => {
+            let now = time::OffsetDateTime::now_utc();
+            let filename = format!(
+                "moltis-backup-{:04}{:02}{:02}-{:02}{:02}{:02}.tar.gz",
+                now.year(),
+                now.month() as u8,
+                now.day(),
+                now.hour(),
+                now.minute(),
+                now.second(),
+            );
+            let headers = [
+                (header::CONTENT_TYPE, "application/gzip".to_owned()),
+                (
+                    header::CONTENT_DISPOSITION,
+                    format!("attachment; filename=\"{filename}\""),
+                ),
+            ];
+            (headers, buf).into_response()
+        },
+        Err(e) => {
+            warn!(error = %e, "data export failed");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({"ok": false, "error": e.to_string()})),
+            )
+                .into_response()
+        },
+    }
+}
+
+/// `POST /api/data/import`
+async fn import_handler(Query(query): Query<ImportQuery>, body: Bytes) -> impl IntoResponse {
+    run_import(query, body, false).await
+}
+
+/// `POST /api/data/import/preview`
+async fn import_preview_handler(
+    Query(query): Query<ImportQuery>,
+    body: Bytes,
+) -> impl IntoResponse {
+    run_import(query, body, true).await
+}
+
+async fn run_import(query: ImportQuery, body: Bytes, dry_run: bool) -> impl IntoResponse {
+    if body.is_empty() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({"ok": false, "error": "empty body"})),
+        )
+            .into_response();
+    }
+
+    let config_dir = match moltis_config::config_dir() {
+        Some(d) => d,
+        None => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({"ok": false, "error": "config directory not set"})),
+            )
+                .into_response();
+        },
+    };
+    let data_dir = moltis_config::data_dir();
+
+    let conflict = match query.conflict.as_deref() {
+        Some("overwrite") => ConflictStrategy::Overwrite,
+        _ => ConflictStrategy::Skip,
+    };
+
+    let opts = ImportOptions { conflict, dry_run };
+
+    let reader = std::io::Cursor::new(body.to_vec());
+    match moltis_portable::import_archive(&config_dir, &data_dir, &opts, reader).await {
+        Ok(result) => Json(serde_json::json!({
+            "ok": true,
+            "imported": result.imported,
+            "skipped": result.skipped,
+            "warnings": result.warnings,
+            "manifest": result.manifest,
+        }))
+        .into_response(),
+        Err(e) => {
+            warn!(error = %e, "data import failed");
+            (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({"ok": false, "error": e.to_string()})),
+            )
+                .into_response()
+        },
+    }
+}

--- a/crates/httpd/src/lib.rs
+++ b/crates/httpd/src/lib.rs
@@ -10,6 +10,7 @@
 pub mod auth_middleware;
 pub mod auth_routes;
 pub mod channel_webhook_middleware;
+pub mod data_routes;
 pub mod env_routes;
 pub mod error;
 pub mod login_guard;

--- a/crates/portable/Cargo.toml
+++ b/crates/portable/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+description       = "Import/export Moltis config, data, and databases as portable .tar.gz archives"
+edition.workspace = true
+license.workspace = true
+name              = "moltis-portable"
+version.workspace = true
+
+[dependencies]
+anyhow     = { workspace = true }
+flate2     = { workspace = true }
+hex        = { workspace = true }
+serde      = { workspace = true }
+serde_json = { workspace = true }
+sha2       = { workspace = true }
+sqlx       = { workspace = true }
+tar        = { workspace = true }
+time       = { workspace = true }
+tokio      = { workspace = true }
+tracing    = { workspace = true }
+walkdir    = { workspace = true }
+
+moltis-config = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/portable/src/export.rs
+++ b/crates/portable/src/export.rs
@@ -15,6 +15,16 @@ use {
 
 use crate::manifest::{ArchiveInventory, ExportManifest, FORMAT_VERSION};
 
+/// Drop guard that removes a temporary file when it goes out of scope,
+/// ensuring cleanup even on early `?` returns.
+struct TempFileGuard(PathBuf);
+
+impl Drop for TempFileGuard {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.0);
+    }
+}
+
 /// Options controlling what gets included in the export.
 #[derive(Debug, Clone)]
 pub struct ExportOptions {
@@ -119,9 +129,9 @@ pub async fn export_archive<W: Write>(
     let moltis_db = data_dir.join("moltis.db");
     if moltis_db.exists() {
         let snapshot = vacuum_snapshot(&moltis_db).await?;
+        let _guard = TempFileGuard(snapshot.clone());
         strip_auth_tables(&snapshot).await?;
         add_file_to_tar(&mut builder, &snapshot, &format!("{prefix}/db/moltis.db"))?;
-        let _ = std::fs::remove_file(&snapshot);
         inventory.has_moltis_db = true;
         info!("exported moltis.db snapshot");
     }
@@ -129,8 +139,8 @@ pub async fn export_archive<W: Write>(
     let memory_db = data_dir.join("memory.db");
     if memory_db.exists() {
         let snapshot = vacuum_snapshot(&memory_db).await?;
+        let _guard = TempFileGuard(snapshot.clone());
         add_file_to_tar(&mut builder, &snapshot, &format!("{prefix}/db/memory.db"))?;
-        let _ = std::fs::remove_file(&snapshot);
         inventory.has_memory_db = true;
         info!("exported memory.db snapshot");
     }
@@ -283,7 +293,8 @@ async fn vacuum_snapshot(db_path: &Path) -> anyhow::Result<PathBuf> {
     let pool = sqlx::SqlitePool::connect(&db_url).await?;
 
     let snapshot_str = snapshot_path.display().to_string();
-    sqlx::query(&format!("VACUUM INTO '{snapshot_str}'"))
+    let escaped = snapshot_str.replace('\'', "''");
+    sqlx::query(&format!("VACUUM INTO '{escaped}'"))
         .execute(&pool)
         .await?;
     pool.close().await;

--- a/crates/portable/src/export.rs
+++ b/crates/portable/src/export.rs
@@ -1,0 +1,350 @@
+//! Export Moltis data into a `.tar.gz` archive.
+
+use std::{
+    io::Write,
+    path::{Path, PathBuf},
+};
+
+use {
+    flate2::{Compression, write::GzEncoder},
+    sha2::{Digest, Sha256},
+    tar::{Builder, Header},
+    tracing::{debug, info},
+    walkdir::WalkDir,
+};
+
+use crate::manifest::{ArchiveInventory, ExportManifest, FORMAT_VERSION};
+
+/// Options controlling what gets included in the export.
+#[derive(Debug, Clone)]
+pub struct ExportOptions {
+    /// Include provider API keys (provider_keys.json). Default: true.
+    pub include_provider_keys: bool,
+    /// Include session media (audio, images). Default: false.
+    pub include_media: bool,
+}
+
+impl Default for ExportOptions {
+    fn default() -> Self {
+        Self {
+            include_provider_keys: true,
+            include_media: false,
+        }
+    }
+}
+
+/// Auth tables to clear from the exported moltis.db snapshot.
+const AUTH_TABLES_TO_CLEAR: &[&str] = &[
+    "auth_password",
+    "auth_sessions",
+    "api_keys",
+    "passkeys",
+    "device_pairing",
+    "session_shares",
+];
+
+/// Export a `.tar.gz` archive to the given writer.
+///
+/// Uses `VACUUM INTO` for SQLite snapshots so the live DB is never locked.
+pub async fn export_archive<W: Write>(
+    config_dir: &Path,
+    data_dir: &Path,
+    opts: &ExportOptions,
+    writer: W,
+) -> anyhow::Result<ExportManifest> {
+    let encoder = GzEncoder::new(writer, Compression::default());
+    let mut builder = Builder::new(encoder);
+    let mut inventory = ArchiveInventory::default();
+
+    let prefix = archive_prefix();
+
+    // ── Config files ─────────────────────────────────────────────────
+    add_config_file(
+        &mut builder,
+        config_dir,
+        "moltis.toml",
+        &prefix,
+        &mut inventory,
+    )?;
+    add_config_file(
+        &mut builder,
+        config_dir,
+        "mcp-servers.json",
+        &prefix,
+        &mut inventory,
+    )?;
+    if opts.include_provider_keys {
+        add_config_file(
+            &mut builder,
+            config_dir,
+            "provider_keys.json",
+            &prefix,
+            &mut inventory,
+        )?;
+    }
+
+    // ── Workspace markdown ───────────────────────────────────────────
+    let workspace_files = [
+        "SOUL.md",
+        "IDENTITY.md",
+        "USER.md",
+        "BOOT.md",
+        "TOOLS.md",
+        "MEMORY.md",
+        "AGENTS.md",
+        "HEARTBEAT.md",
+    ];
+    for name in workspace_files {
+        add_workspace_file(&mut builder, data_dir, name, &prefix, &mut inventory)?;
+    }
+
+    // Agent workspace sub-directories.
+    let agents_dir = data_dir.join("agents");
+    if agents_dir.is_dir() {
+        for entry in WalkDir::new(&agents_dir)
+            .min_depth(1)
+            .into_iter()
+            .filter_map(|e| e.ok())
+        {
+            if entry.file_type().is_file() {
+                let rel = entry.path().strip_prefix(data_dir).unwrap_or(entry.path());
+                let archive_path = format!("{prefix}/workspace/{}", rel.display());
+                add_file_to_tar(&mut builder, entry.path(), &archive_path)?;
+                inventory.workspace_files.push(rel.display().to_string());
+            }
+        }
+    }
+
+    // ── SQLite databases ─────────────────────────────────────────────
+    let moltis_db = data_dir.join("moltis.db");
+    if moltis_db.exists() {
+        let snapshot = vacuum_snapshot(&moltis_db).await?;
+        strip_auth_tables(&snapshot).await?;
+        add_file_to_tar(&mut builder, &snapshot, &format!("{prefix}/db/moltis.db"))?;
+        let _ = std::fs::remove_file(&snapshot);
+        inventory.has_moltis_db = true;
+        info!("exported moltis.db snapshot");
+    }
+
+    let memory_db = data_dir.join("memory.db");
+    if memory_db.exists() {
+        let snapshot = vacuum_snapshot(&memory_db).await?;
+        add_file_to_tar(&mut builder, &snapshot, &format!("{prefix}/db/memory.db"))?;
+        let _ = std::fs::remove_file(&snapshot);
+        inventory.has_memory_db = true;
+        info!("exported memory.db snapshot");
+    }
+
+    // ── Session JSONL files ──────────────────────────────────────────
+    let sessions_dir = data_dir.join("sessions");
+    if sessions_dir.is_dir() {
+        for entry in WalkDir::new(&sessions_dir)
+            .min_depth(1)
+            .into_iter()
+            .filter_map(|e| e.ok())
+        {
+            if !entry.file_type().is_file() {
+                continue;
+            }
+            let rel = entry
+                .path()
+                .strip_prefix(&sessions_dir)
+                .unwrap_or(entry.path());
+            let rel_str = rel.display().to_string();
+
+            let is_media = rel_str.starts_with("media/") || rel_str.starts_with("media\\");
+
+            if is_media && !opts.include_media {
+                continue;
+            }
+
+            let archive_path = format!("{prefix}/sessions/{rel_str}");
+            add_file_to_tar(&mut builder, entry.path(), &archive_path)?;
+
+            if is_media {
+                inventory.media_files.push(rel_str);
+            } else {
+                inventory.session_files.push(rel_str);
+            }
+        }
+    }
+
+    // ── Manifest (written last so it has the full inventory) ─────────
+    let now = time::OffsetDateTime::now_utc();
+    let created_at = now
+        .format(&time::format_description::well_known::Rfc3339)
+        .unwrap_or_else(|_| "unknown".into());
+
+    let moltis_version =
+        std::env::var("MOLTIS_VERSION").unwrap_or_else(|_| env!("CARGO_PKG_VERSION").into());
+
+    let manifest = ExportManifest {
+        format_version: FORMAT_VERSION,
+        moltis_version,
+        created_at,
+        inventory,
+    };
+
+    let manifest_json = serde_json::to_vec_pretty(&manifest)?;
+    let mut header = Header::new_gnu();
+    header.set_size(manifest_json.len() as u64);
+    header.set_mode(0o644);
+    header.set_cksum();
+    builder.append_data(
+        &mut header,
+        format!("{prefix}/manifest.json"),
+        manifest_json.as_slice(),
+    )?;
+
+    builder.into_inner()?.finish()?;
+    info!(
+        sessions = manifest.inventory.session_count(),
+        media = manifest.inventory.media_count(),
+        "export complete"
+    );
+    Ok(manifest)
+}
+
+/// Generate a timestamped archive prefix.
+fn archive_prefix() -> String {
+    let now = time::OffsetDateTime::now_utc();
+    format!(
+        "moltis-backup-{:04}{:02}{:02}-{:02}{:02}{:02}",
+        now.year(),
+        now.month() as u8,
+        now.day(),
+        now.hour(),
+        now.minute(),
+        now.second(),
+    )
+}
+
+/// Add a config-dir file to the archive if it exists.
+fn add_config_file<W: Write>(
+    builder: &mut Builder<W>,
+    config_dir: &Path,
+    name: &str,
+    prefix: &str,
+    inventory: &mut ArchiveInventory,
+) -> anyhow::Result<()> {
+    let path = config_dir.join(name);
+    if path.is_file() {
+        add_file_to_tar(builder, &path, &format!("{prefix}/config/{name}"))?;
+        inventory.config_files.push(name.to_owned());
+        debug!(file = name, "added config file");
+    }
+    Ok(())
+}
+
+/// Add a workspace (data_dir root) file to the archive if it exists.
+fn add_workspace_file<W: Write>(
+    builder: &mut Builder<W>,
+    data_dir: &Path,
+    name: &str,
+    prefix: &str,
+    inventory: &mut ArchiveInventory,
+) -> anyhow::Result<()> {
+    let path = data_dir.join(name);
+    if path.is_file() {
+        add_file_to_tar(builder, &path, &format!("{prefix}/workspace/{name}"))?;
+        inventory.workspace_files.push(name.to_owned());
+        debug!(file = name, "added workspace file");
+    }
+    Ok(())
+}
+
+/// Append a file from disk into the tar archive.
+fn add_file_to_tar<W: Write>(
+    builder: &mut Builder<W>,
+    source: &Path,
+    archive_path: &str,
+) -> anyhow::Result<()> {
+    let metadata = std::fs::metadata(source)?;
+    let mut header = Header::new_gnu();
+    header.set_size(metadata.len());
+    header.set_mode(0o644);
+    header.set_cksum();
+
+    let file = std::fs::File::open(source)?;
+    builder.append_data(&mut header, archive_path, file)?;
+    Ok(())
+}
+
+/// Create a consistent snapshot of a SQLite database via `VACUUM INTO`.
+async fn vacuum_snapshot(db_path: &Path) -> anyhow::Result<PathBuf> {
+    let snapshot_path = db_path.with_extension("db.export-snapshot");
+
+    // Remove stale snapshot if present.
+    if snapshot_path.exists() {
+        std::fs::remove_file(&snapshot_path)?;
+    }
+
+    let db_url = format!("sqlite:{}?mode=ro", db_path.display());
+    let pool = sqlx::SqlitePool::connect(&db_url).await?;
+
+    let snapshot_str = snapshot_path.display().to_string();
+    sqlx::query(&format!("VACUUM INTO '{snapshot_str}'"))
+        .execute(&pool)
+        .await?;
+    pool.close().await;
+
+    debug!(path = %snapshot_path.display(), "created db snapshot");
+    Ok(snapshot_path)
+}
+
+/// Strip authentication tables from a snapshot so secrets are never exported.
+async fn strip_auth_tables(snapshot_path: &Path) -> anyhow::Result<()> {
+    let db_url = format!("sqlite:{}?mode=rwc", snapshot_path.display());
+    let pool = sqlx::SqlitePool::connect(&db_url).await?;
+
+    for table in AUTH_TABLES_TO_CLEAR {
+        // Tables may not exist if the user never set up auth.
+        let result = sqlx::query(&format!("DELETE FROM [{table}]"))
+            .execute(&pool)
+            .await;
+        match result {
+            Ok(r) => {
+                if r.rows_affected() > 0 {
+                    debug!(table, rows = r.rows_affected(), "cleared auth table");
+                }
+            },
+            Err(e) => {
+                // Table doesn't exist — fine.
+                debug!(table, error = %e, "skipped auth table (may not exist)");
+            },
+        }
+    }
+
+    pool.close().await;
+    Ok(())
+}
+
+/// Compute SHA-256 of a file (unused in export itself, useful for manifest extensions).
+#[allow(dead_code)]
+fn sha256_file(path: &Path) -> anyhow::Result<String> {
+    use std::io::Read;
+    let mut file = std::fs::File::open(path)?;
+    let mut hasher = Sha256::new();
+    let mut buf = [0u8; 8192];
+    loop {
+        let n = file.read(&mut buf)?;
+        if n == 0 {
+            break;
+        }
+        hasher.update(&buf[..n]);
+    }
+    Ok(hex::encode(hasher.finalize()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn archive_prefix_format() {
+        let prefix = archive_prefix();
+        assert!(prefix.starts_with("moltis-backup-"));
+        // e.g. moltis-backup-20260501-143022
+        assert_eq!(prefix.len(), "moltis-backup-YYYYMMDD-HHMMSS".len());
+    }
+}

--- a/crates/portable/src/import.rs
+++ b/crates/portable/src/import.rs
@@ -14,6 +14,15 @@ use {
 
 use crate::manifest::{ExportManifest, FORMAT_VERSION};
 
+/// Drop guard that removes a temporary file when it goes out of scope.
+struct TempFileGuard(std::path::PathBuf);
+
+impl Drop for TempFileGuard {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.0);
+    }
+}
+
 /// How to handle conflicts with existing data.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
@@ -342,16 +351,19 @@ async fn merge_moltis_db(
         return Ok(vec![("(full copy)".into(), 1)]);
     }
 
-    // Write imported data to a temporary file.
+    // Write imported data to a temporary file, with a drop guard so it is
+    // cleaned up even if an error occurs during the merge sequence.
     let import_path = data_dir.join("moltis.db.import-tmp");
     std::fs::write(&import_path, imported_data)?;
+    let _guard = TempFileGuard(import_path.clone());
 
     let db_url = format!("sqlite:{}?mode=rwc", live_db.display());
     let pool = sqlx::SqlitePool::connect(&db_url).await?;
 
     // Attach the imported database.
     let import_path_str = import_path.display().to_string();
-    sqlx::query(&format!("ATTACH DATABASE '{import_path_str}' AS import_db"))
+    let escaped = import_path_str.replace('\'', "''");
+    sqlx::query(&format!("ATTACH DATABASE '{escaped}' AS import_db"))
         .execute(&pool)
         .await?;
 
@@ -404,7 +416,7 @@ async fn merge_moltis_db(
         .await?;
     pool.close().await;
 
-    let _ = std::fs::remove_file(&import_path);
+    // _guard drops here, removing the temp file.
     Ok(counts)
 }
 

--- a/crates/portable/src/import.rs
+++ b/crates/portable/src/import.rs
@@ -1,0 +1,459 @@
+//! Import a `.tar.gz` archive into a Moltis instance.
+
+use std::{
+    io::Read,
+    path::{Component, Path},
+};
+
+use {
+    flate2::read::GzDecoder,
+    serde::{Deserialize, Serialize},
+    tar::Archive,
+    tracing::{debug, info, warn},
+};
+
+use crate::manifest::{ExportManifest, FORMAT_VERSION};
+
+/// How to handle conflicts with existing data.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ConflictStrategy {
+    /// Keep existing data, skip conflicting imports.
+    #[default]
+    Skip,
+    /// Replace existing data with imported data.
+    Overwrite,
+}
+
+/// Options for importing an archive.
+#[derive(Debug, Clone)]
+pub struct ImportOptions {
+    pub conflict: ConflictStrategy,
+    pub dry_run: bool,
+}
+
+impl Default for ImportOptions {
+    fn default() -> Self {
+        Self {
+            conflict: ConflictStrategy::Skip,
+            dry_run: false,
+        }
+    }
+}
+
+/// A single item that was imported.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ImportedItem {
+    pub category: String,
+    pub path: String,
+    pub action: String,
+}
+
+/// Result of an import operation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ImportResult {
+    pub manifest: ExportManifest,
+    pub imported: Vec<ImportedItem>,
+    pub skipped: Vec<ImportedItem>,
+    pub warnings: Vec<String>,
+}
+
+/// Import a `.tar.gz` archive into the given config and data directories.
+pub async fn import_archive<R: Read>(
+    config_dir: &Path,
+    data_dir: &Path,
+    opts: &ImportOptions,
+    reader: R,
+) -> anyhow::Result<ImportResult> {
+    let decoder = GzDecoder::new(reader);
+    let mut archive = Archive::new(decoder);
+
+    let mut manifest: Option<ExportManifest> = None;
+    let mut imported = Vec::new();
+    let mut skipped = Vec::new();
+    let mut warnings = Vec::new();
+    let mut db_snapshots: Vec<(String, Vec<u8>)> = Vec::new();
+
+    for entry in archive.entries()? {
+        let mut entry = entry?;
+        let raw_path = entry.path()?.to_path_buf();
+
+        // Strip the top-level prefix directory (moltis-backup-YYYYMMDD-HHMMSS/).
+        let stripped = strip_archive_prefix(&raw_path);
+
+        // Validate path safety — reject traversal attacks.
+        if !is_safe_path(stripped) {
+            warnings.push(format!("skipped unsafe path: {}", raw_path.display()));
+            continue;
+        }
+
+        let stripped_str = stripped.display().to_string();
+
+        if stripped_str == "manifest.json" {
+            let m: ExportManifest = serde_json::from_reader(&mut entry)?;
+            if m.format_version > FORMAT_VERSION {
+                anyhow::bail!(
+                    "archive format version {} is newer than supported version {FORMAT_VERSION}",
+                    m.format_version
+                );
+            }
+            manifest = Some(m);
+            continue;
+        }
+
+        if stripped_str.starts_with("config/") {
+            let filename = stripped.strip_prefix("config/").unwrap_or(stripped);
+            let dest = config_dir.join(filename);
+            let action = apply_file(&mut entry, &dest, opts)?;
+            record_action(
+                &action,
+                "config",
+                &stripped_str,
+                &mut imported,
+                &mut skipped,
+            );
+            continue;
+        }
+
+        if stripped_str.starts_with("workspace/") {
+            let rel = stripped.strip_prefix("workspace/").unwrap_or(stripped);
+            let dest = data_dir.join(rel);
+            let action = apply_file(&mut entry, &dest, opts)?;
+            record_action(
+                &action,
+                "workspace",
+                &stripped_str,
+                &mut imported,
+                &mut skipped,
+            );
+            continue;
+        }
+
+        if stripped_str.starts_with("db/") {
+            // Buffer database files in memory — they need special merge handling.
+            let mut buf = Vec::new();
+            entry.read_to_end(&mut buf)?;
+            db_snapshots.push((stripped_str.clone(), buf));
+            continue;
+        }
+
+        if stripped_str.starts_with("sessions/") {
+            let rel = stripped.strip_prefix("sessions/").unwrap_or(stripped);
+            let dest = data_dir.join("sessions").join(rel);
+            let action = apply_file(&mut entry, &dest, opts)?;
+            let category = if stripped_str.contains("media/") {
+                "media"
+            } else {
+                "session"
+            };
+            record_action(
+                &action,
+                category,
+                &stripped_str,
+                &mut imported,
+                &mut skipped,
+            );
+            continue;
+        }
+
+        debug!(path = %stripped_str, "ignoring unknown archive entry");
+    }
+
+    let manifest = manifest.ok_or_else(|| anyhow::anyhow!("archive missing manifest.json"))?;
+
+    // ── Merge SQLite databases ───────────────────────────────────────
+    if !opts.dry_run {
+        for (archive_path, data) in &db_snapshots {
+            if archive_path == "db/moltis.db" {
+                match merge_moltis_db(data_dir, data, opts.conflict).await {
+                    Ok(counts) => {
+                        for (table, n) in &counts {
+                            if *n > 0 {
+                                imported.push(ImportedItem {
+                                    category: "database".into(),
+                                    path: format!("moltis.db/{table}"),
+                                    action: format!("merged {n} rows"),
+                                });
+                            }
+                        }
+                    },
+                    Err(e) => {
+                        warnings.push(format!("failed to merge moltis.db: {e}"));
+                    },
+                }
+            } else if archive_path == "db/memory.db" {
+                match apply_memory_db(data_dir, data, opts.conflict).await {
+                    Ok(action) => {
+                        imported.push(ImportedItem {
+                            category: "database".into(),
+                            path: "memory.db".into(),
+                            action,
+                        });
+                    },
+                    Err(e) => {
+                        warnings.push(format!("failed to import memory.db: {e}"));
+                    },
+                }
+            }
+        }
+    } else {
+        for (archive_path, _) in &db_snapshots {
+            skipped.push(ImportedItem {
+                category: "database".into(),
+                path: archive_path.clone(),
+                action: "dry-run".into(),
+            });
+        }
+    }
+
+    info!(
+        imported = imported.len(),
+        skipped = skipped.len(),
+        warnings = warnings.len(),
+        "import complete"
+    );
+
+    Ok(ImportResult {
+        manifest,
+        imported,
+        skipped,
+        warnings,
+    })
+}
+
+/// Strip the top-level archive directory prefix.
+fn strip_archive_prefix(path: &Path) -> &Path {
+    let mut components = path.components();
+    // Skip the first component (the dated prefix directory).
+    if let Some(Component::Normal(_)) = components.next() {
+        components.as_path()
+    } else {
+        path
+    }
+}
+
+/// Reject paths that could escape the target directory.
+fn is_safe_path(path: &Path) -> bool {
+    for component in path.components() {
+        match component {
+            Component::Normal(_) => {},
+            _ => return false,
+        }
+    }
+    true
+}
+
+enum FileAction {
+    Created,
+    Overwritten,
+    Skipped,
+    DryRun,
+}
+
+fn apply_file<R: Read>(
+    reader: &mut R,
+    dest: &Path,
+    opts: &ImportOptions,
+) -> anyhow::Result<FileAction> {
+    if opts.dry_run {
+        return Ok(FileAction::DryRun);
+    }
+
+    let exists = dest.exists();
+    if exists && opts.conflict == ConflictStrategy::Skip {
+        return Ok(FileAction::Skipped);
+    }
+
+    if let Some(parent) = dest.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+
+    let mut file = std::fs::File::create(dest)?;
+    std::io::copy(reader, &mut file)?;
+
+    if exists {
+        Ok(FileAction::Overwritten)
+    } else {
+        Ok(FileAction::Created)
+    }
+}
+
+fn record_action(
+    action: &FileAction,
+    category: &str,
+    path: &str,
+    imported: &mut Vec<ImportedItem>,
+    skipped: &mut Vec<ImportedItem>,
+) {
+    match action {
+        FileAction::Created | FileAction::Overwritten => {
+            let action_str = match action {
+                FileAction::Created => "created",
+                FileAction::Overwritten => "overwritten",
+                _ => unreachable!(),
+            };
+            imported.push(ImportedItem {
+                category: category.into(),
+                path: path.into(),
+                action: action_str.into(),
+            });
+        },
+        FileAction::Skipped => {
+            skipped.push(ImportedItem {
+                category: category.into(),
+                path: path.into(),
+                action: "skipped (exists)".into(),
+            });
+        },
+        FileAction::DryRun => {
+            skipped.push(ImportedItem {
+                category: category.into(),
+                path: path.into(),
+                action: "dry-run".into(),
+            });
+        },
+    }
+}
+
+/// Tables to merge from the imported moltis.db, in dependency order.
+/// Auth tables are intentionally excluded.
+const MERGE_TABLES: &[&str] = &[
+    "projects",
+    "sessions",
+    "channel_sessions",
+    "cron_jobs",
+    "cron_runs",
+    "env_variables",
+    "channels",
+    "agents",
+    "message_log",
+];
+
+/// Merge rows from an imported moltis.db into the live database.
+async fn merge_moltis_db(
+    data_dir: &Path,
+    imported_data: &[u8],
+    conflict: ConflictStrategy,
+) -> anyhow::Result<Vec<(String, u64)>> {
+    let live_db = data_dir.join("moltis.db");
+    if !live_db.exists() {
+        // No live DB — just write the imported one directly.
+        std::fs::write(&live_db, imported_data)?;
+        return Ok(vec![("(full copy)".into(), 1)]);
+    }
+
+    // Write imported data to a temporary file.
+    let import_path = data_dir.join("moltis.db.import-tmp");
+    std::fs::write(&import_path, imported_data)?;
+
+    let db_url = format!("sqlite:{}?mode=rwc", live_db.display());
+    let pool = sqlx::SqlitePool::connect(&db_url).await?;
+
+    // Attach the imported database.
+    let import_path_str = import_path.display().to_string();
+    sqlx::query(&format!("ATTACH DATABASE '{import_path_str}' AS import_db"))
+        .execute(&pool)
+        .await?;
+
+    let insert_mode = match conflict {
+        ConflictStrategy::Skip => "INSERT OR IGNORE",
+        ConflictStrategy::Overwrite => "INSERT OR REPLACE",
+    };
+
+    let mut counts = Vec::new();
+
+    for table in MERGE_TABLES {
+        // Check if the table exists in the imported DB.
+        let exists: bool = sqlx::query_scalar::<_, i32>(
+            "SELECT COUNT(*) FROM import_db.sqlite_master WHERE type='table' AND name=?",
+        )
+        .bind(table)
+        .fetch_one(&pool)
+        .await
+        .map(|n| n > 0)
+        .unwrap_or(false);
+
+        if !exists {
+            debug!(table, "table not in imported db, skipping");
+            continue;
+        }
+
+        let result = sqlx::query(&format!(
+            "{insert_mode} INTO main.[{table}] SELECT * FROM import_db.[{table}]"
+        ))
+        .execute(&pool)
+        .await;
+
+        match result {
+            Ok(r) => {
+                counts.push(((*table).to_owned(), r.rows_affected()));
+                if r.rows_affected() > 0 {
+                    debug!(table, rows = r.rows_affected(), "merged table");
+                }
+            },
+            Err(e) => {
+                // Schema mismatch between versions — warn but continue.
+                warn!(table, error = %e, "failed to merge table");
+                counts.push(((*table).to_owned(), 0));
+            },
+        }
+    }
+
+    sqlx::query("DETACH DATABASE import_db")
+        .execute(&pool)
+        .await?;
+    pool.close().await;
+
+    let _ = std::fs::remove_file(&import_path);
+    Ok(counts)
+}
+
+/// Import memory.db — copy if missing, merge if exists.
+async fn apply_memory_db(
+    data_dir: &Path,
+    imported_data: &[u8],
+    conflict: ConflictStrategy,
+) -> anyhow::Result<String> {
+    let live_db = data_dir.join("memory.db");
+    if !live_db.exists() {
+        std::fs::write(&live_db, imported_data)?;
+        return Ok("created (no existing memory.db)".into());
+    }
+
+    match conflict {
+        ConflictStrategy::Skip => Ok("skipped (memory.db exists)".into()),
+        ConflictStrategy::Overwrite => {
+            std::fs::write(&live_db, imported_data)?;
+            Ok("overwritten".into())
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn safe_path_rejects_traversal() {
+        assert!(is_safe_path(Path::new("config/moltis.toml")));
+        assert!(is_safe_path(Path::new("db/moltis.db")));
+        assert!(!is_safe_path(Path::new("../etc/passwd")));
+        assert!(!is_safe_path(Path::new("/absolute/path")));
+        assert!(!is_safe_path(Path::new("config/../../etc/passwd")));
+    }
+
+    #[test]
+    fn strip_prefix_works() {
+        let path = Path::new("moltis-backup-20260501-143022/config/moltis.toml");
+        let stripped = strip_archive_prefix(path);
+        assert_eq!(stripped, Path::new("config/moltis.toml"));
+    }
+
+    #[test]
+    fn conflict_strategy_serde() {
+        let json = serde_json::to_string(&ConflictStrategy::Skip).unwrap();
+        assert_eq!(json, "\"skip\"");
+        let parsed: ConflictStrategy = serde_json::from_str("\"overwrite\"").unwrap();
+        assert_eq!(parsed, ConflictStrategy::Overwrite);
+    }
+}

--- a/crates/portable/src/lib.rs
+++ b/crates/portable/src/lib.rs
@@ -1,0 +1,241 @@
+//! Portable import/export of Moltis configuration, databases, and session data.
+//!
+//! Archives are `.tar.gz` files containing a manifest, config files, workspace
+//! markdown, SQLite databases, and optionally session media.
+
+mod export;
+mod import;
+mod manifest;
+
+pub use {
+    export::{ExportOptions, export_archive},
+    import::{ConflictStrategy, ImportOptions, ImportResult, ImportedItem, import_archive},
+    manifest::{ArchiveInventory, ExportManifest, inspect_archive},
+};
+
+#[cfg(test)]
+mod integration_tests {
+    use {super::*, std::io::Cursor};
+
+    #[tokio::test]
+    async fn round_trip_export_import() {
+        let src_config = tempfile::tempdir().unwrap();
+        let src_data = tempfile::tempdir().unwrap();
+
+        // Create some config files.
+        std::fs::write(
+            src_config.path().join("moltis.toml"),
+            "[server]\nport = 8080\n",
+        )
+        .unwrap();
+        std::fs::write(
+            src_config.path().join("provider_keys.json"),
+            r#"{"openai":{"apiKey":"sk-test"}}"#,
+        )
+        .unwrap();
+
+        // Create workspace files.
+        std::fs::write(src_data.path().join("SOUL.md"), "# Soul\nBe helpful.").unwrap();
+        std::fs::write(src_data.path().join("IDENTITY.md"), "name: Moltis").unwrap();
+
+        // Create a session JSONL file.
+        let sessions_dir = src_data.path().join("sessions");
+        std::fs::create_dir_all(&sessions_dir).unwrap();
+        std::fs::write(
+            sessions_dir.join("main.jsonl"),
+            "{\"role\":\"user\",\"content\":\"hello\"}\n",
+        )
+        .unwrap();
+
+        // Export.
+        let opts = ExportOptions {
+            include_provider_keys: true,
+            include_media: false,
+        };
+        let mut archive_buf = Vec::new();
+        let manifest = export_archive(src_config.path(), src_data.path(), &opts, &mut archive_buf)
+            .await
+            .unwrap();
+
+        assert_eq!(manifest.format_version, 1);
+        assert!(
+            manifest
+                .inventory
+                .config_files
+                .contains(&"moltis.toml".to_owned())
+        );
+        assert!(
+            manifest
+                .inventory
+                .config_files
+                .contains(&"provider_keys.json".to_owned())
+        );
+        assert!(
+            manifest
+                .inventory
+                .workspace_files
+                .contains(&"SOUL.md".to_owned())
+        );
+        assert_eq!(manifest.inventory.session_count(), 1);
+
+        // Inspect.
+        let inspected = inspect_archive(Cursor::new(&archive_buf)).unwrap();
+        assert_eq!(inspected.format_version, manifest.format_version);
+
+        // Import into a fresh destination.
+        let dst_config = tempfile::tempdir().unwrap();
+        let dst_data = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dst_data.path().join("sessions")).unwrap();
+
+        let import_opts = ImportOptions {
+            conflict: ConflictStrategy::Skip,
+            dry_run: false,
+        };
+        let result = import_archive(
+            dst_config.path(),
+            dst_data.path(),
+            &import_opts,
+            Cursor::new(&archive_buf),
+        )
+        .await
+        .unwrap();
+
+        // Verify files were created.
+        assert!(dst_config.path().join("moltis.toml").exists());
+        assert!(dst_config.path().join("provider_keys.json").exists());
+        assert!(dst_data.path().join("SOUL.md").exists());
+        assert!(dst_data.path().join("IDENTITY.md").exists());
+        assert!(dst_data.path().join("sessions/main.jsonl").exists());
+
+        // Verify content.
+        let toml = std::fs::read_to_string(dst_config.path().join("moltis.toml")).unwrap();
+        assert!(toml.contains("port = 8080"));
+
+        let soul = std::fs::read_to_string(dst_data.path().join("SOUL.md")).unwrap();
+        assert!(soul.contains("Be helpful"));
+
+        assert!(!result.imported.is_empty());
+        assert!(result.warnings.is_empty());
+    }
+
+    #[tokio::test]
+    async fn import_skip_existing() {
+        let src_config = tempfile::tempdir().unwrap();
+        let src_data = tempfile::tempdir().unwrap();
+
+        std::fs::write(src_config.path().join("moltis.toml"), "original").unwrap();
+        std::fs::write(src_data.path().join("SOUL.md"), "original soul").unwrap();
+
+        // Export.
+        let mut buf = Vec::new();
+        export_archive(
+            src_config.path(),
+            src_data.path(),
+            &ExportOptions::default(),
+            &mut buf,
+        )
+        .await
+        .unwrap();
+
+        // Create destination with pre-existing files.
+        let dst_config = tempfile::tempdir().unwrap();
+        let dst_data = tempfile::tempdir().unwrap();
+        std::fs::write(dst_config.path().join("moltis.toml"), "modified").unwrap();
+        std::fs::write(dst_data.path().join("SOUL.md"), "modified soul").unwrap();
+
+        // Import with Skip strategy.
+        let result = import_archive(
+            dst_config.path(),
+            dst_data.path(),
+            &ImportOptions {
+                conflict: ConflictStrategy::Skip,
+                dry_run: false,
+            },
+            Cursor::new(&buf),
+        )
+        .await
+        .unwrap();
+
+        // Existing files should NOT be overwritten.
+        let toml = std::fs::read_to_string(dst_config.path().join("moltis.toml")).unwrap();
+        assert_eq!(toml, "modified");
+        assert!(!result.skipped.is_empty());
+    }
+
+    #[tokio::test]
+    async fn import_overwrite_existing() {
+        let src_config = tempfile::tempdir().unwrap();
+        let src_data = tempfile::tempdir().unwrap();
+
+        std::fs::write(src_config.path().join("moltis.toml"), "from-export").unwrap();
+
+        let mut buf = Vec::new();
+        export_archive(
+            src_config.path(),
+            src_data.path(),
+            &ExportOptions::default(),
+            &mut buf,
+        )
+        .await
+        .unwrap();
+
+        let dst_config = tempfile::tempdir().unwrap();
+        let dst_data = tempfile::tempdir().unwrap();
+        std::fs::write(dst_config.path().join("moltis.toml"), "local-version").unwrap();
+
+        let result = import_archive(
+            dst_config.path(),
+            dst_data.path(),
+            &ImportOptions {
+                conflict: ConflictStrategy::Overwrite,
+                dry_run: false,
+            },
+            Cursor::new(&buf),
+        )
+        .await
+        .unwrap();
+
+        // File should be overwritten.
+        let toml = std::fs::read_to_string(dst_config.path().join("moltis.toml")).unwrap();
+        assert_eq!(toml, "from-export");
+        assert!(result.imported.iter().any(|i| i.action == "overwritten"));
+    }
+
+    #[tokio::test]
+    async fn dry_run_does_not_write() {
+        let src_config = tempfile::tempdir().unwrap();
+        let src_data = tempfile::tempdir().unwrap();
+
+        std::fs::write(src_config.path().join("moltis.toml"), "content").unwrap();
+
+        let mut buf = Vec::new();
+        export_archive(
+            src_config.path(),
+            src_data.path(),
+            &ExportOptions::default(),
+            &mut buf,
+        )
+        .await
+        .unwrap();
+
+        let dst_config = tempfile::tempdir().unwrap();
+        let dst_data = tempfile::tempdir().unwrap();
+
+        let result = import_archive(
+            dst_config.path(),
+            dst_data.path(),
+            &ImportOptions {
+                conflict: ConflictStrategy::Skip,
+                dry_run: true,
+            },
+            Cursor::new(&buf),
+        )
+        .await
+        .unwrap();
+
+        // Nothing should be written.
+        assert!(!dst_config.path().join("moltis.toml").exists());
+        assert!(result.imported.is_empty());
+        assert!(!result.skipped.is_empty());
+    }
+}

--- a/crates/portable/src/manifest.rs
+++ b/crates/portable/src/manifest.rs
@@ -1,0 +1,96 @@
+//! Archive manifest: versioning, inventory, and inspection.
+
+use std::io::Read;
+
+use {
+    flate2::read::GzDecoder,
+    serde::{Deserialize, Serialize},
+    tar::Archive,
+};
+
+/// Current archive format version. Bump when layout changes in a
+/// backwards-incompatible way.
+pub const FORMAT_VERSION: u32 = 1;
+
+/// Top-level manifest stored as `manifest.json` inside the archive.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExportManifest {
+    pub format_version: u32,
+    pub moltis_version: String,
+    pub created_at: String,
+    pub inventory: ArchiveInventory,
+}
+
+/// Counts of items in the archive, used for preview before import.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ArchiveInventory {
+    pub config_files: Vec<String>,
+    pub workspace_files: Vec<String>,
+    pub has_moltis_db: bool,
+    pub has_memory_db: bool,
+    pub session_files: Vec<String>,
+    pub media_files: Vec<String>,
+}
+
+impl ArchiveInventory {
+    pub fn session_count(&self) -> usize {
+        self.session_files
+            .iter()
+            .filter(|f| f.ends_with(".jsonl"))
+            .count()
+    }
+
+    pub fn media_count(&self) -> usize {
+        self.media_files.len()
+    }
+}
+
+/// Read the manifest from an archive without extracting anything else.
+pub fn inspect_archive<R: Read>(reader: R) -> anyhow::Result<ExportManifest> {
+    let decoder = GzDecoder::new(reader);
+    let mut archive = Archive::new(decoder);
+
+    for entry in archive.entries()? {
+        let mut entry = entry?;
+        let path = entry.path()?.to_path_buf();
+
+        // The manifest is always the first entry, but search regardless.
+        let name = path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or_default();
+        if name == "manifest.json" {
+            let manifest: ExportManifest = serde_json::from_reader(&mut entry)?;
+            return Ok(manifest);
+        }
+    }
+
+    anyhow::bail!("archive does not contain a manifest.json")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn manifest_round_trip() {
+        let manifest = ExportManifest {
+            format_version: FORMAT_VERSION,
+            moltis_version: "test".into(),
+            created_at: "2026-05-01T00:00:00Z".into(),
+            inventory: ArchiveInventory {
+                config_files: vec!["moltis.toml".into()],
+                workspace_files: vec!["SOUL.md".into()],
+                has_moltis_db: true,
+                has_memory_db: false,
+                session_files: vec!["main.jsonl".into()],
+                media_files: vec![],
+            },
+        };
+        let json = serde_json::to_string(&manifest).unwrap();
+        let decoded: ExportManifest = serde_json::from_str(&json).unwrap();
+        assert_eq!(decoded.format_version, FORMAT_VERSION);
+        assert!(decoded.inventory.has_moltis_db);
+        assert_eq!(decoded.inventory.session_count(), 1);
+    }
+}

--- a/crates/web/src/lib.rs
+++ b/crates/web/src/lib.rs
@@ -211,7 +211,8 @@ fn build_api_routes() -> Router<AppState> {
             "/api/sessions/{session_key}/media/{filename}",
             get(api::api_session_media_handler),
         )
-        .route("/api/logs/download", get(api::api_logs_download_handler));
+        .route("/api/logs/download", get(api::api_logs_download_handler))
+        .nest("/api/data", moltis_httpd::data_routes::data_router());
 
     // Add metrics API routes (protected).
     #[cfg(feature = "metrics")]

--- a/crates/web/ui/src/pages/sections/ImportSection.tsx
+++ b/crates/web/ui/src/pages/sections/ImportSection.tsx
@@ -9,6 +9,7 @@ import type { RpcResponse } from "./_shared";
 import { ClaudeImportSection } from "./ClaudeImportSection";
 import { CodexImportSection } from "./CodexImportSection";
 import { HermesImportSection } from "./HermesImportSection";
+import { MoltisDataSection } from "./MoltisDataSection";
 import { OpenClawImportSection } from "./OpenClawImportSection";
 
 interface ImportTabDef {
@@ -94,7 +95,7 @@ function getAllTabs(): ImportTabDef[] {
 
 export function ImportSection(): VNode {
 	const detectedTabs = getAllTabs().filter((t) => t.detected);
-	const [activeTab, setActiveTab] = useState(detectedTabs[0]?.id || "openclaw");
+	const [activeTab, setActiveTab] = useState("moltis");
 	const [badges, setBadges] = useState<Record<string, number>>({});
 
 	useEffect(() => {
@@ -110,14 +111,24 @@ export function ImportSection(): VNode {
 		}
 	}, []);
 
-	const tabs = detectedTabs.map((t) => ({
+	// Moltis tab is always first, then detected external sources.
+	const moltisTab = {
+		id: "moltis",
+		label: "Moltis",
+		icon: <span className="icon icon-download" />,
+		badge: undefined as number | undefined,
+	};
+
+	const externalTabs = detectedTabs.map((t) => ({
 		id: t.id,
 		label: t.label,
 		icon: t.icon,
 		badge: badges[t.id] as number | undefined,
 	}));
 
-	// Single source detected — render directly without tab bar
+	const tabs = [moltisTab, ...externalTabs];
+
+	// Only Moltis tab — render directly without tab bar
 	if (tabs.length === 1) {
 		return <div className="flex-1 flex flex-col min-w-0 p-4 gap-4 overflow-y-auto">{renderTab(tabs[0].id)}</div>;
 	}
@@ -134,6 +145,8 @@ export function ImportSection(): VNode {
 
 function renderTab(id: string): VNode | null {
 	switch (id) {
+		case "moltis":
+			return <MoltisDataSection />;
 		case "openclaw":
 			return <OpenClawImportSection />;
 		case "claude":

--- a/crates/web/ui/src/pages/sections/MoltisDataSection.tsx
+++ b/crates/web/ui/src/pages/sections/MoltisDataSection.tsx
@@ -1,0 +1,363 @@
+// ── Moltis data import/export section ─────────────────────────
+
+import type { VNode } from "preact";
+import { useRef, useState } from "preact/hooks";
+import { CheckboxField, Loading, SectionHeading, StatusMessage, SubHeading } from "../../components/forms";
+import { rerender } from "./_shared";
+
+interface ImportedItem {
+	category: string;
+	path: string;
+	action: string;
+}
+
+interface ImportPreview {
+	manifest: {
+		format_version: number;
+		moltis_version: string;
+		created_at: string;
+		inventory: {
+			config_files: string[];
+			workspace_files: string[];
+			has_moltis_db: boolean;
+			has_memory_db: boolean;
+			session_files: string[];
+			media_files: string[];
+		};
+	};
+	imported: ImportedItem[];
+	skipped: ImportedItem[];
+	warnings: string[];
+}
+
+export function MoltisDataSection(): VNode {
+	return (
+		<div className="flex flex-col gap-6">
+			<ExportSection />
+			<hr className="border-gray-700" />
+			<ImportDataSection />
+		</div>
+	);
+}
+
+// ── Export ────────────────────────────────────────────────────
+
+function ExportSection(): VNode {
+	const [includeKeys, setIncludeKeys] = useState(true);
+	const [includeMedia, setIncludeMedia] = useState(false);
+	const [exporting, setExporting] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+
+	function doExport(): void {
+		setExporting(true);
+		setError(null);
+		const params = new URLSearchParams();
+		params.set("include_provider_keys", String(includeKeys));
+		params.set("include_media", String(includeMedia));
+
+		fetch(`/api/data/export?${params.toString()}`)
+			.then((res) => {
+				if (!res.ok) throw new Error(`Export failed: ${res.statusText}`);
+				return res.blob().then((blob) => {
+					const disposition = res.headers.get("content-disposition") || "";
+					const match = /filename="?([^"]+)"?/.exec(disposition);
+					const filename = match?.[1] || "moltis-backup.tar.gz";
+					const url = URL.createObjectURL(blob);
+					const a = document.createElement("a");
+					a.href = url;
+					a.download = filename;
+					a.click();
+					URL.revokeObjectURL(url);
+				});
+			})
+			.catch((e: Error) => {
+				setError(e.message);
+			})
+			.finally(() => {
+				setExporting(false);
+				rerender();
+			});
+	}
+
+	return (
+		<div className="flex flex-col gap-3">
+			<SectionHeading title="Export" />
+			<p className="text-sm text-gray-400">
+				Download a backup of your Moltis config, databases, sessions, and workspace files.
+			</p>
+			<div className="flex flex-col gap-2">
+				<CheckboxField
+					label="Include provider API keys"
+					checked={includeKeys}
+					onChange={(checked) => {
+						setIncludeKeys(checked);
+						rerender();
+					}}
+				/>
+				<CheckboxField
+					label="Include session media (audio, images)"
+					checked={includeMedia}
+					onChange={(checked) => {
+						setIncludeMedia(checked);
+						rerender();
+					}}
+				/>
+			</div>
+			<div>
+				<button type="button" className="provider-btn" disabled={exporting} onClick={doExport}>
+					{exporting ? "Exporting..." : "Download backup (.tar.gz)"}
+				</button>
+			</div>
+			<StatusMessage error={error} />
+		</div>
+	);
+}
+
+// ── Import ───────────────────────────────────────────────────
+
+function ImportDataSection(): VNode {
+	const [conflict, setConflict] = useState<"skip" | "overwrite">("skip");
+	const [uploading, setUploading] = useState(false);
+	const [applying, setApplying] = useState(false);
+	const [preview, setPreview] = useState<ImportPreview | null>(null);
+	const [result, setResult] = useState<ImportPreview | null>(null);
+	const [error, setError] = useState<string | null>(null);
+	const [selectedFile, setSelectedFile] = useState<File | null>(null);
+	const fileRef = useRef<HTMLInputElement>(null);
+
+	function onFileSelect(file: File | null): void {
+		setSelectedFile(file);
+		setPreview(null);
+		setResult(null);
+		setError(null);
+		if (file) {
+			doPreview(file);
+		}
+		rerender();
+	}
+
+	function doPreview(file: File): void {
+		setUploading(true);
+		setError(null);
+		file
+			.arrayBuffer()
+			.then((buf) =>
+				fetch(`/api/data/import/preview?conflict=${conflict}`, {
+					method: "POST",
+					headers: { "Content-Type": "application/gzip" },
+					body: buf,
+				}),
+			)
+			.then((res) => res.json())
+			.then((data: ImportPreview & { ok?: boolean; error?: string }) => {
+				if (data.ok === false) {
+					setError(data.error || "Preview failed");
+				} else {
+					setPreview(data);
+				}
+			})
+			.catch((e: Error) => setError(e.message))
+			.finally(() => {
+				setUploading(false);
+				rerender();
+			});
+	}
+
+	function doApply(): void {
+		if (!selectedFile) return;
+		setApplying(true);
+		setError(null);
+		selectedFile
+			.arrayBuffer()
+			.then((buf) =>
+				fetch(`/api/data/import?conflict=${conflict}`, {
+					method: "POST",
+					headers: { "Content-Type": "application/gzip" },
+					body: buf,
+				}),
+			)
+			.then((res) => res.json())
+			.then((data: ImportPreview & { ok?: boolean; error?: string }) => {
+				if (data.ok === false) {
+					setError(data.error || "Import failed");
+				} else {
+					setResult(data);
+					setPreview(null);
+				}
+			})
+			.catch((e: Error) => setError(e.message))
+			.finally(() => {
+				setApplying(false);
+				rerender();
+			});
+	}
+
+	return (
+		<div className="flex flex-col gap-3">
+			<SectionHeading title="Import" />
+			<p className="text-sm text-gray-400">Restore from a previously exported Moltis backup archive.</p>
+
+			{/* Conflict strategy */}
+			<div className="flex flex-col gap-1">
+				<SubHeading title="On conflict" />
+				<div className="flex gap-4 text-sm">
+					<label className="flex items-center gap-1.5 cursor-pointer">
+						<input
+							type="radio"
+							name="conflict"
+							checked={conflict === "skip"}
+							onChange={() => {
+								setConflict("skip");
+								rerender();
+							}}
+						/>
+						Skip existing
+					</label>
+					<label className="flex items-center gap-1.5 cursor-pointer">
+						<input
+							type="radio"
+							name="conflict"
+							checked={conflict === "overwrite"}
+							onChange={() => {
+								setConflict("overwrite");
+								rerender();
+							}}
+						/>
+						Overwrite
+					</label>
+				</div>
+			</div>
+
+			{/* File picker */}
+			<button
+				type="button"
+				className="border-2 border-dashed border-gray-600 rounded-lg p-6 text-center cursor-pointer hover:border-gray-400 transition-colors w-full bg-transparent"
+				onClick={() => fileRef.current?.click()}
+				onDragOver={(e) => e.preventDefault()}
+				onDrop={(e) => {
+					e.preventDefault();
+					const file = e.dataTransfer?.files[0];
+					if (file) onFileSelect(file);
+				}}
+			>
+				<input
+					ref={fileRef}
+					type="file"
+					accept=".tar.gz,.tgz"
+					className="hidden"
+					onChange={(e) => {
+						const file = (e.target as HTMLInputElement).files?.[0] || null;
+						onFileSelect(file);
+					}}
+				/>
+				{selectedFile ? (
+					<span className="text-sm">
+						Selected: <strong>{selectedFile.name}</strong> ({(selectedFile.size / 1024 / 1024).toFixed(1)} MB)
+					</span>
+				) : (
+					<span className="text-sm text-gray-400">Drop a .tar.gz archive here or click to select</span>
+				)}
+			</button>
+
+			{uploading ? <Loading /> : null}
+			<StatusMessage error={error} />
+
+			{/* Preview */}
+			{preview ? <PreviewTable preview={preview} onApply={doApply} applying={applying} /> : null}
+
+			{/* Result */}
+			{result ? <ResultTable result={result} /> : null}
+		</div>
+	);
+}
+
+// ── Preview table ────────────────────────────────────────────
+
+interface PreviewTableProps {
+	preview: ImportPreview;
+	onApply: () => void;
+	applying: boolean;
+}
+
+function PreviewTable({ preview, onApply, applying }: PreviewTableProps): VNode {
+	const inv = preview.manifest.inventory;
+	return (
+		<div className="flex flex-col gap-3 p-3 bg-gray-800 rounded-lg">
+			<SubHeading title="Archive preview" />
+			<p className="text-xs text-gray-400">
+				Moltis {preview.manifest.moltis_version} — {preview.manifest.created_at}
+			</p>
+			<table className="text-sm w-full">
+				<tbody>
+					<Row label="Config files" value={inv.config_files.length} />
+					<Row label="Workspace files" value={inv.workspace_files.length} />
+					<Row label="moltis.db" value={inv.has_moltis_db ? "Yes" : "No"} />
+					<Row label="memory.db" value={inv.has_memory_db ? "Yes" : "No"} />
+					<Row label="Sessions" value={inv.session_files.filter((f) => f.endsWith(".jsonl")).length} />
+					<Row label="Media files" value={inv.media_files.length} />
+				</tbody>
+			</table>
+			{preview.warnings.length > 0 ? (
+				<div className="text-xs text-yellow-400">
+					{preview.warnings.map((w) => (
+						<p key={w}>{w}</p>
+					))}
+				</div>
+			) : null}
+			<button type="button" className="provider-btn" disabled={applying} onClick={onApply}>
+				{applying ? "Importing..." : "Apply import"}
+			</button>
+		</div>
+	);
+}
+
+// ── Result table ─────────────────────────────────────────────
+
+function ResultTable({ result }: { result: ImportPreview }): VNode {
+	return (
+		<div className="flex flex-col gap-2 p-3 bg-gray-800 rounded-lg">
+			<SubHeading title="Import complete" />
+			<StatusMessage success={`${result.imported.length} items imported, ${result.skipped.length} skipped.`} />
+			{result.imported.length > 0 ? (
+				<details className="text-xs">
+					<summary className="cursor-pointer text-gray-400">Imported ({result.imported.length})</summary>
+					<ul className="mt-1 ml-4 list-disc">
+						{result.imported.map((item) => (
+							<li key={`${item.category}-${item.path}`}>
+								[{item.category}] {item.path} — {item.action}
+							</li>
+						))}
+					</ul>
+				</details>
+			) : null}
+			{result.skipped.length > 0 ? (
+				<details className="text-xs">
+					<summary className="cursor-pointer text-gray-400">Skipped ({result.skipped.length})</summary>
+					<ul className="mt-1 ml-4 list-disc">
+						{result.skipped.map((item) => (
+							<li key={`${item.category}-${item.path}`}>
+								[{item.category}] {item.path} — {item.action}
+							</li>
+						))}
+					</ul>
+				</details>
+			) : null}
+			{result.warnings.length > 0 ? (
+				<div className="text-xs text-yellow-400 mt-1">
+					{result.warnings.map((w) => (
+						<p key={w}>{w}</p>
+					))}
+				</div>
+			) : null}
+		</div>
+	);
+}
+
+function Row({ label, value }: { label: string; value: string | number }): VNode {
+	return (
+		<tr>
+			<td className="pr-4 text-gray-400 py-0.5">{label}</td>
+			<td className="py-0.5">{value}</td>
+		</tr>
+	);
+}


### PR DESCRIPTION
## Summary

Add full backup/restore capability for Moltis instances via a new `moltis-portable` crate, exposed through CLI, REST API, and web UI.

- **New crate `moltis-portable`**: Core export/import logic for `.tar.gz` archives containing config, workspace markdown, SQLite databases, and sessions
- **CLI**: `moltis data export/import/inspect` subcommands with options for media inclusion, conflict strategy, dry-run, and JSON output
- **API**: `GET /api/data/export`, `POST /api/data/import`, `POST /api/data/import/preview` with 2GB upload limit
- **Web UI**: New "Moltis" tab in Settings > Imports with export checkboxes and drag-and-drop import with preview

### Security
- Auth tables (passwords, session tokens, API keys, passkeys) are always stripped from exported databases
- Path traversal protection on import rejects `../` and absolute paths
- Provider keys inclusion is user-controlled (checkbox in UI, `--no-provider-keys` in CLI)

### Archive format
- `.tar.gz` (no zip 4GB limit), uses existing workspace deps (`tar`, `flate2`)
- `VACUUM INTO` for consistent SQLite snapshots without locking the live DB
- Import merges via `ATTACH DATABASE` + `INSERT OR IGNORE/REPLACE` per table

## Validation

### Completed
- [x] `cargo check -p moltis-portable -p moltis-httpd` (clean)
- [x] `cargo check -p moltis --features full` (clean)
- [x] `cargo test -p moltis-portable` (9/9 pass: round-trip, skip, overwrite, dry-run, path safety, manifest serde)
- [x] `cargo clippy -p moltis-portable -- -D warnings` (clean)
- [x] `cargo fmt --all -- --check` (clean)
- [x] `biome check --write` on new TSX files (clean)
- [x] `tsc --noEmit` (0 errors)

### Remaining
- [ ] `./scripts/local-validate.sh` (full CI validation)
- [ ] E2E tests for the web UI import/export flow
- [ ] Manual QA of export download + import via web UI

## Manual QA
1. Start gateway, go to Settings > Imports — verify "Moltis" tab appears first
2. Export: toggle checkboxes, click "Download backup" — verify `.tar.gz` downloads
3. `moltis data inspect <archive>` — verify manifest output
4. Import: drop the archive in the import zone — verify preview table shows
5. Click "Apply import" — verify success message with counts
6. `moltis data export --include-media` / `moltis data import <archive> --dry-run` via CLI