### PR TITLE
fix(web): prevent chat composer horizontal overflow

### DIFF
--- a/crates/web/src/assets/css/chat.css
+++ b/crates/web/src/assets/css/chat.css
@@ -39,7 +39,9 @@
 
 .msg {
   border-radius: var(--radius);
+  min-width: 0;
   word-wrap: break-word;
+  overflow-wrap: anywhere;
   white-space: pre-wrap;
   max-width: 80%;
   padding: 10px 14px;
@@ -699,11 +701,15 @@
 .chat-input-row {
   border-top: 0;
   background: var(--bg);
+  min-width: 0;
   padding: 16px 24px 18px;
 }
 
 .chat-composer {
   width: min(100%, 980px);
+  max-width: 100%;
+  min-width: 0;
+  box-sizing: border-box;
   margin: 0 auto;
   border: 1px solid var(--border);
   border-radius: 18px;
@@ -721,10 +727,13 @@
   display: flex;
   align-items: flex-start;
   gap: 10px;
+  min-width: 0;
 }
 
 .chat-composer-textarea {
   flex: 1;
+  width: 100%;
+  min-width: 0;
   min-height: 40px;
   max-height: 140px;
   border: 0;
@@ -736,6 +745,8 @@
   font-size: 0.95rem;
   line-height: 1.6;
   padding: 4px 2px;
+  overflow-x: hidden;
+  overflow-wrap: anywhere;
 }
 
 .chat-composer-textarea::placeholder {

--- a/crates/web/src/assets/css/chat.css
+++ b/crates/web/src/assets/css/chat.css
@@ -707,7 +707,6 @@
 
 .chat-composer {
   width: min(100%, 980px);
-  max-width: 100%;
   min-width: 0;
   box-sizing: border-box;
   margin: 0 auto;
@@ -732,7 +731,6 @@
 
 .chat-composer-textarea {
   flex: 1;
-  width: 100%;
   min-width: 0;
   min-height: 40px;
   max-height: 140px;

--- a/crates/web/ui/e2e/specs/chat-layout.spec.js
+++ b/crates/web/ui/e2e/specs/chat-layout.spec.js
@@ -40,6 +40,29 @@ async function injectLongMessages(page, count) {
 	}, count);
 }
 
+async function getHorizontalOverflow(page) {
+	return await page.evaluate(() => {
+		var messages = document.getElementById("messages");
+		var composer = document.getElementById("chatComposer");
+		var input = document.getElementById("chatInput");
+		if (!messages) throw new Error("#messages element not found");
+		if (!composer) throw new Error("#chatComposer element not found");
+		if (!input) throw new Error("#chatInput element not found");
+
+		var doc = document.documentElement;
+		return {
+			documentScrollWidth: doc.scrollWidth,
+			documentClientWidth: doc.clientWidth,
+			messagesScrollWidth: messages.scrollWidth,
+			messagesClientWidth: messages.clientWidth,
+			composerRight: composer.getBoundingClientRect().right,
+			inputScrollWidth: input.scrollWidth,
+			inputClientWidth: input.clientWidth,
+			viewportWidth: window.innerWidth,
+		};
+	});
+}
+
 test.describe("Chat layout — no horizontal overflow (#945)", () => {
 	test.beforeEach(async ({ page }) => {
 		await navigateAndWait(page, "/chats/main");
@@ -82,6 +105,34 @@ test.describe("Chat layout — no horizontal overflow (#945)", () => {
 			// No horizontal scrollbar: content fits within the visible area
 			expect(overflow.scrollWidth, `scrollWidth <= clientWidth at ${width}px`).toBeLessThanOrEqual(
 				overflow.clientWidth,
+			);
+		}
+
+		expect(pageErrors).toEqual([]);
+	});
+
+	test("long prompt text does not widen the composer or page", async ({ page }) => {
+		const pageErrors = watchPageErrors(page);
+		const longPrompt = `Please inspect this path ${"very-long-unbroken-prompt-segment".repeat(24)} and explain it.`;
+
+		for (const width of [1119, 600]) {
+			await page.setViewportSize({ width, height: 800 });
+			await page.waitForFunction((w) => window.innerWidth === w, width, { timeout: 5_000 });
+
+			const chatInput = page.locator("#chatInput");
+			await expect(chatInput).toBeVisible({ timeout: 10_000 });
+			await chatInput.fill(longPrompt);
+
+			const overflow = await getHorizontalOverflow(page);
+			expect(overflow.documentScrollWidth, `document scrollWidth at ${width}px`).toBeLessThanOrEqual(
+				overflow.documentClientWidth,
+			);
+			expect(overflow.messagesScrollWidth, `messages scrollWidth at ${width}px`).toBeLessThanOrEqual(
+				overflow.messagesClientWidth,
+			);
+			expect(overflow.composerRight, `composer right edge at ${width}px`).toBeLessThanOrEqual(overflow.viewportWidth);
+			expect(overflow.inputScrollWidth, `input scrollWidth at ${width}px`).toBeLessThanOrEqual(
+				overflow.inputClientWidth,
 			);
 		}
 

--- a/crates/web/ui/e2e/specs/chat-layout.spec.js
+++ b/crates/web/ui/e2e/specs/chat-layout.spec.js
@@ -30,7 +30,8 @@ async function injectLongMessages(page, count) {
 			"This is a fairly long message that contains enough text to potentially cause horizontal overflow " +
 			"if the container does not properly constrain its width. It includes some inline code like " +
 			"`const result = await fetch('/api/endpoint')` and continues with more text to fill the line. " +
-			"The layout must wrap this text rather than extending the container beyond the viewport.";
+			"The layout must wrap this text rather than extending the container beyond the viewport. " +
+			"very-long-unbroken-message-segment".repeat(16);
 		for (var i = 0; i < msgCount; i++) {
 			var el = document.createElement("div");
 			el.className = i % 2 === 0 ? "msg assistant" : "msg user";
@@ -114,6 +115,7 @@ test.describe("Chat layout — no horizontal overflow (#945)", () => {
 	test("long prompt text does not widen the composer or page", async ({ page }) => {
 		const pageErrors = watchPageErrors(page);
 		const longPrompt = `Please inspect this path ${"very-long-unbroken-prompt-segment".repeat(24)} and explain it.`;
+		await injectLongMessages(page, 4);
 
 		for (const width of [1119, 600]) {
 			await page.setViewportSize({ width, height: 800 });


### PR DESCRIPTION
## Summary
- Fixes #994 by constraining chat message bubbles, composer wrappers, and textarea flex sizing so long prompt text cannot widen the page.
- Adds a Playwright regression test for long unbroken prompt text at desktop and mobile widths.

## Validation
### Completed
- [x] `biome check --write crates/web/ui/e2e/specs/chat-layout.spec.js`
- [x] `cd crates/web/ui && npm run build`
- [x] `cd crates/web/ui && npx tsc --noEmit`
- [x] `cd crates/web/ui && npm run build:css`
- [x] `cd crates/web/ui && npm run build:sw`
- [x] `cd crates/web/ui && npm run e2e -- e2e/specs/chat-layout.spec.js`

### Remaining
- [ ] Full repository validation was not run for this focused CSS/E2E fix.

## Manual QA
- Confirmed via Playwright that chat layout has no horizontal overflow with long unbroken prompt text at 1119px and 600px viewport widths.