### PR TITLE
Auto-unseal vault from recovery key at startup

### DIFF
--- a/crates/gateway/src/lib.rs
+++ b/crates/gateway/src/lib.rs
@@ -58,6 +58,8 @@ pub mod teams_agent_tools;
 pub mod tts_phrases;
 pub mod update_check;
 pub mod updater;
+#[cfg(feature = "vault")]
+pub mod vault_lifecycle;
 pub mod voice;
 pub mod voice_agent_tools;
 pub mod voice_persona;

--- a/crates/gateway/src/server/prepare_core.rs
+++ b/crates/gateway/src/server/prepare_core.rs
@@ -441,15 +441,21 @@ pub async fn prepare_gateway_core(
     startup_mem_probe.checkpoint("sqlite.migrations.complete");
 
     #[cfg(feature = "vault")]
-    let vault: Option<Arc<moltis_vault::Vault>> = {
+    let (vault, auto_unsealed_vault): (Option<Arc<moltis_vault::Vault>>, bool) = {
         match moltis_vault::Vault::new(db_pool.clone()).await {
             Ok(v) => {
                 info!(status = ?v.status().await, "vault ready");
-                Some(Arc::new(v))
+                let vault = Arc::new(v);
+                let auto_unseal_result = crate::vault_lifecycle::auto_unseal_from_env(&vault).await;
+                let auto_unsealed = matches!(
+                    auto_unseal_result,
+                    crate::vault_lifecycle::AutoUnsealResult::Unsealed
+                );
+                (Some(vault), auto_unsealed)
             },
             Err(e) => {
                 warn!(error = %e, "vault init failed, encryption disabled");
-                None
+                (None, false)
             },
         }
     };
@@ -460,6 +466,10 @@ pub async fn prepare_gateway_core(
             .await
             .expect("failed to init credential store"),
     );
+    #[cfg(feature = "vault")]
+    if auto_unsealed_vault {
+        crate::vault_lifecycle::run_vault_env_migration(&credential_store).await;
+    }
     #[cfg(not(feature = "vault"))]
     let credential_store = Arc::new(
         auth::CredentialStore::new(db_pool.clone())

--- a/crates/gateway/src/server/prepare_core.rs
+++ b/crates/gateway/src/server/prepare_core.rs
@@ -450,6 +450,7 @@ pub async fn prepare_gateway_core(
                 let auto_unsealed = matches!(
                     auto_unseal_result,
                     crate::vault_lifecycle::AutoUnsealResult::Unsealed
+                        | crate::vault_lifecycle::AutoUnsealResult::AlreadyUnsealed
                 );
                 (Some(vault), auto_unsealed)
             },

--- a/crates/gateway/src/vault_lifecycle.rs
+++ b/crates/gateway/src/vault_lifecycle.rs
@@ -1,0 +1,303 @@
+use {
+    crate::{auth::CredentialStore, state::GatewayState},
+    secrecy::{ExposeSecret, Secret},
+    std::{path::PathBuf, sync::Arc},
+};
+
+pub const AUTO_UNSEAL_KEY_ENV: &str = "MOLTIS_VAULT_AUTO_UNSEAL_KEY";
+pub const AUTO_UNSEAL_KEY_FILE_ENV: &str = "MOLTIS_VAULT_AUTO_UNSEAL_KEY_FILE";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AutoUnsealResult {
+    NotConfigured,
+    AlreadyUnsealed,
+    Unsealed,
+    NotInitialized,
+    BadCredential,
+    EmptySecret,
+    Error,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AutoUnsealSourceKind {
+    Env,
+    File,
+}
+
+struct AutoUnsealSecret {
+    value: Secret<String>,
+    kind: AutoUnsealSourceKind,
+}
+
+#[tracing::instrument(skip(vault))]
+pub async fn auto_unseal_from_env(vault: &moltis_vault::Vault) -> AutoUnsealResult {
+    let Some(secret) = auto_unseal_secret_from_env().await else {
+        return AutoUnsealResult::NotConfigured;
+    };
+    auto_unseal_with_secret(vault, secret).await
+}
+
+async fn auto_unseal_with_secret(
+    vault: &moltis_vault::Vault,
+    secret: AutoUnsealSecret,
+) -> AutoUnsealResult {
+    if vault.is_unsealed().await {
+        tracing::debug!("vault auto-unseal skipped: already unsealed");
+        return AutoUnsealResult::AlreadyUnsealed;
+    }
+
+    let phrase = secret.value.expose_secret().trim();
+    if phrase.is_empty() {
+        tracing::warn!(
+            source = ?secret.kind,
+            "vault auto-unseal skipped: configured recovery key is empty"
+        );
+        return AutoUnsealResult::EmptySecret;
+    }
+
+    match vault.unseal_with_recovery(phrase).await {
+        Ok(()) => {
+            tracing::info!(source = ?secret.kind, "vault auto-unsealed");
+            AutoUnsealResult::Unsealed
+        },
+        Err(moltis_vault::VaultError::NotInitialized) => {
+            tracing::debug!("vault auto-unseal skipped: vault is not initialized");
+            AutoUnsealResult::NotInitialized
+        },
+        Err(moltis_vault::VaultError::BadCredential) => {
+            tracing::warn!(
+                source = ?secret.kind,
+                "vault auto-unseal failed: recovery key was rejected"
+            );
+            AutoUnsealResult::BadCredential
+        },
+        Err(error) => {
+            tracing::warn!(source = ?secret.kind, %error, "vault auto-unseal failed");
+            AutoUnsealResult::Error
+        },
+    }
+}
+
+async fn auto_unseal_secret_from_env() -> Option<AutoUnsealSecret> {
+    let key = std::env::var(AUTO_UNSEAL_KEY_ENV).ok();
+    let key_file = std::env::var(AUTO_UNSEAL_KEY_FILE_ENV).ok();
+
+    match (key, key_file) {
+        (None, None) => None,
+        (Some(value), None) => Some(AutoUnsealSecret {
+            value: Secret::new(value),
+            kind: AutoUnsealSourceKind::Env,
+        }),
+        (env_value, Some(path)) => {
+            if env_value.is_some() {
+                tracing::warn!(
+                    key_env = AUTO_UNSEAL_KEY_ENV,
+                    file_env = AUTO_UNSEAL_KEY_FILE_ENV,
+                    "both vault auto-unseal env vars are set; using recovery key file"
+                );
+            }
+            read_auto_unseal_secret_file(PathBuf::from(path)).await
+        },
+    }
+}
+
+async fn read_auto_unseal_secret_file(path: PathBuf) -> Option<AutoUnsealSecret> {
+    match tokio::fs::read_to_string(&path).await {
+        Ok(value) => Some(AutoUnsealSecret {
+            value: Secret::new(value),
+            kind: AutoUnsealSourceKind::File,
+        }),
+        Err(error) => {
+            tracing::warn!(
+                path = %path.display(),
+                %error,
+                "vault auto-unseal recovery key file could not be read"
+            );
+            None
+        },
+    }
+}
+
+/// Migrate plaintext secrets to encrypted storage after vault unseal.
+pub async fn run_vault_env_migration(credential_store: &CredentialStore) {
+    if let Some(vault) = credential_store.vault() {
+        let pool = credential_store.db_pool();
+        match moltis_vault::migration::migrate_env_vars(vault, pool).await {
+            Ok(n) if n > 0 => {
+                tracing::info!(count = n, "migrated env vars to encrypted");
+            },
+            Ok(_) => {},
+            Err(error) => {
+                tracing::warn!(%error, "env var migration failed");
+            },
+        }
+        match moltis_vault::migration::migrate_ssh_keys(vault, pool).await {
+            Ok(n) if n > 0 => {
+                tracing::info!(count = n, "migrated ssh keys to encrypted");
+            },
+            Ok(_) => {},
+            Err(error) => {
+                tracing::warn!(%error, "ssh key migration failed");
+            },
+        }
+
+        if let Some(config_dir) = moltis_config::config_dir() {
+            let provider_keys_path = config_dir.join("provider_keys.json");
+            match moltis_vault::migration::encrypt_json_file(
+                vault,
+                &provider_keys_path,
+                "provider_keys",
+            )
+            .await
+            {
+                Ok(true) => {
+                    tracing::info!("encrypted provider_keys.json to vault storage");
+                },
+                Ok(false) => {},
+                Err(error) => {
+                    tracing::warn!(%error, "provider_keys.json encryption failed");
+                },
+            }
+        }
+    }
+}
+
+/// Start stored channel accounts after vault unseal.
+///
+/// When the vault is unsealed, previously encrypted channel configs become
+/// decryptable. This handles the case where the vault was sealed at startup
+/// and channels could not be started until a later manual unlock.
+#[tracing::instrument(skip(state))]
+pub async fn start_stored_channels_on_vault_unseal(state: &Arc<GatewayState>) {
+    let Some(registry) = state.services.channel_registry.as_ref() else {
+        tracing::debug!("no channel registry available, skipping channel startup on vault unseal");
+        return;
+    };
+    let Some(store) = state.services.channel_store.as_ref() else {
+        tracing::debug!("no channel store available, skipping channel startup on vault unseal");
+        return;
+    };
+
+    let stored = match store.list().await {
+        Ok(channels) => channels,
+        Err(error) => {
+            tracing::warn!(%error, "failed to list stored channels on vault unseal");
+            return;
+        },
+    };
+
+    if stored.is_empty() {
+        return;
+    }
+
+    for channel in stored {
+        if registry.get(&channel.channel_type).is_none() {
+            tracing::debug!(
+                account_id = channel.account_id,
+                channel_type = channel.channel_type,
+                "unsupported channel type on vault unseal, skipping stored account"
+            );
+            continue;
+        }
+
+        if registry.resolve_channel_type(&channel.account_id).is_some() {
+            continue;
+        }
+
+        tracing::info!(
+            account_id = channel.account_id,
+            channel_type = channel.channel_type,
+            "starting stored channel on vault unseal"
+        );
+
+        if let Err(error) = registry
+            .start_account(&channel.channel_type, &channel.account_id, channel.config)
+            .await
+        {
+            tracing::warn!(
+                account_id = channel.account_id,
+                channel_type = channel.channel_type,
+                %error,
+                "failed to start stored channel on vault unseal"
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used)]
+
+    use {
+        crate::vault_lifecycle::{
+            AutoUnsealResult, AutoUnsealSecret, AutoUnsealSourceKind, auto_unseal_with_secret,
+        },
+        secrecy::Secret,
+        sqlx::SqlitePool,
+        std::sync::Arc,
+    };
+
+    async fn test_vault() -> Arc<moltis_vault::Vault> {
+        let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        moltis_vault::run_migrations(&pool).await.unwrap();
+        Arc::new(moltis_vault::Vault::new(pool).await.unwrap())
+    }
+
+    #[tokio::test]
+    async fn auto_unseal_with_recovery_key_unseals_vault() {
+        let vault = test_vault().await;
+        let recovery_key = vault.initialize("test-password-123").await.unwrap();
+        let recovery_phrase = recovery_key.phrase().to_owned();
+        vault.seal().await;
+
+        let result = auto_unseal_with_secret(&vault, AutoUnsealSecret {
+            value: Secret::new(recovery_phrase),
+            kind: AutoUnsealSourceKind::Env,
+        })
+        .await;
+
+        assert_eq!(result, AutoUnsealResult::Unsealed);
+        assert_eq!(
+            vault.status().await.unwrap(),
+            moltis_vault::VaultStatus::Unsealed
+        );
+    }
+
+    #[tokio::test]
+    async fn auto_unseal_rejects_wrong_recovery_key() {
+        let vault = test_vault().await;
+        vault.initialize("test-password-123").await.unwrap();
+        vault.seal().await;
+
+        let result = auto_unseal_with_secret(&vault, AutoUnsealSecret {
+            value: Secret::new("WRNG-WRNG-WRNG-WRNG-WRNG-WRNG-WRNG-WRNG".to_string()),
+            kind: AutoUnsealSourceKind::Env,
+        })
+        .await;
+
+        assert_eq!(result, AutoUnsealResult::BadCredential);
+        assert_eq!(
+            vault.status().await.unwrap(),
+            moltis_vault::VaultStatus::Sealed
+        );
+    }
+
+    #[tokio::test]
+    async fn auto_unseal_empty_secret_is_noop() {
+        let vault = test_vault().await;
+        vault.initialize("test-password-123").await.unwrap();
+        vault.seal().await;
+
+        let result = auto_unseal_with_secret(&vault, AutoUnsealSecret {
+            value: Secret::new(" \n ".to_string()),
+            kind: AutoUnsealSourceKind::File,
+        })
+        .await;
+
+        assert_eq!(result, AutoUnsealResult::EmptySecret);
+        assert_eq!(
+            vault.status().await.unwrap(),
+            moltis_vault::VaultStatus::Sealed
+        );
+    }
+}

--- a/crates/gateway/src/vault_lifecycle.rs
+++ b/crates/gateway/src/vault_lifecycle.rs
@@ -84,10 +84,17 @@ async fn auto_unseal_secret_from_env() -> Option<AutoUnsealSecret> {
 
     match (key, key_file) {
         (None, None) => None,
-        (Some(value), None) => Some(AutoUnsealSecret {
-            value: Secret::new(value),
-            kind: AutoUnsealSourceKind::Env,
-        }),
+        (Some(value), None) => {
+            tracing::warn!(
+                key_env = AUTO_UNSEAL_KEY_ENV,
+                file_env = AUTO_UNSEAL_KEY_FILE_ENV,
+                "vault auto-unseal recovery key supplied directly through the process environment; use a secret file when possible"
+            );
+            Some(AutoUnsealSecret {
+                value: Secret::new(value),
+                kind: AutoUnsealSourceKind::Env,
+            })
+        },
         (env_value, Some(path)) => {
             if env_value.is_some() {
                 tracing::warn!(
@@ -257,6 +264,25 @@ mod tests {
         .await;
 
         assert_eq!(result, AutoUnsealResult::Unsealed);
+        assert_eq!(
+            vault.status().await.unwrap(),
+            moltis_vault::VaultStatus::Unsealed
+        );
+    }
+
+    #[tokio::test]
+    async fn auto_unseal_already_unsealed_is_successful_noop() {
+        let vault = test_vault().await;
+        let recovery_key = vault.initialize("test-password-123").await.unwrap();
+        let recovery_phrase = recovery_key.phrase().to_owned();
+
+        let result = auto_unseal_with_secret(&vault, AutoUnsealSecret {
+            value: Secret::new(recovery_phrase),
+            kind: AutoUnsealSourceKind::Env,
+        })
+        .await;
+
+        assert_eq!(result, AutoUnsealResult::AlreadyUnsealed);
         assert_eq!(
             vault.status().await.unwrap(),
             moltis_vault::VaultStatus::Unsealed

--- a/crates/httpd/src/auth_routes/vault.rs
+++ b/crates/httpd/src/auth_routes/vault.rs
@@ -88,50 +88,7 @@ pub(super) async fn vault_recovery_handler(
 /// Migrate plaintext secrets to encrypted storage after vault unseal.
 #[cfg(feature = "vault")]
 pub(super) async fn run_vault_env_migration(state: &AuthState) {
-    if let Some(vault) = state.credential_store.vault() {
-        let pool = state.credential_store.db_pool();
-        match moltis_vault::migration::migrate_env_vars(vault, pool).await {
-            Ok(n) if n > 0 => {
-                tracing::info!(count = n, "migrated env vars to encrypted");
-            },
-            Ok(_) => {},
-            Err(e) => {
-                tracing::warn!(error = %e, "env var migration failed");
-            },
-        }
-        match moltis_vault::migration::migrate_ssh_keys(vault, pool).await {
-            Ok(n) if n > 0 => {
-                tracing::info!(count = n, "migrated ssh keys to encrypted");
-            },
-            Ok(_) => {},
-            Err(e) => {
-                tracing::warn!(error = %e, "ssh key migration failed");
-            },
-        }
-
-        // Migrate provider_keys.json (LLM + voice API keys) to encrypted storage.
-        // This uses `encrypt_json_file` which creates a `.enc` alongside the
-        // original instead of renaming it, so sync callers (KeyStore) can still
-        // read the plaintext until KeyStore gains a vault-aware read path.
-        if let Some(config_dir) = moltis_config::config_dir() {
-            let provider_keys_path = config_dir.join("provider_keys.json");
-            match moltis_vault::migration::encrypt_json_file(
-                vault,
-                &provider_keys_path,
-                "provider_keys",
-            )
-            .await
-            {
-                Ok(true) => {
-                    tracing::info!("encrypted provider_keys.json to vault storage");
-                },
-                Ok(false) => {},
-                Err(e) => {
-                    tracing::warn!(error = %e, "provider_keys.json encryption failed");
-                },
-            }
-        }
-    }
+    moltis_gateway::vault_lifecycle::run_vault_env_migration(&state.credential_store).await;
 }
 
 /// Start stored channel accounts after vault unseal.
@@ -144,61 +101,8 @@ pub(super) async fn run_vault_env_migration(state: &AuthState) {
 #[cfg(feature = "vault")]
 #[tracing::instrument(skip(state))]
 pub(super) async fn start_stored_channels_on_vault_unseal(state: &AuthState) {
-    let Some(registry) = state.gateway_state.services.channel_registry.as_ref() else {
-        tracing::debug!("no channel registry available, skipping channel startup on vault unseal");
-        return;
-    };
-    let Some(store) = state.gateway_state.services.channel_store.as_ref() else {
-        tracing::debug!("no channel store available, skipping channel startup on vault unseal");
-        return;
-    };
-
-    let stored = match store.list().await {
-        Ok(s) => s,
-        Err(e) => {
-            tracing::warn!(error = %e, "failed to list stored channels on vault unseal");
-            return;
-        },
-    };
-
-    if stored.is_empty() {
-        return;
-    }
-
-    for ch in stored {
-        // Skip channel types with no registered plugin.
-        if registry.get(&ch.channel_type).is_none() {
-            tracing::debug!(
-                account_id = ch.account_id,
-                channel_type = ch.channel_type,
-                "unsupported channel type on vault unseal, skipping stored account"
-            );
-            continue;
-        }
-
-        // Skip accounts that are already running.
-        if registry.resolve_channel_type(&ch.account_id).is_some() {
-            continue;
-        }
-
-        tracing::info!(
-            account_id = ch.account_id,
-            channel_type = ch.channel_type,
-            "starting stored channel on vault unseal"
-        );
-
-        if let Err(e) = registry
-            .start_account(&ch.channel_type, &ch.account_id, ch.config)
-            .await
-        {
-            tracing::warn!(
-                account_id = ch.account_id,
-                channel_type = ch.channel_type,
-                error = %e,
-                "failed to start stored channel on vault unseal"
-            );
-        }
-    }
+    moltis_gateway::vault_lifecycle::start_stored_channels_on_vault_unseal(&state.gateway_state)
+        .await;
 }
 
 #[cfg(test)]

--- a/docs/src/docker.md
+++ b/docs/src/docker.md
@@ -152,6 +152,26 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
 ```
 
+For unattended recovery after host reboots or in-place `/update`, store the
+vault recovery key as a Docker secret and point Moltis at the mounted file:
+
+```yaml
+services:
+  moltis:
+    image: ghcr.io/moltis-org/moltis:latest
+    environment:
+      MOLTIS_VAULT_AUTO_UNSEAL_KEY_FILE: /run/secrets/moltis_vault_recovery_key
+    secrets:
+      - moltis_vault_recovery_key
+
+secrets:
+  moltis_vault_recovery_key:
+    file: ./moltis-vault-recovery-key
+```
+
+This lets encrypted environment variables and channel credentials load during
+startup. Treat the secret file as sensitive as the vault recovery key itself.
+
 ### Coolify (Hetzner/VPS)
 
 For Coolify service stacks, use

--- a/docs/src/vault.md
+++ b/docs/src/vault.md
@@ -62,9 +62,10 @@ Uninitialized ──────────────► Unsealed
                               Sealed
 ```
 
-After a server restart, the vault is always in the **Sealed** state until
+After a server restart, the vault is normally in the **Sealed** state until
 the user logs in (which provides the password needed to derive the KEK and
-unwrap the DEK).
+unwrap the DEK). For unattended deployments, Moltis can also auto-unseal at
+startup from an explicitly configured recovery key.
 
 ## Lifecycle Integration
 
@@ -98,8 +99,36 @@ No new recovery key is generated during normal password rotation.
 
 ### Server restart
 
-The vault starts in **Sealed** state. All encrypted data is unreadable
-until the user logs in, which triggers unseal.
+The vault starts in **Sealed** state unless unattended auto-unseal is
+configured. All encrypted data is unreadable until the user logs in or the
+configured auto-unseal recovery key is accepted.
+
+### Unattended auto-unseal
+
+For servers that need to recover fully after a reboot or `/update`, set one
+of these environment variables:
+
+| Variable | Purpose |
+|----------|---------|
+| `MOLTIS_VAULT_AUTO_UNSEAL_KEY_FILE` | Path to a file containing the vault recovery key. Preferred for Docker/Kubernetes secrets. |
+| `MOLTIS_VAULT_AUTO_UNSEAL_KEY` | Vault recovery key value directly in the process environment. |
+
+If both are set, Moltis logs a warning and uses
+`MOLTIS_VAULT_AUTO_UNSEAL_KEY_FILE`.
+
+Auto-unseal runs immediately after the vault is opened from SQLite and before
+Moltis loads persisted environment variables, MCP server configuration, cron
+runtime environment, and stored channel accounts. That means encrypted env vars
+and channel credentials are available during normal startup rather than only
+after a manual browser unlock.
+
+```admonish warning
+Auto-unseal trades manual recovery for unattended availability. If an attacker
+can read both the Moltis database and the configured recovery-key env/file, they
+can decrypt vault-protected secrets. Prefer a Docker/Kubernetes secret file over
+a plain env var, restrict file permissions, and keep the recovery key out of
+`moltis.toml`.
+```
 
 ## Recovery Key
 


### PR DESCRIPTION
## Summary

- Add unattended vault auto-unseal from `MOLTIS_VAULT_AUTO_UNSEAL_KEY_FILE` or `MOLTIS_VAULT_AUTO_UNSEAL_KEY`.
- Run auto-unseal immediately after vault initialization and before persisted env vars, MCP runtime env, cron setup, and stored channels are loaded.
- Move post-unseal env/SSH/provider-key migration and stored-channel restart lifecycle into `moltis-gateway` so startup and HTTP unlock paths share behavior.
- Document Docker secret usage and the security tradeoff for unattended recovery.

## Validation

### Completed

- [x] `just format`
- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p moltis-gateway vault_lifecycle --no-default-features --features vault,voice`
- [x] `cargo test -p moltis-httpd starts_channels_successfully --features vault`
- [x] `just build-web-assets`
- [x] `just lint`

### Remaining

- [ ] Full `just test` was not run in this session.
- [ ] `cargo test -p moltis-gateway vault_lifecycle --all-features` was attempted, but macOS tried to configure `llama-cpp-sys-2` with CUDA enabled and failed because CUDA Toolkit is not installed locally.

## Manual QA

- Not manually exercised against a Docker deployment. The behavior is covered by focused vault lifecycle unit tests and the existing stored-channel restart test path.