### PR TITLE
fix(providers): replay DeepSeek reasoning content

### DIFF
--- a/crates/agents/src/model/chat.rs
+++ b/crates/agents/src/model/chat.rs
@@ -20,6 +20,7 @@ pub enum ChatMessage {
     Assistant {
         content: Option<String>,
         tool_calls: Vec<ToolCall>,
+        reasoning: Option<String>,
     },
     Tool {
         tool_call_id: String,
@@ -93,6 +94,7 @@ impl ChatMessage {
         Self::Assistant {
             content: Some(content.into()),
             tool_calls: vec![],
+            reasoning: None,
         }
     }
 
@@ -101,6 +103,7 @@ impl ChatMessage {
         Self::Assistant {
             content,
             tool_calls,
+            reasoning: None,
         }
     }
 
@@ -182,6 +185,7 @@ impl ChatMessage {
             ChatMessage::Assistant {
                 content,
                 tool_calls,
+                ..
             } => {
                 if tool_calls.is_empty() {
                     serde_json::json!({

--- a/crates/agents/src/model/convert.rs
+++ b/crates/agents/src/model/convert.rs
@@ -168,6 +168,10 @@ pub fn values_to_chat_messages(values: &[serde_json::Value]) -> Vec<ChatMessage>
             },
             "assistant" => {
                 let content = val["content"].as_str().map(|s| s.to_string());
+                let reasoning = val["reasoning"].as_str().and_then(|s| {
+                    let trimmed = s.trim();
+                    (!trimmed.is_empty()).then(|| trimmed.to_string())
+                });
                 let tool_calls: Vec<ToolCall> = val["tool_calls"]
                     .as_array()
                     .map(|tcs| {
@@ -194,6 +198,7 @@ pub fn values_to_chat_messages(values: &[serde_json::Value]) -> Vec<ChatMessage>
                 messages.push(ChatMessage::Assistant {
                     content,
                     tool_calls,
+                    reasoning,
                 });
             },
             "tool" => {
@@ -216,6 +221,16 @@ pub fn values_to_chat_messages(values: &[serde_json::Value]) -> Vec<ChatMessage>
                 if !pending_tool_call_ids.remove(&tool_call_id) {
                     tracing::debug!(tool_call_id, "skipping orphan tool_result message");
                     continue;
+                }
+                if let Some(reasoning) = val["reasoning"].as_str().and_then(|s| {
+                    let trimmed = s.trim();
+                    (!trimmed.is_empty()).then(|| trimmed.to_string())
+                }) {
+                    attach_reasoning_to_assistant_tool_call(
+                        &mut messages,
+                        &tool_call_id,
+                        reasoning,
+                    );
                 }
                 let content = if let Some(err) = val["error"].as_str() {
                     format!("Error: {err}")
@@ -242,4 +257,31 @@ pub fn values_to_chat_messages(values: &[serde_json::Value]) -> Vec<ChatMessage>
         }
     }
     messages
+}
+
+fn attach_reasoning_to_assistant_tool_call(
+    messages: &mut [ChatMessage],
+    tool_call_id: &str,
+    tool_reasoning: String,
+) {
+    for message in messages.iter_mut().rev() {
+        let ChatMessage::Assistant {
+            tool_calls,
+            reasoning,
+            ..
+        } = message
+        else {
+            continue;
+        };
+
+        if tool_calls
+            .iter()
+            .any(|tool_call| tool_call.id == tool_call_id)
+        {
+            if reasoning.is_none() {
+                *reasoning = Some(tool_reasoning);
+            }
+            return;
+        }
+    }
 }

--- a/crates/agents/src/model/convert.rs
+++ b/crates/agents/src/model/convert.rs
@@ -284,4 +284,5 @@ fn attach_reasoning_to_assistant_tool_call(
             return;
         }
     }
+    tracing::debug!(tool_call_id, "no assistant message found for reasoning attachment");
 }

--- a/crates/agents/src/model/mod.rs
+++ b/crates/agents/src/model/mod.rs
@@ -72,7 +72,7 @@ mod tests {
     fn assistant_message_text() {
         let msg = ChatMessage::assistant("Hi there");
         assert!(
-            matches!(msg, ChatMessage::Assistant { content: Some(t), tool_calls } if t == "Hi there" && tool_calls.is_empty())
+            matches!(msg, ChatMessage::Assistant { content: Some(t), tool_calls, .. } if t == "Hi there" && tool_calls.is_empty())
         );
     }
 
@@ -324,11 +324,13 @@ mod tests {
             ChatMessage::Assistant {
                 content,
                 tool_calls,
+                reasoning,
             } => {
                 assert_eq!(content.as_deref(), Some("thinking"));
                 assert_eq!(tool_calls.len(), 1);
                 assert_eq!(tool_calls[0].name, "exec");
                 assert_eq!(tool_calls[0].arguments["cmd"], "ls");
+                assert!(reasoning.is_none());
             },
             _ => panic!("expected assistant message"),
         }
@@ -413,6 +415,7 @@ mod tests {
                     arguments: serde_json::json!({}),
                     metadata: None,
                 }],
+                reasoning: None,
             },
             ChatMessage::tool("call_1", "result"),
         ];
@@ -435,6 +438,7 @@ mod tests {
                 }),
                 metadata: None,
             }],
+            reasoning: None,
         }];
         let values: Vec<serde_json::Value> = original.iter().map(|m| m.to_openai_value()).collect();
         let roundtripped = values_to_chat_messages(&values);
@@ -570,6 +574,37 @@ mod tests {
                 assert!(content.contains("file.txt"));
             },
             other => panic!("expected Tool, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn convert_tool_result_reasoning_attaches_to_assistant_tool_call() {
+        let values = vec![
+            serde_json::json!({
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [{
+                    "id": "call_1",
+                    "function": {"name": "exec", "arguments": "{\"command\":\"ls\"}"}
+                }]
+            }),
+            serde_json::json!({
+                "role": "tool_result",
+                "tool_call_id": "call_1",
+                "tool_name": "exec",
+                "success": true,
+                "result": {"stdout": "file.txt"},
+                "reasoning": "I should inspect the directory first."
+            }),
+        ];
+        let msgs = values_to_chat_messages(&values);
+
+        match &msgs[0] {
+            ChatMessage::Assistant { reasoning, .. } => assert_eq!(
+                reasoning.as_deref(),
+                Some("I should inspect the directory first.")
+            ),
+            other => panic!("expected Assistant, got {other:?}"),
         }
     }
 
@@ -870,6 +905,7 @@ mod tests {
                 arguments: serde_json::json!({}),
                 metadata: Some(meta),
             }],
+            reasoning: None,
         }];
         let values: Vec<serde_json::Value> = original.iter().map(|m| m.to_openai_value()).collect();
         match &values_to_chat_messages(&values)[0] {

--- a/crates/agents/src/runner/tests/basic.rs
+++ b/crates/agents/src/runner/tests/basic.rs
@@ -545,6 +545,7 @@ impl LlmProvider for DirectCommandNoToolProvider {
                     if let ChatMessage::Assistant {
                         content,
                         tool_calls,
+                        ..
                     } = m
                     {
                         if tool_calls.is_empty() {

--- a/crates/providers/src/anthropic.rs
+++ b/crates/providers/src/anthropic.rs
@@ -543,6 +543,7 @@ fn to_anthropic_messages(
             ChatMessage::Assistant {
                 content,
                 tool_calls,
+                ..
             } => {
                 if tool_calls.is_empty() {
                     out.push(serde_json::json!({

--- a/crates/providers/src/anthropic/tests.rs
+++ b/crates/providers/src/anthropic/tests.rs
@@ -398,6 +398,7 @@ fn last_user_message_gets_cache_control() {
         ChatMessage::Assistant {
             content: Some("reply".into()),
             tool_calls: vec![],
+            reasoning: None,
         },
         ChatMessage::User {
             content: UserContent::Text("second".into()),

--- a/crates/providers/src/openai/provider/request.rs
+++ b/crates/providers/src/openai/provider/request.rs
@@ -116,6 +116,9 @@ impl OpenAiProvider {
             || self.base_url.contains("moonshot.ai")
             || self.base_url.contains("moonshot.cn")
             || self.model.starts_with("kimi-")
+            || self.provider_name.eq_ignore_ascii_case("deepseek")
+            || self.base_url.contains("api.deepseek.com")
+            || self.model.to_ascii_lowercase().starts_with("deepseek-v4")
     }
 
     /// Some providers (e.g. MiniMax) reject `role: "system"` in the messages
@@ -303,6 +306,10 @@ impl OpenAiProvider {
         let mut out = Vec::with_capacity(messages.len());
 
         for message in messages {
+            let assistant_reasoning = match message {
+                ChatMessage::Assistant { reasoning, .. } => reasoning.as_deref(),
+                _ => None,
+            };
             let mut value = message.to_openai_value();
 
             // Strip the `name` field for providers that reject it entirely.
@@ -354,11 +361,16 @@ impl OpenAiProvider {
                     .is_some_and(|calls| !calls.is_empty());
 
                 if is_assistant && has_tool_calls {
-                    let reasoning_content = value
-                        .get("content")
-                        .and_then(serde_json::Value::as_str)
-                        .unwrap_or("")
-                        .to_string();
+                    let reasoning_content = assistant_reasoning
+                        .filter(|reasoning| !reasoning.trim().is_empty())
+                        .map(str::to_string)
+                        .or_else(|| {
+                            value
+                                .get("content")
+                                .and_then(serde_json::Value::as_str)
+                                .map(str::to_string)
+                        })
+                        .unwrap_or_default();
 
                     if value.get("content").is_none() {
                         value["content"] = serde_json::Value::String(String::new());
@@ -706,6 +718,15 @@ mod tests {
         assert!(p.requires_reasoning_content_on_tool_messages());
     }
 
+    #[test]
+    fn deepseek_v4_auto_detects_reasoning_content() {
+        let p = provider("deepseek-v4-flash", "deepseek", "https://api.deepseek.com");
+        assert!(
+            p.requires_reasoning_content_on_tool_messages(),
+            "DeepSeek V4 thinking-mode tool calls require reasoning_content replay (issue #959)"
+        );
+    }
+
     // ── Wire-format tests: verify serialized request body (issue #810) ──
 
     /// Kimi router with strict_tools=false must NOT emit `"strict": true` in
@@ -780,6 +801,51 @@ mod tests {
             assistant_msg.get("reasoning_content").is_some(),
             "assistant tool-call message must have reasoning_content, got: {assistant_msg}"
         );
+    }
+
+    #[test]
+    fn deepseek_v4_replays_persisted_tool_reasoning_content() {
+        let p = provider("deepseek-v4-flash", "deepseek", "https://api.deepseek.com");
+        let persisted = vec![
+            serde_json::json!({"role": "user", "content": "What is the weather?"}),
+            serde_json::json!({
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [{
+                    "id": "call_959",
+                    "type": "function",
+                    "function": {
+                        "name": "get_weather",
+                        "arguments": "{\"location\":\"Berlin\"}"
+                    }
+                }]
+            }),
+            serde_json::json!({
+                "role": "tool_result",
+                "tool_call_id": "call_959",
+                "tool_name": "get_weather",
+                "success": true,
+                "result": {"temperature": 20},
+                "reasoning": "Need live weather before answering."
+            }),
+            serde_json::json!({"role": "assistant", "content": "It is 20 C."}),
+            serde_json::json!({"role": "user", "content": "What about tomorrow?"}),
+        ];
+        let messages = moltis_agents::model::values_to_chat_messages(&persisted);
+
+        let serialized = p.serialize_messages_for_request(&messages);
+
+        let Some(assistant_tool_message) = serialized.iter().find(|message| {
+            message.get("role").and_then(serde_json::Value::as_str) == Some("assistant")
+                && message.get("tool_calls").is_some()
+        }) else {
+            panic!("assistant tool-call message should be serialized");
+        };
+        assert_eq!(
+            assistant_tool_message["reasoning_content"],
+            "Need live weather before answering."
+        );
+        assert_eq!(assistant_tool_message["content"], "");
     }
 
     /// Mistral provider must strip the `name` field from user messages.

--- a/crates/providers/src/openai/provider/request.rs
+++ b/crates/providers/src/openai/provider/request.rs
@@ -116,8 +116,6 @@ impl OpenAiProvider {
             || self.base_url.contains("moonshot.ai")
             || self.base_url.contains("moonshot.cn")
             || self.model.starts_with("kimi-")
-            || self.provider_name.eq_ignore_ascii_case("deepseek")
-            || self.base_url.contains("api.deepseek.com")
             || self.model.to_ascii_lowercase().starts_with("deepseek-v4")
     }
 

--- a/crates/providers/src/openai_codex.rs
+++ b/crates/providers/src/openai_codex.rs
@@ -238,6 +238,7 @@ impl OpenAiCodexProvider {
                     ChatMessage::Assistant {
                         content,
                         tool_calls,
+                        ..
                     } => {
                         if !tool_calls.is_empty() {
                             let mut items: Vec<serde_json::Value> = vec![];

--- a/crates/providers/src/openai_compat/provider.rs
+++ b/crates/providers/src/openai_compat/provider.rs
@@ -214,6 +214,7 @@ pub fn to_responses_input(messages: &[ChatMessage]) -> Vec<serde_json::Value> {
             ChatMessage::Assistant {
                 content,
                 tool_calls,
+                ..
             } => {
                 if !tool_calls.is_empty() {
                     let mut items: Vec<serde_json::Value> = tool_calls


### PR DESCRIPTION
## Summary

- Fixes #959.
- Preserve provider reasoning on typed assistant messages when converting persisted chat history.
- Replay persisted tool reasoning as `reasoning_content` for DeepSeek/OpenAI-compatible follow-up requests that require it.
- Add regression coverage for DeepSeek V4 thinking-mode tool-call history.

## Validation

### Completed

- [x] `just format`
- [x] `cargo test -p moltis-providers deepseek_v4`
- [x] `cargo test -p moltis-agents convert_tool_result_reasoning_attaches_to_assistant_tool_call`
- [x] `just lint`

### Remaining

- [ ] CI on the PR

## Manual QA

- Not run. Covered by focused serialization/conversion regression tests and the workspace lint gate.