### PR TITLE
debug(e2e): add RPC logging + gateway.log capture for CI diagnosis

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -358,6 +358,7 @@ jobs:
           path: |
             crates/web/ui/playwright-report/
             crates/web/ui/test-results/
+            target/e2e-runtime/gateway.log
           if-no-files-found: ignore
           retention-days: 14
 

--- a/crates/httpd/src/ws.rs
+++ b/crates/httpd/src/ws.rs
@@ -570,8 +570,12 @@ pub async fn handle_connection(
                 let _rpc_t = std::time::Instant::now();
                 let response = methods.dispatch(ctx).await;
                 let rpc_ms = _rpc_t.elapsed().as_millis();
+                // Always log RPCs so CI gateway.log shows whether they arrive.
+                // TODO: remove once CI RPC issue is diagnosed.
                 if rpc_ms > 50 {
-                    warn!(conn_id = %conn_id, method = %req.method, rpc_ms, "ws: RPC dispatch slow");
+                    warn!(conn_id = %conn_id, method = %req.method, rpc_ms, ok = response.ok, "ws: RPC slow");
+                } else {
+                    info!(conn_id = %conn_id, method = %req.method, rpc_ms, ok = response.ok, "ws: RPC");
                 }
                 if state.ws_request_logs {
                     info!(
@@ -645,7 +649,7 @@ pub async fn handle_connection(
     #[cfg(feature = "metrics")]
     moltis_metrics::gauge!(moltis_metrics::websocket::CONNECTIONS_ACTIVE).decrement(1.0);
 
-    debug!(
+    warn!(
         conn_id = %conn_id,
         duration_secs = duration.as_secs(),
         "ws: connection closed"

--- a/crates/web/ui/e2e/start-gateway.sh
+++ b/crates/web/ui/e2e/start-gateway.sh
@@ -79,15 +79,10 @@ if [ -n "${BINARY}" ] && binary_is_stale "${BINARY}"; then
 	BINARY=""
 fi
 
+# Redirect all output to log file AND stdout so Playwright can see health
+# endpoint responses while the log is also captured for CI artifacts.
 if [ -n "${BINARY}" ]; then
-	"${BINARY}" --no-tls --bind 127.0.0.1 --port "${PORT}" 2>"${GATEWAY_LOG}" &
-	CHILD=$!
-	# Copy to stdout for Playwright health checks, tail in background
-	tail -f "${GATEWAY_LOG}" &
-	wait "${CHILD}"
+	exec "${BINARY}" --no-tls --bind 127.0.0.1 --port "${PORT}" > >(tee -a "${GATEWAY_LOG}") 2>&1
 else
-	cargo run --bin moltis -- --no-tls --bind 127.0.0.1 --port "${PORT}" 2>"${GATEWAY_LOG}" &
-	CHILD=$!
-	tail -f "${GATEWAY_LOG}" &
-	wait "${CHILD}"
+	exec cargo run --bin moltis -- --no-tls --bind 127.0.0.1 --port "${PORT}" > >(tee -a "${GATEWAY_LOG}") 2>&1
 fi


### PR DESCRIPTION
## Summary
- Log ALL WS RPCs at info level (method, timing, ok/error)
- Connection close events at warn level
- Gateway stderr → gateway.log via tee, uploaded as CI artifact
- Timing warnings >50ms on lock acquisition + RPC dispatch

## Why
RPCs hang on CI (30s timeout fires) but work locally. Need server-side logs to see:
1. Does the RPC even arrive at the server?
2. Does dispatch block on a lock?
3. Does the WS close unexpectedly?

## Validation
- [x] Local: 366 e2e tests pass
- [ ] CI: waiting for this run to get the gateway.log