### PR TITLE
feat(mcp): support OAuth client secrets

### DIFF
--- a/crates/config/src/schema/runtime.rs
+++ b/crates/config/src/schema/runtime.rs
@@ -169,6 +169,14 @@ pub struct McpServerEntry {
 pub struct McpOAuthOverrideEntry {
     /// The OAuth client ID.
     pub client_id: String,
+    /// Optional OAuth client secret sent to the token endpoint.
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        serialize_with = "super::serialize_option_secret",
+        deserialize_with = "super::deserialize_option_secret"
+    )]
+    pub client_secret: Option<Secret<String>>,
     /// The authorization endpoint URL.
     pub auth_url: String,
     /// The token endpoint URL.

--- a/crates/config/src/schema/tests.rs
+++ b/crates/config/src/schema/tests.rs
@@ -195,6 +195,33 @@ request_timeout_secs = 75
 }
 
 #[test]
+fn mcp_oauth_override_parses_client_secret_as_secret() {
+    let config: MoltisConfig = toml::from_str(
+        r#"
+[mcp.servers.hubspot]
+url = "https://mcp.hubspot.com"
+transport = "streamable-http"
+
+[mcp.servers.hubspot.oauth]
+client_id = "client-id"
+client_secret = "client-secret"
+auth_url = "https://mcp.hubspot.com/oauth/authorize/user"
+token_url = "https://mcp.hubspot.com/oauth/v3/token"
+"#,
+    )
+    .unwrap();
+
+    let secret = config
+        .mcp
+        .servers
+        .get("hubspot")
+        .and_then(|entry| entry.oauth.as_ref())
+        .and_then(|oauth| oauth.client_secret.as_ref())
+        .map(ExposeSecret::expose_secret);
+    assert_eq!(secret.map(String::as_str), Some("client-secret"));
+}
+
+#[test]
 fn agents_config_parses_presets() {
     let toml = r#"
 [agents]

--- a/crates/config/src/template.rs
+++ b/crates/config/src/template.rs
@@ -492,6 +492,13 @@ port = {port}                           # Port number (auto-generated for this i
 # env = {{ KEY = "value" }}           # Environment variables
 # transport = "stdio"               # "stdio" | "sse" | "streamable-http"
 
+# [mcp.servers.server-name.oauth]
+# client_id = "your-client-id"       # Manual OAuth client ID
+# client_secret = "your-secret"      # Optional secret for token exchange
+# auth_url = "https://auth.example.com/authorize"
+# token_url = "https://auth.example.com/token"
+# scopes = ["mcp:read"]
+
 # ══════════════════════════════════════════════════════════════════════════════
 # METRICS
 # ══════════════════════════════════════════════════════════════════════════════

--- a/crates/config/src/validate/schema_map.rs
+++ b/crates/config/src/validate/schema_map.rs
@@ -235,6 +235,7 @@ pub(super) fn build_schema_map() -> KnownKeys {
     let mcp_oauth_override = || {
         Struct(HashMap::from([
             ("client_id", Leaf),
+            ("client_secret", Leaf),
             ("auth_url", Leaf),
             ("token_url", Leaf),
             ("scopes", Leaf),

--- a/crates/config/src/validate/tests/structural.rs
+++ b/crates/config/src/validate/tests/structural.rs
@@ -42,3 +42,28 @@ unknwon = "value"
         result.diagnostics
     );
 }
+
+#[test]
+fn mcp_oauth_client_secret_is_known_field() {
+    let toml = r#"
+[mcp.servers.hubspot]
+url = "https://mcp.hubspot.com"
+transport = "streamable-http"
+
+[mcp.servers.hubspot.oauth]
+client_id = "client-id"
+client_secret = "client-secret"
+auth_url = "https://mcp.hubspot.com/oauth/authorize/user"
+token_url = "https://mcp.hubspot.com/oauth/v3/token"
+"#;
+    let result = validate_toml_str(toml);
+    assert!(
+        !result
+            .diagnostics
+            .iter()
+            .any(|d| d.category == "unknown-field"
+                && d.path == "mcp.servers.hubspot.oauth.client_secret"),
+        "client_secret should be accepted, got: {:?}",
+        result.diagnostics
+    );
+}

--- a/crates/gateway/src/server/prepare_core.rs
+++ b/crates/gateway/src/server/prepare_core.rs
@@ -325,6 +325,7 @@ pub async fn prepare_gateway_core(
                     .as_ref()
                     .map(|o| moltis_mcp::registry::McpOAuthConfig {
                         client_id: o.client_id.clone(),
+                        client_secret: o.client_secret.clone(),
                         auth_url: o.auth_url.clone(),
                         token_url: o.token_url.clone(),
                         scopes: o.scopes.clone(),

--- a/crates/mcp/src/auth.rs
+++ b/crates/mcp/src/auth.rs
@@ -81,6 +81,7 @@ pub trait McpAuthProvider: Send + Sync {
 #[derive(Debug, Clone)]
 pub struct McpOAuthOverride {
     pub client_id: String,
+    pub client_secret: Option<Secret<String>>,
     pub auth_url: String,
     pub token_url: String,
     pub scopes: Vec<String>,
@@ -180,9 +181,11 @@ impl McpOAuthProvider {
         };
 
         // Need the token endpoint. Try loading from stored registration or override.
-        let (client_id, token_url, resource) = if let Some(ov) = &self.oauth_override {
+        let (client_id, client_secret, token_url, resource) = if let Some(ov) = &self.oauth_override
+        {
             (
                 ov.client_id.clone(),
+                ov.client_secret.clone(),
                 ov.token_url.clone(),
                 Some(self.server_url.expose_secret().to_string()),
             )
@@ -190,7 +193,12 @@ impl McpOAuthProvider {
             .registration_store
             .load(self.server_url.expose_secret())
         {
-            (reg.client_id, reg.token_endpoint, Some(reg.resource))
+            (
+                reg.client_id,
+                reg.client_secret,
+                reg.token_endpoint,
+                Some(reg.resource),
+            )
         } else {
             return Ok(None); // Can't refresh without knowing where to send the request
         };
@@ -199,6 +207,7 @@ impl McpOAuthProvider {
 
         let config = OAuthConfig {
             client_id,
+            client_secret,
             auth_url: String::new(), // Not needed for refresh
             token_url,
             redirect_uri: String::new(),
@@ -241,11 +250,12 @@ impl McpOAuthProvider {
         let redirect_uri = normalize_loopback_redirect(redirect_uri);
         let redirect_uri = redirect_uri.as_str();
 
-        let (client_id, auth_url, token_url, scopes, resource) =
+        let (client_id, client_secret, auth_url, token_url, scopes, resource) =
             if let Some(ov) = &self.oauth_override {
                 // Manual override: skip discovery
                 (
                     ov.client_id.clone(),
+                    ov.client_secret.clone(),
                     ov.auth_url.clone(),
                     ov.token_url.clone(),
                     ov.scopes.clone(),
@@ -269,6 +279,7 @@ impl McpOAuthProvider {
 
         let config = OAuthConfig {
             client_id,
+            client_secret,
             auth_url,
             token_url,
             redirect_uri: redirect_uri.to_string(),
@@ -360,7 +371,7 @@ impl McpOAuthProvider {
 
     /// Discover resource + AS metadata and perform dynamic client registration.
     ///
-    /// Returns `(client_id, auth_url, token_url, scopes, resource)`.
+    /// Returns `(client_id, client_secret, auth_url, token_url, scopes, resource)`.
     ///
     /// Per the MCP Authorization spec, well-known metadata URLs are tried at the
     /// server's full URL first (path-aware), then at the origin (scheme + host)
@@ -369,7 +380,14 @@ impl McpOAuthProvider {
         &self,
         www_authenticate: Option<&str>,
         redirect_uri: &str,
-    ) -> Result<(String, String, String, Vec<String>, String)> {
+    ) -> Result<(
+        String,
+        Option<Secret<String>>,
+        String,
+        String,
+        Vec<String>,
+        String,
+    )> {
         let server_url = Url::parse(self.server_url.expose_secret())
             .with_context(|| format!("invalid MCP server URL: {}", self.server_url_display))?;
         let origin = Self::origin_url(&server_url);
@@ -474,7 +492,7 @@ impl McpOAuthProvider {
         );
 
         // Step 3: Dynamic client registration (or use cached)
-        let client_id = if let Some(cached) = self
+        let (client_id, client_secret) = if let Some(cached) = self
             .registration_store
             .load(self.server_url.expose_secret())
         {
@@ -483,7 +501,7 @@ impl McpOAuthProvider {
                 client_id = %cached.client_id,
                 "reusing cached dynamic registration"
             );
-            cached.client_id
+            (cached.client_id, cached.client_secret)
         } else if let Some(reg_endpoint) = &as_meta.registration_endpoint {
             // Register the exact callback URI that we'll use for this auth flow.
             // Some providers require an exact redirect URI match and reject
@@ -513,7 +531,7 @@ impl McpOAuthProvider {
                 .save(self.server_url.expose_secret(), &stored)
                 .context("failed to persist OAuth registration")?;
 
-            reg.client_id
+            (reg.client_id, stored.client_secret)
         } else {
             return Err(Error::message(
                 "AS does not support dynamic client registration and no client_id configured",
@@ -522,6 +540,7 @@ impl McpOAuthProvider {
 
         Ok((
             client_id,
+            client_secret,
             as_meta.authorization_endpoint,
             as_meta.token_endpoint,
             as_meta.scopes_supported,
@@ -936,12 +955,13 @@ mod tests {
             RegistrationStore::with_path(dir.path().join("registrations.json")),
         );
 
-        let (client_id, auth_url, token_url, scopes, resource) = provider
+        let (client_id, client_secret, auth_url, token_url, scopes, resource) = provider
             .discover_and_register(None, redirect_uri)
             .await
             .unwrap();
 
         assert_eq!(client_id, "client-fallback");
+        assert!(client_secret.is_none());
         assert_eq!(auth_url, format!("{base}/authorize"));
         assert_eq!(token_url, format!("{base}/token"));
         assert_eq!(scopes, vec!["read".to_string()]);

--- a/crates/mcp/src/config_parsing.rs
+++ b/crates/mcp/src/config_parsing.rs
@@ -136,6 +136,10 @@ pub fn parse_server_config(
                 .and_then(|val| val.as_str())
                 .ok_or_else(|| Error::message("missing 'oauth.client_id' parameter"))?
                 .to_string();
+            let client_secret = v
+                .get("client_secret")
+                .and_then(|val| val.as_str())
+                .map(|value| Secret::new(value.to_string()));
             let auth_url = v
                 .get("auth_url")
                 .and_then(|val| val.as_str())
@@ -152,6 +156,7 @@ pub fn parse_server_config(
                 .unwrap_or_default();
             Some(McpOAuthConfig {
                 client_id,
+                client_secret,
                 auth_url,
                 token_url,
                 scopes,
@@ -350,6 +355,7 @@ mod tests {
             headers: HashMap::new(),
             oauth: Some(McpOAuthConfig {
                 client_id: "test-client".to_string(),
+                client_secret: Some(Secret::new("test-secret".to_string())),
                 auth_url: "http://auth.example.com".to_string(),
                 token_url: "http://token.example.com".to_string(),
                 scopes: vec!["read".to_string()],
@@ -367,7 +373,44 @@ mod tests {
 
         let oauth = cfg.oauth.as_ref().unwrap();
         assert_eq!(oauth.client_id, "test-client");
+        assert_eq!(
+            oauth
+                .client_secret
+                .as_ref()
+                .map(ExposeSecret::expose_secret)
+                .map(String::as_str),
+            Some("test-secret")
+        );
         assert_eq!(oauth.scopes, vec!["read"]);
+    }
+
+    #[test]
+    fn parse_server_config_accepts_oauth_client_secret() {
+        let cfg = parse_server_config(
+            &serde_json::json!({
+                "transport": "sse",
+                "url": "http://example.com/mcp",
+                "oauth": {
+                    "client_id": "test-client",
+                    "client_secret": "test-secret",
+                    "auth_url": "http://auth.example.com",
+                    "token_url": "http://token.example.com"
+                }
+            }),
+            None,
+        )
+        .unwrap();
+
+        let oauth = cfg.oauth.as_ref().unwrap();
+        assert_eq!(oauth.client_id, "test-client");
+        assert_eq!(
+            oauth
+                .client_secret
+                .as_ref()
+                .map(ExposeSecret::expose_secret)
+                .map(String::as_str),
+            Some("test-secret")
+        );
     }
 
     #[test]

--- a/crates/mcp/src/manager.rs
+++ b/crates/mcp/src/manager.rs
@@ -134,6 +134,7 @@ impl McpManager {
             McpOAuthProvider::new(name, remote.request_url()).with_oauth_override(
                 McpOAuthOverride {
                     client_id: ov.client_id.clone(),
+                    client_secret: ov.client_secret.clone(),
                     auth_url: ov.auth_url.clone(),
                     token_url: ov.token_url.clone(),
                     scopes: ov.scopes.clone(),
@@ -1005,6 +1006,7 @@ mod tests {
             // simulating a server that was previously configured with OAuth.
             oauth: Some(McpOAuthConfig {
                 client_id: "test-client".into(),
+                client_secret: None,
                 auth_url: "https://auth.example.com/authorize".into(),
                 token_url: "https://auth.example.com/token".into(),
                 scopes: vec![],
@@ -1049,6 +1051,7 @@ mod tests {
             enabled: true,
             oauth: Some(McpOAuthConfig {
                 client_id: "test-client".into(),
+                client_secret: None,
                 auth_url: "https://auth.example.com/authorize".into(),
                 token_url: "https://auth.example.com/token".into(),
                 scopes: vec![],

--- a/crates/mcp/src/registry.rs
+++ b/crates/mcp/src/registry.rs
@@ -41,8 +41,8 @@ pub struct McpOAuthConfig {
     #[serde(
         default,
         skip_serializing_if = "Option::is_none",
-        serialize_with = "serialize_option_secret_string",
-        deserialize_with = "deserialize_option_secret_string"
+        serialize_with = "moltis_oauth::types::serialize_option_secret",
+        deserialize_with = "moltis_oauth::types::deserialize_option_secret"
     )]
     pub client_secret: Option<Secret<String>>,
     pub auth_url: String,
@@ -70,8 +70,8 @@ pub struct McpServerConfig {
     #[serde(
         default,
         skip_serializing_if = "Option::is_none",
-        serialize_with = "serialize_option_secret_string",
-        deserialize_with = "deserialize_option_secret_string"
+        serialize_with = "moltis_oauth::types::serialize_option_secret",
+        deserialize_with = "moltis_oauth::types::deserialize_option_secret"
     )]
     pub url: Option<Secret<String>>,
     /// Custom headers for remote HTTP/SSE transport.
@@ -214,26 +214,6 @@ impl McpRegistry {
             .map(|(name, cfg)| (name.as_str(), cfg))
             .collect()
     }
-}
-
-fn serialize_option_secret_string<S: serde::Serializer>(
-    secret: &Option<Secret<String>>,
-    serializer: S,
-) -> std::result::Result<S::Ok, S::Error> {
-    match secret {
-        Some(value) => serializer.serialize_some(value.expose_secret()),
-        None => serializer.serialize_none(),
-    }
-}
-
-fn deserialize_option_secret_string<'de, D>(
-    deserializer: D,
-) -> std::result::Result<Option<Secret<String>>, D::Error>
-where
-    D: serde::Deserializer<'de>,
-{
-    let opt: Option<String> = Option::deserialize(deserializer)?;
-    Ok(opt.map(Secret::new))
 }
 
 fn serialize_secret_string_map<S: serde::Serializer>(

--- a/crates/mcp/src/registry.rs
+++ b/crates/mcp/src/registry.rs
@@ -38,6 +38,13 @@ impl std::fmt::Display for TransportType {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct McpOAuthConfig {
     pub client_id: String,
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        serialize_with = "serialize_option_secret_string",
+        deserialize_with = "deserialize_option_secret_string"
+    )]
+    pub client_secret: Option<Secret<String>>,
     pub auth_url: String,
     pub token_url: String,
     #[serde(default)]
@@ -368,5 +375,29 @@ mod tests {
             Some("https://example.com/mcp?api_key=secret-value")
         );
         assert_eq!(server.headers["x-api-key"].expose_secret(), "header-secret");
+    }
+
+    #[test]
+    fn test_registry_roundtrips_oauth_client_secret() {
+        let mut reg = McpRegistry::new();
+        reg.servers.insert("remote".into(), McpServerConfig {
+            oauth: Some(McpOAuthConfig {
+                client_id: "client".to_string(),
+                client_secret: Some(Secret::new("secret".to_string())),
+                auth_url: "https://auth.example.com/authorize".to_string(),
+                token_url: "https://auth.example.com/token".to_string(),
+                scopes: Vec::new(),
+            }),
+            ..Default::default()
+        });
+
+        let json = serde_json::to_string(&reg).unwrap();
+        let parsed: McpRegistry = serde_json::from_str(&json).unwrap();
+        let secret = parsed.servers["remote"]
+            .oauth
+            .as_ref()
+            .and_then(|oauth| oauth.client_secret.as_ref())
+            .map(ExposeSecret::expose_secret);
+        assert_eq!(secret.map(String::as_str), Some("secret"));
     }
 }

--- a/crates/oauth/src/defaults.rs
+++ b/crates/oauth/src/defaults.rs
@@ -10,6 +10,7 @@ fn builtin_defaults() -> HashMap<String, OAuthConfig> {
     // and the gateway recognises it as an OAuth provider.
     m.insert("github-copilot".into(), OAuthConfig {
         client_id: "Iv1.b507a08c87ecfe98".into(),
+        client_secret: None,
         auth_url: "https://github.com/login/device/code".into(),
         token_url: "https://github.com/login/oauth/access_token".into(),
         redirect_uri: String::new(),
@@ -20,6 +21,7 @@ fn builtin_defaults() -> HashMap<String, OAuthConfig> {
     });
     m.insert("kimi-code".into(), OAuthConfig {
         client_id: "17e5f671-d194-4dfb-9706-5516cb48c098".into(),
+        client_secret: None,
         auth_url: "https://auth.kimi.com/api/oauth/device_authorization".into(),
         token_url: "https://auth.kimi.com/api/oauth/token".into(),
         redirect_uri: String::new(),
@@ -30,6 +32,7 @@ fn builtin_defaults() -> HashMap<String, OAuthConfig> {
     });
     m.insert("openai-codex".into(), OAuthConfig {
         client_id: "app_EMoamEEZ73f0CkXaXp7hrann".into(),
+        client_secret: None,
         auth_url: "https://auth.openai.com/oauth/authorize".into(),
         token_url: "https://auth.openai.com/oauth/token".into(),
         redirect_uri: "http://localhost:1455/auth/callback".into(),

--- a/crates/oauth/src/device_flow.rs
+++ b/crates/oauth/src/device_flow.rs
@@ -1,4 +1,7 @@
-use {reqwest::header::HeaderMap, secrecy::Secret};
+use {
+    reqwest::header::HeaderMap,
+    secrecy::{ExposeSecret, Secret},
+};
 
 use crate::{
     Error, Result,
@@ -86,14 +89,19 @@ pub async fn poll_for_token_with_headers(
     loop {
         tokio::time::sleep(std::time::Duration::from_secs(interval)).await;
 
+        let mut form = vec![
+            ("client_id", config.client_id.as_str()),
+            ("device_code", device_code),
+            ("grant_type", "urn:ietf:params:oauth:grant-type:device_code"),
+        ];
+        if let Some(client_secret) = &config.client_secret {
+            form.push(("client_secret", client_secret.expose_secret().as_str()));
+        }
+
         let mut req = client
             .post(&config.token_url)
             .header("Accept", "application/json")
-            .form(&[
-                ("client_id", config.client_id.as_str()),
-                ("device_code", device_code),
-                ("grant_type", "urn:ietf:params:oauth:grant-type:device_code"),
-            ]);
+            .form(&form);
 
         if let Some(headers) = extra_headers {
             req = req.headers(headers.clone());
@@ -146,6 +154,7 @@ mod tests {
     fn test_config(auth_url: String, token_url: String) -> OAuthConfig {
         OAuthConfig {
             client_id: "test-client".into(),
+            client_secret: None,
             auth_url,
             token_url,
             redirect_uri: String::new(),

--- a/crates/oauth/src/device_flow.rs
+++ b/crates/oauth/src/device_flow.rs
@@ -39,10 +39,15 @@ pub async fn request_device_code_with_headers(
     config: &OAuthConfig,
     extra_headers: Option<&HeaderMap>,
 ) -> Result<DeviceCodeResponse> {
+    let mut form = vec![("client_id", config.client_id.as_str()), ("scope", "")];
+    if let Some(client_secret) = &config.client_secret {
+        form.push(("client_secret", client_secret.expose_secret().as_str()));
+    }
+
     let mut req = client
         .post(&config.auth_url)
         .header("Accept", "application/json")
-        .form(&[("client_id", config.client_id.as_str()), ("scope", "")]);
+        .form(&form);
 
     if let Some(headers) = extra_headers {
         req = req.headers(headers.clone());
@@ -284,6 +289,37 @@ mod tests {
         let resp = request_device_code_with_headers(&client, &config, Some(&headers))
             .await
             .unwrap();
+        assert_eq!(resp.device_code, "dc");
+    }
+
+    #[tokio::test]
+    async fn request_device_code_sends_client_secret_when_configured() {
+        let app = Router::new().route(
+            "/device/code",
+            post(
+                |Form(form): Form<std::collections::HashMap<String, String>>| async move {
+                    assert_eq!(
+                        form.get("client_id").map(String::as_str),
+                        Some("test-client")
+                    );
+                    assert_eq!(
+                        form.get("client_secret").map(String::as_str),
+                        Some("test-secret")
+                    );
+                    axum::Json(serde_json::json!({
+                        "device_code": "dc",
+                        "user_code": "CODE",
+                        "verification_uri": "https://example.com",
+                    }))
+                },
+            ),
+        );
+        let base = start_mock(app).await;
+        let mut config = test_config(format!("{base}/device/code"), String::new());
+        config.client_secret = Some(Secret::new("test-secret".to_string()));
+
+        let client = reqwest::Client::new();
+        let resp = request_device_code(&client, &config).await.unwrap();
         assert_eq!(resp.device_code, "dc");
     }
 

--- a/crates/oauth/src/flow.rs
+++ b/crates/oauth/src/flow.rs
@@ -3,7 +3,7 @@ use {
         Engine,
         engine::general_purpose::{STANDARD, URL_SAFE_NO_PAD},
     },
-    secrecy::Secret,
+    secrecy::{ExposeSecret, Secret},
     url::Url,
 };
 
@@ -93,6 +93,12 @@ impl OAuthFlow {
         if let Some(resource) = &self.config.resource {
             form.push(("resource".to_string(), resource.clone()));
         }
+        if let Some(client_secret) = &self.config.client_secret {
+            form.push((
+                "client_secret".to_string(),
+                client_secret.expose_secret().clone(),
+            ));
+        }
 
         let result = self
             .client
@@ -130,6 +136,12 @@ impl OAuthFlow {
         ];
         if let Some(resource) = &self.config.resource {
             form.push(("resource".to_string(), resource.clone()));
+        }
+        if let Some(client_secret) = &self.config.client_secret {
+            form.push((
+                "client_secret".to_string(),
+                client_secret.expose_secret().clone(),
+            ));
         }
 
         let result = self

--- a/crates/oauth/src/types.rs
+++ b/crates/oauth/src/types.rs
@@ -7,6 +7,13 @@ use {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct OAuthConfig {
     pub client_id: String,
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        serialize_with = "serialize_option_secret",
+        deserialize_with = "deserialize_option_secret"
+    )]
+    pub client_secret: Option<Secret<String>>,
     pub auth_url: String,
     pub token_url: String,
     pub redirect_uri: String,
@@ -92,4 +99,15 @@ pub fn serialize_option_secret<S: serde::Serializer>(
         Some(s) => serializer.serialize_some(s.expose_secret()),
         None => serializer.serialize_none(),
     }
+}
+
+/// Deserialize an `Option<Secret<String>>` from its stored string value.
+pub fn deserialize_option_secret<'de, D>(
+    deserializer: D,
+) -> Result<Option<Secret<String>>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let opt: Option<String> = Option::deserialize(deserializer)?;
+    Ok(opt.map(Secret::new))
 }

--- a/crates/oauth/tests/oauth_tests.rs
+++ b/crates/oauth/tests/oauth_tests.rs
@@ -125,10 +125,46 @@ async fn oauth_flow_exchange_sends_resource_indicator_when_configured() {
 
     let flow = OAuthFlow::new(OAuthConfig {
         client_id: "client-123".into(),
+        client_secret: None,
         auth_url: format!("{}/authorize", server.url()),
         token_url: format!("{}{}", server.url(), token_path),
         redirect_uri: "http://127.0.0.1:1455/auth/callback".into(),
         resource: Some(resource.into()),
+        scopes: vec![],
+        extra_auth_params: vec![],
+        device_flow: false,
+    });
+
+    let tokens = flow.exchange("code-123", "verifier-123").await.unwrap();
+    assert_eq!(tokens.access_token.expose_secret(), "token-abc");
+    mock.assert_async().await;
+}
+
+#[tokio::test]
+async fn oauth_flow_exchange_sends_client_secret_when_configured() {
+    let mut server = mockito::Server::new_async().await;
+    let token_path = "/token";
+
+    let mock = server
+        .mock("POST", token_path)
+        .match_body(Matcher::AllOf(vec![
+            Matcher::UrlEncoded("client_id".into(), "client-123".into()),
+            Matcher::UrlEncoded("client_secret".into(), "secret-456".into()),
+            Matcher::UrlEncoded("grant_type".into(), "authorization_code".into()),
+        ]))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"access_token":"token-abc","expires_in":3600}"#)
+        .create_async()
+        .await;
+
+    let flow = OAuthFlow::new(OAuthConfig {
+        client_id: "client-123".into(),
+        client_secret: Some(Secret::new("secret-456".into())),
+        auth_url: format!("{}/authorize", server.url()),
+        token_url: format!("{}{}", server.url(), token_path),
+        redirect_uri: "http://127.0.0.1:1455/auth/callback".into(),
+        resource: None,
         scopes: vec![],
         extra_auth_params: vec![],
         device_flow: false,

--- a/crates/provider-setup/src/oauth.rs
+++ b/crates/provider-setup/src/oauth.rs
@@ -188,6 +188,7 @@ mod tests {
     fn make_oauth_config(redirect_uri: &str) -> moltis_oauth::OAuthConfig {
         moltis_oauth::OAuthConfig {
             client_id: "client".into(),
+            client_secret: None,
             auth_url: "https://example.com/authorize".into(),
             token_url: "https://example.com/token".into(),
             redirect_uri: redirect_uri.into(),

--- a/docs/src/configuration-reference.md
+++ b/docs/src/configuration-reference.md
@@ -672,6 +672,7 @@ Each channel account (`channels.<channel_type>.<account_name>`) is an arbitrary 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | `client_id` | string | *(required)* | The OAuth client ID. |
+| `client_secret` | optional string | `None` | Optional OAuth client secret sent to the token endpoint. |
 | `auth_url` | string | *(required)* | The authorization endpoint URL. |
 | `token_url` | string | *(required)* | The token endpoint URL. |
 | `scopes` | array of string | `[]` | OAuth scopes to request. |

--- a/docs/src/mcp.md
+++ b/docs/src/mcp.md
@@ -282,6 +282,8 @@ transport = "sse"
 
 [mcp.servers.private_api.oauth]
 client_id = "your-client-id"
+# Optional: required by some servers for token exchange even with PKCE.
+client_secret = "your-client-secret"
 auth_url = "https://auth.example.com/authorize"
 token_url = "https://auth.example.com/token"
 scopes = ["mcp:read", "mcp:write"]


### PR DESCRIPTION
## Summary
- Add optional `client_secret` support for MCP OAuth override config.
- Pass configured client secrets through MCP auth and OAuth token/refresh requests.
- Update validation, config template, docs, and targeted tests.

## Validation
### Completed
- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p moltis-oauth client_secret`
- [x] `cargo test -p moltis-config client_secret`
- [x] `cargo test -p moltis-mcp client_secret`
- [x] `cargo check -p moltis-gateway`

### Remaining
- [ ] Full CI

## Manual QA
- Not run locally. The new behavior is covered by targeted Rust tests that verify config parsing, validation, registry persistence, and token exchange form fields.