### PR TITLE
feat(skills): add agent system builder skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Verify releases with `gh attestation verify <artifact> -R moltis-org/moltis` or 
 - **Communication** — Web UI, Telegram, Signal, Microsoft Teams, Discord, API access, voice I/O (8 TTS + 7 STT providers), mobile PWA with push notifications
 - **Memory & Recall** — Per-agent memory workspaces, embeddings-powered long-term memory, hybrid vector + full-text search, session persistence with auto-compaction, cross-session recall, Cursor-compatible project context, context-file safety scanning
 - **Safer Agent Editing** — Automatic checkpoints before built-in skill and memory mutations, restore tooling, session branching
-- **Extensibility** — MCP servers (stdio + HTTP/SSE), skill system, 15 lifecycle hook events with circuit breaker, destructive command guard
+- **Extensibility** — MCP servers (stdio + HTTP/SSE), skill system with bundled agent-system design guidance, 15 lifecycle hook events with circuit breaker, destructive command guard
 - **Security** — Encryption-at-rest vault (XChaCha20-Poly1305 + Argon2id), password + passkey + API key auth, sandbox isolation, SSRF/CSWSH protection
 - **Operations** — Cron scheduling, OpenTelemetry tracing, Prometheus metrics, cloud deploy (Fly.io, DigitalOcean), Tailscale integration, managed SSH deploy keys, host-pinned remote targets, live tool inventory in Settings, and CLI/web remote-exec doctor flows
 

--- a/crates/skills/src/assets/autonomous-ai-agents/build-agent-systems/SKILL.md
+++ b/crates/skills/src/assets/autonomous-ai-agents/build-agent-systems/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: build-agent-systems
+description: Design, specify, or review agent systems and reusable agent Skills, especially multi-user, multi-channel, distributed, or Kubernetes/pod-based agent products. Use when asked to extract agentic patterns, define agent roles, author portable Skills, design tool registries, session/memory models, channel adapters, orchestration flows, or safety controls for building agents without copying an existing codebase.
+origin:
+  source: moltis
+  url: https://github.com/moltis-org/moltis
+---
+
+# Build Agent Systems
+
+Use this skill to turn product requirements into an implementable agent-system blueprint and reusable Skills.
+
+## Workflow
+
+1. Define the operating envelope:
+   - users and tenant boundaries
+   - channels and inbound modes
+   - tasks the agent may perform
+   - tool side effects and approval requirements
+   - deployment constraints such as pods, queues, stores, secrets, and sandboxing
+
+2. Choose the agent primitives:
+   - agent presets for identity, model, tool policy, memory scope, iteration limits, and delegation rules
+   - tools for deterministic actions with typed schemas
+   - Skills for procedural knowledge and domain workflows
+   - sessions for durable conversation state, channel bindings, and cross-session coordination
+   - memory for facts that must survive compaction or restart
+
+3. Design the runtime loop:
+   - normalize inbound input into a session message
+   - build a prompt from identity, user context, project context, skills, memory, runtime state, and tool schemas
+   - call the model in streaming mode when the channel can surface partial output
+   - validate, sanitize, and execute tool calls
+   - append tool results, compact oversized results, and repeat until final answer or limit
+   - route the final answer and errors back to the originating channel
+
+4. Design the Skill:
+   - keep `SKILL.md` concise and trigger-focused
+   - move detailed patterns, templates, and checklists into `references/`
+   - include scripts only for fragile or repeated deterministic work
+   - validate that the Skill gives an agent enough context to produce concrete artifacts
+
+5. Map to distributed deployment:
+   - keep agent runner pods stateless except for in-flight stream state
+   - store sessions, channel account config, memory, and job metadata in shared durable stores
+   - use queues or leases for inbound events so only one worker handles a message
+   - use idempotency keys for channel webhooks and retries
+   - isolate tool execution in sandbox workers or separate execution pods
+
+6. Verify the design:
+   - require explicit access policy for every channel and tool class
+   - define what the user sees on failures; avoid silent drops
+   - test prompt assembly, tool validation, loop limits, channel routing, and crash recovery
+   - document remaining risks and operational runbooks
+
+## References
+
+- Read `references/moltis-agent-patterns.md` when extracting architecture patterns from Moltis-like systems.
+- Read `references/agent-system-blueprint.md` when producing a user-facing blueprint or implementation plan.
+- Read `references/skill-authoring-template.md` when writing the actual Skill artifact.
+
+## Output Shape
+
+Prefer concrete artifacts over prose:
+
+- agent roles and preset table
+- tool registry and policy matrix
+- channel adapter matrix
+- session and memory model
+- runtime loop sequence
+- Kubernetes/pod deployment map
+- Skill draft with trigger description and references
+- verification checklist and security review
+
+Do not copy project-specific source code into the new system. Extract contracts, boundaries, invariants, and operational patterns.

--- a/crates/skills/src/assets/autonomous-ai-agents/build-agent-systems/references/agent-system-blueprint.md
+++ b/crates/skills/src/assets/autonomous-ai-agents/build-agent-systems/references/agent-system-blueprint.md
@@ -1,0 +1,137 @@
+# Agent System Blueprint
+
+Use this template when producing a concrete design for an agent product.
+
+## 1. Product Frame
+
+- Target users:
+- Tenant model:
+- Channels:
+- Primary tasks:
+- Human approval points:
+- Data retention needs:
+- Deployment target:
+
+## 2. Agent Roles
+
+| Agent | Purpose | Model Policy | Tool Policy | Memory Scope | Session Access | Limits |
+|---|---|---|---|---|---|---|
+| coordinator | Decompose and route work | default or strong reasoning | delegate/session tools only | project | cross-session as needed | low tool side effects |
+| researcher | Gather evidence | cheap/fast or search-optimized | read/search/fetch only | project | read-only | no writes |
+| operator | Execute bounded actions | reliable tool-use model | narrow side-effect tools | user/project | current session | approval required |
+| reviewer | Check correctness and safety | strong reasoning | read/test tools | project | read-only | no writes |
+
+Adapt rows to the actual product. Avoid creating roles without distinct policy needs.
+
+## 3. Runtime Loop
+
+```text
+channel event / UI message / scheduled job
+  -> authenticate and authorize sender
+  -> deduplicate by event id
+  -> resolve session key and channel binding
+  -> load session history, memory, skills, runtime context
+  -> build prompt and tool schema list
+  -> run streaming model loop
+  -> validate and execute tool calls
+  -> persist assistant/tool messages
+  -> publish stream events
+  -> send final answer or error through reply route
+```
+
+## 4. Tool Registry
+
+| Tool Class | Examples | Allowed Agents | Side Effects | Approval | Audit |
+|---|---|---|---|---|---|
+| read-only | search, fetch, history | most agents | none | no | basic |
+| local mutation | file edit, skill patch | coder/operator | workspace writes | sometimes | required |
+| external action | send message, create ticket | operator | external side effect | often | required |
+| admin/config | update channel settings, MCP add | admin/operator | persistent config | yes | required |
+
+Rules:
+
+- hide disallowed tools before prompt assembly
+- validate every parameter object before execution
+- sanitize tool results before appending to model context
+- classify tool errors as retryable or non-retryable
+
+## 5. Skill System
+
+Skill sources:
+
+- bundled skills for product-owned workflows
+- project skills for team/domain workflows
+- personal skills for user-local customization
+- registry/plugin skills for installable extensions
+
+Skill lifecycle:
+
+1. discover metadata
+2. show trigger descriptions in prompt
+3. load full skill only when needed
+4. use references/scripts/assets progressively
+5. checkpoint before agent-side mutations
+6. watch for `SKILL.md` changes and refresh availability
+
+## 6. Multi-Channel Model
+
+| Channel | Inbound Mode | Streaming | Threads | Voice/File Handling | Access Control |
+|---|---|---|---|---|---|
+| chat app with webhook | HTTP webhook | optional | platform-specific | upload to media store | signature + allowlist |
+| chat app with gateway | WebSocket/sync loop | often | platform-specific | gateway download | token + allowlist |
+| polling bot | polling loop | edit-in-place | limited | API download | token + allowlist |
+| web UI | direct API/WebSocket | native | session branches | browser upload | authenticated session |
+
+Normalize all channels into one session/event contract instead of giving every channel its own agent runtime.
+
+## 7. Kubernetes/Pod Architecture
+
+```text
+Ingress/Webhook Pods
+  -> Event Queue
+  -> Dispatcher Workers
+  -> Agent Runner Pods
+  -> Tool/Sandbox Pods
+  -> Provider APIs and MCP Servers
+
+Shared: SQL DB, object store/PV, pubsub, secret manager, observability, auth.
+```
+
+Design decisions:
+
+- use horizontal pod autoscaling for ingress and runner pools separately
+- use per-message idempotency keys
+- use per-session leases when order matters
+- keep stream fanout outside the runner process when possible
+- make tool execution cancellable
+- keep channel credentials in a secret manager, not pod environment dumps
+
+## 8. Verification Plan
+
+Minimum tests:
+
+- prompt assembly includes identity, skills, memory, runtime context, and allowed tools
+- denied tools are absent from model-visible schemas
+- malformed tool calls are rejected without executing
+- repeated failing tool calls trigger loop intervention
+- channel duplicate events do not duplicate replies
+- unauthorized channel senders get visible access feedback when policy allows
+- approved sender LLM failures return an error/fallback message
+- session history persists across runner pod restart
+- skill metadata parses and reference paths are valid
+- webhook signatures and SSRF protections are covered
+
+## 9. Output Checklist
+
+Deliver:
+
+- roles and policies
+- runtime sequence
+- data model
+- channel matrix
+- tool matrix
+- Skill draft
+- deployment map
+- security invariants
+- test plan
+- operational risks

--- a/crates/skills/src/assets/autonomous-ai-agents/build-agent-systems/references/moltis-agent-patterns.md
+++ b/crates/skills/src/assets/autonomous-ai-agents/build-agent-systems/references/moltis-agent-patterns.md
@@ -1,0 +1,187 @@
+# Moltis-Derived Agent Patterns
+
+This reference captures reusable agent-system patterns visible in Moltis. Use it as architecture knowledge, not as code to copy.
+
+## Pattern 1: Preset-Driven Agent Roles
+
+Represent an agent role as data:
+
+- identity: name, tone, persona, and user-facing role
+- model selection: explicit model, preset model, then default model
+- tool policy: allow-list first, deny-list second
+- session policy: which sessions can be read or messaged
+- memory scope: user, project, or local
+- safety limits: max iterations, timeout, delegation restrictions
+
+Why it matters: roles become configurable and auditable instead of hardcoded prompt forks.
+
+## Pattern 2: Tool Registry with Source Metadata
+
+Expose tools through a uniform contract:
+
+- stable name
+- short description
+- JSON parameter schema
+- async execution
+- source metadata such as built-in, MCP, or component
+
+Keep the registry cloneable and filterable so each agent receives only the tools it may use. Preserve source metadata for auditing and policy decisions.
+
+## Pattern 3: Lazy Tool Discovery
+
+When the tool surface is large, start the model with a small `tool_search` meta-tool. The model searches by keyword, activates exact tools, and receives full schemas on later turns.
+
+Use lazy discovery to reduce prompt bloat, but increase iteration limits because tool discovery itself consumes turns.
+
+## Pattern 4: Streaming Agent Loop with Tool Turns
+
+A robust loop has these phases:
+
+1. build typed messages from system prompt, history, and current user input
+2. list currently available tool schemas
+3. call the provider, preferably streaming when the surface can display deltas
+4. accumulate text, reasoning, tool-call starts, and argument deltas
+5. validate and normalize tool names and arguments
+6. execute allowed tool calls
+7. append sanitized tool results
+8. compact or truncate old tool results before context overflow
+9. continue until final answer, max iterations, or a controlled error
+
+Emit runner events for thinking, text deltas, tool start/end, rejections, retries, loop interventions, and sub-agent lifecycle.
+
+## Pattern 5: Tool-Call Recovery and Guardrails
+
+Models produce imperfect tool calls. Handle common failures explicitly:
+
+- trim and normalize tool names
+- repair JSON-like argument strings when safe
+- reject invalid arguments before execution
+- tell the model how to retry malformed tool calls
+- detect repeated identical failures
+- first nudge the model to explain and answer in text
+- then strip tool schemas for one turn if it keeps looping
+
+This keeps bad tool calls visible while preventing runaway loops.
+
+## Pattern 6: Hook Boundaries
+
+Place hook points around high-risk boundaries:
+
+- before LLM call
+- after LLM call
+- before tool call
+- after tool call
+
+Hooks may continue, block, or modify payloads where the type system allows it. Use this for logging, approvals, policy checks, auditing, and integration tests.
+
+## Pattern 7: Skill as Progressive Disclosure
+
+Make Skills metadata-first:
+
+- frontmatter name and description are the trigger surface
+- `SKILL.md` contains the minimum workflow
+- `references/` contains larger pattern guides and templates
+- `scripts/` contains deterministic helper code only when repeated and fragile
+- `assets/` contains output resources, not explanatory docs
+
+Dynamic skill creation should checkpoint first, validate paths, reject hidden or escaping sidecar writes, and audit mutations.
+
+## Pattern 8: Session-Centered Multi-Channel Routing
+
+Normalize every channel event into a session:
+
+- compute or look up a session key from channel type, account, chat, and thread
+- persist the channel binding on the session
+- inject channel metadata into the agent call
+- mark inbound activity as seen
+- route final text, stream deltas, and errors back through the binding
+
+This lets web UI, channel messages, and proactive tools share one conversation model.
+
+## Pattern 9: Channel Plugin Contract
+
+Represent channels as plugins with a lifecycle:
+
+- descriptor: type, display name, inbound mode, capabilities
+- start account
+- stop account
+- account status and config view
+- outbound sender
+- stream outbound sender when supported
+- event sink for inbound messages, commands, voice, files, interactions, and pairing
+
+Contract-test every channel for lifecycle, duplicate start, unknown stop, outbound behavior, streaming completion, and retryable versus non-retryable errors.
+
+## Pattern 10: Shared Access Control Vocabulary
+
+Use the same policy vocabulary across channels:
+
+- DM policy: open, allowlist, disabled
+- group policy: open, allowlist, disabled
+- mention mode: mention, always, none
+- allowlist matching with exact and wildcard support
+- OTP or explicit approval for onboarding when supported
+
+Default private access conservatively. Always send visible fallback or error messages to approved senders.
+
+## Pattern 11: Proactive Outbound Tools
+
+Give agents narrow tools for outbound channel side effects:
+
+- `send_message` style tool for intentional proactive messages
+- `update_channel_settings` style tool for non-secret channel settings only
+- per-channel model or agent routing overrides
+
+Do not expose arbitrary raw config editing or secret mutation as an agent tool.
+
+## Pattern 12: Distributed Pod Mapping
+
+For Kubernetes-like deployments, map the patterns to pods:
+
+- channel ingress pods: receive webhooks, polling, socket, or gateway events
+- dispatcher workers: deduplicate, authorize, bind session, enqueue agent runs
+- agent runner pods: execute model loop and stream events
+- tool execution pods: run sandboxed shell/browser/filesystem work
+- MCP connector pods: maintain external tool-server connections
+- scheduler pods: enqueue cron or proactive jobs
+- UI/API pods: serve web UI and session streams
+
+Shared infrastructure:
+
+- SQL database for session metadata, auth, channel accounts, and job state
+- object storage or persistent volumes for JSONL session logs, media, and artifacts
+- queue for inbound events and agent jobs
+- pub/sub for stream deltas and UI/channel fanout
+- distributed lock or lease keyed by session/message id
+- secret manager for tokens and provider keys
+
+## Pattern 13: Idempotency and Crash Recovery
+
+Every inbound message should have a stable idempotency key. Store processing status before executing side effects. On retry, resume or no-op rather than sending duplicate replies.
+
+Use per-session append-only logs for durable history. Keep runner pods stateless enough that a crashed pod can be replaced by another worker using the shared store.
+
+## Pattern 14: Security and Safety Invariants
+
+Require these invariants before shipping:
+
+- validate webhook signatures and WebSocket origins
+- block SSRF to private, loopback, link-local, and metadata ranges
+- store secrets with redaction and expose them only at consumption points
+- keep tool schemas narrow and typed
+- reject unsafe path writes for Skills and artifacts
+- enforce tool allow/deny policy before the model sees schemas
+- audit tool execution and skill mutations
+- surface errors to authorized users instead of failing silently
+- keep channel credential storage and rotation behavior documented
+
+## Pattern 15: Knowledge Extraction Method
+
+When extracting from an existing agent codebase:
+
+1. list runtime primitives: agents, tools, skills, sessions, memory, channels, hooks
+2. identify contracts and invariants, not implementation details
+3. map each contract to a product capability
+4. separate portable patterns from product-specific names
+5. write the Skill that makes another agent reproduce the design
+6. verify against source evidence and expected user workflows

--- a/crates/skills/src/assets/autonomous-ai-agents/build-agent-systems/references/skill-authoring-template.md
+++ b/crates/skills/src/assets/autonomous-ai-agents/build-agent-systems/references/skill-authoring-template.md
@@ -1,0 +1,83 @@
+# Skill Authoring Template
+
+Use this when writing a Skill for an agent system.
+
+## Folder Shape
+
+```text
+skill-name/
+  SKILL.md
+  references/
+    domain-patterns.md
+    blueprint.md
+```
+
+Add `scripts/` only when deterministic helper code is repeatedly needed. Add `assets/` only for files used in outputs.
+
+## SKILL.md Skeleton
+
+```markdown
+---
+name: skill-name
+description: What the skill does and exact situations that should trigger it. Mention domain, task types, and important contexts.
+---
+
+# Skill Title
+
+Use this skill to ...
+
+## Workflow
+
+1. Clarify the operating envelope.
+2. Select the right reference file.
+3. Produce concrete artifacts.
+4. Validate against the checklist.
+
+## References
+
+- Read `references/domain-patterns.md` when ...
+- Read `references/blueprint.md` when ...
+
+## Output Shape
+
+- artifact 1
+- artifact 2
+- risks and validation
+```
+
+## Trigger Description Rules
+
+The frontmatter `description` is the only part visible before the skill loads. Include:
+
+- what the skill helps build or analyze
+- trigger phrases or user intents
+- domain contexts
+- important constraints such as Kubernetes, multi-channel, security, or skill authoring
+
+Do not put "when to use" only in the body.
+
+## Body Rules
+
+- keep the body procedural
+- use imperative steps
+- avoid generic agent advice
+- link each reference file by name and say when to read it
+- prefer output shapes and checklists over essays
+- avoid copying implementation code from source projects
+
+## Reference Rules
+
+- one level deep from `SKILL.md`
+- split by decision context, not by arbitrary topic
+- include contracts, invariants, and examples
+- omit source-code details unless they define a portable boundary
+
+## Quality Checklist
+
+- frontmatter has `name` and `description`
+- skill name is lowercase, hyphenated, and under 64 characters
+- description is specific enough to trigger correctly
+- `SKILL.md` can be read in under a few minutes
+- all referenced files exist
+- output shape is explicit
+- security and validation are included for side-effectful systems


### PR DESCRIPTION
## Summary
- Add a bundled `build-agent-systems` skill for designing multi-user, multi-channel, distributed agent systems.
- Capture Moltis-derived agentic patterns, an agent-system blueprint template, and a skill-authoring template as progressive-disclosure references.
- Update the README feature list to mention bundled agent-system design guidance.

## Validation

### Completed
- [x] `cargo test -p moltis-skills --features bundled-skills bundled`

### Remaining
- [ ] Full workspace validation was not run; this change is limited to bundled skill/docs assets.
- [ ] `bd` issue sync could not run locally because the Dolt server reports `database "moltis" not found`.

## Manual QA
- Reviewed the new skill frontmatter and reference links.
- Confirmed bundled skill tests cover discovery, name validation, origin metadata, category assignment, duplicate names, sidecar handling, and body readability.
