### PR TITLE
fix(install): avoid Proxmox Docker prompt failure

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -498,18 +498,18 @@ install_proxmox() {
     # and make the Docker prompt safe when lxc-attach has no interactive stdin.
     awk -v repo_url="$PROXMOX_REPO_URL" '
         {
-            print
             if ($0 ~ /^source <\(curl -fsSL / && !curl_patched) {
                 print "curl() {"
                 print "  case \"${*: -1}\" in"
                 print "    */install/moltis-install.sh)"
-                print "      command curl \"$@\" | sed '\''s/read -r -p \"${TAB3}Would you like to install Docker for sandbox support? <y\\/N> \" prompt/if [[ -t 0 ]]; then read -r -p \"${TAB3}Would you like to install Docker for sandbox support? <y\\/N> \" prompt; else prompt=\"${MOLTIS_INSTALL_DOCKER:-no}\"; fi/'\''"
+                print "      command curl \"$@\" | sed '\''s|^[[:space:]]*read -r -p \".*Docker for sandbox support.*\" prompt$|if [[ -t 0 ]]; then &; else prompt=\"${MOLTIS_INSTALL_DOCKER:-no}\"; fi|'\''"
                 print "      ;;"
                 print "    *) command curl \"$@\" ;;"
                 print "  esac"
                 print "}"
                 curl_patched = 1
             }
+            print
             if ($0 == "description" && !patched) {
                 q = sprintf("%c", 39)
                 print "pct exec \"$CTID\" -- bash -c \"cat > /usr/bin/update <<" q "MOLTIS_UPDATE_EOF" q
@@ -520,6 +520,9 @@ install_proxmox() {
             }
         }
     ' "$proxmox_script" >"$patched_script"
+
+    grep -q 'curl()' "$patched_script" || error "Failed to apply Docker prompt patch to Proxmox helper"
+    grep -q 'MOLTIS_UPDATE_EOF' "$patched_script" || error "Failed to apply update URL patch to Proxmox helper"
 
     info "Launching Proxmox VE helper script..."
     bash "$patched_script"

--- a/install.sh
+++ b/install.sh
@@ -493,12 +493,23 @@ install_proxmox() {
 
     download "$PROXMOX_SCRIPT_URL" "$proxmox_script" || error "Failed to download Proxmox helper"
 
-    # The upstream community-scripts install helper currently writes a hardcoded
-    # /usr/bin/update URL. Patch the fetched helper so new Moltis LXCs update
-    # from the Moltis fork until the helper honors COMMUNITY_SCRIPTS_URL there.
+    # Patch the fetched helper at launch time for Moltis-specific fixes that live
+    # in remote community-scripts files: keep /usr/bin/update on the Moltis fork,
+    # and make the Docker prompt safe when lxc-attach has no interactive stdin.
     awk -v repo_url="$PROXMOX_REPO_URL" '
         {
             print
+            if ($0 ~ /^source <\(curl -fsSL / && !curl_patched) {
+                print "curl() {"
+                print "  case \"${*: -1}\" in"
+                print "    */install/moltis-install.sh)"
+                print "      command curl \"$@\" | sed '\''s/read -r -p \"${TAB3}Would you like to install Docker for sandbox support? <y\\/N> \" prompt/if [[ -t 0 ]]; then read -r -p \"${TAB3}Would you like to install Docker for sandbox support? <y\\/N> \" prompt; else prompt=\"${MOLTIS_INSTALL_DOCKER:-no}\"; fi/'\''"
+                print "      ;;"
+                print "    *) command curl \"$@\" ;;"
+                print "  esac"
+                print "}"
+                curl_patched = 1
+            }
             if ($0 == "description" && !patched) {
                 q = sprintf("%c", 39)
                 print "pct exec \"$CTID\" -- bash -c \"cat > /usr/bin/update <<" q "MOLTIS_UPDATE_EOF" q

--- a/website/install.sh
+++ b/website/install.sh
@@ -498,18 +498,18 @@ install_proxmox() {
     # and make the Docker prompt safe when lxc-attach has no interactive stdin.
     awk -v repo_url="$PROXMOX_REPO_URL" '
         {
-            print
             if ($0 ~ /^source <\(curl -fsSL / && !curl_patched) {
                 print "curl() {"
                 print "  case \"${*: -1}\" in"
                 print "    */install/moltis-install.sh)"
-                print "      command curl \"$@\" | sed '\''s/read -r -p \"${TAB3}Would you like to install Docker for sandbox support? <y\\/N> \" prompt/if [[ -t 0 ]]; then read -r -p \"${TAB3}Would you like to install Docker for sandbox support? <y\\/N> \" prompt; else prompt=\"${MOLTIS_INSTALL_DOCKER:-no}\"; fi/'\''"
+                print "      command curl \"$@\" | sed '\''s|^[[:space:]]*read -r -p \".*Docker for sandbox support.*\" prompt$|if [[ -t 0 ]]; then &; else prompt=\"${MOLTIS_INSTALL_DOCKER:-no}\"; fi|'\''"
                 print "      ;;"
                 print "    *) command curl \"$@\" ;;"
                 print "  esac"
                 print "}"
                 curl_patched = 1
             }
+            print
             if ($0 == "description" && !patched) {
                 q = sprintf("%c", 39)
                 print "pct exec \"$CTID\" -- bash -c \"cat > /usr/bin/update <<" q "MOLTIS_UPDATE_EOF" q
@@ -520,6 +520,9 @@ install_proxmox() {
             }
         }
     ' "$proxmox_script" >"$patched_script"
+
+    grep -q 'curl()' "$patched_script" || error "Failed to apply Docker prompt patch to Proxmox helper"
+    grep -q 'MOLTIS_UPDATE_EOF' "$patched_script" || error "Failed to apply update URL patch to Proxmox helper"
 
     info "Launching Proxmox VE helper script..."
     bash "$patched_script"

--- a/website/install.sh
+++ b/website/install.sh
@@ -493,12 +493,23 @@ install_proxmox() {
 
     download "$PROXMOX_SCRIPT_URL" "$proxmox_script" || error "Failed to download Proxmox helper"
 
-    # The upstream community-scripts install helper currently writes a hardcoded
-    # /usr/bin/update URL. Patch the fetched helper so new Moltis LXCs update
-    # from the Moltis fork until the helper honors COMMUNITY_SCRIPTS_URL there.
+    # Patch the fetched helper at launch time for Moltis-specific fixes that live
+    # in remote community-scripts files: keep /usr/bin/update on the Moltis fork,
+    # and make the Docker prompt safe when lxc-attach has no interactive stdin.
     awk -v repo_url="$PROXMOX_REPO_URL" '
         {
             print
+            if ($0 ~ /^source <\(curl -fsSL / && !curl_patched) {
+                print "curl() {"
+                print "  case \"${*: -1}\" in"
+                print "    */install/moltis-install.sh)"
+                print "      command curl \"$@\" | sed '\''s/read -r -p \"${TAB3}Would you like to install Docker for sandbox support? <y\\/N> \" prompt/if [[ -t 0 ]]; then read -r -p \"${TAB3}Would you like to install Docker for sandbox support? <y\\/N> \" prompt; else prompt=\"${MOLTIS_INSTALL_DOCKER:-no}\"; fi/'\''"
+                print "      ;;"
+                print "    *) command curl \"$@\" ;;"
+                print "  esac"
+                print "}"
+                curl_patched = 1
+            }
             if ($0 == "description" && !patched) {
                 q = sprintf("%c", 39)
                 print "pct exec \"$CTID\" -- bash -c \"cat > /usr/bin/update <<" q "MOLTIS_UPDATE_EOF" q


### PR DESCRIPTION
## Summary
- Fixes the Proxmox LXC install path so the Docker sandbox prompt does not fail when `lxc-attach` has no interactive stdin.
- Preserves interactive behavior when a TTY is available and defaults to `MOLTIS_INSTALL_DOCKER` or `no` otherwise.
- Keeps root and website installer copies synchronized.

## Validation
### Completed
- [x] `sh -n install.sh`
- [x] `sh -n website/install.sh`
- [x] `./scripts/check-website-install-sync.sh`
- [x] Simulated the Proxmox helper patch and verified patched scripts parse with `bash -n`

### Remaining
- [ ] Full Proxmox LXC install smoke test on a PVE host

## Manual QA
- Not run locally because this requires a Proxmox VE host. The shell patch was syntax-checked and the fetched helper patch path was simulated.

Fixes #991