### PR TITLE
fix(install): tolerate missing Proxmox CA cert

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -495,7 +495,8 @@ install_proxmox() {
 
     # Patch the fetched helper at launch time for Moltis-specific fixes that live
     # in remote community-scripts files: keep /usr/bin/update on the Moltis fork,
-    # and make the Docker prompt safe when lxc-attach has no interactive stdin.
+    # make the Docker prompt safe when lxc-attach has no interactive stdin, and
+    # keep optional CA certificate display failures from removing the container.
     awk -v repo_url="$PROXMOX_REPO_URL" '
         {
             if ($0 ~ /^source <\(curl -fsSL / && !curl_patched) {
@@ -508,6 +509,10 @@ install_proxmox() {
                 print "  esac"
                 print "}"
                 curl_patched = 1
+            }
+            if ($0 == "CA_CERT=$(pct exec \"$CTID\" -- cat /etc/moltis/certs/ca.pem 2>/dev/null)" && !ca_cert_patched) {
+                sub(/\)$/, " || true)")
+                ca_cert_patched = 1
             }
             print
             if ($0 == "description" && !patched) {
@@ -523,6 +528,7 @@ install_proxmox() {
 
     grep -q 'curl()' "$patched_script" || error "Failed to apply Docker prompt patch to Proxmox helper"
     grep -q 'MOLTIS_UPDATE_EOF' "$patched_script" || error "Failed to apply update URL patch to Proxmox helper"
+    grep -q 'cat /etc/moltis/certs/ca.pem 2>/dev/null || true' "$patched_script" || error "Failed to apply CA certificate patch to Proxmox helper"
 
     info "Launching Proxmox VE helper script..."
     bash "$patched_script"

--- a/install.sh
+++ b/install.sh
@@ -528,7 +528,7 @@ install_proxmox() {
 
     grep -q 'curl()' "$patched_script" || error "Failed to apply Docker prompt patch to Proxmox helper"
     grep -q 'MOLTIS_UPDATE_EOF' "$patched_script" || error "Failed to apply update URL patch to Proxmox helper"
-    grep -q 'cat /etc/moltis/certs/ca.pem 2>/dev/null || true' "$patched_script" || error "Failed to apply CA certificate patch to Proxmox helper"
+    grep -q 'cat /etc/moltis/certs/ca.pem 2>/dev/null || true' "$patched_script" || warn "Could not apply optional CA certificate patch to Proxmox helper"
 
     info "Launching Proxmox VE helper script..."
     bash "$patched_script"

--- a/website/install.sh
+++ b/website/install.sh
@@ -495,7 +495,8 @@ install_proxmox() {
 
     # Patch the fetched helper at launch time for Moltis-specific fixes that live
     # in remote community-scripts files: keep /usr/bin/update on the Moltis fork,
-    # and make the Docker prompt safe when lxc-attach has no interactive stdin.
+    # make the Docker prompt safe when lxc-attach has no interactive stdin, and
+    # keep optional CA certificate display failures from removing the container.
     awk -v repo_url="$PROXMOX_REPO_URL" '
         {
             if ($0 ~ /^source <\(curl -fsSL / && !curl_patched) {
@@ -508,6 +509,10 @@ install_proxmox() {
                 print "  esac"
                 print "}"
                 curl_patched = 1
+            }
+            if ($0 == "CA_CERT=$(pct exec \"$CTID\" -- cat /etc/moltis/certs/ca.pem 2>/dev/null)" && !ca_cert_patched) {
+                sub(/\)$/, " || true)")
+                ca_cert_patched = 1
             }
             print
             if ($0 == "description" && !patched) {
@@ -523,6 +528,7 @@ install_proxmox() {
 
     grep -q 'curl()' "$patched_script" || error "Failed to apply Docker prompt patch to Proxmox helper"
     grep -q 'MOLTIS_UPDATE_EOF' "$patched_script" || error "Failed to apply update URL patch to Proxmox helper"
+    grep -q 'cat /etc/moltis/certs/ca.pem 2>/dev/null || true' "$patched_script" || error "Failed to apply CA certificate patch to Proxmox helper"
 
     info "Launching Proxmox VE helper script..."
     bash "$patched_script"

--- a/website/install.sh
+++ b/website/install.sh
@@ -528,7 +528,7 @@ install_proxmox() {
 
     grep -q 'curl()' "$patched_script" || error "Failed to apply Docker prompt patch to Proxmox helper"
     grep -q 'MOLTIS_UPDATE_EOF' "$patched_script" || error "Failed to apply update URL patch to Proxmox helper"
-    grep -q 'cat /etc/moltis/certs/ca.pem 2>/dev/null || true' "$patched_script" || error "Failed to apply CA certificate patch to Proxmox helper"
+    grep -q 'cat /etc/moltis/certs/ca.pem 2>/dev/null || true' "$patched_script" || warn "Could not apply optional CA certificate patch to Proxmox helper"
 
     info "Launching Proxmox VE helper script..."
     bash "$patched_script"


### PR DESCRIPTION
## Summary
- Prevent the Proxmox LXC helper from treating optional CA certificate read failures as fatal.
- Apply the same runtime patch to both the root installer and website installer copy.
- Avoid deleting a successfully-created LXC when `pct exec` cannot read `/etc/moltis/certs/ca.pem`.

## Validation
### Completed
- [x] `sh -n install.sh && sh -n website/install.sh`
- [x] Simulated the Proxmox helper patch against the fetched upstream helper and confirmed the CA certificate command becomes best-effort with `|| true`.

### Remaining
- [ ] Manual Proxmox LXC install on a PVE 9 host.

## Manual QA
- Run `curl -fsSL https://www.moltis.org/install.sh | sh -s -- --method=proxmox` on a Proxmox host.
- Confirm the LXC remains after setup even if `/etc/moltis/certs/ca.pem` cannot be read via `pct exec`.

Fixes #993