### PR TITLE
fix(sandbox): update discrawl module path

### DIFF
--- a/crates/skills/src/assets/messaging/discrawl/SKILL.md
+++ b/crates/skills/src/assets/messaging/discrawl/SKILL.md
@@ -2,7 +2,7 @@
 name: discrawl
 description: Archive and search Discord guild messages, threads, and members via the discrawl CLI. Supports bot API sync, local cache import, full-text and semantic search, and Git-backed NDJSON snapshots.
 platforms: [linux, macos]
-homepage: https://github.com/steipete/discrawl
+homepage: https://github.com/openclaw/discrawl
 requires:
   bins: [discrawl]
   install:
@@ -11,7 +11,7 @@ requires:
       bins: [discrawl]
       os: [darwin]
     - kind: go
-      module: "github.com/steipete/discrawl/cmd/discrawl@latest"
+      module: "github.com/openclaw/discrawl/cmd/discrawl@latest"
       bins: [discrawl]
 origin:
   source: moltis

--- a/crates/tools/src/sandbox/tests/docker_router.rs
+++ b/crates/tools/src/sandbox/tests/docker_router.rs
@@ -589,6 +589,8 @@ fn test_sandbox_image_dockerfile_installs_gogcli() {
 #[test]
 fn test_sandbox_image_dockerfile_installs_crawl_tools() {
     let dockerfile = sandbox_image_dockerfile("ubuntu:25.10", &["curl".into()]);
+    assert!(dockerfile.contains("go install github.com/openclaw/discrawl/cmd/discrawl@latest"));
+    assert!(!dockerfile.contains("github.com/steipete/discrawl"));
     for (module, version, _bin) in GO_TOOL_INSTALLS {
         assert!(
             dockerfile.contains(&format!("go install {module}@{version}")),

--- a/crates/tools/src/sandbox/types.rs
+++ b/crates/tools/src/sandbox/types.rs
@@ -572,7 +572,7 @@ pub(crate) const GOGCLI_VERSION: &str = "latest";
 /// (e.g. wacrawl) are host-only and install via their skill's `requires.install`.
 pub(crate) const GO_TOOL_INSTALLS: &[(&str, &str, &str)] = &[
     (
-        "github.com/steipete/discrawl/cmd/discrawl",
+        "github.com/openclaw/discrawl/cmd/discrawl",
         "latest",
         "discrawl",
     ),


### PR DESCRIPTION
## Summary
- Update sandbox discrawl Go install path from `github.com/steipete/discrawl` to `github.com/openclaw/discrawl`.
- Update bundled discrawl skill metadata to match the new repository/module path.
- Add a sandbox Dockerfile regression assertion to prevent reintroducing the stale module path.

Fixes #988

## Validation
### Completed
- [x] `GOBIN=/var/folders/0h/dmk6d6mj52s98cq24w9_n4d00000gn/T/opencode go install github.com/openclaw/discrawl/cmd/discrawl@latest`
- [x] `cargo test -p moltis-tools sandbox::tests::docker_router::test_sandbox_image_dockerfile_installs_crawl_tools`
- [x] `cargo test -p moltis-skills bundled::tests::every_bundled_skill_body_is_readable --features bundled-skills`
- [x] `cargo fmt --all -- --check`

### Remaining
- [ ] Full CI

## Manual QA
- Verified the replacement module path resolves with `go install`.