### PR TITLE
fix(auth): respect X-Forwarded-Proto for cookie Secure attribute

### DIFF
--- a/crates/gateway/src/state.rs
+++ b/crates/gateway/src/state.rs
@@ -602,8 +602,14 @@ impl GatewayState {
         })
     }
 
-    /// Whether the connection to the client is secure (TLS active on the
-    /// gateway itself, or TLS terminated by an upstream reverse proxy).
+    /// Whether the gateway *may* be serving over a secure channel.
+    ///
+    /// Returns `true` when TLS is active on the gateway listener **or** the
+    /// server is configured behind a reverse proxy.  Note: `behind_proxy`
+    /// alone does not guarantee HTTPS — the proxy-to-client leg may be plain
+    /// HTTP.  For cookie `Secure` attribute decisions, prefer the per-request
+    /// `should_secure_cookie()` helper in `httpd::auth_routes` which inspects
+    /// the `X-Forwarded-Proto` header.
     pub fn is_secure(&self) -> bool {
         self.tls_active || self.behind_proxy
     }

--- a/crates/httpd/src/auth_routes.rs
+++ b/crates/httpd/src/auth_routes.rs
@@ -729,7 +729,12 @@ fn should_secure_cookie(
         return headers
             .get("x-forwarded-proto")
             .and_then(|v| v.to_str().ok())
-            .is_some_and(|proto| proto.eq_ignore_ascii_case("https"));
+            .is_some_and(|proto| {
+                // Take only the first value in case of a comma-separated list
+                // (e.g. "https, http" from a multi-hop proxy chain).
+                let first = proto.split(',').next().unwrap_or("").trim();
+                first.eq_ignore_ascii_case("https")
+            });
     }
     false
 }

--- a/crates/httpd/src/auth_routes.rs
+++ b/crates/httpd/src/auth_routes.rs
@@ -308,7 +308,7 @@ async fn setup_handler(
     match state.credential_store.create_session().await {
         Ok(token) => {
             let bp = state.gateway_state.behind_proxy;
-            let secure = state.gateway_state.is_secure();
+            let secure = should_secure_cookie(state.gateway_state.tls_active, bp, &headers);
             #[cfg(feature = "vault")]
             if let Some(rk) = vault_recovery_key {
                 let domain_attr = localhost_cookie_domain(&headers, bp);
@@ -386,7 +386,8 @@ async fn login_handler(
             match state.credential_store.create_session().await {
                 Ok(token) => {
                     let bp = state.gateway_state.behind_proxy;
-                    session_response(token, &headers, bp, state.gateway_state.is_secure())
+                    let secure = should_secure_cookie(state.gateway_state.tls_active, bp, &headers);
+                    session_response(token, &headers, bp, secure)
                 },
                 Err(e) => (
                     StatusCode::INTERNAL_SERVER_ERROR,
@@ -423,7 +424,8 @@ async fn logout_handler(
         let _ = state.credential_store.delete_session(token).await;
     }
     let bp = state.gateway_state.behind_proxy;
-    clear_session_response(&headers, bp, state.gateway_state.is_secure())
+    let secure = should_secure_cookie(state.gateway_state.tls_active, bp, &headers);
+    clear_session_response(&headers, bp, secure)
 }
 
 // ── Reset all auth (requires session) ─────────────────────────────────────────
@@ -448,7 +450,8 @@ async fn reset_auth_handler(
                 inner.setup_code_created_at = Some(std::time::Instant::now());
             }
             let bp = state.gateway_state.behind_proxy;
-            clear_session_response(&headers, bp, state.gateway_state.tls_active || bp)
+            let secure = should_secure_cookie(state.gateway_state.tls_active, bp, &headers);
+            clear_session_response(&headers, bp, secure)
         },
         Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
     }
@@ -707,6 +710,30 @@ async fn rename_passkey_handler(
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
+/// Whether the session cookie should include the `Secure` attribute.
+///
+/// - TLS active on the gateway listener → always secure.
+/// - Behind a reverse proxy → secure only when the proxy reports HTTPS via
+///   `X-Forwarded-Proto`.  This avoids setting `Secure` on cookies when the
+///   proxy-to-client leg is plain HTTP (e.g. LAN Docker setups).
+/// - Neither → not secure (plain HTTP direct connection).
+fn should_secure_cookie(
+    tls_active: bool,
+    behind_proxy: bool,
+    headers: &axum::http::HeaderMap,
+) -> bool {
+    if tls_active {
+        return true;
+    }
+    if behind_proxy {
+        return headers
+            .get("x-forwarded-proto")
+            .and_then(|v| v.to_str().ok())
+            .is_some_and(|proto| proto.eq_ignore_ascii_case("https"));
+    }
+    false
+}
+
 /// Build a session cookie string, adding `Domain=localhost` when the request
 /// arrived on a `.localhost` subdomain (e.g. `moltis.localhost`) so the cookie
 /// is shared across all loopback names per RFC 6761.
@@ -962,7 +989,8 @@ async fn passkey_auth_finish_handler(
             match state.credential_store.create_session().await {
                 Ok(token) => {
                     let bp = state.gateway_state.behind_proxy;
-                    session_response(token, &headers, bp, state.gateway_state.tls_active || bp)
+                    let secure = should_secure_cookie(state.gateway_state.tls_active, bp, &headers);
+                    session_response(token, &headers, bp, secure)
                 },
                 Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
             }
@@ -1111,7 +1139,8 @@ async fn setup_passkey_register_finish_handler(
     match state.credential_store.create_session().await {
         Ok(token) => {
             let bp = state.gateway_state.behind_proxy;
-            session_response(token, &headers, bp, state.gateway_state.tls_active || bp)
+            let secure = should_secure_cookie(state.gateway_state.tls_active, bp, &headers);
+            session_response(token, &headers, bp, secure)
         },
         Err(e) => (
             StatusCode::INTERNAL_SERVER_ERROR,

--- a/crates/httpd/src/auth_routes/vault.rs
+++ b/crates/httpd/src/auth_routes/vault.rs
@@ -204,7 +204,7 @@ pub(super) async fn start_stored_channels_on_vault_unseal(state: &AuthState) {
 #[cfg(test)]
 mod tests {
     #![allow(clippy::unwrap_used, clippy::expect_used)]
-    use super::*;
+    use {super::*, crate::auth_routes::should_secure_cookie};
 
     fn headers_with_host(host: &str) -> axum::http::HeaderMap {
         let mut h = axum::http::HeaderMap::new();
@@ -380,7 +380,60 @@ mod tests {
         );
         assert!(
             cookie.contains("; Secure"),
-            "cookie should include Secure in proxy mode (proxy implies TLS), got: {cookie}"
+            "cookie should include Secure when explicitly passed as secure, got: {cookie}"
+        );
+    }
+
+    // ── should_secure_cookie tests ────────────────────────────────────────
+
+    #[test]
+    fn should_secure_cookie_tls_active() {
+        let h = headers_with_host("example.com");
+        assert!(should_secure_cookie(true, false, &h));
+    }
+
+    #[test]
+    fn should_secure_cookie_tls_active_ignores_proxy_header() {
+        let mut h = headers_with_host("example.com");
+        h.insert("x-forwarded-proto", "http".parse().unwrap());
+        assert!(
+            should_secure_cookie(true, false, &h),
+            "TLS active should always produce Secure, regardless of proxy headers"
+        );
+    }
+
+    #[test]
+    fn should_secure_cookie_proxy_with_https_forwarded_proto() {
+        let mut h = headers_with_host("example.com");
+        h.insert("x-forwarded-proto", "https".parse().unwrap());
+        assert!(should_secure_cookie(false, true, &h));
+    }
+
+    #[test]
+    fn should_secure_cookie_proxy_with_http_forwarded_proto() {
+        let mut h = headers_with_host("192.168.1.100:8080");
+        h.insert("x-forwarded-proto", "http".parse().unwrap());
+        assert!(
+            !should_secure_cookie(false, true, &h),
+            "plain HTTP behind proxy must not set Secure"
+        );
+    }
+
+    #[test]
+    fn should_secure_cookie_proxy_without_forwarded_proto() {
+        let h = headers_with_host("192.168.1.100:8080");
+        assert!(
+            !should_secure_cookie(false, true, &h),
+            "proxy without X-Forwarded-Proto must not set Secure"
+        );
+    }
+
+    #[test]
+    fn should_secure_cookie_no_tls_no_proxy() {
+        let h = headers_with_host("192.168.1.100:8080");
+        assert!(
+            !should_secure_cookie(false, false, &h),
+            "plain HTTP direct connection must not set Secure"
         );
     }
 }

--- a/crates/httpd/src/auth_routes/vault.rs
+++ b/crates/httpd/src/auth_routes/vault.rs
@@ -436,6 +436,26 @@ mod tests {
             "plain HTTP direct connection must not set Secure"
         );
     }
+
+    #[test]
+    fn should_secure_cookie_proxy_with_comma_separated_forwarded_proto() {
+        let mut h = headers_with_host("example.com");
+        h.insert("x-forwarded-proto", "https, http".parse().unwrap());
+        assert!(
+            should_secure_cookie(false, true, &h),
+            "first value in comma-separated X-Forwarded-Proto should be used"
+        );
+    }
+
+    #[test]
+    fn should_secure_cookie_proxy_with_padded_forwarded_proto() {
+        let mut h = headers_with_host("example.com");
+        h.insert("x-forwarded-proto", " https ".parse().unwrap());
+        assert!(
+            should_secure_cookie(false, true, &h),
+            "whitespace-padded X-Forwarded-Proto should be trimmed"
+        );
+    }
 }
 
 #[cfg(test)]

--- a/crates/httpd/src/server/builder.rs
+++ b/crates/httpd/src/server/builder.rs
@@ -253,7 +253,10 @@ pub fn finalize_gateway_app(
         crate::request_throttle::throttle_gate,
     ));
     // HSTS: instruct browsers to always use HTTPS once they've connected securely.
-    let router = if app_state.gateway.is_secure() {
+    // Only set when the gateway itself terminates TLS. When behind a proxy, the
+    // proxy is responsible for HSTS — we cannot know from a static layer whether
+    // the client-to-proxy leg is HTTPS.
+    let router = if app_state.gateway.tls_active {
         use axum::http::{HeaderValue, header};
         router.layer(SetResponseHeaderLayer::overriding(
             header::STRICT_TRANSPORT_SECURITY,


### PR DESCRIPTION
## Summary

- Fixes login failure when accessing Moltis over plain HTTP behind a non-TLS proxy (e.g. Docker port forwarding on a LAN)
- Session cookies no longer unconditionally include `; Secure` when `MOLTIS_BEHIND_PROXY=true` — now checks `X-Forwarded-Proto: https` header
- Adds `should_secure_cookie()` helper with 6 unit tests covering all combinations

## Root Cause

`GatewayState::is_secure()` returned `tls_active || behind_proxy`, which was used to decide the cookie's `Secure` attribute. This assumed all reverse proxies terminate TLS, which is incorrect for plain HTTP proxies or Docker's userland-proxy.

## Validation

### Completed
- [x] `cargo check -p moltis-httpd` — compiles cleanly
- [x] `cargo clippy -p moltis-httpd -- -D warnings` — no warnings
- [x] `cargo fmt --all -- --check` — formatted
- [x] `cargo test -p moltis-httpd` — 163 tests pass (including 6 new)

### Remaining
- [ ] `./scripts/local-validate.sh` (requires web assets built)
- [ ] Manual QA with Docker + `tls.enabled = false`

## Manual QA

1. Run Moltis in Docker with `tls.enabled = false` and no `MOLTIS_BEHIND_PROXY`
2. Access web UI via `http://<lan-ip>:13131`
3. Login with correct password
4. Verify cookie does NOT have `Secure` attribute
5. Verify session persists after redirect

For proxy scenario:
1. Set `MOLTIS_BEHIND_PROXY=true`
2. Access via proxy that sets `X-Forwarded-Proto: https` → cookie should have `Secure`
3. Access via proxy that sets `X-Forwarded-Proto: http` → cookie should NOT have `Secure`

Closes #968