### PR TITLE
fix(telegram): upgrade teloxide 0.13→0.17 to fix multipart ThreadId panic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,14 +18,14 @@ dependencies = [
  "erased-serde",
  "http 1.4.0",
  "http-body-util",
- "hyper 1.9.0",
+ "hyper",
  "hyper-rustls 0.26.0",
  "hyper-util",
  "parking_lot 0.12.5",
  "pem 3.0.6",
  "ring",
  "rustls 0.22.4",
- "rustls-pemfile 2.2.0",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
@@ -241,20 +241,6 @@ dependencies = [
 
 [[package]]
 name = "aquamarine"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21cc1548309245035eb18aa7f0967da6bc65587005170c56e6ef2788a4cf3f4e"
-dependencies = [
- "include_dir",
- "itertools 0.10.5",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "aquamarine"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f50776554130342de4836ba542aa85a4ddb361690d7e8df13774d7284c3d5c2"
@@ -265,6 +251,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "ar_archive_writer"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eb93bbb63b9c227414f6eb3a0adfddca591a8ce1e9b60661bb08969b87e340b"
+dependencies = [
+ "object",
 ]
 
 [[package]]
@@ -830,9 +825,9 @@ dependencies = [
  "form_urlencoded",
  "futures-util",
  "http 1.4.0",
- "http-body 1.0.1",
+ "http-body",
  "http-body-util",
- "hyper 1.9.0",
+ "hyper",
  "hyper-util",
  "itoa",
  "matchit",
@@ -845,7 +840,7 @@ dependencies = [
  "serde_path_to_error",
  "serde_urlencoded",
  "sha1",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tokio",
  "tokio-tungstenite 0.29.0",
  "tower",
@@ -864,12 +859,12 @@ dependencies = [
  "bytes",
  "futures-util",
  "http 1.4.0",
- "http-body 1.0.1",
+ "http-body",
  "http-body-util",
  "mime",
  "pin-project-lite",
  "rustversion",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tower-layer",
  "tower-service",
 ]
@@ -883,11 +878,11 @@ dependencies = [
  "bytes",
  "futures-core",
  "http 1.4.0",
- "http-body 1.0.1",
+ "http-body",
  "http-body-util",
  "mime",
  "pin-project-lite",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -905,7 +900,7 @@ dependencies = [
  "cookie",
  "futures-util",
  "http 1.4.0",
- "http-body 1.0.1",
+ "http-body",
  "http-body-util",
  "mime",
  "pin-project-lite",
@@ -1619,7 +1614,7 @@ dependencies = [
  "anstream",
  "anstyle",
  "clap_lex",
- "strsim 0.11.1",
+ "strsim",
  "terminal_size",
 ]
 
@@ -1857,12 +1852,6 @@ name = "constant_time_eq"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
-
-[[package]]
-name = "convert_case"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
 name = "convert_case"
@@ -2276,7 +2265,7 @@ dependencies = [
  "openssl-probe 0.1.6",
  "openssl-sys",
  "schannel",
- "socket2 0.6.3",
+ "socket2",
  "windows-sys 0.59.0",
 ]
 
@@ -2326,16 +2315,6 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a01d95850c592940db9b8194bc39f4bc0e89dee5c4265e4b1807c34a9aba453c"
-dependencies = [
- "darling_core 0.13.4",
- "darling_macro 0.13.4",
-]
-
-[[package]]
-name = "darling"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
@@ -2356,20 +2335,6 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "859d65a907b6852c9361e3185c862aae7fafd2887876799fa55f5f99dc40d610"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim 0.10.0",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "darling_core"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
@@ -2378,7 +2343,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim 0.11.1",
+ "strsim",
  "syn 2.0.117",
 ]
 
@@ -2391,19 +2356,8 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim 0.11.1",
+ "strsim",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
-dependencies = [
- "darling_core 0.13.4",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -2653,19 +2607,6 @@ dependencies = [
 
 [[package]]
 name = "derive_more"
-version = "0.99.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f"
-dependencies = [
- "convert_case 0.4.0",
- "proc-macro2",
- "quote",
- "rustc_version",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "derive_more"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
@@ -2691,6 +2632,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -2699,7 +2641,7 @@ version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
 dependencies = [
- "convert_case 0.10.0",
+ "convert_case",
  "proc-macro2",
  "quote",
  "rustc_version",
@@ -2898,10 +2840,11 @@ checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "dptree"
-version = "0.3.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d81175dab5ec79c30e0576df2ed2c244e1721720c302000bb321b107e82e265c"
+checksum = "db96968fcf52fe063a98c75df1d1f2b1fba304e7ae29b72fdc81c1165b7e2fd0"
 dependencies = [
+ "colored 3.1.1",
  "futures",
 ]
 
@@ -3692,7 +3635,7 @@ dependencies = [
  "reqwest 0.13.2",
  "serde",
  "serde_json",
- "serde_with 3.18.0",
+ "serde_with",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -4785,25 +4728,6 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
-dependencies = [
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "futures-util",
- "http 0.2.12",
- "indexmap 2.14.0",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
-name = "h2"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
@@ -5148,17 +5072,6 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
-dependencies = [
- "bytes",
- "http 0.2.12",
- "pin-project-lite",
-]
-
-[[package]]
-name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
@@ -5176,7 +5089,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "http 1.4.0",
- "http-body 1.0.1",
+ "http-body",
  "pin-project-lite",
 ]
 
@@ -5209,30 +5122,6 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "0.14.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
-dependencies = [
- "bytes",
- "futures-channel",
- "futures-core",
- "futures-util",
- "h2 0.3.27",
- "http 0.2.12",
- "http-body 0.4.6",
- "httparse",
- "httpdate",
- "itoa",
- "pin-project-lite",
- "socket2 0.5.10",
- "tokio",
- "tower-service",
- "tracing",
- "want",
-]
-
-[[package]]
-name = "hyper"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
@@ -5241,9 +5130,9 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2 0.4.13",
+ "h2",
  "http 1.4.0",
- "http-body 1.0.1",
+ "http-body",
  "httparse",
  "httpdate",
  "itoa",
@@ -5263,7 +5152,7 @@ dependencies = [
  "futures-util",
  "headers",
  "http 1.4.0",
- "hyper 1.9.0",
+ "hyper",
  "hyper-rustls 0.27.9",
  "hyper-util",
  "pin-project-lite",
@@ -5281,7 +5170,7 @@ checksum = "a0bea761b46ae2b24eb4aef630d8d1c398157b6fc29e6350ecf090a0b70c952c"
 dependencies = [
  "futures-util",
  "http 1.4.0",
- "hyper 1.9.0",
+ "hyper",
  "hyper-util",
  "rustls 0.22.4",
  "rustls-pki-types",
@@ -5298,7 +5187,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
  "http 1.4.0",
- "hyper 1.9.0",
+ "hyper",
  "hyper-util",
  "log",
  "rustls 0.23.39",
@@ -5311,26 +5200,13 @@ dependencies = [
 
 [[package]]
 name = "hyper-tls"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
-dependencies = [
- "bytes",
- "hyper 0.14.32",
- "native-tls",
- "tokio",
- "tokio-native-tls",
-]
-
-[[package]]
-name = "hyper-tls"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
  "http-body-util",
- "hyper 1.9.0",
+ "hyper",
  "hyper-util",
  "native-tls",
  "tokio",
@@ -5349,14 +5225,14 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "http 1.4.0",
- "http-body 1.0.1",
- "hyper 1.9.0",
+ "http-body",
+ "hyper",
  "ipnet",
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
- "system-configuration 0.7.0",
+ "socket2",
+ "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
@@ -6246,7 +6122,7 @@ dependencies = [
  "domain",
  "http 1.4.0",
  "http-body-util",
- "hyper 1.9.0",
+ "hyper",
  "log",
  "roxmltree",
  "thiserror 2.0.18",
@@ -6581,7 +6457,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b33f9bc45edd7f8e25161521fdd30654da5c55e6749be6afa1aa9d6cf838ace0"
 dependencies = [
  "anymap2",
- "aquamarine 0.6.0",
+ "aquamarine",
  "as_variant",
  "async-channel",
  "async-stream",
@@ -6689,7 +6565,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "304fc576810a9618bb831c4ad6403c758ec424f677668a49a196e3cde4b8f99f"
 dependencies = [
  "aes 0.8.4",
- "aquamarine 0.6.0",
+ "aquamarine",
  "as_variant",
  "async-trait",
  "bs58",
@@ -6888,7 +6764,7 @@ dependencies = [
  "log",
  "mio",
  "socket-pktinfo",
- "socket2 0.6.3",
+ "socket2",
 ]
 
 [[package]]
@@ -6943,7 +6819,7 @@ checksum = "dd7399781913e5393588a8d8c6a2867bf85fb38eaf2502fdce465aad2dc6f034"
 dependencies = [
  "base64 0.22.1",
  "http-body-util",
- "hyper 1.9.0",
+ "hyper",
  "hyper-rustls 0.27.9",
  "hyper-util",
  "indexmap 2.14.0",
@@ -7100,9 +6976,9 @@ dependencies = [
  "colored 3.1.1",
  "futures-core",
  "http 1.4.0",
- "http-body 1.0.1",
+ "http-body",
  "http-body-util",
- "hyper 1.9.0",
+ "hyper",
  "hyper-util",
  "log",
  "pin-project-lite",
@@ -7293,7 +7169,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "http 1.4.0",
- "hyper 1.9.0",
+ "hyper",
  "hyper-rustls 0.27.9",
  "hyper-util",
  "icalendar",
@@ -8424,7 +8300,7 @@ dependencies = [
  "moltis-config",
  "rcgen",
  "rustls 0.23.39",
- "rustls-pemfile 2.2.0",
+ "rustls-pemfile",
  "tempfile",
  "thiserror 2.0.18",
  "time",
@@ -8771,7 +8647,7 @@ dependencies = [
  "proxy-protocol",
  "regex",
  "rustls-native-certs 0.7.3",
- "rustls-pemfile 2.2.0",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -9787,7 +9663,7 @@ dependencies = [
  "shared_library",
  "shell-words",
  "winapi",
- "winreg 0.10.1",
+ "winreg",
 ]
 
 [[package]]
@@ -9870,30 +9746,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
-]
-
-[[package]]
 name = "proc-macro-error-attr2"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9960,7 +9812,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools 0.14.0",
  "log",
  "multimap",
@@ -10014,6 +9866,16 @@ checksum = "0e50c72c21c738f5c5f350cc33640aee30bf7cd20f9d9da20ed41bce2671d532"
 dependencies = [
  "bytes",
  "snafu",
+]
+
+[[package]]
+name = "psm"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645dbe486e346d9b5de3ef16ede18c26e6c70ad97418f4874b8b1889d6e761ea"
+dependencies = [
+ "ar_archive_writer",
+ "cc",
 ]
 
 [[package]]
@@ -10129,7 +9991,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.39",
- "socket2 0.6.3",
+ "socket2",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -10167,7 +10029,7 @@ dependencies = [
  "cfg_aliases 0.2.1",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -10501,49 +10363,6 @@ checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
 
 [[package]]
 name = "reqwest"
-version = "0.11.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
-dependencies = [
- "base64 0.21.7",
- "bytes",
- "encoding_rs",
- "futures-core",
- "futures-util",
- "h2 0.3.27",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.32",
- "hyper-tls 0.5.0",
- "ipnet",
- "js-sys",
- "log",
- "mime",
- "mime_guess",
- "native-tls",
- "once_cell",
- "percent-encoding",
- "pin-project-lite",
- "rustls-pemfile 1.0.4",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper 0.1.2",
- "system-configuration 0.5.1",
- "tokio",
- "tokio-native-tls",
- "tokio-util",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "wasm-streams 0.4.2",
- "web-sys",
- "winreg 0.50.0",
-]
-
-[[package]]
-name = "reqwest"
 version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
@@ -10552,13 +10371,13 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
- "h2 0.4.13",
+ "h2",
  "http 1.4.0",
- "http-body 1.0.1",
+ "http-body",
  "http-body-util",
- "hyper 1.9.0",
+ "hyper",
  "hyper-rustls 0.27.9",
- "hyper-tls 0.6.0",
+ "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
@@ -10573,7 +10392,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tokio",
  "tokio-native-tls",
  "tokio-rustls 0.26.4",
@@ -10601,11 +10420,11 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.4.13",
+ "h2",
  "http 1.4.0",
- "http-body 1.0.1",
+ "http-body",
  "http-body-util",
- "hyper 1.9.0",
+ "hyper",
  "hyper-rustls 0.27.9",
  "hyper-util",
  "js-sys",
@@ -10621,7 +10440,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tokio",
  "tokio-rustls 0.26.4",
  "tokio-util",
@@ -10659,6 +10478,15 @@ checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
  "hmac 0.12.1",
  "subtle",
+]
+
+[[package]]
+name = "rgb"
+version = "0.8.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b34b781b31e5d73e9fbc8689c70551fd1ade9a19e3e28cfec8580a79290cc4"
+dependencies = [
+ "bytemuck",
 ]
 
 [[package]]
@@ -11058,7 +10886,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
 dependencies = [
  "openssl-probe 0.1.6",
- "rustls-pemfile 2.2.0",
+ "rustls-pemfile",
  "rustls-pki-types",
  "schannel",
  "security-framework 2.11.1",
@@ -11074,15 +10902,6 @@ dependencies = [
  "rustls-pki-types",
  "schannel",
  "security-framework 3.7.0",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
-dependencies = [
- "base64 0.21.7",
 ]
 
 [[package]]
@@ -11565,16 +11384,6 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "1.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678b5a069e50bf00ecd22d0cd8ddf7c236f68581b03db652061ed5eb13a312ff"
-dependencies = [
- "serde",
- "serde_with_macros 1.5.2",
-]
-
-[[package]]
-name = "serde_with"
 version = "3.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd5414fad8e6907dbdd5bc441a50ae8d6e26151a03b1de04d89a5576de61d01f"
@@ -11588,20 +11397,8 @@ dependencies = [
  "schemars 1.2.1",
  "serde_core",
  "serde_json",
- "serde_with_macros 3.18.0",
+ "serde_with_macros",
  "time",
-]
-
-[[package]]
-name = "serde_with_macros"
-version = "1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e182d6ec6f05393cc0e5ed1bf81ad6db3a8feedf8ee515ecdd369809bcce8082"
-dependencies = [
- "darling 0.13.4",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -11929,7 +11726,7 @@ dependencies = [
  "hmac 0.13.0",
  "http 1.4.0",
  "http-body-util",
- "hyper 1.9.0",
+ "hyper",
  "hyper-rustls 0.27.9",
  "hyper-util",
  "lazy_static",
@@ -11940,7 +11737,7 @@ dependencies = [
  "rvstruct",
  "serde",
  "serde_json",
- "serde_with 3.18.0",
+ "serde_with",
  "sha2 0.11.0",
  "signal-hook",
  "signal-hook-tokio",
@@ -12026,18 +11823,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "927136cc2ae6a1b0e66ac6b1210902b75c3f726db004a73bc18686dcd0dcd22f"
 dependencies = [
  "libc",
- "socket2 0.6.3",
+ "socket2",
  "windows-sys 0.60.2",
-]
-
-[[package]]
-name = "socket2"
-version = "0.5.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -12281,6 +12068,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "stacker"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "640c8cdd92b6b12f5bcb1803ca3bbf5ab96e5e6b6b96b9ab77dabe9e880b3190"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "psm",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12370,12 +12170,6 @@ dependencies = [
 
 [[package]]
 name = "strsim"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
-
-[[package]]
-name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
@@ -12447,12 +12241,6 @@ dependencies = [
 
 [[package]]
 name = "sync_wrapper"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
-
-[[package]]
-name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
@@ -12498,34 +12286,13 @@ dependencies = [
 
 [[package]]
 name = "system-configuration"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
-dependencies = [
- "bitflags 1.3.2",
- "core-foundation 0.9.4",
- "system-configuration-sys 0.5.0",
-]
-
-[[package]]
-name = "system-configuration"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
  "bitflags 2.11.1",
  "core-foundation 0.9.4",
- "system-configuration-sys 0.6.0",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
-dependencies = [
- "core-foundation-sys",
- "libc",
+ "system-configuration-sys",
 ]
 
 [[package]]
@@ -12591,13 +12358,13 @@ checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "teloxide"
-version = "0.13.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f79dd283eb21b90451c03fa7c7f83b9985130efb876b33bad89a2c208ccbc16"
+checksum = "84992abeed3ae42e8401b25d266d12bcba1def0abe59d22f6b9781167545f71e"
 dependencies = [
- "aquamarine 0.5.0",
+ "aquamarine",
  "bytes",
- "derive_more 0.99.20",
+ "derive_more 1.0.0",
  "dptree",
  "either",
  "futures",
@@ -12608,7 +12375,7 @@ dependencies = [
  "serde_json",
  "teloxide-core",
  "teloxide-macros",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -12617,14 +12384,14 @@ dependencies = [
 
 [[package]]
 name = "teloxide-core"
-version = "0.10.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1642a7ef10e7af63b8298c8d13c0f986d4fc646d42649ff060359607f62f69"
+checksum = "7f7a34ca8e971fa892e633858c07547fe138ef4a02e4a4eaa1d35e517d6e0bc4"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.11.1",
  "bytes",
  "chrono",
- "derive_more 0.99.20",
+ "derive_more 1.0.0",
  "either",
  "futures",
  "log",
@@ -12632,13 +12399,15 @@ dependencies = [
  "once_cell",
  "pin-project",
  "rc-box",
- "reqwest 0.11.27",
+ "reqwest 0.12.28",
+ "rgb",
  "serde",
  "serde_json",
- "serde_with 1.14.0",
+ "serde_with",
+ "stacker",
  "take_mut",
  "takecell",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-util",
  "url",
@@ -12647,14 +12416,14 @@ dependencies = [
 
 [[package]]
 name = "teloxide-macros"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e2d33d809c3e7161a9ab18bedddf98821245014f0a78fa4d2c9430b2ec018c1"
+checksum = "300fadcaf0c182f19b5ca10bf23a45dc9a48925f00c704405fd90ee2c03942f9"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -12866,7 +12635,7 @@ dependencies = [
  "parking_lot 0.12.5",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.3",
+ "socket2",
  "tokio-macros",
  "tracing",
  "windows-sys 0.61.2",
@@ -13151,7 +12920,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "pin-project-lite",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tokio",
  "tower-layer",
  "tower-service",
@@ -13171,7 +12940,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "http 1.4.0",
- "http-body 1.0.1",
+ "http-body",
  "http-body-util",
  "iri-string",
  "mime",
@@ -15558,16 +15327,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "winreg"
-version = "0.50.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
-dependencies = [
- "cfg-if",
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "winsafe"
 version = "0.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -15595,7 +15354,7 @@ dependencies = [
  "futures",
  "http 1.4.0",
  "http-body-util",
- "hyper 1.9.0",
+ "hyper",
  "hyper-util",
  "log",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -238,7 +238,7 @@ sha2               = "0.10"
 slack-morphism     = { features = ["axum", "hyper"], version = "2.20" }
 sled               = "0.34"
 sysinfo            = "0.34"
-teloxide           = { features = ["macros"], version = "0.13" }
+teloxide           = { features = ["macros"], version = "0.17" }
 # WhatsApp (sqlite-storage disabled to avoid libsqlite3-sys conflict with sqlx;
 # re-enable once sqlx 0.9 stabilises).
 wacore                         = { default-features = false, version = "0.5" }

--- a/crates/telegram/src/handlers/callbacks.rs
+++ b/crates/telegram/src/handlers/callbacks.rs
@@ -357,7 +357,7 @@ pub(super) async fn handle_callback_query(
         None
     } else {
         if let Some(ref bot) = bot {
-            let _ = bot.answer_callback_query(&query.id).await;
+            let _ = bot.answer_callback_query(query.id.clone()).await;
         }
         return Ok(());
     };
@@ -399,7 +399,7 @@ pub(super) async fn handle_callback_query(
 
     if let Some(provider_name) = data.strip_prefix("model_provider:") {
         if let Some(ref bot) = bot {
-            let _ = bot.answer_callback_query(&query.id).await;
+            let _ = bot.answer_callback_query(query.id.clone()).await;
         }
         if let Some(ref sink) = event_sink {
             let cmd = format!("model provider:{provider_name}");
@@ -439,7 +439,10 @@ pub(super) async fn handle_callback_query(
         };
 
         if let Some(ref bot) = bot {
-            let _ = bot.answer_callback_query(&query.id).text(&response).await;
+            let _ = bot
+                .answer_callback_query(query.id.clone())
+                .text(&response)
+                .await;
         }
 
         if let Err(e) = outbound
@@ -449,7 +452,7 @@ pub(super) async fn handle_callback_query(
             warn!(account_id, "failed to send callback response: {e}");
         }
     } else if let Some(ref bot) = bot {
-        let _ = bot.answer_callback_query(&query.id).await;
+        let _ = bot.answer_callback_query(query.id.clone()).await;
     }
 
     Ok(())

--- a/crates/telegram/src/handlers/implementation.rs
+++ b/crates/telegram/src/handlers/implementation.rs
@@ -71,7 +71,6 @@ pub struct HandlerContext {
 /// Build the teloxide update handler.
 pub fn build_handler() -> Handler<
     'static,
-    DependencyMap,
     Result<(), Box<dyn std::error::Error + Send + Sync>>,
     teloxide::dispatching::DpHandlerDescription,
 > {
@@ -895,7 +894,7 @@ pub async fn handle_callback_query(
         Some(format!("{cmd_part} {val}"))
     } else {
         if let Some(ref bot) = bot {
-            let _ = bot.answer_callback_query(&query.id).await;
+            let _ = bot.answer_callback_query(query.id.clone()).await;
         }
         return Ok(());
     };
@@ -938,7 +937,7 @@ pub async fn handle_callback_query(
     // Provider selection → fetch models for that provider and show a new keyboard.
     if let Some(provider_name) = data.strip_prefix("model_provider:") {
         if let Some(ref bot) = bot {
-            let _ = bot.answer_callback_query(&query.id).await;
+            let _ = bot.answer_callback_query(query.id.clone()).await;
         }
         if let Some(ref sink) = event_sink {
             let cmd = format!("model provider:{provider_name}");
@@ -979,7 +978,10 @@ pub async fn handle_callback_query(
 
         // Answer callback query with the response text (shows as toast).
         if let Some(ref bot) = bot {
-            let _ = bot.answer_callback_query(&query.id).text(&response).await;
+            let _ = bot
+                .answer_callback_query(query.id.clone())
+                .text(&response)
+                .await;
         }
 
         // Also send as a regular message for visibility.
@@ -990,7 +992,7 @@ pub async fn handle_callback_query(
             warn!(account_id, "failed to send callback response: {e}");
         }
     } else if let Some(ref bot) = bot {
-        let _ = bot.answer_callback_query(&query.id).await;
+        let _ = bot.answer_callback_query(query.id.clone()).await;
     }
 
     Ok(())

--- a/crates/telegram/src/handlers/media.rs
+++ b/crates/telegram/src/handlers/media.rs
@@ -67,7 +67,7 @@ pub(super) fn extract_voice_file(msg: &Message) -> Option<VoiceFileInfo> {
     match &msg.kind {
         MessageKind::Common(common) => match &common.media_kind {
             MediaKind::Voice(v) => Some(VoiceFileInfo {
-                file_id: v.voice.file.id.clone(),
+                file_id: v.voice.file.id.to_string(),
                 format: "ogg".to_string(),
             }),
             MediaKind::Audio(a) => {
@@ -86,7 +86,7 @@ pub(super) fn extract_voice_file(msg: &Message) -> Option<VoiceFileInfo> {
                     .unwrap_or("mp3")
                     .to_string();
                 Some(VoiceFileInfo {
-                    file_id: a.audio.file.id.clone(),
+                    file_id: a.audio.file.id.to_string(),
                     format,
                 })
             },
@@ -105,7 +105,7 @@ pub(super) fn extract_photo_file(msg: &Message) -> Option<PhotoFileInfo> {
     match &msg.kind {
         MessageKind::Common(common) => match &common.media_kind {
             MediaKind::Photo(p) => p.photo.last().map(|ps| PhotoFileInfo {
-                file_id: ps.file.id.clone(),
+                file_id: ps.file.id.to_string(),
                 media_type: "image/jpeg".to_string(),
             }),
             _ => None,
@@ -148,7 +148,7 @@ pub(super) fn extract_document_file(msg: &Message) -> Option<DocumentFileInfo> {
                     normalized
                 };
                 Some(DocumentFileInfo {
-                    file_id: d.document.file.id.clone(),
+                    file_id: d.document.file.id.to_string(),
                     media_type,
                     file_name: d.document.file_name.clone(),
                 })
@@ -429,7 +429,9 @@ impl ToChannelMessageKind for MediaKind {
 }
 
 pub(super) async fn download_telegram_file(bot: &Bot, file_id: &str) -> Result<Vec<u8>> {
-    let file = bot.get_file(file_id).await?;
+    let file = bot
+        .get_file(teloxide::types::FileId(file_id.to_string()))
+        .await?;
     let token = bot.token();
     let base = bot.api_url();
     let url = format!("{base}file/bot{token}/{}", file.path);

--- a/crates/telegram/src/outbound/tests.rs
+++ b/crates/telegram/src/outbound/tests.rs
@@ -127,7 +127,7 @@ fn retry_after_duration_extracts_wait() {
 
 #[test]
 fn retry_after_duration_ignores_other_errors() {
-    let err = RequestError::Io(std::io::Error::other("boom"));
+    let err = RequestError::Io(std::io::Error::other("boom").into());
     assert_eq!(retry_after_duration(&err), None);
 }
 
@@ -175,7 +175,7 @@ fn is_message_not_modified_error_detects_variant() {
 
 #[test]
 fn is_message_not_modified_error_ignores_other_errors() {
-    let err = RequestError::Io(std::io::Error::other("boom"));
+    let err = RequestError::Io(std::io::Error::other("boom").into());
     assert!(!is_message_not_modified_error(&err));
 }
 
@@ -279,6 +279,112 @@ async fn send_html_fallback_sends_plain_text_without_raw_tags() {
         assert_eq!(requests[1].parse_mode, None);
         assert_eq!(requests[1].text, "Hello & world\n<ok>");
     }
+
+    let _ = shutdown_tx.send(());
+    server.await.expect("server join");
+}
+
+/// Regression test for <https://github.com/moltis-org/moltis/issues/947>.
+///
+/// teloxide-core 0.10.1 panicked in `PartSerializer::serialize_newtype_struct`
+/// when serializing `ThreadId` (a newtype wrapping `MessageId`) in a multipart
+/// request.  This happened whenever `send_document`, `send_voice`, or any media
+/// method was called with `message_thread_id` set (i.e. forum/topic chats).
+///
+/// teloxide-core 0.13.0 (shipped with teloxide 0.17) fixes this by delegating
+/// to `value.serialize(self)`.  This test verifies the fix by sending a
+/// document to a topic chat target (`chat_id:thread_id` format), ensuring the
+/// multipart request completes without panicking.
+#[tokio::test]
+async fn send_document_to_topic_chat_does_not_panic() {
+    use {
+        axum::{Router, body::Bytes, http::Uri, routing::post},
+        moltis_channels::plugin::ChannelOutbound,
+        moltis_common::types::{MediaAttachment, ReplyPayload},
+    };
+
+    // Mock Telegram API that returns a message result for every method.
+    // This is sufficient for outbound media tests that only need a
+    // non-error response.
+    async fn api_handler(_uri: Uri, _body: Bytes) -> Json<serde_json::Value> {
+        Json(serde_json::json!({
+            "ok": true,
+            "result": {
+                "message_id": 1,
+                "date": 0,
+                "chat": { "id": -1001234, "type": "supergroup" },
+                "text": ""
+            }
+        }))
+    }
+
+    let app = Router::new().route("/{*path}", post(api_handler));
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind");
+    let addr = listener.local_addr().expect("addr");
+    let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
+    let server = tokio::spawn(async move {
+        axum::serve(listener, app)
+            .with_graceful_shutdown(async {
+                let _ = shutdown_rx.await;
+            })
+            .await
+            .expect("serve");
+    });
+
+    let api_url = reqwest::Url::parse(&format!("http://{addr}/")).expect("parse url");
+    let bot = teloxide::Bot::new("test-token").set_api_url(api_url);
+
+    let accounts: AccountStateMap = Arc::new(std::sync::RwLock::new(HashMap::new()));
+    let outbound = Arc::new(TelegramOutbound {
+        accounts: Arc::clone(&accounts),
+    });
+    let account_id = "topic-test";
+
+    {
+        let mut map = accounts.write().expect("lock");
+        map.insert(account_id.to_string(), AccountState {
+            bot: bot.clone(),
+            bot_username: Some("test_bot".into()),
+            account_id: account_id.to_string(),
+            config: TelegramAccountConfig {
+                token: Secret::new("test-token".into()),
+                ..Default::default()
+            },
+            outbound: Arc::clone(&outbound),
+            cancel: CancellationToken::new(),
+            message_log: None,
+            event_sink: None,
+            otp: Mutex::new(OtpState::new(300)),
+        });
+    }
+
+    // Encode a small file as base64 data URI.
+    let data = base64::Engine::encode(&base64::engine::general_purpose::STANDARD, b"OGG test data");
+    let data_uri = format!("data:audio/ogg;base64,{data}");
+
+    // Target is "chat_id:thread_id" — a forum topic chat.
+    // With teloxide 0.13 (teloxide-core 0.10.1) this would panic in the
+    // multipart serializer when ThreadId was serialized.
+    let to = "-1001234:42";
+
+    let payload = ReplyPayload {
+        text: "voice test".into(),
+        media: Some(MediaAttachment {
+            url: data_uri,
+            mime_type: "audio/ogg".into(),
+            filename: Some("voice.ogg".into()),
+        }),
+        reply_to_id: None,
+        silent: false,
+    };
+
+    // This must not panic.
+    outbound
+        .send_media(account_id, to, &payload, None)
+        .await
+        .expect("send_media to topic chat should succeed");
 
     let _ = shutdown_tx.send(());
     server.await.expect("server join");


### PR DESCRIPTION
## Summary

- Upgrades teloxide from 0.13 to 0.17 (teloxide-core 0.10.1 → 0.13.0)
- Fixes #947: `send_document` / `send_voice` panics when uploading media to forum/topic chats

### Root cause

`teloxide-core` 0.10.1's `PartSerializer::serialize_newtype_struct` was `unimplemented!()`. When `ThreadId` (a newtype wrapping `MessageId`) was serialized in a multipart request — which happens for any media upload to a forum/topic chat — the serializer panicked and crashed Moltis.

### What changed

| File | Change |
|------|--------|
| `Cargo.toml` | teloxide `0.13` → `0.17` |
| `handlers/media.rs` | `file.id.clone()` → `.to_string()` (`FileId` newtype); `get_file` takes `FileId` |
| `handlers/implementation.rs` | `answer_callback_query(&id)` → `(id.clone())` (`CallbackQueryId` newtype); `Handler` generics reordered |
| `handlers/callbacks.rs` | Same `answer_callback_query` fix |
| `outbound/tests.rs` | `RequestError::Io` wraps `Arc`; added regression test |

## Validation

### Completed

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy -p moltis-telegram --all-targets -- -D warnings` — zero warnings
- [x] `cargo test -p moltis-telegram` — 113 tests pass (112 existing + 1 new)
- [x] `cargo check --workspace` passes (except pre-existing web assets)
- [x] `cargo fetch --locked` — lockfile consistent

### Remaining

- [x] `./scripts/local-validate.sh` (full CI validation)

## Manual QA

1. Configure a Telegram bot with a forum/supergroup (topic chats enabled)
2. Send a voice message or document to a topic thread
3. Verify the file is delivered without Moltis crashing
4. Verify non-topic chat media sends still work