### PR TITLE
feat(tls): support public IP SAN for generated certs

### DIFF
--- a/crates/config/src/schema/runtime.rs
+++ b/crates/config/src/schema/runtime.rs
@@ -365,6 +365,8 @@ pub struct TlsConfig {
     pub key_path: Option<String>,
     /// Path to the CA certificate (PEM) used for trust instructions.
     pub ca_cert_path: Option<String>,
+    /// Public IP address to include as an IP SAN in auto-generated certificates.
+    pub public_ip: Option<String>,
     /// Port for the plain-HTTP redirect/CA-download server.
     /// Defaults to the gateway port + 1 when not set.
     pub http_redirect_port: Option<u16>,
@@ -378,6 +380,7 @@ impl Default for TlsConfig {
             cert_path: None,
             key_path: None,
             ca_cert_path: None,
+            public_ip: None,
             http_redirect_port: None,
         }
     }

--- a/crates/config/src/template.rs
+++ b/crates/config/src/template.rs
@@ -81,6 +81,7 @@ port = {port}                           # Port number (auto-generated for this i
 # [tls]
 # enabled = true                    # Enable HTTPS (recommended)
 # auto_generate = true              # Auto-generate local CA and server certificate
+# public_ip = "203.0.113.10"        # Optional IP SAN for direct https://IP access
 # http_redirect_port = 18790        # Optional override (default: server.port + 1)
 # cert_path = "/path/to/cert.pem"   # Custom certificate file (overrides auto-gen)
 # key_path = "/path/to/key.pem"     # Custom private key file

--- a/crates/config/src/validate/schema_map.rs
+++ b/crates/config/src/validate/schema_map.rs
@@ -449,6 +449,7 @@ pub(super) fn build_schema_map() -> KnownKeys {
                 ("cert_path", Leaf),
                 ("key_path", Leaf),
                 ("ca_cert_path", Leaf),
+                ("public_ip", Leaf),
                 ("http_redirect_port", Leaf),
             ])),
         ),

--- a/crates/config/src/validate/semantic.rs
+++ b/crates/config/src/validate/semantic.rs
@@ -171,15 +171,36 @@ pub(super) fn check_semantic_warnings(config: &MoltisConfig, diagnostics: &mut V
             message: "tls.key_path is set but tls.cert_path is missing".into(),
         });
     }
-    if let Some(public_ip) = config.tls.public_ip.as_deref()
-        && public_ip.parse::<std::net::IpAddr>().is_err()
-    {
-        diagnostics.push(Diagnostic {
-            severity: Severity::Error,
-            category: "security",
-            path: "tls.public_ip".into(),
-            message: "tls.public_ip must be an IPv4 or IPv6 address".into(),
-        });
+    if let Some(public_ip) = config.tls.public_ip.as_deref() {
+        match public_ip.parse::<std::net::IpAddr>() {
+            Ok(ip) if ip.is_loopback() || ip.is_unspecified() => {
+                diagnostics.push(Diagnostic {
+                    severity: Severity::Warning,
+                    category: "security",
+                    path: "tls.public_ip".into(),
+                    message: "tls.public_ip is a loopback or unspecified address and will not be useful as a public IP SAN".into(),
+                });
+            },
+            Ok(_) => {},
+            Err(_) => {
+                diagnostics.push(Diagnostic {
+                    severity: Severity::Error,
+                    category: "security",
+                    path: "tls.public_ip".into(),
+                    message: "tls.public_ip must be an IPv4 or IPv6 address".into(),
+                });
+            },
+        }
+
+        if has_cert && has_key {
+            diagnostics.push(Diagnostic {
+                severity: Severity::Warning,
+                category: "security",
+                path: "tls.public_ip".into(),
+                message: "tls.public_ip has no effect when tls.cert_path and tls.key_path are set"
+                    .into(),
+            });
+        }
     }
 
     // Sandbox mode off

--- a/crates/config/src/validate/semantic.rs
+++ b/crates/config/src/validate/semantic.rs
@@ -171,6 +171,16 @@ pub(super) fn check_semantic_warnings(config: &MoltisConfig, diagnostics: &mut V
             message: "tls.key_path is set but tls.cert_path is missing".into(),
         });
     }
+    if let Some(public_ip) = config.tls.public_ip.as_deref()
+        && public_ip.parse::<std::net::IpAddr>().is_err()
+    {
+        diagnostics.push(Diagnostic {
+            severity: Severity::Error,
+            category: "security",
+            path: "tls.public_ip".into(),
+            message: "tls.public_ip must be an IPv4 or IPv6 address".into(),
+        });
+    }
 
     // Sandbox mode off
     if config.tools.exec.sandbox.mode == "off" {

--- a/crates/config/src/validate/tests/security.rs
+++ b/crates/config/src/validate/tests/security.rs
@@ -74,6 +74,38 @@ key_path = "/path/to/key.pem"
 }
 
 #[test]
+fn tls_public_ip_accepts_ip_address() {
+    let toml = r#"
+[tls]
+public_ip = "203.0.113.10"
+"#;
+    let result = validate_toml_str(toml);
+    assert!(
+        result.diagnostics.iter().all(|d| d.path != "tls.public_ip"),
+        "expected no public_ip diagnostics, got: {:?}",
+        result.diagnostics
+    );
+}
+
+#[test]
+fn tls_public_ip_rejects_dns_name() {
+    let toml = r#"
+[tls]
+public_ip = "chat.example.com"
+"#;
+    let result = validate_toml_str(toml);
+    let error = result
+        .diagnostics
+        .iter()
+        .find(|d| d.severity == Severity::Error && d.path == "tls.public_ip");
+    assert!(
+        error.is_some(),
+        "expected error for non-IP public_ip, got: {:?}",
+        result.diagnostics
+    );
+}
+
+#[test]
 fn unknown_tailscale_mode_warned() {
     let toml = r#"
 [tailscale]

--- a/crates/config/src/validate/tests/security.rs
+++ b/crates/config/src/validate/tests/security.rs
@@ -106,6 +106,50 @@ public_ip = "chat.example.com"
 }
 
 #[test]
+fn tls_public_ip_warns_for_loopback_or_unspecified_address() {
+    for public_ip in ["127.0.0.1", "::1", "0.0.0.0", "::"] {
+        let toml = format!(
+            r#"
+[tls]
+public_ip = "{public_ip}"
+"#
+        );
+        let result = validate_toml_str(&toml);
+        let warning = result.diagnostics.iter().find(|d| {
+            d.severity == Severity::Warning
+                && d.path == "tls.public_ip"
+                && d.message.contains("loopback or unspecified")
+        });
+        assert!(
+            warning.is_some(),
+            "expected warning for {public_ip}, got: {:?}",
+            result.diagnostics
+        );
+    }
+}
+
+#[test]
+fn tls_public_ip_warns_with_custom_cert_paths() {
+    let toml = r#"
+[tls]
+cert_path = "/path/to/cert.pem"
+key_path = "/path/to/key.pem"
+public_ip = "203.0.113.10"
+"#;
+    let result = validate_toml_str(toml);
+    let warning = result.diagnostics.iter().find(|d| {
+        d.severity == Severity::Warning
+            && d.path == "tls.public_ip"
+            && d.message.contains("has no effect")
+    });
+    assert!(
+        warning.is_some(),
+        "expected warning for public_ip with custom certs, got: {:?}",
+        result.diagnostics
+    );
+}
+
+#[test]
 fn unknown_tailscale_mode_warned() {
     let toml = r#"
 [tailscale]

--- a/crates/httpd/src/server/handlers.rs
+++ b/crates/httpd/src/server/handlers.rs
@@ -282,6 +282,16 @@ pub(super) fn tls_runtime_sans(bind: &str) -> Vec<moltis_tls::ServerSan> {
     }
 }
 
+#[cfg(feature = "tls")]
+pub(super) fn tls_configured_sans(
+    public_ip: Option<&str>,
+) -> Result<Vec<moltis_tls::ServerSan>, std::net::AddrParseError> {
+    public_ip
+        .map(str::parse)
+        .transpose()
+        .map(|ip| ip.map(moltis_tls::ServerSan::Ip).into_iter().collect())
+}
+
 pub(super) fn startup_bind_line(addr: SocketAddr) -> String {
     format!("bind (--bind): {addr}")
 }
@@ -531,6 +541,20 @@ mod tests {
         assert_eq!(tls_runtime_sans("192.168.1.9"), vec![
             moltis_tls::ServerSan::Ip("192.168.1.9".parse().unwrap())
         ]);
+    }
+
+    #[cfg(feature = "tls")]
+    #[test]
+    fn tls_configured_sans_uses_public_ip() {
+        assert_eq!(tls_configured_sans(Some("203.0.113.10")).unwrap(), vec![
+            moltis_tls::ServerSan::Ip("203.0.113.10".parse().unwrap())
+        ]);
+    }
+
+    #[cfg(feature = "tls")]
+    #[test]
+    fn tls_configured_sans_rejects_dns_name() {
+        assert!(tls_configured_sans(Some("chat.example.com")).is_err());
     }
 
     #[cfg(feature = "tls")]

--- a/crates/httpd/src/server/runtime.rs
+++ b/crates/httpd/src/server/runtime.rs
@@ -136,7 +136,11 @@ pub(super) async fn finalize_prepared_gateway(
             // Auto-generate certificates.
             let mgr =
                 moltis_tls::FsCertManager::new().map_err(|e| crate::Error::Tls(e.to_string()))?;
-            let runtime_sans = tls_runtime_sans(bind);
+            let mut runtime_sans = tls_runtime_sans(bind);
+            runtime_sans.extend(
+                tls_configured_sans(tls_config.public_ip.as_deref())
+                    .map_err(|e| crate::Error::Tls(format!("invalid tls.public_ip: {e}")))?,
+            );
             let (ca, cert, key) = mgr
                 .ensure_certs(&runtime_sans)
                 .map_err(|e| crate::Error::Tls(e.to_string()))?;
@@ -1117,7 +1121,11 @@ pub async fn start_gateway(
             // Auto-generate certificates.
             let mgr =
                 moltis_tls::FsCertManager::new().map_err(|e| crate::Error::Tls(e.to_string()))?;
-            let runtime_sans = tls_runtime_sans(bind);
+            let mut runtime_sans = tls_runtime_sans(bind);
+            runtime_sans.extend(
+                tls_configured_sans(tls_config.public_ip.as_deref())
+                    .map_err(|e| crate::Error::Tls(format!("invalid tls.public_ip: {e}")))?,
+            );
             let (ca, cert, key) = mgr
                 .ensure_certs(&runtime_sans)
                 .map_err(|e| crate::Error::Tls(e.to_string()))?;

--- a/docs/src/configuration-reference.md
+++ b/docs/src/configuration-reference.md
@@ -151,11 +151,12 @@ TLS configuration for the gateway HTTPS server.
 
 | Key | Type | Default | Description |
 |---|---|---|---|
-| `enabled` | bool | `true` | Enable HTTPS with auto-generated certificates. |
-| `auto_generate` | bool | `true` | Auto-generate a local CA and server certificate on first run. |
+| `enabled` | bool | `true` | Enable HTTPS. Auto-generated certificates are local/private-network certificates, not public CA certificates. |
+| `auto_generate` | bool | `true` | Auto-generate a local CA and server certificate on first run. The generated certificate is only valid for names/IPs included in its SAN list. |
 | `cert_path` | optional string | — | Path to a custom server certificate (PEM). Overrides auto-generation. |
 | `key_path` | optional string | — | Path to a custom server private key (PEM). Overrides auto-generation. |
 | `ca_cert_path` | optional string | — | Path to the CA certificate (PEM) used for trust instructions. |
+| `public_ip` | optional string | — | Public IPv4 or IPv6 address to include as an IP SAN in auto-generated certificates. Use this for direct `https://<public-ip>` access after trusting Moltis' local CA. |
 | `http_redirect_port` | optional integer | — | Port for the plain-HTTP redirect/CA-download server. Defaults to the gateway port + 1 when not set. |
 
 

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -384,7 +384,11 @@ See [Slack](slack.md) for full configuration reference and setup instructions.
 enabled = true
 cert_path = "~/.config/moltis/cert.pem"
 key_path = "~/.config/moltis/key.pem"
-# If paths don't exist, a self-signed certificate is generated
+# If custom paths are not set and auto_generate is true, Moltis generates a
+# local CA and server certificate for localhost/private-network names. Public
+# VPS IP access should set public_ip; public domains should use a reverse proxy
+# or custom CA-issued certificates.
+# public_ip = "203.0.113.10"
 
 # Port for the plain-HTTP redirect / CA-download server.
 # Defaults to the server port + 1 when not set.

--- a/docs/src/deploy-vps.md
+++ b/docs/src/deploy-vps.md
@@ -13,8 +13,9 @@ talk to your agent from anywhere.
 
 ## Option A: Docker (recommended)
 
-Docker is the fastest path. It handles TLS certificates, sandbox isolation,
-and upgrades via image pulls.
+Docker is the fastest path. It handles sandbox isolation and upgrades via image
+pulls. For browser-trusted TLS on a VPS, put Moltis behind a reverse proxy
+such as Caddy, nginx, or Traefik and let the proxy manage public certificates.
 
 ### 1. Install Docker
 
@@ -39,9 +40,41 @@ docker compose up -d
 
 ### 3. Access the web UI
 
-Open `https://<your-server-ip>:13131` in your browser. You'll see a TLS
-warning because Moltis generates a self-signed certificate. Accept it or
-download the CA from `http://<your-server-ip>:13132`.
+For a production VPS, use a domain name and terminate TLS at a reverse proxy:
+
+```yaml
+services:
+  moltis:
+    image: ghcr.io/moltis-org/moltis:latest
+    command: ["--bind", "0.0.0.0", "--port", "13131", "--no-tls"]
+    environment:
+      - MOLTIS_BEHIND_PROXY=true
+      - MOLTIS_EXTERNAL_URL=https://chat.example.com
+```
+
+Point your proxy at `http://<moltis-host>:13131`, then open your public URL,
+for example `https://chat.example.com`.
+
+Moltis can also auto-generate a local CA and server certificate, but that mode
+is meant for local development or private networks. Trusting the generated CA
+only makes the issuer trusted; the browser still requires the certificate's
+Subject Alternative Name (SAN) to match the exact hostname or IP you open.
+An IP-address URL such as `https://<your-server-ip>:13131` only works if the
+certificate contains that IP address as an IP SAN, and normal public TLS setups
+are domain-name based. Inside Docker, Moltis usually cannot know your VPS public
+IP or provider domain, so direct IP access may fail with a certificate name
+mismatch even after importing the CA. To use direct IP access with the
+auto-generated certificate, set the public IP explicitly:
+
+```toml
+[tls]
+public_ip = "203.0.113.10"
+```
+
+Then restart Moltis so it regenerates the server certificate and import the
+generated CA from `http://<your-server-ip>:13132/certs/ca.pem`. If you want
+Moltis to serve HTTPS directly on a public domain, configure `tls.cert_path` and
+`tls.key_path` with a certificate issued for that domain.
 
 Log in with the password you set, then configure your LLM provider in
 Settings.
@@ -107,14 +140,17 @@ instructions.
 
 ## Firewall
 
-Open ports 13131 (HTTPS gateway) and 13132 (HTTP CA download) in your
-firewall. If you put Moltis behind a reverse proxy (nginx, Caddy), you only
-need to expose the proxy port and can use `--no-tls` on Moltis.
+If you use the recommended reverse proxy setup, expose only the proxy ports
+(`80` and `443`) publicly and keep Moltis' `13131` port private to the host or
+container network.
+
+Only expose `13131` directly if you intentionally serve Moltis without a proxy.
+Only expose `13132` if you intentionally use Moltis' local CA download endpoint.
 
 ```bash
-# UFW example
-sudo ufw allow 13131/tcp
-sudo ufw allow 13132/tcp
+# UFW example for the recommended reverse proxy setup
+sudo ufw allow 80/tcp
+sudo ufw allow 443/tcp
 ```
 
 ## Upgrades

--- a/docs/src/docker.md
+++ b/docs/src/docker.md
@@ -28,8 +28,8 @@ provider so you can skip the browser setup wizard entirely.
 
 | Port | Purpose |
 |------|---------|
-| 13131 | Gateway (HTTPS) — web UI, API, WebSocket |
-| 13132 | HTTP — CA certificate download for TLS trust |
+| 13131 | Gateway (HTTPS by default, HTTP with `--no-tls`) — web UI, API, WebSocket |
+| 13132 | HTTP — CA certificate download for local TLS trust |
 | 1455 | OAuth callback — required for OpenAI Codex and other providers with pre-registered redirect URIs |
 
 ### Trusting the TLS certificate
@@ -53,6 +53,29 @@ sudo update-ca-certificates
 
 After trusting the CA, restart your browser. The warning will not appear again
 (the CA persists in the mounted config volume).
+
+This local CA only solves certificate trust for names included in the generated
+server certificate, such as `localhost`, `moltis.localhost`, the container or
+host name, and sometimes an inferred non-loopback bind IP. It does not make a
+certificate valid for an arbitrary public VPS IP address or hosting-provider
+domain. Browsers still reject those targets with a certificate name mismatch if
+they are not present in the certificate SAN list. IP-address URLs require an IP
+SAN. For direct `https://<public-ip>:13131` access, set `tls.public_ip` to that
+address before starting Moltis so the auto-generated certificate includes it:
+
+```toml
+[tls]
+public_ip = "203.0.113.10"
+```
+
+Regular public TLS deployments should use a domain name.
+
+For internet-facing Docker deployments, prefer a domain name plus a reverse
+proxy with public CA certificates. Run Moltis with `--no-tls`, set
+`MOLTIS_BEHIND_PROXY=true`, and point the proxy at `http://<moltis-host>:13131`.
+If you want Moltis to serve HTTPS directly, mount a certificate and private key
+whose SANs cover the public hostname and set `tls.cert_path` and `tls.key_path`
+in `moltis.toml`.
 
 ```admonish note
 When accessing from localhost, no authentication is required. If you access Moltis from a different machine (e.g., over the network), a setup code is printed to the container logs for authentication setup:

--- a/docs/src/security.md
+++ b/docs/src/security.md
@@ -291,7 +291,15 @@ auto_generate = true
 ```
 
 For production, use certificates from a trusted CA or configure custom
-certificates.
+certificates. The auto-generated certificate is intended for localhost and
+private-network access; importing the generated CA does not make the certificate
+valid for public IP addresses or domains that are not listed in its SANs. IP
+address URLs require a certificate with that address as an IP SAN; set
+`tls.public_ip` to include a direct-access VPS IP in Moltis' auto-generated
+certificate. Regular public TLS deployments should use a domain name. For VPS and other
+internet-facing deployments, terminate TLS at a reverse proxy or configure
+`tls.cert_path` and `tls.key_path` with a certificate issued for your public
+hostname.
 
 ### Origin Validation
 


### PR DESCRIPTION
## Summary
- Add `tls.public_ip` so auto-generated Moltis TLS certificates can include a configured public IP as an IP SAN.
- Validate `tls.public_ip` as IPv4/IPv6 and include it in generated cert SANs alongside runtime-detected SANs.
- Update VPS, Docker, security, and configuration docs to explain direct `https://<public-ip>` usage and reverse-proxy recommendations.

## Validation
### Completed
- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p moltis-config tls_public_ip -- --nocapture`
- [x] `cargo test -p moltis-httpd tls_configured_sans -- --nocapture`
- [x] `cargo test -p moltis-tls sans -- --nocapture`

### Remaining
- [ ] Full workspace `just lint` / `just test` not run in this session.

## Manual QA
- Reviewed the generated cert flow to confirm `tls.public_ip` is appended before `ensure_certs()` so SAN metadata triggers regeneration when the configured IP changes.
- Reviewed docs for direct public-IP TLS guidance and reverse-proxy guidance.