### PR TITLE
feat(voice): add whisper-local STT provider, show all voice providers by default

### DIFF
--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -54,7 +54,7 @@ pub use {
         SessionExportMode, Timezone, ToolMode, ToolPolicyConfig, ToolRegistryMode, UserProfile,
         UserProfileWriteMode, VoiceConfig, VoiceElevenLabsConfig, VoiceOpenAiConfig,
         VoiceSttConfig, VoiceSttProvider, VoiceTtsConfig, VoiceTtsProvider, VoiceWhisperConfig,
-        WireApi, parse_byte_size,
+        VoiceWhisperLocalConfig, WireApi, parse_byte_size,
     },
     validate::{Diagnostic, Severity, ValidationResult},
 };

--- a/crates/config/src/schema/voice.rs
+++ b/crates/config/src/schema/voice.rs
@@ -246,6 +246,8 @@ pub struct VoiceSttConfig {
     pub elevenlabs: VoiceElevenLabsSttConfig,
     /// Voxtral local (vLLM server) settings.
     pub voxtral_local: VoiceVoxtralLocalConfig,
+    /// Whisper local (OpenAI-compatible server) settings.
+    pub whisper_local: VoiceWhisperLocalConfig,
     /// whisper-cli (whisper.cpp) settings.
     pub whisper_cli: VoiceWhisperCliConfig,
     /// sherpa-onnx offline settings.
@@ -265,6 +267,7 @@ impl Default for VoiceSttConfig {
             mistral: VoiceMistralSttConfig::default(),
             elevenlabs: VoiceElevenLabsSttConfig::default(),
             voxtral_local: VoiceVoxtralLocalConfig::default(),
+            whisper_local: VoiceWhisperLocalConfig::default(),
             whisper_cli: VoiceWhisperCliConfig::default(),
             sherpa_onnx: VoiceSherpaOnnxConfig::default(),
         }
@@ -366,6 +369,8 @@ pub enum VoiceSttProvider {
     ElevenLabs,
     #[serde(rename = "voxtral-local")]
     VoxtralLocal,
+    #[serde(rename = "whisper-local")]
+    WhisperLocal,
     #[serde(rename = "whisper-cli")]
     WhisperCli,
     #[serde(rename = "sherpa-onnx")]
@@ -383,6 +388,7 @@ impl VoiceSttProvider {
             Self::Mistral => "mistral",
             Self::ElevenLabs => "elevenlabs-stt",
             Self::VoxtralLocal => "voxtral-local",
+            Self::WhisperLocal => "whisper-local",
             Self::WhisperCli => "whisper-cli",
             Self::SherpaOnnx => "sherpa-onnx",
         }
@@ -398,6 +404,7 @@ impl VoiceSttProvider {
             "mistral" => Some(Self::Mistral),
             "elevenlabs" | "elevenlabs-stt" => Some(Self::ElevenLabs),
             "voxtral-local" => Some(Self::VoxtralLocal),
+            "whisper-local" => Some(Self::WhisperLocal),
             "whisper-cli" => Some(Self::WhisperCli),
             "sherpa-onnx" => Some(Self::SherpaOnnx),
             _ => None,
@@ -414,6 +421,7 @@ impl VoiceSttProvider {
             Self::Google => "Google Cloud",
             Self::Mistral => "Mistral AI",
             Self::VoxtralLocal => "Voxtral (Local)",
+            Self::WhisperLocal => "Whisper (Local)",
             Self::WhisperCli => "whisper.cpp",
             Self::SherpaOnnx => "sherpa-onnx",
             Self::ElevenLabs => "ElevenLabs Scribe",
@@ -430,6 +438,7 @@ impl VoiceSttProvider {
             Self::Google,
             Self::Mistral,
             Self::VoxtralLocal,
+            Self::WhisperLocal,
             Self::WhisperCli,
             Self::SherpaOnnx,
             Self::ElevenLabs,
@@ -665,6 +674,32 @@ impl Default for VoiceVoxtralLocalConfig {
         Self {
             enabled: true,
             endpoint: "http://localhost:8000".into(),
+            model: None,
+            language: None,
+        }
+    }
+}
+
+/// Whisper local (OpenAI-compatible server) configuration.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct VoiceWhisperLocalConfig {
+    /// Whether this provider is enabled.
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+    /// Server endpoint (default: http://localhost:8080).
+    pub endpoint: String,
+    /// Model to use (optional, server default if not set).
+    pub model: Option<String>,
+    /// Language hint (ISO 639-1 code).
+    pub language: Option<String>,
+}
+
+impl Default for VoiceWhisperLocalConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            endpoint: "http://localhost:8080".into(),
             model: None,
             language: None,
         }

--- a/crates/config/src/template.rs
+++ b/crates/config/src/template.rs
@@ -540,7 +540,7 @@ port = {port}                           # Port number (auto-generated for this i
 
 # [voice.tts]
 # enabled = true
-# providers = ["openai", "elevenlabs"]  # UI allowlist (empty = show all)
+# providers = []                        # UI allowlist (empty = show all)
 
 # Voice personas — named voice identities injected into TTS calls.
 # Personas are managed via the web UI (Settings > Voice > Voice Personas)
@@ -557,7 +557,12 @@ port = {port}                           # Port number (auto-generated for this i
 
 # [voice.stt]
 # enabled = true
-# providers = ["whisper", "mistral", "elevenlabs"]  # UI allowlist (empty = show all)
+# providers = []                        # UI allowlist (empty = show all)
+
+# [voice.stt.whisper_local]
+# endpoint = "http://localhost:8080"    # OpenAI-compatible transcription server
+# model = "whisper-large-v3"            # Model name (server-specific)
+# language = "en"                       # Optional ISO 639-1 hint
 
 # ══════════════════════════════════════════════════════════════════════════════
 # NGROK

--- a/crates/config/src/validate/schema_map.rs
+++ b/crates/config/src/validate/schema_map.rs
@@ -748,6 +748,15 @@ pub(super) fn build_schema_map() -> KnownKeys {
                             ])),
                         ),
                         (
+                            "whisper_local",
+                            Struct(HashMap::from([
+                                ("enabled", Leaf),
+                                ("endpoint", Leaf),
+                                ("model", Leaf),
+                                ("language", Leaf),
+                            ])),
+                        ),
+                        (
                             "whisper_cli",
                             Struct(HashMap::from([
                                 ("enabled", Leaf),

--- a/crates/config/src/validate/semantic.rs
+++ b/crates/config/src/validate/semantic.rs
@@ -714,6 +714,7 @@ pub(super) fn check_semantic_warnings(config: &MoltisConfig, diagnostics: &mut V
         "elevenlabs",
         "elevenlabs-stt",
         "voxtral-local",
+        "whisper-local",
         "whisper-cli",
         "sherpa-onnx",
     ];

--- a/crates/gateway/src/methods/voice.rs
+++ b/crates/gateway/src/methods/voice.rs
@@ -153,6 +153,7 @@ pub(super) enum VoiceProviderId {
     Mistral,
     ElevenlabsStt,
     VoxtralLocal,
+    WhisperLocal,
     WhisperCli,
     SherpaOnnx,
 }
@@ -272,6 +273,13 @@ impl VoiceProviderId {
                 key_url_label: None,
                 hint: None,
             },
+            Self::WhisperLocal => VoiceProviderMeta {
+                description: "Local Whisper via OpenAI-compatible server (faster-whisper-server, whisper.cpp server, LocalAI)",
+                key_placeholder: None,
+                key_url: None,
+                key_url_label: None,
+                hint: None,
+            },
         }
     }
 
@@ -295,6 +303,7 @@ impl VoiceProviderId {
             "mistral" => Some(Self::Mistral),
             "elevenlabs" | "elevenlabs-stt" => Some(Self::ElevenlabsStt),
             "voxtral-local" => Some(Self::VoxtralLocal),
+            "whisper-local" => Some(Self::WhisperLocal),
             "whisper-cli" => Some(Self::WhisperCli),
             "sherpa-onnx" => Some(Self::SherpaOnnx),
             _ => None,
@@ -519,8 +528,10 @@ pub(super) async fn detect_voice_providers(
         ),
     ];
 
-    // Check voxtral local server
+    // Check local servers
     let voxtral_server_running = check_vllm_server(&config.voice.stt.voxtral_local.endpoint).await;
+    let whisper_local_server_running =
+        check_vllm_server(&config.voice.stt.whisper_local.endpoint).await;
 
     // Build STT providers list
     let stt_providers = vec![
@@ -641,6 +652,22 @@ pub(super) async fn detect_voice_providers(
             None,
             None,
             if !voxtral_server_running {
+                Some("server not running")
+            } else {
+                None
+            },
+        ),
+        build_provider_info(
+            VoiceProviderId::WhisperLocal,
+            "Whisper (Local)",
+            "stt",
+            "local",
+            whisper_local_server_running,
+            config.voice.stt.whisper_local.enabled && config.voice.stt.enabled,
+            false,
+            None,
+            None,
+            if !whisper_local_server_running {
                 Some("server not running")
             } else {
                 None
@@ -1092,6 +1119,17 @@ pub(super) fn apply_voice_provider_settings(
                 .and_then(|v| u32::try_from(v).ok())
             {
                 cfg.voice.tts.piper.speaker_id = Some(speaker_id);
+            }
+        },
+        "whisper-local" => {
+            if let Some(endpoint) = get_string("endpoint") {
+                cfg.voice.stt.whisper_local.endpoint = endpoint;
+            }
+            if let Some(model) = get_string("model") {
+                cfg.voice.stt.whisper_local.model = Some(model);
+            }
+            if let Some(language) = get_string("language") {
+                cfg.voice.stt.whisper_local.language = Some(language);
             }
         },
         _ => {},

--- a/crates/gateway/src/voice/stt_service.rs
+++ b/crates/gateway/src/voice/stt_service.rs
@@ -10,7 +10,8 @@ use {
 
 use moltis_voice::{
     AudioFormat, DeepgramStt, ElevenLabsStt, GoogleStt, GroqStt, MistralStt, SherpaOnnxStt,
-    SttProvider, SttProviderId, TranscribeRequest, VoxtralLocalStt, WhisperCliStt, WhisperStt,
+    SttProvider, SttProviderId, TranscribeRequest, VoxtralLocalStt, WhisperCliStt, WhisperLocalStt,
+    WhisperStt,
 };
 
 use crate::services::{ServiceResult, SttService};
@@ -170,6 +171,18 @@ impl LiveSttService {
                     None
                 }
             },
+            SttProviderId::WhisperLocal => {
+                let provider = WhisperLocalStt::with_options(
+                    Some(cfg.voice.stt.whisper_local.endpoint.clone()),
+                    cfg.voice.stt.whisper_local.model.clone(),
+                    cfg.voice.stt.whisper_local.language.clone(),
+                );
+                if provider.is_configured() {
+                    Some(Box::new(provider) as Box<dyn SttProvider + Send + Sync>)
+                } else {
+                    None
+                }
+            },
             SttProviderId::WhisperCli => {
                 let provider = WhisperCliStt::with_options(
                     cfg.voice.stt.whisper_cli.binary_path.clone(),
@@ -228,6 +241,7 @@ impl LiveSttService {
                 cfg.voice.stt.mistral.api_key.is_some(),
             ),
             (SttProviderId::VoxtralLocal, true), // Always available
+            (SttProviderId::WhisperLocal, true), // Always available
             (
                 SttProviderId::WhisperCli,
                 cfg.voice.stt.whisper_cli.model_path.is_some(),

--- a/crates/voice/src/config.rs
+++ b/crates/voice/src/config.rs
@@ -273,6 +273,9 @@ pub struct SttConfig {
     /// Voxtral local (vLLM) settings.
     pub voxtral_local: VoxtralLocalConfig,
 
+    /// Whisper local (OpenAI-compatible server) settings.
+    pub whisper_local: WhisperLocalConfig,
+
     /// whisper-cli (whisper.cpp) settings.
     pub whisper_cli: WhisperCliConfig,
 
@@ -294,6 +297,7 @@ impl Default for SttConfig {
             google: GoogleSttConfig::default(),
             mistral: MistralSttConfig::default(),
             voxtral_local: VoxtralLocalConfig::default(),
+            whisper_local: WhisperLocalConfig::default(),
             whisper_cli: WhisperCliConfig::default(),
             sherpa_onnx: SherpaOnnxConfig::default(),
             elevenlabs: ElevenLabsSttConfig::default(),
@@ -457,6 +461,30 @@ impl Default for VoxtralLocalConfig {
     fn default() -> Self {
         Self {
             endpoint: "http://localhost:8000".into(),
+            model: None,
+            language: None,
+        }
+    }
+}
+
+/// Whisper local (OpenAI-compatible server) configuration.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct WhisperLocalConfig {
+    /// Server endpoint (default: http://localhost:8080).
+    pub endpoint: String,
+
+    /// Model to use (optional, server default if not set).
+    pub model: Option<String>,
+
+    /// Language hint (ISO 639-1 code).
+    pub language: Option<String>,
+}
+
+impl Default for WhisperLocalConfig {
+    fn default() -> Self {
+        Self {
+            endpoint: "http://localhost:8080".into(),
             model: None,
             language: None,
         }

--- a/crates/voice/src/lib.rs
+++ b/crates/voice/src/lib.rs
@@ -13,11 +13,11 @@ pub use {
         GoogleSttConfig, GoogleTtsConfig, GroqSttConfig, MistralSttConfig, OpenAiTtsConfig,
         PiperTtsConfig, SherpaOnnxConfig, SttConfig, SttProviderId, TtsAutoMode, TtsConfig,
         TtsProviderId, VoiceConfig, VoicePersona, VoicePersonaPrompt, VoicePersonaProviderBinding,
-        VoxtralLocalConfig, WhisperCliConfig, WhisperConfig,
+        VoxtralLocalConfig, WhisperCliConfig, WhisperConfig, WhisperLocalConfig,
     },
     stt::{
         DeepgramStt, ElevenLabsStt, GoogleStt, GroqStt, MistralStt, SherpaOnnxStt, SttProvider,
-        TranscribeRequest, Transcript, VoxtralLocalStt, WhisperCliStt, WhisperStt,
+        TranscribeRequest, Transcript, VoxtralLocalStt, WhisperCliStt, WhisperLocalStt, WhisperStt,
     },
     tts::{
         AudioFormat, AudioOutput, CoquiTts, ElevenLabsTts, GoogleTts, OpenAiTts, PiperTts,

--- a/crates/voice/src/stt/mod.rs
+++ b/crates/voice/src/stt/mod.rs
@@ -7,15 +7,17 @@ mod google;
 mod groq;
 mod mistral;
 pub mod mock;
+mod openai_compat;
 mod sherpa_onnx;
 mod voxtral_local;
 mod whisper;
 mod whisper_cli;
+mod whisper_local;
 
 pub use {
     deepgram::DeepgramStt, elevenlabs::ElevenLabsStt, google::GoogleStt, groq::GroqStt,
     mistral::MistralStt, mock::MockStt, sherpa_onnx::SherpaOnnxStt, voxtral_local::VoxtralLocalStt,
-    whisper::WhisperStt, whisper_cli::WhisperCliStt,
+    whisper::WhisperStt, whisper_cli::WhisperCliStt, whisper_local::WhisperLocalStt,
 };
 
 use {

--- a/crates/voice/src/stt/openai_compat.rs
+++ b/crates/voice/src/stt/openai_compat.rs
@@ -1,0 +1,153 @@
+//! Shared OpenAI-compatible transcription logic.
+//!
+//! Used by providers that speak the `/v1/audio/transcriptions` protocol:
+//! `voxtral-local`, `whisper-local`, and any future OpenAI-compat STT server.
+
+use {
+    anyhow::{Context, Result, anyhow},
+    reqwest::{
+        Client,
+        multipart::{Form, Part},
+    },
+    serde::Deserialize,
+};
+
+use {
+    super::{Transcript, Word},
+    crate::tts::AudioFormat,
+};
+
+/// Send an OpenAI-compatible `/v1/audio/transcriptions` multipart request
+/// and return a [`Transcript`].
+pub async fn transcribe_openai_compat(
+    client: &Client,
+    endpoint: &str,
+    audio: &[u8],
+    format: AudioFormat,
+    model: Option<&str>,
+    language: Option<&str>,
+    server_label: &str,
+) -> Result<Transcript> {
+    let filename = format!("audio.{}", format.extension());
+    let mime_type = format.mime_type();
+
+    let file_part = Part::bytes(audio.to_vec())
+        .file_name(filename)
+        .mime_str(mime_type)
+        .context("failed to create file part")?;
+
+    let mut form = Form::new()
+        .part("file", file_part)
+        .text("response_format", "verbose_json");
+
+    if let Some(model) = model {
+        form = form.text("model", model.to_owned());
+    }
+
+    if let Some(language) = language {
+        form = form.text("language", language.to_owned());
+    }
+
+    let url = format!("{}/v1/audio/transcriptions", endpoint.trim_end_matches('/'));
+    let response = client
+        .post(&url)
+        .multipart(form)
+        .send()
+        .await
+        .with_context(|| format!("failed to send request to {server_label} server"))?;
+
+    if !response.status().is_success() {
+        let status = response.status();
+        let body = response.text().await.unwrap_or_default();
+        return Err(anyhow!(
+            "{server_label} transcription request failed: {status} - {body}",
+        ));
+    }
+
+    let compat_response: OpenAiCompatResponse = response
+        .json()
+        .await
+        .with_context(|| format!("failed to parse {server_label} response"))?;
+
+    Ok(Transcript {
+        text: compat_response.text,
+        language: compat_response.language,
+        confidence: None,
+        duration_seconds: compat_response.duration,
+        words: compat_response.words.map(|words| {
+            words
+                .into_iter()
+                .map(|w| Word {
+                    word: w.word,
+                    start: w.start,
+                    end: w.end,
+                })
+                .collect()
+        }),
+    })
+}
+
+/// Check if an OpenAI-compatible server is reachable via its `/health` endpoint.
+pub async fn check_server_health(client: &Client, endpoint: &str) -> bool {
+    let health_url = format!("{}/health", endpoint.trim_end_matches('/'));
+    client
+        .get(&health_url)
+        .timeout(std::time::Duration::from_secs(2))
+        .send()
+        .await
+        .is_ok_and(|r| r.status().is_success())
+}
+
+// ── API Types (OpenAI-compatible verbose_json response) ─────────────────────
+
+#[derive(Debug, Deserialize)]
+struct OpenAiCompatResponse {
+    text: String,
+    #[serde(default)]
+    language: Option<String>,
+    #[serde(default)]
+    duration: Option<f32>,
+    #[serde(default)]
+    words: Option<Vec<OpenAiCompatWord>>,
+}
+
+#[derive(Debug, Deserialize)]
+struct OpenAiCompatWord {
+    word: String,
+    start: f32,
+    end: f32,
+}
+
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_response_parsing_full() {
+        let json = r#"{
+            "text": "Hello, how are you?",
+            "language": "en",
+            "duration": 2.5,
+            "words": [
+                {"word": "Hello", "start": 0.0, "end": 0.5},
+                {"word": "how", "start": 0.6, "end": 0.8}
+            ]
+        }"#;
+
+        let response: OpenAiCompatResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(response.text, "Hello, how are you?");
+        assert_eq!(response.language, Some("en".into()));
+        assert_eq!(response.duration, Some(2.5));
+        assert_eq!(response.words.as_ref().unwrap().len(), 2);
+    }
+
+    #[test]
+    fn test_response_parsing_minimal() {
+        let json = r#"{"text": "Hello"}"#;
+        let response: OpenAiCompatResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(response.text, "Hello");
+        assert!(response.language.is_none());
+        assert!(response.words.is_none());
+    }
+}

--- a/crates/voice/src/stt/whisper_local.rs
+++ b/crates/voice/src/stt/whisper_local.rs
@@ -6,7 +6,7 @@
 //! Example with faster-whisper-server:
 //! ```bash
 //! pip install faster-whisper-server
-//! faster-whisper-server --model Systran/faster-whisper-large-v3
+//! faster-whisper-server --model Systran/faster-whisper-large-v3 --port 8080
 //! ```
 
 use {

--- a/crates/voice/src/stt/whisper_local.rs
+++ b/crates/voice/src/stt/whisper_local.rs
@@ -1,13 +1,12 @@
-//! Local Voxtral STT provider via vLLM server.
+//! Local Whisper STT provider via an OpenAI-compatible server.
 //!
-//! Connects to a locally running vLLM server serving the Voxtral model.
-//! The server exposes an OpenAI-compatible transcription endpoint.
+//! Works with any server that implements the `/v1/audio/transcriptions`
+//! endpoint: faster-whisper-server, whisper.cpp server, LocalAI, etc.
 //!
-//! Setup:
+//! Example with faster-whisper-server:
 //! ```bash
-//! pip install "vllm[audio]"
-//! vllm serve mistralai/Voxtral-Mini-3B-2507 \
-//!   --tokenizer_mode mistral --config_format mistral --load_format mistral
+//! pip install faster-whisper-server
+//! faster-whisper-server --model Systran/faster-whisper-large-v3
 //! ```
 
 use {
@@ -18,26 +17,26 @@ use {
 
 use super::{SttProvider, TranscribeRequest, Transcript, openai_compat};
 
-/// Default vLLM server endpoint.
-const DEFAULT_ENDPOINT: &str = "http://localhost:8000";
+/// Default local server endpoint.
+const DEFAULT_ENDPOINT: &str = "http://localhost:8080";
 
-/// Local Voxtral STT provider via vLLM.
+/// Local Whisper STT provider via an OpenAI-compatible server.
 #[derive(Clone, Debug)]
-pub struct VoxtralLocalStt {
+pub struct WhisperLocalStt {
     client: Client,
     endpoint: String,
     model: Option<String>,
     language: Option<String>,
 }
 
-impl Default for VoxtralLocalStt {
+impl Default for WhisperLocalStt {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl VoxtralLocalStt {
-    /// Create a new local Voxtral STT provider with default settings.
+impl WhisperLocalStt {
+    /// Create a new local Whisper STT provider with default settings.
     #[must_use]
     pub fn new() -> Self {
         Self {
@@ -65,26 +64,24 @@ impl VoxtralLocalStt {
 }
 
 #[async_trait]
-impl SttProvider for VoxtralLocalStt {
+impl SttProvider for WhisperLocalStt {
     fn id(&self) -> &'static str {
-        "voxtral-local"
+        "whisper-local"
     }
 
     fn name(&self) -> &'static str {
-        "Voxtral (Local)"
+        "Whisper (Local)"
     }
 
     fn is_configured(&self) -> bool {
-        // We can't do async check in is_configured, so we require explicit configuration.
-        // The user must either set a non-default endpoint or specify a model.
-        // The actual server check happens at transcription time.
+        // Require explicit configuration: non-default endpoint or a model specified.
         self.model.is_some() || self.endpoint != DEFAULT_ENDPOINT
     }
 
     async fn transcribe(&self, request: TranscribeRequest) -> Result<Transcript> {
         if !openai_compat::check_server_health(&self.client, &self.endpoint).await {
             return Err(anyhow!(
-                "vLLM server not reachable at {}. Start it with: vllm serve mistralai/Voxtral-Mini-3B-2507 --tokenizer_mode mistral --config_format mistral --load_format mistral",
+                "Whisper server not reachable at {}. Start an OpenAI-compatible Whisper server (e.g. faster-whisper-server, whisper.cpp server, or LocalAI).",
                 self.endpoint
             ));
         }
@@ -98,7 +95,7 @@ impl SttProvider for VoxtralLocalStt {
             request.format,
             self.model.as_deref(),
             language.as_deref(),
-            "vLLM",
+            "whisper-local",
         )
         .await
     }
@@ -111,54 +108,47 @@ mod tests {
 
     #[test]
     fn test_provider_metadata() {
-        let provider = VoxtralLocalStt::new();
-        assert_eq!(provider.id(), "voxtral-local");
-        assert_eq!(provider.name(), "Voxtral (Local)");
-        // Not configured by default (requires explicit model or non-default endpoint)
+        let provider = WhisperLocalStt::new();
+        assert_eq!(provider.id(), "whisper-local");
+        assert_eq!(provider.name(), "Whisper (Local)");
         assert!(!provider.is_configured());
     }
 
     #[test]
     fn test_is_configured_with_model() {
-        let provider = VoxtralLocalStt::with_options(None, Some("my-model".into()), None);
+        let provider = WhisperLocalStt::with_options(None, Some("large-v3".into()), None);
         assert!(provider.is_configured());
     }
 
     #[test]
     fn test_is_configured_with_custom_endpoint() {
         let provider =
-            VoxtralLocalStt::with_options(Some("http://localhost:9000".into()), None, None);
+            WhisperLocalStt::with_options(Some("http://localhost:9000".into()), None, None);
         assert!(provider.is_configured());
     }
 
     #[test]
     fn test_with_options() {
-        let provider = VoxtralLocalStt::with_options(
+        let provider = WhisperLocalStt::with_options(
             Some("http://localhost:9000".into()),
-            Some("mistralai/Voxtral-Mini-3B-2507".into()),
+            Some("large-v3".into()),
             Some("en".into()),
         );
         assert_eq!(provider.endpoint, "http://localhost:9000");
-        assert_eq!(
-            provider.model,
-            Some("mistralai/Voxtral-Mini-3B-2507".into())
-        );
+        assert_eq!(provider.model, Some("large-v3".into()));
         assert_eq!(provider.language, Some("en".into()));
     }
 
     #[test]
     fn test_default_endpoint() {
-        let provider = VoxtralLocalStt::new();
-        assert_eq!(provider.endpoint, "http://localhost:8000");
+        let provider = WhisperLocalStt::new();
+        assert_eq!(provider.endpoint, "http://localhost:8080");
     }
 
     #[tokio::test]
     async fn test_transcribe_server_not_running() {
-        let provider = VoxtralLocalStt::with_options(
-            Some("http://localhost:59999".into()), // Unlikely to be in use
-            None,
-            None,
-        );
+        let provider =
+            WhisperLocalStt::with_options(Some("http://localhost:59998".into()), None, None);
         let request = TranscribeRequest {
             audio: Bytes::from_static(b"fake audio"),
             format: AudioFormat::Mp3,

--- a/crates/voice/src/stt/whisper_local.rs
+++ b/crates/voice/src/stt/whisper_local.rs
@@ -74,8 +74,10 @@ impl SttProvider for WhisperLocalStt {
     }
 
     fn is_configured(&self) -> bool {
-        // Require explicit configuration: non-default endpoint or a model specified.
-        self.model.is_some() || self.endpoint != DEFAULT_ENDPOINT
+        // Always report as configured — the actual server reachability check
+        // happens at transcription time. The `enabled` field in the config
+        // gates whether this provider is offered to users.
+        true
     }
 
     async fn transcribe(&self, request: TranscribeRequest) -> Result<Transcript> {
@@ -111,19 +113,7 @@ mod tests {
         let provider = WhisperLocalStt::new();
         assert_eq!(provider.id(), "whisper-local");
         assert_eq!(provider.name(), "Whisper (Local)");
-        assert!(!provider.is_configured());
-    }
-
-    #[test]
-    fn test_is_configured_with_model() {
-        let provider = WhisperLocalStt::with_options(None, Some("large-v3".into()), None);
-        assert!(provider.is_configured());
-    }
-
-    #[test]
-    fn test_is_configured_with_custom_endpoint() {
-        let provider =
-            WhisperLocalStt::with_options(Some("http://localhost:9000".into()), None, None);
+        // Always configured — runtime health check gates actual use
         assert!(provider.is_configured());
     }
 

--- a/crates/web/src/templates/index.html
+++ b/crates/web/src/templates/index.html
@@ -322,6 +322,24 @@ endpoint = "http://localhost:8000"</code>
   <strong>Languages:</strong> English, French, German, Spanish, Portuguese, Italian, Dutch, Polish, Swedish, Norwegian, Danish, Finnish, Arabic
 </div>
 
+<div id="voice-whisper-local-instructions" class="text-xs text-[var(--muted)]" style="display:none;line-height:1.6;">
+  Run any OpenAI-compatible Whisper server locally. Popular choices:<br /><br />
+  <strong>faster-whisper-server</strong> (recommended):<br />
+  <code class="font-mono text-xs block my-1 p-1.5 bg-[var(--bg)] rounded whitespace-pre-wrap">pip install faster-whisper-server
+faster-whisper-server --model Systran/faster-whisper-large-v3</code>
+  <br />
+  <strong>whisper.cpp server:</strong><br />
+  <code class="font-mono text-xs block my-1 p-1.5 bg-[var(--bg)] rounded whitespace-pre-wrap">whisper-server --model ggml-large-v3.bin --port 8080</code>
+  <br />
+  <strong>Configuration:</strong><br />
+  Add to your <code class="font-mono text-xs">moltis.toml</code>:
+  <code class="font-mono text-xs block my-1 p-1.5 bg-[var(--bg)] rounded whitespace-pre-wrap">[voice.stt]
+provider = "whisper-local"
+
+[voice.stt.whisper_local]
+endpoint = "http://localhost:8080"</code>
+</div>
+
 <div id="voice-voxtral-requirements-ok" class="text-xs p-2 rounded-md mb-3 border border-[var(--accent)]" style="display:none;background:color-mix(in srgb, var(--accent) 10%, transparent);">
   <div class="font-medium text-[var(--accent)]">✓ System requirements met</div>
   <div class="text-[var(--muted)] mt-1">

--- a/crates/web/src/templates/index.html
+++ b/crates/web/src/templates/index.html
@@ -326,7 +326,7 @@ endpoint = "http://localhost:8000"</code>
   Run any OpenAI-compatible Whisper server locally. Popular choices:<br /><br />
   <strong>faster-whisper-server</strong> (recommended):<br />
   <code class="font-mono text-xs block my-1 p-1.5 bg-[var(--bg)] rounded whitespace-pre-wrap">pip install faster-whisper-server
-faster-whisper-server --model Systran/faster-whisper-large-v3</code>
+faster-whisper-server --model Systran/faster-whisper-large-v3 --port 8080</code>
   <br />
   <strong>whisper.cpp server:</strong><br />
   <code class="font-mono text-xs block my-1 p-1.5 bg-[var(--bg)] rounded whitespace-pre-wrap">whisper-server --model ggml-large-v3.bin --port 8080</code>

--- a/crates/web/ui/e2e/specs/voice-providers.spec.js
+++ b/crates/web/ui/e2e/specs/voice-providers.spec.js
@@ -1,29 +1,74 @@
 const { expect, test } = require("../base-test");
-const { navigateAndWait, waitForWsConnected, watchPageErrors } = require("../helpers");
+const { navigateAndWait, waitForWsConnected, watchPageErrors, sendRpcFromPage, expectRpcOk } = require("../helpers");
 
 async function openVoicePage(page) {
 	await navigateAndWait(page, "/settings/voice");
 	await expect.poll(() => new URL(page.url()).pathname).toBe("/settings/voice");
 }
 
-test.describe("Voice provider settings", () => {
+async function waitForProviderCards(page) {
+	await waitForWsConnected(page);
+	await expect(page.locator(".provider-card").first()).toBeVisible({ timeout: 15_000 });
+}
+
+/**
+ * Find a provider card by its display name text.
+ */
+function providerCard(page, name) {
+	return page
+		.locator(".provider-card")
+		.filter({ has: page.getByText(name, { exact: true }) })
+		.first();
+}
+
+/**
+ * Open the Configure modal for a provider, fill the API key, and save.
+ * Returns true if the modal closed (success), false if the configure
+ * button was not visible (provider may already be configured).
+ */
+async function configureCloudProvider(page, providerName, apiKey) {
+	const card = providerCard(page, providerName);
+	await expect(card).toBeVisible();
+
+	const configureBtn = card.getByRole("button", { name: "Configure", exact: true });
+	if (!(await configureBtn.isVisible().catch(() => false))) return false;
+
+	await configureBtn.click();
+
+	const modal = page
+		.locator(".modal-box")
+		.filter({ has: page.getByText(providerName, { exact: false }) })
+		.last();
+	await expect(modal).toBeVisible();
+
+	// Fill API key field — cloud providers show an input with type=password or autocomplete=new-password
+	const keyInput = modal.locator('input[type="password"], input[autocomplete="new-password"]').first();
+	if (await keyInput.isVisible().catch(() => false)) {
+		await keyInput.fill(apiKey);
+	}
+
+	await modal.getByRole("button", { name: "Save", exact: true }).click();
+	await expect(modal).toBeHidden({ timeout: 10_000 });
+	return true;
+}
+
+// ── Provider Visibility ─────────────────────────────────────────────────────
+
+test.describe("Voice provider visibility", () => {
 	test("voice settings page loads without JS errors", async ({ page }) => {
-		var pageErrors = watchPageErrors(page);
+		const pageErrors = watchPageErrors(page);
 		await openVoicePage(page);
-		await waitForWsConnected(page);
-		// Wait for provider cards to render (STT or TTS section)
-		await expect(page.locator(".provider-card").first()).toBeVisible({ timeout: 15_000 });
+		await waitForProviderCards(page);
 		expect(pageErrors).toEqual([]);
 	});
 
 	test("all STT providers are visible by default", async ({ page }) => {
 		await openVoicePage(page);
-		await waitForWsConnected(page);
-		await expect(page.locator(".provider-card").first()).toBeVisible({ timeout: 15_000 });
+		await waitForProviderCards(page);
 
-		var pageText = await page.locator("#pageContent").innerText();
+		const pageText = await page.locator("#pageContent").innerText();
 
-		// Cloud STT providers
+		// Cloud STT
 		expect(pageText).toContain("OpenAI Whisper");
 		expect(pageText).toContain("Groq");
 		expect(pageText).toContain("Deepgram");
@@ -31,7 +76,7 @@ test.describe("Voice provider settings", () => {
 		expect(pageText).toContain("Mistral");
 		expect(pageText).toContain("ElevenLabs Scribe");
 
-		// Local STT providers
+		// Local STT
 		expect(pageText).toContain("Voxtral (Local)");
 		expect(pageText).toContain("Whisper (Local)");
 		expect(pageText).toContain("whisper.cpp");
@@ -40,10 +85,9 @@ test.describe("Voice provider settings", () => {
 
 	test("all TTS providers are visible by default", async ({ page }) => {
 		await openVoicePage(page);
-		await waitForWsConnected(page);
-		await expect(page.locator(".provider-card").first()).toBeVisible({ timeout: 15_000 });
+		await waitForProviderCards(page);
 
-		var pageText = await page.locator("#pageContent").innerText();
+		const pageText = await page.locator("#pageContent").innerText();
 
 		expect(pageText).toContain("ElevenLabs");
 		expect(pageText).toContain("OpenAI TTS");
@@ -51,37 +95,235 @@ test.describe("Voice provider settings", () => {
 		expect(pageText).toContain("Piper");
 		expect(pageText).toContain("Coqui TTS");
 	});
+});
 
-	test("whisper-local provider shows setup instructions", async ({ page }) => {
+// ── Local Provider Instructions ─────────────────────────────────────────────
+
+test.describe("Local provider setup instructions", () => {
+	test("whisper-local shows setup instructions", async ({ page }) => {
 		await openVoicePage(page);
-		await waitForWsConnected(page);
-		await expect(page.locator(".provider-card").first()).toBeVisible({ timeout: 15_000 });
+		await waitForProviderCards(page);
 
-		// Find Whisper (Local) card and click Configure
-		var whisperLocalCard = page.locator(".provider-card", { hasText: "Whisper (Local)" });
-		await expect(whisperLocalCard).toBeVisible();
+		const card = providerCard(page, "Whisper (Local)");
+		await expect(card).toBeVisible();
 
-		// Click configure button on the card
-		var configureBtn = whisperLocalCard.getByRole("button", { name: /configure/i });
+		const configureBtn = card.getByRole("button", { name: /configure/i });
 		if (await configureBtn.isVisible().catch(() => false)) {
 			await configureBtn.click();
-			// Should show the setup instructions modal/panel
 			await expect(page.getByText("faster-whisper-server")).toBeVisible({ timeout: 5_000 });
 		}
 	});
 
-	test("voxtral-local provider shows setup instructions", async ({ page }) => {
+	test("voxtral-local shows setup instructions", async ({ page }) => {
 		await openVoicePage(page);
-		await waitForWsConnected(page);
-		await expect(page.locator(".provider-card").first()).toBeVisible({ timeout: 15_000 });
+		await waitForProviderCards(page);
 
-		var voxtralCard = page.locator(".provider-card", { hasText: "Voxtral (Local)" });
-		await expect(voxtralCard).toBeVisible();
+		const card = providerCard(page, "Voxtral (Local)");
+		await expect(card).toBeVisible();
 
-		var configureBtn = voxtralCard.getByRole("button", { name: /configure/i });
+		const configureBtn = card.getByRole("button", { name: /configure/i });
 		if (await configureBtn.isVisible().catch(() => false)) {
 			await configureBtn.click();
 			await expect(page.getByText("vllm serve")).toBeVisible({ timeout: 5_000 });
 		}
+	});
+});
+
+// ── Cloud STT Provider Configuration ────────────────────────────────────────
+//
+// These tests require real API keys passed via environment variables.
+// They skip gracefully when the key is not set.
+
+const OPENAI_KEY = process.env.MOLTIS_E2E_OPENAI_API_KEY || "";
+const GROQ_KEY = process.env.MOLTIS_E2E_GROQ_API_KEY || "";
+const DEEPGRAM_KEY = process.env.MOLTIS_E2E_DEEPGRAM_API_KEY || "";
+const GOOGLE_KEY = process.env.MOLTIS_E2E_GOOGLE_API_KEY || "";
+const MISTRAL_KEY = process.env.MOLTIS_E2E_MISTRAL_API_KEY || "";
+const ELEVENLABS_KEY = process.env.MOLTIS_E2E_ELEVENLABS_API_KEY || "";
+
+test.describe("Cloud STT provider configuration", () => {
+	test("configure OpenAI Whisper with API key", async ({ page }) => {
+		test.skip(!OPENAI_KEY, "requires MOLTIS_E2E_OPENAI_API_KEY");
+		const pageErrors = watchPageErrors(page);
+		await openVoicePage(page);
+		await waitForProviderCards(page);
+
+		await configureCloudProvider(page, "OpenAI Whisper", OPENAI_KEY);
+
+		// After saving, the provider card should show as available
+		const card = providerCard(page, "OpenAI Whisper");
+		await expect(card).toBeVisible();
+
+		expect(pageErrors).toEqual([]);
+	});
+
+	test("configure Groq with API key", async ({ page }) => {
+		test.skip(!GROQ_KEY, "requires MOLTIS_E2E_GROQ_API_KEY");
+		const pageErrors = watchPageErrors(page);
+		await openVoicePage(page);
+		await waitForProviderCards(page);
+
+		await configureCloudProvider(page, "Groq", GROQ_KEY);
+
+		const card = providerCard(page, "Groq");
+		await expect(card).toBeVisible();
+
+		expect(pageErrors).toEqual([]);
+	});
+
+	test("configure Deepgram with API key", async ({ page }) => {
+		test.skip(!DEEPGRAM_KEY, "requires MOLTIS_E2E_DEEPGRAM_API_KEY");
+		const pageErrors = watchPageErrors(page);
+		await openVoicePage(page);
+		await waitForProviderCards(page);
+
+		await configureCloudProvider(page, "Deepgram", DEEPGRAM_KEY);
+
+		const card = providerCard(page, "Deepgram");
+		await expect(card).toBeVisible();
+
+		expect(pageErrors).toEqual([]);
+	});
+
+	test("configure Google Cloud STT with API key", async ({ page }) => {
+		test.skip(!GOOGLE_KEY, "requires MOLTIS_E2E_GOOGLE_API_KEY");
+		const pageErrors = watchPageErrors(page);
+		await openVoicePage(page);
+		await waitForProviderCards(page);
+
+		await configureCloudProvider(page, "Google Cloud STT", GOOGLE_KEY);
+
+		const card = providerCard(page, "Google Cloud STT");
+		await expect(card).toBeVisible();
+
+		expect(pageErrors).toEqual([]);
+	});
+
+	test("configure Mistral (Voxtral) with API key", async ({ page }) => {
+		test.skip(!MISTRAL_KEY, "requires MOLTIS_E2E_MISTRAL_API_KEY");
+		const pageErrors = watchPageErrors(page);
+		await openVoicePage(page);
+		await waitForProviderCards(page);
+
+		await configureCloudProvider(page, "Mistral (Voxtral)", MISTRAL_KEY);
+
+		const card = providerCard(page, "Mistral (Voxtral)");
+		await expect(card).toBeVisible();
+
+		expect(pageErrors).toEqual([]);
+	});
+
+	test("configure ElevenLabs Scribe with API key", async ({ page }) => {
+		test.skip(!ELEVENLABS_KEY, "requires MOLTIS_E2E_ELEVENLABS_API_KEY");
+		const pageErrors = watchPageErrors(page);
+		await openVoicePage(page);
+		await waitForProviderCards(page);
+
+		await configureCloudProvider(page, "ElevenLabs Scribe", ELEVENLABS_KEY);
+
+		const card = providerCard(page, "ElevenLabs Scribe");
+		await expect(card).toBeVisible();
+
+		expect(pageErrors).toEqual([]);
+	});
+});
+
+// ── Cloud TTS Provider Configuration ────────────────────────────────────────
+
+test.describe("Cloud TTS provider configuration", () => {
+	test("configure OpenAI TTS with API key", async ({ page }) => {
+		test.skip(!OPENAI_KEY, "requires MOLTIS_E2E_OPENAI_API_KEY");
+		const pageErrors = watchPageErrors(page);
+		await openVoicePage(page);
+		await waitForProviderCards(page);
+
+		await configureCloudProvider(page, "OpenAI TTS", OPENAI_KEY);
+
+		const card = providerCard(page, "OpenAI TTS");
+		await expect(card).toBeVisible();
+
+		expect(pageErrors).toEqual([]);
+	});
+
+	test("configure ElevenLabs TTS with API key", async ({ page }) => {
+		test.skip(!ELEVENLABS_KEY, "requires MOLTIS_E2E_ELEVENLABS_API_KEY");
+		const pageErrors = watchPageErrors(page);
+		await openVoicePage(page);
+		await waitForProviderCards(page);
+
+		await configureCloudProvider(page, "ElevenLabs", ELEVENLABS_KEY);
+
+		const card = providerCard(page, "ElevenLabs");
+		await expect(card).toBeVisible();
+
+		expect(pageErrors).toEqual([]);
+	});
+
+	test("configure Google Cloud TTS with API key", async ({ page }) => {
+		test.skip(!GOOGLE_KEY, "requires MOLTIS_E2E_GOOGLE_API_KEY");
+		const pageErrors = watchPageErrors(page);
+		await openVoicePage(page);
+		await waitForProviderCards(page);
+
+		await configureCloudProvider(page, "Google Cloud TTS", GOOGLE_KEY);
+
+		const card = providerCard(page, "Google Cloud TTS");
+		await expect(card).toBeVisible();
+
+		expect(pageErrors).toEqual([]);
+	});
+});
+
+// ── Provider Toggle ─────────────────────────────────────────────────────────
+
+test.describe("Voice provider toggle", () => {
+	test("toggle OpenAI Whisper on and off via RPC", async ({ page }) => {
+		test.skip(!OPENAI_KEY, "requires MOLTIS_E2E_OPENAI_API_KEY");
+		const pageErrors = watchPageErrors(page);
+		await openVoicePage(page);
+		await waitForProviderCards(page);
+
+		// Enable
+		await expectRpcOk(page, "voice.provider.toggle", {
+			provider: "whisper",
+			enabled: true,
+			type: "stt",
+		});
+
+		// Verify via providers list
+		const result = await expectRpcOk(page, "voice.providers.all", {});
+		const stt = result?.result?.stt || [];
+		const whisper = stt.find((p) => p.id === "whisper");
+		expect(whisper).toBeTruthy();
+
+		// Disable
+		await expectRpcOk(page, "voice.provider.toggle", {
+			provider: "whisper",
+			enabled: false,
+			type: "stt",
+		});
+
+		expect(pageErrors).toEqual([]);
+	});
+
+	test("toggle ElevenLabs TTS on and off via RPC", async ({ page }) => {
+		test.skip(!ELEVENLABS_KEY, "requires MOLTIS_E2E_ELEVENLABS_API_KEY");
+		const pageErrors = watchPageErrors(page);
+		await openVoicePage(page);
+		await waitForProviderCards(page);
+
+		await expectRpcOk(page, "voice.provider.toggle", {
+			provider: "elevenlabs",
+			enabled: true,
+			type: "tts",
+		});
+
+		await expectRpcOk(page, "voice.provider.toggle", {
+			provider: "elevenlabs",
+			enabled: false,
+			type: "tts",
+		});
+
+		expect(pageErrors).toEqual([]);
 	});
 });

--- a/crates/web/ui/e2e/specs/voice-providers.spec.js
+++ b/crates/web/ui/e2e/specs/voice-providers.spec.js
@@ -1,0 +1,87 @@
+const { expect, test } = require("../base-test");
+const { navigateAndWait, waitForWsConnected, watchPageErrors } = require("../helpers");
+
+async function openVoicePage(page) {
+	await navigateAndWait(page, "/settings/voice");
+	await expect.poll(() => new URL(page.url()).pathname).toBe("/settings/voice");
+}
+
+test.describe("Voice provider settings", () => {
+	test("voice settings page loads without JS errors", async ({ page }) => {
+		var pageErrors = watchPageErrors(page);
+		await openVoicePage(page);
+		await waitForWsConnected(page);
+		// Wait for provider cards to render (STT or TTS section)
+		await expect(page.locator(".provider-card").first()).toBeVisible({ timeout: 15_000 });
+		expect(pageErrors).toEqual([]);
+	});
+
+	test("all STT providers are visible by default", async ({ page }) => {
+		await openVoicePage(page);
+		await waitForWsConnected(page);
+		await expect(page.locator(".provider-card").first()).toBeVisible({ timeout: 15_000 });
+
+		var pageText = await page.locator("#pageContent").innerText();
+
+		// Cloud STT providers
+		expect(pageText).toContain("OpenAI Whisper");
+		expect(pageText).toContain("Groq");
+		expect(pageText).toContain("Deepgram");
+		expect(pageText).toContain("Google Cloud STT");
+		expect(pageText).toContain("Mistral");
+		expect(pageText).toContain("ElevenLabs Scribe");
+
+		// Local STT providers
+		expect(pageText).toContain("Voxtral (Local)");
+		expect(pageText).toContain("Whisper (Local)");
+		expect(pageText).toContain("whisper.cpp");
+		expect(pageText).toContain("sherpa-onnx");
+	});
+
+	test("all TTS providers are visible by default", async ({ page }) => {
+		await openVoicePage(page);
+		await waitForWsConnected(page);
+		await expect(page.locator(".provider-card").first()).toBeVisible({ timeout: 15_000 });
+
+		var pageText = await page.locator("#pageContent").innerText();
+
+		expect(pageText).toContain("ElevenLabs");
+		expect(pageText).toContain("OpenAI TTS");
+		expect(pageText).toContain("Google Cloud TTS");
+		expect(pageText).toContain("Piper");
+		expect(pageText).toContain("Coqui TTS");
+	});
+
+	test("whisper-local provider shows setup instructions", async ({ page }) => {
+		await openVoicePage(page);
+		await waitForWsConnected(page);
+		await expect(page.locator(".provider-card").first()).toBeVisible({ timeout: 15_000 });
+
+		// Find Whisper (Local) card and click Configure
+		var whisperLocalCard = page.locator(".provider-card", { hasText: "Whisper (Local)" });
+		await expect(whisperLocalCard).toBeVisible();
+
+		// Click configure button on the card
+		var configureBtn = whisperLocalCard.getByRole("button", { name: /configure/i });
+		if (await configureBtn.isVisible().catch(() => false)) {
+			await configureBtn.click();
+			// Should show the setup instructions modal/panel
+			await expect(page.getByText("faster-whisper-server")).toBeVisible({ timeout: 5_000 });
+		}
+	});
+
+	test("voxtral-local provider shows setup instructions", async ({ page }) => {
+		await openVoicePage(page);
+		await waitForWsConnected(page);
+		await expect(page.locator(".provider-card").first()).toBeVisible({ timeout: 15_000 });
+
+		var voxtralCard = page.locator(".provider-card", { hasText: "Voxtral (Local)" });
+		await expect(voxtralCard).toBeVisible();
+
+		var configureBtn = voxtralCard.getByRole("button", { name: /configure/i });
+		if (await configureBtn.isVisible().catch(() => false)) {
+			await configureBtn.click();
+			await expect(page.getByText("vllm serve")).toBeVisible({ timeout: 5_000 });
+		}
+	});
+});

--- a/crates/web/ui/e2e/specs/voice-providers.spec.js
+++ b/crates/web/ui/e2e/specs/voice-providers.spec.js
@@ -1,5 +1,5 @@
 const { expect, test } = require("../base-test");
-const { navigateAndWait, waitForWsConnected, watchPageErrors, sendRpcFromPage, expectRpcOk } = require("../helpers");
+const { navigateAndWait, waitForWsConnected, watchPageErrors, expectRpcOk } = require("../helpers");
 
 async function openVoicePage(page) {
 	await navigateAndWait(page, "/settings/voice");
@@ -107,11 +107,8 @@ test.describe("Local provider setup instructions", () => {
 		const card = providerCard(page, "Whisper (Local)");
 		await expect(card).toBeVisible();
 
-		const configureBtn = card.getByRole("button", { name: /configure/i });
-		if (await configureBtn.isVisible().catch(() => false)) {
-			await configureBtn.click();
-			await expect(page.getByText("faster-whisper-server")).toBeVisible({ timeout: 5_000 });
-		}
+		await card.getByRole("button", { name: /configure/i }).click();
+		await expect(page.getByText("faster-whisper-server")).toBeVisible({ timeout: 5_000 });
 	});
 
 	test("voxtral-local shows setup instructions", async ({ page }) => {
@@ -121,11 +118,8 @@ test.describe("Local provider setup instructions", () => {
 		const card = providerCard(page, "Voxtral (Local)");
 		await expect(card).toBeVisible();
 
-		const configureBtn = card.getByRole("button", { name: /configure/i });
-		if (await configureBtn.isVisible().catch(() => false)) {
-			await configureBtn.click();
-			await expect(page.getByText("vllm serve")).toBeVisible({ timeout: 5_000 });
-		}
+		await card.getByRole("button", { name: /configure/i }).click();
+		await expect(page.getByText("vllm serve")).toBeVisible({ timeout: 5_000 });
 	});
 });
 

--- a/crates/web/ui/src/pages/sections/VoiceModals.tsx
+++ b/crates/web/ui/src/pages/sections/VoiceModals.tsx
@@ -382,6 +382,7 @@ function LocalProviderInstructions({ providerId, voxtralReqs }: LocalProviderIns
 
 		const templateId: Record<string, string> = {
 			"whisper-cli": "voice-whisper-cli-instructions",
+			"whisper-local": "voice-whisper-local-instructions",
 			"sherpa-onnx": "voice-sherpa-onnx-instructions",
 			piper: "voice-piper-instructions",
 			coqui: "voice-coqui-instructions",


### PR DESCRIPTION
## Summary

Add a new `whisper-local` STT provider for privacy-conscious users who want to run OpenAI-compatible Whisper servers locally (faster-whisper-server, whisper.cpp server, LocalAI, etc.). Also change the default voice provider lists from restrictive allowlists to empty (show all available providers), and add comprehensive E2E tests for voice provider configuration.

### Changes

**New whisper-local provider:**
- `crates/voice/src/stt/whisper_local.rs` — `WhisperLocalStt` struct, default endpoint `http://localhost:8080`
- `crates/voice/src/stt/openai_compat.rs` — shared `transcribe_openai_compat()` helper extracted from voxtral-local
- `crates/voice/src/stt/voxtral_local.rs` — refactored to use shared helper (removes ~100 lines of duplication)

**Config & schema (all crates):**
- `VoiceSttProvider::WhisperLocal` variant in config schema, validate, voice config
- `VoiceWhisperLocalConfig` struct (endpoint, model, language)
- `whisper_local` field in `VoiceSttConfig` with default
- Schema map and semantic validation updated

**Gateway:**
- `create_provider` / `list_providers` / `apply_voice_provider_settings` for WhisperLocal
- Detection, metadata, and UI instructions in `methods/voice.rs`

**Web UI:**
- Hidden HTML template with setup instructions (faster-whisper-server, whisper.cpp server)
- `LocalProviderInstructions` map entry in VoiceModals.tsx

**Show all providers by default:**
- Changed `providers = ["openai", "elevenlabs"]` (TTS) and `providers = ["whisper", "mistral", "elevenlabs"]` (STT) to `providers = []` in config template
- Gateway `filter_listed_voice_providers()` already treats empty list as "show all"

**E2E tests (16 tests):**
- Provider visibility: all 10 STT + 5 TTS providers visible
- Local provider setup instructions (whisper-local, voxtral-local)
- Cloud provider configuration with API keys (6 STT + 3 TTS)
- Provider toggle on/off via RPC
- Cloud tests skip gracefully without keys

## Validation

### Completed
- [x] `cargo check -p moltis-voice -p moltis-config -p moltis-gateway`
- [x] `cargo test -p moltis-voice` — 161 passed
- [x] `cargo test -p moltis-config` — 299 passed
- [x] `cargo fmt -p moltis-voice -p moltis-config -p moltis-gateway -- --check`
- [x] `biome check --write` on TSX changes

### Remaining
- [ ] `just lint`
- [ ] `just test`
- [ ] `npx playwright test e2e/specs/voice-providers.spec.js`
- [ ] Manual: verify all providers visible in Settings > Voice

## Manual QA

1. Start moltis, go to Settings > Voice
2. Verify all 10 STT providers and 5 TTS providers are visible (no allowlist filtering)
3. Click Configure on "Whisper (Local)" — verify setup instructions appear mentioning faster-whisper-server
4. If running a local Whisper server on :8080, configure and test transcription
