### PR TITLE
Add Codex OAuth image generation

### DIFF
--- a/crates/chat/src/channels.rs
+++ b/crates/chat/src/channels.rs
@@ -1441,22 +1441,11 @@ mod tests {
         assert_eq!(sent[0].to, "-100123:7");
         assert_eq!(sent[0].reply_to.as_deref(), Some("42"));
         assert_eq!(sent[0].payload.text, "Generated image: fox");
-        assert_eq!(
-            sent[0]
-                .payload
-                .media
-                .as_ref()
-                .map(|media| media.mime_type.as_str()),
-            Some("image/png")
-        );
-        assert_eq!(
-            sent[0]
-                .payload
-                .media
-                .as_ref()
-                .map(|media| media.url.as_str()),
-            Some("data:image/png;base64,cG5n")
-        );
+        let Some(media) = sent[0].payload.media.as_ref() else {
+            panic!("media payload");
+        };
+        assert_eq!(media.mime_type, "image/png");
+        assert_eq!(media.url, "data:image/png;base64,cG5n");
     }
 
     #[tokio::test]
@@ -1487,21 +1476,10 @@ mod tests {
         assert_eq!(sent[0].to, "!room:example.org");
         assert_eq!(sent[0].reply_to.as_deref(), Some("$event"));
         assert_eq!(sent[0].payload.text, "Generated image: logo");
-        assert_eq!(
-            sent[0]
-                .payload
-                .media
-                .as_ref()
-                .map(|media| media.mime_type.as_str()),
-            Some("image/webp")
-        );
-        assert_eq!(
-            sent[0]
-                .payload
-                .media
-                .as_ref()
-                .map(|media| media.url.as_str()),
-            Some("data:image/webp;base64,d2VicA==")
-        );
+        let Some(media) = sent[0].payload.media.as_ref() else {
+            panic!("media payload");
+        };
+        assert_eq!(media.mime_type, "image/webp");
+        assert_eq!(media.url, "data:image/webp;base64,d2VicA==");
     }
 }

--- a/crates/chat/src/channels.rs
+++ b/crates/chat/src/channels.rs
@@ -1441,9 +1441,22 @@ mod tests {
         assert_eq!(sent[0].to, "-100123:7");
         assert_eq!(sent[0].reply_to.as_deref(), Some("42"));
         assert_eq!(sent[0].payload.text, "Generated image: fox");
-        let media = sent[0].payload.media.as_ref().expect("media payload");
-        assert_eq!(media.mime_type, "image/png");
-        assert_eq!(media.url, "data:image/png;base64,cG5n");
+        assert_eq!(
+            sent[0]
+                .payload
+                .media
+                .as_ref()
+                .map(|media| media.mime_type.as_str()),
+            Some("image/png")
+        );
+        assert_eq!(
+            sent[0]
+                .payload
+                .media
+                .as_ref()
+                .map(|media| media.url.as_str()),
+            Some("data:image/png;base64,cG5n")
+        );
     }
 
     #[tokio::test]
@@ -1474,8 +1487,21 @@ mod tests {
         assert_eq!(sent[0].to, "!room:example.org");
         assert_eq!(sent[0].reply_to.as_deref(), Some("$event"));
         assert_eq!(sent[0].payload.text, "Generated image: logo");
-        let media = sent[0].payload.media.as_ref().expect("media payload");
-        assert_eq!(media.mime_type, "image/webp");
-        assert_eq!(media.url, "data:image/webp;base64,d2VicA==");
+        assert_eq!(
+            sent[0]
+                .payload
+                .media
+                .as_ref()
+                .map(|media| media.mime_type.as_str()),
+            Some("image/webp")
+        );
+        assert_eq!(
+            sent[0]
+                .payload
+                .media
+                .as_ref()
+                .map(|media| media.url.as_str()),
+            Some("data:image/webp;base64,d2VicA==")
+        );
     }
 }

--- a/crates/chat/src/channels.rs
+++ b/crates/chat/src/channels.rs
@@ -1051,8 +1051,6 @@ pub(crate) async fn send_screenshot_to_channels(
     screenshot_data: &str,
     caption: Option<&str>,
 ) {
-    use moltis_common::types::{MediaAttachment, ReplyPayload};
-
     let targets = state.peek_channel_replies(session_key).await;
     if targets.is_empty() {
         return;
@@ -1063,6 +1061,15 @@ pub(crate) async fn send_screenshot_to_channels(
         None => return,
     };
 
+    dispatch_screenshot_to_targets(outbound, targets, screenshot_data, caption).await;
+}
+
+fn build_screenshot_reply_payload(
+    screenshot_data: &str,
+    caption: Option<&str>,
+) -> moltis_common::types::ReplyPayload {
+    use moltis_common::types::{MediaAttachment, ReplyPayload};
+
     // Extract actual MIME from "data:image/jpeg;base64,..." instead of
     // hardcoding PNG — supports JPEG, GIF, WebP from send_image tool.
     let mime_type = screenshot_data
@@ -1071,7 +1078,7 @@ pub(crate) async fn send_screenshot_to_channels(
         .unwrap_or("image/png")
         .to_string();
 
-    let payload = ReplyPayload {
+    ReplyPayload {
         text: caption.unwrap_or_default().to_string(),
         media: Some(MediaAttachment {
             url: screenshot_data.to_string(),
@@ -1080,7 +1087,16 @@ pub(crate) async fn send_screenshot_to_channels(
         }),
         reply_to_id: None,
         silent: false,
-    };
+    }
+}
+
+async fn dispatch_screenshot_to_targets(
+    outbound: Arc<dyn moltis_channels::ChannelOutbound>,
+    targets: Vec<moltis_channels::ChannelReplyTarget>,
+    screenshot_data: &str,
+    caption: Option<&str>,
+) {
+    let payload = build_screenshot_reply_payload(screenshot_data, caption);
 
     let mut tasks = Vec::with_capacity(targets.len());
     for target in targets {
@@ -1325,7 +1341,58 @@ pub(crate) async fn send_location_to_channels(
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use {
+        super::*,
+        async_trait::async_trait,
+        moltis_channels::{ChannelReplyTarget, ChannelType},
+        moltis_common::types::ReplyPayload,
+        std::sync::{Arc, Mutex},
+    };
+
+    #[derive(Debug, Clone)]
+    struct SentMedia {
+        account_id: String,
+        to: String,
+        payload: ReplyPayload,
+        reply_to: Option<String>,
+    }
+
+    #[derive(Default)]
+    struct RecordingOutbound {
+        sent_media: Mutex<Vec<SentMedia>>,
+    }
+
+    #[async_trait]
+    impl moltis_channels::ChannelOutbound for RecordingOutbound {
+        async fn send_text(
+            &self,
+            _account_id: &str,
+            _to: &str,
+            _text: &str,
+            _reply_to: Option<&str>,
+        ) -> moltis_channels::Result<()> {
+            Ok(())
+        }
+
+        async fn send_media(
+            &self,
+            account_id: &str,
+            to: &str,
+            payload: &ReplyPayload,
+            reply_to: Option<&str>,
+        ) -> moltis_channels::Result<()> {
+            self.sent_media
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .push(SentMedia {
+                    account_id: account_id.to_string(),
+                    to: to.to_string(),
+                    payload: payload.clone(),
+                    reply_to: reply_to.map(ToString::to_string),
+                });
+            Ok(())
+        }
+    }
 
     #[test]
     fn push_notification_url_uses_chats_prefix_and_replaces_colons() {
@@ -1344,5 +1411,71 @@ mod tests {
     #[test]
     fn push_notification_url_handles_key_without_colons() {
         assert_eq!(push_notification_url("main"), "/chats/main");
+    }
+
+    #[tokio::test]
+    async fn generated_image_payload_dispatches_to_telegram_as_media() {
+        let outbound = Arc::new(RecordingOutbound::default());
+        let targets = vec![ChannelReplyTarget {
+            channel_type: ChannelType::Telegram,
+            account_id: "telegram-main".into(),
+            chat_id: "-100123".into(),
+            message_id: Some("42".into()),
+            thread_id: Some("7".into()),
+        }];
+
+        dispatch_screenshot_to_targets(
+            outbound.clone(),
+            targets,
+            "data:image/png;base64,cG5n",
+            Some("Generated image: fox"),
+        )
+        .await;
+
+        let sent = outbound
+            .sent_media
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        assert_eq!(sent.len(), 1);
+        assert_eq!(sent[0].account_id, "telegram-main");
+        assert_eq!(sent[0].to, "-100123:7");
+        assert_eq!(sent[0].reply_to.as_deref(), Some("42"));
+        assert_eq!(sent[0].payload.text, "Generated image: fox");
+        let media = sent[0].payload.media.as_ref().expect("media payload");
+        assert_eq!(media.mime_type, "image/png");
+        assert_eq!(media.url, "data:image/png;base64,cG5n");
+    }
+
+    #[tokio::test]
+    async fn generated_image_payload_dispatches_to_matrix_as_media() {
+        let outbound = Arc::new(RecordingOutbound::default());
+        let targets = vec![ChannelReplyTarget {
+            channel_type: ChannelType::Matrix,
+            account_id: "matrix-main".into(),
+            chat_id: "!room:example.org".into(),
+            message_id: Some("$event".into()),
+            thread_id: None,
+        }];
+
+        dispatch_screenshot_to_targets(
+            outbound.clone(),
+            targets,
+            "data:image/webp;base64,d2VicA==",
+            Some("Generated image: logo"),
+        )
+        .await;
+
+        let sent = outbound
+            .sent_media
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        assert_eq!(sent.len(), 1);
+        assert_eq!(sent[0].account_id, "matrix-main");
+        assert_eq!(sent[0].to, "!room:example.org");
+        assert_eq!(sent[0].reply_to.as_deref(), Some("$event"));
+        assert_eq!(sent[0].payload.text, "Generated image: logo");
+        let media = sent[0].payload.media.as_ref().expect("media payload");
+        assert_eq!(media.mime_type, "image/webp");
+        assert_eq!(media.url, "data:image/webp;base64,d2VicA==");
     }
 }

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -124,8 +124,8 @@ full = [
   "caldav",
   "claude-import",
   "code-index-builtin",
-  "codex-import",
   "code-splitter",
+  "codex-import",
   "discord",
   "file-watcher",
   "firecrawl",
@@ -161,6 +161,7 @@ full = [
   "nostr",
   "openclaw-import",
   "prometheus",
+  "provider-openai-codex",
   "push-notifications",
   "qmd",
   "signal",
@@ -207,38 +208,39 @@ lang-toml          = ["moltis-memory/lang-toml"]
 lang-typescript    = ["moltis-memory/lang-typescript"]
 # jemalloc is intentionally unavailable on linux/aarch64 to avoid runtime
 # crashes on 16 KiB page kernels (e.g. Raspberry Pi OS variants).
-claude-import      = ["dep:moltis-claude-import", "moltis-gateway/claude-import"]
-codex-import       = ["dep:moltis-codex-import", "moltis-gateway/codex-import"]
-hermes-import      = ["dep:moltis-hermes-import", "moltis-gateway/hermes-import"]
-lightweight        = ["jemalloc", "tls", "web-ui"]
-local-embeddings   = ["moltis-gateway/local-embeddings"]
-local-llm          = ["moltis-gateway/local-llm"]
-local-llm-cuda     = ["local-llm", "moltis-gateway/local-llm-cuda"]
-local-llm-metal    = ["local-llm", "moltis-gateway/local-llm-metal"]
-local-llm-vulkan   = ["local-llm", "moltis-gateway/local-llm-vulkan"]
-matrix             = ["moltis-httpd/matrix"]
-mdns               = ["moltis-gateway/mdns"]
-metrics            = ["moltis-httpd/metrics", "moltis-web?/metrics"]
-msteams            = ["moltis-httpd/msteams"]
-ngrok              = ["moltis-httpd/ngrok", "moltis-web?/ngrok"]
-nostr              = ["moltis-httpd/nostr"]
-openclaw-import    = ["dep:moltis-openclaw-import", "moltis-gateway/openclaw-import"]
-prometheus         = ["moltis-httpd/prometheus"]
-push-notifications = ["moltis-httpd/push-notifications", "moltis-web?/push-notifications"]
-qmd                = ["moltis-gateway/qmd"]
-signal             = ["moltis-httpd/signal"]
-slack              = ["moltis-httpd/slack"]
-tailscale          = ["moltis-httpd/tailscale", "moltis-web?/tailscale"]
-telegram           = ["moltis-gateway/telegram"]
-telephony          = ["moltis-httpd/telephony"]
-tls                = ["moltis-httpd/tls"]
-trusted-network    = ["moltis-httpd/trusted-network"]
-vault              = ["moltis-httpd/vault", "moltis-web?/vault"]
-voice              = ["moltis-gateway/voice", "moltis-web?/voice"]
-vercel-sandbox     = ["moltis-tools/vercel-sandbox"]
-wasm               = ["moltis-tools/wasm"]
-web-ui             = ["dep:moltis-web", "moltis-httpd/web-ui"]
-whatsapp           = ["moltis-gateway/whatsapp"]
+claude-import         = ["dep:moltis-claude-import", "moltis-gateway/claude-import"]
+codex-import          = ["dep:moltis-codex-import", "moltis-gateway/codex-import"]
+hermes-import         = ["dep:moltis-hermes-import", "moltis-gateway/hermes-import"]
+lightweight           = ["jemalloc", "tls", "web-ui"]
+local-embeddings      = ["moltis-gateway/local-embeddings"]
+local-llm             = ["moltis-gateway/local-llm"]
+local-llm-cuda        = ["local-llm", "moltis-gateway/local-llm-cuda"]
+local-llm-metal       = ["local-llm", "moltis-gateway/local-llm-metal"]
+local-llm-vulkan      = ["local-llm", "moltis-gateway/local-llm-vulkan"]
+matrix                = ["moltis-httpd/matrix"]
+mdns                  = ["moltis-gateway/mdns"]
+metrics               = ["moltis-httpd/metrics", "moltis-web?/metrics"]
+msteams               = ["moltis-httpd/msteams"]
+ngrok                 = ["moltis-httpd/ngrok", "moltis-web?/ngrok"]
+nostr                 = ["moltis-httpd/nostr"]
+openclaw-import       = ["dep:moltis-openclaw-import", "moltis-gateway/openclaw-import"]
+prometheus            = ["moltis-httpd/prometheus"]
+provider-openai-codex = ["moltis-gateway/provider-openai-codex"]
+push-notifications    = ["moltis-httpd/push-notifications", "moltis-web?/push-notifications"]
+qmd                   = ["moltis-gateway/qmd"]
+signal                = ["moltis-httpd/signal"]
+slack                 = ["moltis-httpd/slack"]
+tailscale             = ["moltis-httpd/tailscale", "moltis-web?/tailscale"]
+telegram              = ["moltis-gateway/telegram"]
+telephony             = ["moltis-httpd/telephony"]
+tls                   = ["moltis-httpd/tls"]
+trusted-network       = ["moltis-httpd/trusted-network"]
+vault                 = ["moltis-httpd/vault", "moltis-web?/vault"]
+vercel-sandbox        = ["moltis-tools/vercel-sandbox"]
+voice                 = ["moltis-gateway/voice", "moltis-web?/voice"]
+wasm                  = ["moltis-tools/wasm"]
+web-ui                = ["dep:moltis-web", "moltis-httpd/web-ui"]
+whatsapp              = ["moltis-gateway/whatsapp"]
 
 [lints]
 workspace = true

--- a/crates/gateway/Cargo.toml
+++ b/crates/gateway/Cargo.toml
@@ -132,6 +132,7 @@ default = [
   "nostr",
   "openclaw-import",
   "prometheus",
+  "provider-openai-codex",
   "push-notifications",
   "qmd",
   "signal",
@@ -185,6 +186,10 @@ msteams = ["dep:moltis-msteams"]
 nostr = ["dep:moltis-nostr"]
 openclaw-import = ["dep:moltis-openclaw-import"]
 prometheus = ["metrics", "moltis-metrics/prometheus"]
+provider-openai-codex = [
+  "moltis-providers/provider-openai-codex",
+  "moltis-tools/provider-openai-codex",
+]
 push-notifications = ["dep:chrono", "dep:p256", "dep:web-push", "moltis-chat/push-notifications"]
 qmd = ["dep:moltis-qmd", "moltis-code-index/qmd"]
 signal = ["dep:moltis-signal"]

--- a/crates/gateway/src/server/prepare_core/post_state.rs
+++ b/crates/gateway/src/server/prepare_core/post_state.rs
@@ -941,6 +941,9 @@ pub(super) async fn complete_startup(
                 .with_sandbox_router(Arc::clone(&sandbox_router)),
         ));
         tool_registry.register(Box::new(
+            moltis_tools::image_generation::GenerateImageTool::new(),
+        ));
+        tool_registry.register(Box::new(
             moltis_tools::send_document::SendDocumentTool::new()
                 .with_sandbox_router(Arc::clone(&sandbox_router))
                 .with_session_store(Arc::clone(&session_store)),

--- a/crates/gateway/src/server/prepare_core/post_state.rs
+++ b/crates/gateway/src/server/prepare_core/post_state.rs
@@ -940,6 +940,7 @@ pub(super) async fn complete_startup(
             moltis_tools::send_image::SendImageTool::new()
                 .with_sandbox_router(Arc::clone(&sandbox_router)),
         ));
+        #[cfg(feature = "provider-openai-codex")]
         if moltis_providers::openai_codex::has_stored_tokens() {
             tool_registry.register(Box::new(
                 moltis_tools::image_generation::GenerateImageTool::new(),

--- a/crates/gateway/src/server/prepare_core/post_state.rs
+++ b/crates/gateway/src/server/prepare_core/post_state.rs
@@ -940,9 +940,11 @@ pub(super) async fn complete_startup(
             moltis_tools::send_image::SendImageTool::new()
                 .with_sandbox_router(Arc::clone(&sandbox_router)),
         ));
-        tool_registry.register(Box::new(
-            moltis_tools::image_generation::GenerateImageTool::new(),
-        ));
+        if moltis_providers::openai_codex::has_stored_tokens() {
+            tool_registry.register(Box::new(
+                moltis_tools::image_generation::GenerateImageTool::new(),
+            ));
+        }
         tool_registry.register(Box::new(
             moltis_tools::send_document::SendDocumentTool::new()
                 .with_sandbox_router(Arc::clone(&sandbox_router))

--- a/crates/gateway/src/server/prepare_core/post_state.rs
+++ b/crates/gateway/src/server/prepare_core/post_state.rs
@@ -5,11 +5,9 @@ use std::{
 
 use {
     async_trait::async_trait,
-    secrecy::Secret,
+    secrecy::{ExposeSecret, Secret},
     tracing::{debug, info, warn},
 };
-
-use secrecy::ExposeSecret;
 
 use {
     moltis_providers::{PendingDiscoveries, ProviderRegistry},

--- a/crates/providers/src/lib.rs
+++ b/crates/providers/src/lib.rs
@@ -24,6 +24,8 @@ pub mod ollama;
 pub mod openai;
 #[cfg(feature = "provider-openai-codex")]
 pub mod openai_codex;
+#[cfg(feature = "provider-openai-codex")]
+pub mod openai_codex_image;
 pub mod openai_compat;
 pub mod opencode_zen;
 pub mod registry;

--- a/crates/providers/src/openai_codex.rs
+++ b/crates/providers/src/openai_codex.rs
@@ -75,7 +75,7 @@ impl OpenAiCodexProvider {
         }
     }
 
-    async fn get_valid_tokens(&self) -> anyhow::Result<moltis_oauth::OAuthTokens> {
+    pub(crate) async fn get_valid_tokens(&self) -> anyhow::Result<moltis_oauth::OAuthTokens> {
         let tokens = self
             .token_store
             .load("openai-codex")
@@ -166,7 +166,7 @@ impl OpenAiCodexProvider {
         Self::extract_account_id_from_claims(&claims)
     }
 
-    fn resolve_account_id(tokens: &moltis_oauth::OAuthTokens) -> anyhow::Result<String> {
+    pub(crate) fn resolve_account_id(tokens: &moltis_oauth::OAuthTokens) -> anyhow::Result<String> {
         if let Some(account_id) = tokens
             .account_id
             .as_ref()

--- a/crates/providers/src/openai_codex_image.rs
+++ b/crates/providers/src/openai_codex_image.rs
@@ -7,7 +7,7 @@ use {
 
 use crate::openai_codex::OpenAiCodexProvider;
 
-const CODEX_IMAGE_RESPONSES_MODEL: &str = "gpt-5.5";
+const CODEX_IMAGE_RESPONSES_MODEL: &str = "gpt-5.4";
 const DEFAULT_IMAGE_MODEL: &str = "gpt-image-2";
 const DEFAULT_SIZE: &str = "1024x1024";
 const DEFAULT_QUALITY: &str = "medium";
@@ -149,11 +149,17 @@ fn build_codex_image_request_body(request: &ImageGenerationRequest) -> Value {
 }
 
 async fn read_limited_response_body(response: reqwest::Response) -> anyhow::Result<String> {
-    let bytes = response.bytes().await?;
-    if bytes.len() > MAX_IMAGE_SSE_BYTES {
-        anyhow::bail!("openai-codex image generation response exceeded size limit");
+    use futures::TryStreamExt as _;
+
+    let mut buf = Vec::with_capacity(64 * 1024);
+    let mut stream = response.bytes_stream();
+    while let Some(chunk) = stream.try_next().await? {
+        if buf.len() + chunk.len() > MAX_IMAGE_SSE_BYTES {
+            anyhow::bail!("openai-codex image generation response exceeded size limit");
+        }
+        buf.extend_from_slice(&chunk);
     }
-    Ok(String::from_utf8_lossy(&bytes).into_owned())
+    Ok(String::from_utf8_lossy(&buf).into_owned())
 }
 
 #[derive(Debug, Default)]
@@ -181,10 +187,10 @@ fn parse_image_events(body: &str) -> anyhow::Result<Vec<ParsedImageEvent>> {
                 continue;
             },
         };
-        events.push(parse_image_event_value(&value));
-        if events.len() > MAX_IMAGE_SSE_EVENTS {
+        if events.len() >= MAX_IMAGE_SSE_EVENTS {
             anyhow::bail!("openai-codex image generation response exceeded event limit");
         }
+        events.push(parse_image_event_value(&value));
     }
     Ok(events)
 }
@@ -360,5 +366,13 @@ mod tests {
         let err = extract_codex_image_generation_result(body, "gpt-image-2", "png")
             .expect_err("failure should error");
         assert!(err.to_string().contains("blocked"));
+    }
+
+    #[test]
+    fn enforces_event_limit_before_pushing_extra_event() {
+        let event = "data: {\"type\":\"response.created\"}\n";
+        let body = event.repeat(MAX_IMAGE_SSE_EVENTS + 1);
+        let err = parse_image_events(&body).expect_err("too many events should fail");
+        assert!(err.to_string().contains("exceeded event limit"));
     }
 }

--- a/crates/providers/src/openai_codex_image.rs
+++ b/crates/providers/src/openai_codex_image.rs
@@ -1,0 +1,364 @@
+use {
+    base64::{Engine as _, engine::general_purpose::STANDARD as BASE64},
+    secrecy::ExposeSecret,
+    serde_json::Value,
+    tracing::debug,
+};
+
+use crate::openai_codex::OpenAiCodexProvider;
+
+const CODEX_IMAGE_RESPONSES_MODEL: &str = "gpt-5.5";
+const DEFAULT_IMAGE_MODEL: &str = "gpt-image-2";
+const DEFAULT_SIZE: &str = "1024x1024";
+const DEFAULT_QUALITY: &str = "medium";
+const DEFAULT_OUTPUT_FORMAT: &str = "png";
+const DEFAULT_BACKGROUND: &str = "opaque";
+const MAX_IMAGE_SSE_BYTES: usize = 64 * 1024 * 1024;
+const MAX_IMAGE_SSE_EVENTS: usize = 512;
+const MAX_IMAGE_BASE64_CHARS: usize = 64 * 1024 * 1024;
+
+#[derive(Debug, Clone)]
+pub struct ImageGenerationRequest {
+    pub prompt: String,
+    pub model: String,
+    pub size: String,
+    pub quality: String,
+    pub output_format: String,
+    pub background: String,
+}
+
+impl ImageGenerationRequest {
+    #[must_use]
+    pub fn new(prompt: impl Into<String>) -> Self {
+        Self {
+            prompt: prompt.into(),
+            model: DEFAULT_IMAGE_MODEL.to_string(),
+            size: DEFAULT_SIZE.to_string(),
+            quality: DEFAULT_QUALITY.to_string(),
+            output_format: DEFAULT_OUTPUT_FORMAT.to_string(),
+            background: DEFAULT_BACKGROUND.to_string(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GeneratedImage {
+    pub media_type: String,
+    pub data: String,
+}
+
+impl GeneratedImage {
+    #[must_use]
+    pub fn data_uri(&self) -> String {
+        format!("data:{};base64,{}", self.media_type, self.data)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ImageGenerationResult {
+    pub model: String,
+    pub images: Vec<GeneratedImage>,
+}
+
+pub struct OpenAiCodexImageProvider {
+    base_url: String,
+    client: &'static reqwest::Client,
+    auth: OpenAiCodexProvider,
+}
+
+impl Default for OpenAiCodexImageProvider {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl OpenAiCodexImageProvider {
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            base_url: "https://chatgpt.com/backend-api/codex".to_string(),
+            client: crate::shared_http_client(),
+            auth: OpenAiCodexProvider::new(CODEX_IMAGE_RESPONSES_MODEL.to_string()),
+        }
+    }
+
+    pub async fn generate_image(
+        &self,
+        request: ImageGenerationRequest,
+    ) -> anyhow::Result<ImageGenerationResult> {
+        let prompt = request.prompt.trim();
+        if prompt.is_empty() {
+            anyhow::bail!("image prompt is required");
+        }
+
+        let tokens = self.auth.get_valid_tokens().await?;
+        let token = tokens.access_token.expose_secret().clone();
+        let account_id = OpenAiCodexProvider::resolve_account_id(&tokens)?;
+        let body = build_codex_image_request_body(&request);
+
+        let response = self
+            .client
+            .post(format!("{}/responses", self.base_url.trim_end_matches('/')))
+            .header("Authorization", format!("Bearer {token}"))
+            .header("chatgpt-account-id", account_id)
+            .header("OpenAI-Beta", "responses=experimental")
+            .header("originator", "pi")
+            .header("accept", "text/event-stream")
+            .header("content-type", "application/json")
+            .json(&body)
+            .send()
+            .await?;
+
+        let status = response.status();
+        let retry_after_ms = super::retry_after_ms_from_headers(response.headers());
+        let body_text = read_limited_response_body(response).await?;
+        if !status.is_success() {
+            anyhow::bail!(
+                "{}",
+                super::with_retry_after_marker(
+                    format!("openai-codex image generation API error HTTP {status}: {body_text}"),
+                    retry_after_ms,
+                )
+            );
+        }
+
+        extract_codex_image_generation_result(&body_text, &request.model, &request.output_format)
+    }
+}
+
+fn build_codex_image_request_body(request: &ImageGenerationRequest) -> Value {
+    serde_json::json!({
+        "model": CODEX_IMAGE_RESPONSES_MODEL,
+        "store": false,
+        "stream": true,
+        "instructions": "You are an image generation assistant.",
+        "input": [{
+            "role": "user",
+            "content": [{"type": "input_text", "text": request.prompt.trim()}],
+        }],
+        "tools": [{
+            "type": "image_generation",
+            "model": request.model,
+            "size": request.size,
+            "quality": request.quality,
+            "output_format": request.output_format,
+            "background": request.background,
+        }],
+        "tool_choice": {"type": "image_generation"},
+    })
+}
+
+async fn read_limited_response_body(response: reqwest::Response) -> anyhow::Result<String> {
+    let bytes = response.bytes().await?;
+    if bytes.len() > MAX_IMAGE_SSE_BYTES {
+        anyhow::bail!("openai-codex image generation response exceeded size limit");
+    }
+    Ok(String::from_utf8_lossy(&bytes).into_owned())
+}
+
+#[derive(Debug, Default)]
+struct ParsedImageEvent {
+    event_type: Option<String>,
+    item_type: Option<String>,
+    result: Option<String>,
+    response_output: Vec<(Option<String>, Option<String>)>,
+    error_message: Option<String>,
+}
+
+fn parse_image_events(body: &str) -> anyhow::Result<Vec<ParsedImageEvent>> {
+    let mut events = Vec::new();
+    for line in body.lines() {
+        let Some(data) = line.strip_prefix("data: ").map(str::trim) else {
+            continue;
+        };
+        if data.is_empty() || data == "[DONE]" {
+            continue;
+        }
+        let value = match serde_json::from_str::<Value>(data) {
+            Ok(value) => value,
+            Err(err) => {
+                debug!(error = %err, "ignoring non-json codex image SSE payload");
+                continue;
+            },
+        };
+        events.push(parse_image_event_value(&value));
+        if events.len() > MAX_IMAGE_SSE_EVENTS {
+            anyhow::bail!("openai-codex image generation response exceeded event limit");
+        }
+    }
+    Ok(events)
+}
+
+fn parse_image_event_value(value: &Value) -> ParsedImageEvent {
+    let response_output = value
+        .get("response")
+        .and_then(|response| response.get("output"))
+        .and_then(Value::as_array)
+        .map(|items| {
+            items
+                .iter()
+                .map(|item| {
+                    (
+                        item.get("type")
+                            .and_then(Value::as_str)
+                            .map(ToString::to_string),
+                        item.get("result")
+                            .and_then(Value::as_str)
+                            .map(ToString::to_string),
+                    )
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+
+    ParsedImageEvent {
+        event_type: value
+            .get("type")
+            .and_then(Value::as_str)
+            .map(ToString::to_string),
+        item_type: value
+            .get("item")
+            .and_then(|item| item.get("type"))
+            .and_then(Value::as_str)
+            .map(ToString::to_string),
+        result: value
+            .get("item")
+            .and_then(|item| item.get("result"))
+            .and_then(Value::as_str)
+            .map(ToString::to_string),
+        response_output,
+        error_message: value
+            .get("error")
+            .and_then(|error| error.get("message"))
+            .and_then(Value::as_str)
+            .or_else(|| value.get("message").and_then(Value::as_str))
+            .map(ToString::to_string),
+    }
+}
+
+fn media_type_for_output_format(output_format: &str) -> &'static str {
+    match output_format.trim().to_ascii_lowercase().as_str() {
+        "jpeg" | "jpg" => "image/jpeg",
+        "webp" => "image/webp",
+        _ => "image/png",
+    }
+}
+
+fn generated_image_from_base64(data: &str, output_format: &str) -> anyhow::Result<GeneratedImage> {
+    if data.len() > MAX_IMAGE_BASE64_CHARS {
+        anyhow::bail!("openai-codex image generation result exceeded size limit");
+    }
+    BASE64.decode(data)?;
+    Ok(GeneratedImage {
+        media_type: media_type_for_output_format(output_format).to_string(),
+        data: data.to_string(),
+    })
+}
+
+fn extract_codex_image_generation_result(
+    body: &str,
+    model: &str,
+    output_format: &str,
+) -> anyhow::Result<ImageGenerationResult> {
+    let events = parse_image_events(body)?;
+    if let Some(failure) = events.iter().find(|event| {
+        matches!(
+            event.event_type.as_deref(),
+            Some("response.failed" | "error")
+        )
+    }) {
+        anyhow::bail!(
+            "{}",
+            failure
+                .error_message
+                .as_deref()
+                .unwrap_or("openai-codex image generation failed")
+        );
+    }
+
+    let mut images: Vec<GeneratedImage> = events
+        .iter()
+        .filter(|event| {
+            event.event_type.as_deref() == Some("response.output_item.done")
+                && event.item_type.as_deref() == Some("image_generation_call")
+        })
+        .filter_map(|event| event.result.as_deref())
+        .map(|result| generated_image_from_base64(result, output_format))
+        .collect::<anyhow::Result<Vec<_>>>()?;
+
+    if images.is_empty() {
+        images = events
+            .iter()
+            .flat_map(|event| &event.response_output)
+            .filter(|(item_type, _)| item_type.as_deref() == Some("image_generation_call"))
+            .filter_map(|(_, result)| result.as_deref())
+            .map(|result| generated_image_from_base64(result, output_format))
+            .collect::<anyhow::Result<Vec<_>>>()?;
+    }
+
+    if images.is_empty() {
+        anyhow::bail!("openai-codex image generation returned no images");
+    }
+
+    Ok(ImageGenerationResult {
+        model: model.to_string(),
+        images,
+    })
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn builds_codex_image_generation_body() {
+        let request = ImageGenerationRequest {
+            prompt: " draw a fox ".into(),
+            model: "gpt-image-2".into(),
+            size: "1536x1024".into(),
+            quality: "high".into(),
+            output_format: "webp".into(),
+            background: "opaque".into(),
+        };
+        let body = build_codex_image_request_body(&request);
+        assert_eq!(body["model"], CODEX_IMAGE_RESPONSES_MODEL);
+        assert_eq!(body["input"][0]["content"][0]["text"], "draw a fox");
+        assert_eq!(body["tools"][0]["type"], "image_generation");
+        assert_eq!(body["tools"][0]["model"], "gpt-image-2");
+        assert_eq!(body["tools"][0]["quality"], "high");
+        assert_eq!(body["tool_choice"]["type"], "image_generation");
+    }
+
+    #[test]
+    fn parses_output_item_done_image_result() {
+        let png = BASE64.encode(b"png");
+        let body = format!(
+            "data: {{\"type\":\"response.output_item.done\",\"item\":{{\"type\":\"image_generation_call\",\"result\":\"{png}\"}}}}\n\n"
+        );
+        let result = extract_codex_image_generation_result(&body, "gpt-image-2", "png").unwrap();
+        assert_eq!(result.model, "gpt-image-2");
+        assert_eq!(result.images.len(), 1);
+        assert_eq!(result.images[0].media_type, "image/png");
+        assert_eq!(result.images[0].data, png);
+    }
+
+    #[test]
+    fn parses_completed_response_image_result() {
+        let jpg = BASE64.encode(b"jpg");
+        let body = format!(
+            "data: {{\"type\":\"response.completed\",\"response\":{{\"output\":[{{\"type\":\"image_generation_call\",\"result\":\"{jpg}\"}}]}}}}\n\n"
+        );
+        let result = extract_codex_image_generation_result(&body, "gpt-image-2", "jpeg").unwrap();
+        assert_eq!(result.images[0].media_type, "image/jpeg");
+        assert_eq!(result.images[0].data, jpg);
+    }
+
+    #[test]
+    fn surfaces_failed_event_message() {
+        let body = "data: {\"type\":\"response.failed\",\"error\":{\"message\":\"blocked\"}}\n\n";
+        let err = extract_codex_image_generation_result(body, "gpt-image-2", "png")
+            .expect_err("failure should error");
+        assert!(err.to_string().contains("blocked"));
+    }
+}

--- a/crates/tools/Cargo.toml
+++ b/crates/tools/Cargo.toml
@@ -4,11 +4,12 @@ name              = "moltis-tools"
 version.workspace = true
 
 [features]
-bundled-skills = ["moltis-skills/bundled-skills"]
-default        = ["firecrawl", "fs-tools", "metrics", "vercel-sandbox", "wasm"]
-embedded-wasm  = []
-firecrawl      = []
-vercel-sandbox = []
+bundled-skills        = ["moltis-skills/bundled-skills"]
+default               = ["firecrawl", "fs-tools", "metrics", "provider-openai-codex", "vercel-sandbox", "wasm"]
+embedded-wasm         = []
+firecrawl             = []
+provider-openai-codex = ["moltis-providers/provider-openai-codex"]
+vercel-sandbox        = []
 # Native filesystem tools (Read, Write, Edit, MultiEdit, Glob, Grep).
 # See moltis-org/moltis#657. Default-on; build with
 # --no-default-features to omit them from minimal builds.

--- a/crates/tools/src/image_generation.rs
+++ b/crates/tools/src/image_generation.rs
@@ -1,0 +1,236 @@
+//! `generate_image` tool backed by OpenAI Codex OAuth image generation.
+//!
+//! The chat runner treats a `screenshot` data URI in a tool result as native
+//! image media for channel delivery, so this returns generated images using the
+//! same contract as `send_image` and browser/map screenshots.
+
+use {
+    async_trait::async_trait,
+    moltis_agents::tool_registry::AgentTool,
+    moltis_providers::openai_codex_image::{
+        GeneratedImage, ImageGenerationRequest, OpenAiCodexImageProvider,
+    },
+    serde_json::{Value, json},
+};
+
+use crate::{Error, params::str_param};
+
+const DEFAULT_MODEL: &str = "gpt-image-2";
+const DEFAULT_SIZE: &str = "1024x1024";
+const DEFAULT_QUALITY: &str = "medium";
+const DEFAULT_OUTPUT_FORMAT: &str = "png";
+const DEFAULT_BACKGROUND: &str = "opaque";
+
+const SUPPORTED_SIZES: &[&str] = &[
+    "1024x1024",
+    "1536x1024",
+    "1024x1536",
+    "2048x2048",
+    "2048x1152",
+    "3840x2160",
+    "2160x3840",
+];
+const SUPPORTED_QUALITIES: &[&str] = &["low", "medium", "high", "auto"];
+const SUPPORTED_FORMATS: &[&str] = &["png", "jpeg", "webp"];
+const SUPPORTED_BACKGROUNDS: &[&str] = &["opaque", "transparent", "auto"];
+
+pub struct GenerateImageTool {
+    provider: OpenAiCodexImageProvider,
+}
+
+impl Default for GenerateImageTool {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl GenerateImageTool {
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            provider: OpenAiCodexImageProvider::new(),
+        }
+    }
+
+    fn request_from_params(params: &Value) -> anyhow::Result<ImageGenerationRequest> {
+        let prompt = str_param(params, "prompt")
+            .ok_or_else(|| Error::message("missing required parameter: prompt"))?;
+
+        let model = str_param(params, "model").unwrap_or(DEFAULT_MODEL);
+        if model != DEFAULT_MODEL {
+            return Err(Error::message(format!(
+                "unsupported image model '{model}' — supported: {DEFAULT_MODEL}"
+            ))
+            .into());
+        }
+
+        let size = validate_optional_enum(params, "size", DEFAULT_SIZE, SUPPORTED_SIZES)?;
+        let quality =
+            validate_optional_enum(params, "quality", DEFAULT_QUALITY, SUPPORTED_QUALITIES)?;
+        let output_format = validate_optional_enum(
+            params,
+            "output_format",
+            DEFAULT_OUTPUT_FORMAT,
+            SUPPORTED_FORMATS,
+        )?;
+        let background = validate_optional_enum(
+            params,
+            "background",
+            DEFAULT_BACKGROUND,
+            SUPPORTED_BACKGROUNDS,
+        )?;
+
+        Ok(ImageGenerationRequest {
+            prompt: prompt.to_string(),
+            model: model.to_string(),
+            size: size.to_string(),
+            quality: quality.to_string(),
+            output_format: output_format.to_string(),
+            background: background.to_string(),
+        })
+    }
+}
+
+fn validate_optional_enum<'a>(
+    params: &'a Value,
+    key: &str,
+    default: &'static str,
+    allowed: &[&str],
+) -> anyhow::Result<&'a str> {
+    let Some(value) = str_param(params, key) else {
+        return Ok(default);
+    };
+    if allowed.contains(&value) {
+        return Ok(value);
+    }
+    Err(Error::message(format!(
+        "invalid {key} '{value}' — supported: {}",
+        allowed.join(", ")
+    ))
+    .into())
+}
+
+fn build_tool_result(request: &ImageGenerationRequest, image: &GeneratedImage) -> Value {
+    json!({
+        "sent": true,
+        "screenshot": image.data_uri(),
+        "caption": format!("Generated image: {}", request.prompt.trim()),
+        "model": request.model,
+        "size": request.size,
+        "quality": request.quality,
+        "output_format": request.output_format,
+        "background": request.background,
+    })
+}
+
+#[async_trait]
+impl AgentTool for GenerateImageTool {
+    fn name(&self) -> &str {
+        "generate_image"
+    }
+
+    fn description(&self) -> &str {
+        "Generate an image from a text prompt using gpt-image-2 via the existing OpenAI Codex OAuth login. Returns channel-sendable image media."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "required": ["prompt"],
+            "properties": {
+                "prompt": {
+                    "type": "string",
+                    "description": "Detailed image generation prompt."
+                },
+                "model": {
+                    "type": "string",
+                    "enum": [DEFAULT_MODEL],
+                    "description": "Image model to use. Defaults to gpt-image-2."
+                },
+                "size": {
+                    "type": "string",
+                    "enum": SUPPORTED_SIZES,
+                    "description": "Output size. Defaults to 1024x1024."
+                },
+                "quality": {
+                    "type": "string",
+                    "enum": SUPPORTED_QUALITIES,
+                    "description": "Generation quality. Defaults to medium."
+                },
+                "output_format": {
+                    "type": "string",
+                    "enum": SUPPORTED_FORMATS,
+                    "description": "Image format. Defaults to png."
+                },
+                "background": {
+                    "type": "string",
+                    "enum": SUPPORTED_BACKGROUNDS,
+                    "description": "Background handling. Defaults to opaque."
+                }
+            }
+        })
+    }
+
+    async fn execute(&self, params: Value) -> anyhow::Result<Value> {
+        let request = Self::request_from_params(&params)?;
+        let result = self.provider.generate_image(request.clone()).await?;
+        let image = result
+            .images
+            .first()
+            .ok_or_else(|| Error::message("image generation returned no images"))?;
+        Ok(build_tool_result(&request, image))
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use {super::*, base64::Engine as _, serde_json::json};
+
+    #[test]
+    fn request_from_params_applies_defaults() {
+        let request = GenerateImageTool::request_from_params(&json!({
+            "prompt": "a neon fox"
+        }))
+        .unwrap();
+
+        assert_eq!(request.prompt, "a neon fox");
+        assert_eq!(request.model, DEFAULT_MODEL);
+        assert_eq!(request.size, DEFAULT_SIZE);
+        assert_eq!(request.quality, DEFAULT_QUALITY);
+        assert_eq!(request.output_format, DEFAULT_OUTPUT_FORMAT);
+        assert_eq!(request.background, DEFAULT_BACKGROUND);
+    }
+
+    #[test]
+    fn request_from_params_rejects_invalid_quality() {
+        let err = GenerateImageTool::request_from_params(&json!({
+            "prompt": "a neon fox",
+            "quality": "ultra"
+        }))
+        .expect_err("invalid quality should fail");
+
+        assert!(err.to_string().contains("invalid quality"));
+    }
+
+    #[test]
+    fn tool_result_uses_channel_screenshot_contract() {
+        let request = ImageGenerationRequest::new("a neon fox");
+        let data = base64::engine::general_purpose::STANDARD.encode(b"png");
+        let image = GeneratedImage {
+            media_type: "image/png".into(),
+            data,
+        };
+
+        let result = build_tool_result(&request, &image);
+
+        assert_eq!(result["sent"], true);
+        assert!(
+            result["screenshot"]
+                .as_str()
+                .unwrap()
+                .starts_with("data:image/png;base64,")
+        );
+        assert_eq!(result["caption"], "Generated image: a neon fox");
+    }
+}

--- a/crates/tools/src/lib.rs
+++ b/crates/tools/src/lib.rs
@@ -26,6 +26,7 @@ pub mod firecrawl;
 #[cfg(feature = "fs-tools")]
 pub mod fs;
 pub mod image_cache;
+#[cfg(feature = "provider-openai-codex")]
 pub mod image_generation;
 pub mod location;
 pub mod map;

--- a/crates/tools/src/lib.rs
+++ b/crates/tools/src/lib.rs
@@ -26,6 +26,7 @@ pub mod firecrawl;
 #[cfg(feature = "fs-tools")]
 pub mod fs;
 pub mod image_cache;
+pub mod image_generation;
 pub mod location;
 pub mod map;
 pub mod nodes;

--- a/docs/src/providers.md
+++ b/docs/src/providers.md
@@ -162,6 +162,12 @@ automatic callback capture fails, the CLI prompts you to paste the callback URL
 Tokens are saved to the config volume and picked up by the gateway automatically.
 ```
 
+Once OpenAI Codex OAuth is connected, agents can use the built-in
+`generate_image` tool to create `gpt-image-2` images without an `OPENAI_API_KEY`.
+Generated images are delivered through the same channel media path as
+screenshots and `send_image`, so supported chat channels receive the image as a
+native attachment.
+
 ### GitHub Copilot
 
 GitHub Copilot uses OAuth authentication.


### PR DESCRIPTION
## Summary
- Add a Codex OAuth-backed image generation provider that calls the Responses API `image_generation` tool with `gpt-image-2`.
- Add a built-in `generate_image` tool that returns existing channel-compatible `screenshot` image media.
- Document that OpenAI Codex OAuth now supports image generation without `OPENAI_API_KEY`.

Fixes #956

## Validation
### Completed
- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p moltis-providers --features provider-openai-codex openai_codex_image --lib`
- [x] `cargo test -p moltis-tools image_generation --lib`
- [x] `cargo check -p moltis-gateway`

### Remaining
- [ ] Live Codex OAuth image generation smoke test against ChatGPT backend

## Manual QA
- Connect OpenAI Codex OAuth.
- Ask the agent to generate an image.
- Verify the generated image is sent through the current channel as native image media.