### PR TITLE
feat(memory): allow nested subfolders and collection-aware writes

### DIFF
--- a/crates/chat/src/memory_tools.rs
+++ b/crates/chat/src/memory_tools.rs
@@ -199,18 +199,15 @@ fn memory_forget_parameters_schema() -> Value {
 
 fn memory_file_label_from_root(root: &Path, path: &Path) -> Option<String> {
     let relative = path.strip_prefix(root).ok()?;
+    let rel_str = relative.to_str()?;
     let mut components = relative.components();
     let first = components.next()?.as_os_str().to_str()?;
 
     match first {
         "MEMORY.md" | "memory.md" if components.next().is_none() => Some(first.to_string()),
-        "memory" => {
-            let leaf = components.next()?.as_os_str().to_str()?;
-            if components.next().is_some() || !is_valid_agent_memory_leaf_name(leaf) {
-                return None;
-            }
-            Some(format!("memory/{leaf}"))
-        },
+        // Any depth under memory/ is valid now; return the full relative path
+        // (already using forward slashes when produced by strip_prefix).
+        "memory" if rel_str.ends_with(".md") => Some(rel_str.replace('\\', "/")),
         _ => None,
     }
 }
@@ -403,45 +400,47 @@ async fn validate_forget_actions(
     Ok((valid, issues))
 }
 
-pub(crate) fn is_valid_agent_memory_leaf_name(name: &str) -> bool {
-    if name.is_empty() || name.contains('/') || !name.ends_with(".md") {
-        return false;
-    }
-    if name.chars().any(char::is_whitespace) {
-        return false;
-    }
-    let stem = &name[..name.len() - 3];
-    !(stem.is_empty() || stem.starts_with('.'))
-}
-
 pub(crate) fn resolve_agent_memory_target_path(
     agent_id: &str,
     file: &str,
+    shared_collection_roots: &[std::path::PathBuf],
 ) -> anyhow::Result<std::path::PathBuf> {
     let trimmed = file.trim();
     if trimmed.is_empty() {
         anyhow::bail!("memory path cannot be empty");
     }
 
+    // First try a workspace-scoped resolution. This covers MEMORY.md,
+    // memory.md, and memory/**/<name>.md inside the agent's own workspace,
+    // including nested subfolders.
     let workspace = moltis_config::agent_workspace_dir(agent_id);
-    if trimmed == "MEMORY.md" || trimmed == "memory.md" {
-        return Ok(workspace.join(trimmed));
+    if let Ok(path) = moltis_memory::writer::validate_memory_path(&workspace, &[], trimmed) {
+        return Ok(path);
     }
 
-    let Some(name) = trimmed.strip_prefix("memory/") else {
-        anyhow::bail!(
-            "invalid memory path '{trimmed}': allowed targets are MEMORY.md, memory.md, or memory/<name>.md"
-        );
-    };
-    if !is_valid_agent_memory_leaf_name(name) {
-        anyhow::bail!(
-            "invalid memory path '{trimmed}': allowed targets are MEMORY.md, memory.md, or memory/<name>.md"
-        );
+    // Then try resolving under a configured shared collection root
+    // (user-defined QMD collection). Paths there are accessible to every
+    // agent so collections behave as shared knowledge stores.
+    if !shared_collection_roots.is_empty()
+        && let Ok(path) = moltis_memory::writer::validate_memory_path(
+            &moltis_config::data_dir(),
+            shared_collection_roots,
+            trimmed,
+        )
+    {
+        return Ok(path);
     }
-    Ok(workspace.join("memory").join(name))
+
+    anyhow::bail!(
+        "invalid memory path '{trimmed}': allowed targets are MEMORY.md, memory.md, memory/<...>.md, or any path under a configured shared collection"
+    );
 }
 
-pub(crate) fn is_path_in_agent_memory_scope(path: &Path, agent_id: &str) -> bool {
+pub(crate) fn is_path_in_agent_memory_scope(
+    path: &Path,
+    agent_id: &str,
+    shared_collection_roots: &[std::path::PathBuf],
+) -> bool {
     let workspace = moltis_config::agent_workspace_dir(agent_id);
     let workspace_memory_dir = workspace.join("memory");
     if path == workspace.join("MEMORY.md")
@@ -449,6 +448,13 @@ pub(crate) fn is_path_in_agent_memory_scope(path: &Path, agent_id: &str) -> bool
         || path.starts_with(&workspace_memory_dir)
     {
         return true;
+    }
+
+    // Shared collections are visible to every agent.
+    for root in shared_collection_roots {
+        if path.starts_with(root) {
+            return true;
+        }
     }
 
     if agent_id != "main" {
@@ -494,7 +500,11 @@ impl AgentScopedMemoryWriter {
         moltis_tools::checkpoints::CheckpointRecord,
     )> {
         validate_agent_memory_target_for_mode(self.write_mode, file)?;
-        let path = resolve_agent_memory_target_path(&self.agent_id, file)?;
+        let path = resolve_agent_memory_target_path(
+            &self.agent_id,
+            file,
+            self.manager.shared_collection_roots(),
+        )?;
         let checkpoint = self.checkpoints.checkpoint_path(&path, reason).await?;
         Ok((path, checkpoint))
     }
@@ -585,7 +595,11 @@ impl moltis_agents::memory_writer::MemoryWriter for AgentScopedMemoryWriter {
         }
 
         validate_agent_memory_target_for_mode(self.write_mode, file)?;
-        let path = resolve_agent_memory_target_path(&self.agent_id, file)?;
+        let path = resolve_agent_memory_target_path(
+            &self.agent_id,
+            file,
+            self.manager.shared_collection_roots(),
+        )?;
         if let Some(parent) = path.parent() {
             tokio::fs::create_dir_all(parent).await?;
         }
@@ -671,7 +685,13 @@ impl AgentTool for AgentScopedMemorySearchTool {
             .search(query, search_limit)
             .await?
             .into_iter()
-            .filter(|result| is_path_in_agent_memory_scope(Path::new(&result.path), &self.agent_id))
+            .filter(|result| {
+                is_path_in_agent_memory_scope(
+                    Path::new(&result.path),
+                    &self.agent_id,
+                    self.manager.shared_collection_roots(),
+                )
+            })
             .collect();
         results.truncate(limit);
 
@@ -749,7 +769,11 @@ impl AgentTool for AgentScopedMemoryGetTool {
 
         match self.manager.get_chunk(chunk_id).await? {
             Some(chunk)
-                if is_path_in_agent_memory_scope(Path::new(&chunk.path), &self.agent_id) =>
+                if is_path_in_agent_memory_scope(
+                    Path::new(&chunk.path),
+                    &self.agent_id,
+                    self.manager.shared_collection_roots(),
+                ) =>
             {
                 Ok(serde_json::json!({
                     "chunk_id": chunk.id,
@@ -793,7 +817,7 @@ impl AgentTool for AgentScopedMemorySaveTool {
     }
 
     fn description(&self) -> &str {
-        "Save content to long-term memory. Writes to MEMORY.md or memory/<name>.md. Content persists across sessions and is searchable via memory_search."
+        "Save content to long-term memory. Writes to MEMORY.md, memory.md, any nested memory/<...>.md path in this agent's workspace, or any path under a configured shared collection (e.g. people/, journal/). Content persists across sessions and is searchable via memory_search."
     }
 
     fn parameters_schema(&self) -> Value {
@@ -806,7 +830,7 @@ impl AgentTool for AgentScopedMemorySaveTool {
                 },
                 "file": {
                     "type": "string",
-                    "description": "Target file: MEMORY.md, memory.md, or memory/<name>.md",
+                    "description": "Target file (must end with .md). Allowed: MEMORY.md, memory.md, any nested memory/<path>/<name>.md inside this agent's workspace, or any path under a configured shared collection (e.g. people/foo.md). Intermediate directories are created automatically.",
                     "default": "MEMORY.md"
                 },
                 "append": {
@@ -877,7 +901,7 @@ impl AgentTool for AgentScopedMemoryDeleteTool {
             "properties": {
                 "file": {
                     "type": "string",
-                    "description": "Target file: MEMORY.md, memory.md, or memory/<name>.md"
+                    "description": "Target file (must end with .md). Allowed: MEMORY.md, memory.md, any nested memory/<path>/<name>.md inside this agent's workspace, or any path under a configured shared collection."
                 },
                 "text": {
                     "type": "string",
@@ -979,9 +1003,10 @@ impl AgentTool for AgentScopedMemoryForgetTool {
 
     async fn execute(&self, params: Value) -> anyhow::Result<Value> {
         let request = parse_forget_request(&params)?;
+        let shared_roots: Vec<std::path::PathBuf> = self.manager.shared_collection_roots().to_vec();
         let candidates =
             collect_forget_candidates(&self.manager, &request.request, request.limit, |path| {
-                if is_path_in_agent_memory_scope(path, &self.agent_id) {
+                if is_path_in_agent_memory_scope(path, &self.agent_id, &shared_roots) {
                     agent_memory_file_label_for_path(path, &self.agent_id)
                 } else {
                     None

--- a/crates/gateway/src/server/init_memory.rs
+++ b/crates/gateway/src/server/init_memory.rs
@@ -1,7 +1,8 @@
-use std::{collections::HashMap, path::Path as FsPath, sync::Arc};
-
-#[cfg(feature = "local-embeddings")]
-use std::path::PathBuf;
+use std::{
+    collections::HashMap,
+    path::{Path as FsPath, PathBuf},
+    sync::Arc,
+};
 
 use {
     secrecy::ExposeSecret,
@@ -243,9 +244,9 @@ pub(crate) async fn init_memory_system(
 fn collect_writable_roots(
     data_dir: &FsPath,
     mem_cfg: &moltis_config::schema::MemoryEmbeddingConfig,
-) -> Vec<std::path::PathBuf> {
-    let mut roots: Vec<std::path::PathBuf> = Vec::new();
-    let mut push = |path: std::path::PathBuf| {
+) -> Vec<PathBuf> {
+    let mut roots: Vec<PathBuf> = Vec::new();
+    let mut push = |path: PathBuf| {
         if !roots.iter().any(|existing| existing == &path) {
             roots.push(path);
         }
@@ -256,7 +257,7 @@ fn collect_writable_roots(
 
     for collection in mem_cfg.qmd.collections.values() {
         for path in &collection.paths {
-            let candidate = std::path::Path::new(path);
+            let candidate = FsPath::new(path);
             let absolute = if candidate.is_absolute() {
                 candidate.to_path_buf()
             } else {

--- a/crates/gateway/src/server/init_memory.rs
+++ b/crates/gateway/src/server/init_memory.rs
@@ -244,17 +244,24 @@ pub(crate) async fn init_memory_system(
 fn collect_writable_roots(
     data_dir: &FsPath,
     mem_cfg: &moltis_config::schema::MemoryEmbeddingConfig,
-) -> Vec<PathBuf> {
-    let mut roots: Vec<PathBuf> = Vec::new();
-    let mut push = |path: PathBuf| {
-        if !roots.iter().any(|existing| existing == &path) {
-            roots.push(path);
+) -> (Vec<PathBuf>, Vec<PathBuf>) {
+    let mut writable: Vec<PathBuf> = Vec::new();
+    let mut shared: Vec<PathBuf> = Vec::new();
+
+    fn push_unique(list: &mut Vec<PathBuf>, path: PathBuf) {
+        if !list.iter().any(|existing| existing == &path) {
+            list.push(path);
         }
-    };
+    }
 
-    push(data_dir.join("memory"));
-    push(data_dir.join("agents"));
+    // Gateway defaults — usable by the global memory_save tool but not by
+    // per-agent writers (otherwise agents could cross workspace boundaries
+    // through data_dir/agents).
+    push_unique(&mut writable, data_dir.join("memory"));
+    push_unique(&mut writable, data_dir.join("agents"));
 
+    // User-configured QMD collections — shared knowledge stores available
+    // to every agent regardless of its workspace.
     for collection in mem_cfg.qmd.collections.values() {
         for path in &collection.paths {
             let candidate = FsPath::new(path);
@@ -263,11 +270,12 @@ fn collect_writable_roots(
             } else {
                 data_dir.join(candidate)
             };
-            push(absolute);
+            push_unique(&mut writable, absolute.clone());
+            push_unique(&mut shared, absolute);
         }
     }
 
-    roots
+    (writable, shared)
 }
 
 /// Build the memory runtime, start initial sync, file watchers, and periodic syncs.
@@ -297,7 +305,7 @@ async fn build_memory_runtime(
         );
     }
 
-    let writable_roots = collect_writable_roots(data_dir, mem_cfg);
+    let (writable_roots, shared_collection_roots) = collect_writable_roots(data_dir, mem_cfg);
 
     let memory_runtime_config = moltis_memory::config::MemoryConfig {
         db_path: data_dir.join("memory.db").to_string_lossy().into(),
@@ -309,6 +317,7 @@ async fn build_memory_runtime(
             agents_root,
         ],
         writable_roots,
+        shared_collection_roots,
         citations: match mem_cfg.citations {
             moltis_config::MemoryCitationsMode::On => moltis_memory::config::CitationMode::On,
             moltis_config::MemoryCitationsMode::Off => moltis_memory::config::CitationMode::Off,

--- a/crates/gateway/src/server/init_memory.rs
+++ b/crates/gateway/src/server/init_memory.rs
@@ -234,6 +234,41 @@ pub(crate) async fn init_memory_system(
     }
 }
 
+/// Compute the set of directories into which `memory_save` is allowed to write.
+///
+/// Always includes `data_dir/memory` and `data_dir/agents` so the agent can
+/// organise notes under those roots regardless of which backend is active.
+/// When the user has configured QMD collections, their directory paths are
+/// added so writes mirror the searchable surface.
+fn collect_writable_roots(
+    data_dir: &FsPath,
+    mem_cfg: &moltis_config::schema::MemoryEmbeddingConfig,
+) -> Vec<std::path::PathBuf> {
+    let mut roots: Vec<std::path::PathBuf> = Vec::new();
+    let mut push = |path: std::path::PathBuf| {
+        if !roots.iter().any(|existing| existing == &path) {
+            roots.push(path);
+        }
+    };
+
+    push(data_dir.join("memory"));
+    push(data_dir.join("agents"));
+
+    for collection in mem_cfg.qmd.collections.values() {
+        for path in &collection.paths {
+            let candidate = std::path::Path::new(path);
+            let absolute = if candidate.is_absolute() {
+                candidate.to_path_buf()
+            } else {
+                data_dir.join(candidate)
+            };
+            push(absolute);
+        }
+    }
+
+    roots
+}
+
 /// Build the memory runtime, start initial sync, file watchers, and periodic syncs.
 async fn build_memory_runtime(
     mem_cfg: &moltis_config::schema::MemoryEmbeddingConfig,
@@ -261,6 +296,8 @@ async fn build_memory_runtime(
         );
     }
 
+    let writable_roots = collect_writable_roots(data_dir, mem_cfg);
+
     let memory_runtime_config = moltis_memory::config::MemoryConfig {
         db_path: data_dir.join("memory.db").to_string_lossy().into(),
         data_dir: Some(data_dir.to_path_buf()),
@@ -270,6 +307,7 @@ async fn build_memory_runtime(
             data_memory_sub,
             agents_root,
         ],
+        writable_roots,
         citations: match mem_cfg.citations {
             moltis_config::MemoryCitationsMode::On => moltis_memory::config::CitationMode::On,
             moltis_config::MemoryCitationsMode::Off => moltis_memory::config::CitationMode::Off,

--- a/crates/memory/src/config.rs
+++ b/crates/memory/src/config.rs
@@ -65,6 +65,10 @@ pub struct MemoryConfig {
     pub data_dir: Option<PathBuf>,
     /// Directories to scan for markdown files.
     pub memory_dirs: Vec<PathBuf>,
+    /// Roots into which `memory_save` / `memory_delete` are allowed to write.
+    /// Empty falls back to the legacy `memory/` subtree under `data_dir`.
+    /// Paths may be absolute or relative to `data_dir`.
+    pub writable_roots: Vec<PathBuf>,
     /// Target chunk size in tokens (approximate, counted as whitespace-split words).
     pub chunk_size: usize,
     /// Overlap between consecutive chunks in tokens.
@@ -94,6 +98,7 @@ impl Default for MemoryConfig {
             db_path: "memory.db".into(),
             data_dir: None,
             memory_dirs: vec![PathBuf::from("memory")],
+            writable_roots: Vec::new(),
             chunk_size: 400,
             chunk_overlap: 80,
             vector_weight: 0.7,

--- a/crates/memory/src/config.rs
+++ b/crates/memory/src/config.rs
@@ -69,6 +69,13 @@ pub struct MemoryConfig {
     /// Empty falls back to the legacy `memory/` subtree under `data_dir`.
     /// Paths may be absolute or relative to `data_dir`.
     pub writable_roots: Vec<PathBuf>,
+    /// Subset of `writable_roots` that correspond to user-configured QMD
+    /// collections — shared knowledge stores that all agents may write to
+    /// regardless of their per-agent workspace. Empty when no collections
+    /// are configured. Distinct from `writable_roots` so per-agent
+    /// isolation isn't accidentally widened by gateway-added defaults
+    /// (e.g. `data_dir/agents`).
+    pub shared_collection_roots: Vec<PathBuf>,
     /// Target chunk size in tokens (approximate, counted as whitespace-split words).
     pub chunk_size: usize,
     /// Overlap between consecutive chunks in tokens.
@@ -99,6 +106,7 @@ impl Default for MemoryConfig {
             data_dir: None,
             memory_dirs: vec![PathBuf::from("memory")],
             writable_roots: Vec::new(),
+            shared_collection_roots: Vec::new(),
             chunk_size: 400,
             chunk_overlap: 80,
             vector_weight: 0.7,

--- a/crates/memory/src/manager.rs
+++ b/crates/memory/src/manager.rs
@@ -1138,11 +1138,7 @@ mod tests {
         let data_dir = tmp.path().to_path_buf();
 
         manager
-            .write_memory(
-                "memory/work/projects/alpha.md",
-                "alpha kickoff",
-                false,
-            )
+            .write_memory("memory/work/projects/alpha.md", "alpha kickoff", false)
             .await
             .unwrap();
 
@@ -1183,7 +1179,10 @@ mod tests {
         let outside = manager
             .write_memory("elsewhere/notes.md", "no", false)
             .await;
-        assert!(outside.is_err(), "writes outside configured roots must fail");
+        assert!(
+            outside.is_err(),
+            "writes outside configured roots must fail"
+        );
     }
 
     #[tokio::test]

--- a/crates/memory/src/manager.rs
+++ b/crates/memory/src/manager.rs
@@ -101,6 +101,14 @@ impl MemoryManager {
         &self.config.writable_roots
     }
 
+    /// Subset of `writable_roots` containing only user-configured shared
+    /// collections (no gateway-added defaults). Used by the agent-scoped
+    /// writer to decide which paths cross the workspace boundary and
+    /// become shared knowledge stores.
+    pub fn shared_collection_roots(&self) -> &[PathBuf] {
+        &self.config.shared_collection_roots
+    }
+
     /// Whether LLM reranking is enabled.
     pub fn llm_reranking_enabled(&self) -> bool {
         self.config.llm_reranking

--- a/crates/memory/src/manager.rs
+++ b/crates/memory/src/manager.rs
@@ -1,5 +1,5 @@
 /// Memory manager: orchestrates file sync, chunking, embedding, and search.
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use {
     async_trait::async_trait,
@@ -92,6 +92,13 @@ impl MemoryManager {
     /// Root data directory used for memory writes, when configured.
     pub fn data_dir(&self) -> Option<&Path> {
         self.config.data_dir.as_deref()
+    }
+
+    /// Roots into which memory writes are allowed (in addition to the
+    /// `MEMORY.md` / `memory.md` root shortcuts). Empty means legacy
+    /// behaviour — only the `memory/` subtree under `data_dir`.
+    pub fn writable_roots(&self) -> &[PathBuf] {
+        &self.config.writable_roots
     }
 
     /// Whether LLM reranking is enabled.
@@ -445,7 +452,7 @@ impl MemoryWriter for MemoryManager {
             );
         }
 
-        let path = validate_memory_path(data_dir, file)?;
+        let path = validate_memory_path(data_dir, &self.config.writable_roots, file)?;
 
         // Create parent directories if needed.
         if let Some(parent) = path.parent() {
@@ -1113,7 +1120,8 @@ mod tests {
             "memory/notes.txt",
             "memory/.md",
             "memory/a b c.md",
-            "memory/sub/nested.md",
+            "memory/sub/.hidden.md",
+            "memory/sub/../escape.md",
             "random.md",
             "foo/bar.md",
         ];
@@ -1122,6 +1130,60 @@ mod tests {
             let result = manager.write_memory(name, "test", false).await;
             assert!(result.is_err(), "should reject invalid name: {name}");
         }
+    }
+
+    #[tokio::test]
+    async fn test_memory_writer_accepts_nested_subfolders() {
+        let (manager, tmp) = setup_writable().await;
+        let data_dir = tmp.path().to_path_buf();
+
+        manager
+            .write_memory(
+                "memory/work/projects/alpha.md",
+                "alpha kickoff",
+                false,
+            )
+            .await
+            .unwrap();
+
+        let written = data_dir.join("memory/work/projects/alpha.md");
+        assert!(written.exists(), "nested file should be created");
+        let content = std::fs::read_to_string(&written).unwrap();
+        assert_eq!(content, "alpha kickoff");
+    }
+
+    #[tokio::test]
+    async fn test_memory_writer_writable_roots_accepts_outside_memory() {
+        let tmp = TempDir::new().unwrap();
+        let data_dir = tmp.path().to_path_buf();
+        let agents_root = data_dir.join("agents");
+        std::fs::create_dir_all(&agents_root).unwrap();
+        std::fs::create_dir_all(data_dir.join("memory")).unwrap();
+
+        let pool = sqlx::SqlitePool::connect(":memory:").await.unwrap();
+        run_migrations(&pool).await.unwrap();
+        let config = MemoryConfig {
+            db_path: ":memory:".into(),
+            data_dir: Some(data_dir.clone()),
+            memory_dirs: vec![data_dir.join("memory"), agents_root.clone()],
+            writable_roots: vec![data_dir.join("memory"), agents_root.clone()],
+            ..Default::default()
+        };
+        let store = Box::new(SqliteMemoryStore::new(pool));
+        let manager = MemoryManager::keyword_only(config, store);
+
+        manager
+            .write_memory("agents/ops/notes.md", "deployment runbook", false)
+            .await
+            .unwrap();
+
+        assert!(agents_root.join("ops/notes.md").exists());
+
+        // Outside any configured root is still rejected.
+        let outside = manager
+            .write_memory("elsewhere/notes.md", "no", false)
+            .await;
+        assert!(outside.is_err(), "writes outside configured roots must fail");
     }
 
     #[tokio::test]

--- a/crates/memory/src/runtime.rs
+++ b/crates/memory/src/runtime.rs
@@ -1,4 +1,7 @@
-use std::{path::Path, sync::Arc};
+use std::{
+    path::{Path, PathBuf},
+    sync::Arc,
+};
 
 use {async_trait::async_trait, moltis_agents::memory_writer::MemoryWriter};
 
@@ -17,6 +20,10 @@ pub trait MemoryRuntime: MemoryWriter + Send + Sync {
     fn backend_name(&self) -> &'static str;
 
     fn data_dir(&self) -> Option<&Path>;
+
+    /// Roots into which the agent is allowed to save memory. Empty means
+    /// only the legacy `memory/` subtree under `data_dir`.
+    fn writable_roots(&self) -> &[PathBuf];
 
     fn has_embeddings(&self) -> bool;
 
@@ -45,6 +52,10 @@ impl MemoryRuntime for MemoryManager {
 
     fn data_dir(&self) -> Option<&Path> {
         MemoryManager::data_dir(self)
+    }
+
+    fn writable_roots(&self) -> &[PathBuf] {
+        MemoryManager::writable_roots(self)
     }
 
     fn has_embeddings(&self) -> bool {

--- a/crates/memory/src/runtime.rs
+++ b/crates/memory/src/runtime.rs
@@ -25,6 +25,11 @@ pub trait MemoryRuntime: MemoryWriter + Send + Sync {
     /// only the legacy `memory/` subtree under `data_dir`.
     fn writable_roots(&self) -> &[PathBuf];
 
+    /// Subset of `writable_roots` representing user-configured shared
+    /// collections (no gateway defaults). Agent-scoped writers consult
+    /// this to decide which paths cross the per-agent workspace boundary.
+    fn shared_collection_roots(&self) -> &[PathBuf];
+
     fn has_embeddings(&self) -> bool;
 
     fn citation_mode(&self) -> CitationMode;
@@ -56,6 +61,10 @@ impl MemoryRuntime for MemoryManager {
 
     fn writable_roots(&self) -> &[PathBuf] {
         MemoryManager::writable_roots(self)
+    }
+
+    fn shared_collection_roots(&self) -> &[PathBuf] {
+        MemoryManager::shared_collection_roots(self)
     }
 
     fn has_embeddings(&self) -> bool {

--- a/crates/memory/src/tools.rs
+++ b/crates/memory/src/tools.rs
@@ -160,7 +160,7 @@ impl AgentTool for MemorySaveTool {
     }
 
     fn description(&self) -> &str {
-        "Save content to long-term memory. Writes to MEMORY.md or memory/<name>.md. Content persists across sessions and is searchable via memory_search."
+        "Save content to long-term memory. Writes to MEMORY.md or any .md file under a configured memory root (memory/, agents/, or QMD-configured collections). Subfolders are supported. Content persists across sessions and is searchable via memory_search."
     }
 
     fn parameters_schema(&self) -> serde_json::Value {
@@ -173,7 +173,7 @@ impl AgentTool for MemorySaveTool {
                 },
                 "file": {
                     "type": "string",
-                    "description": "Target file: MEMORY.md, memory.md, or memory/<name>.md",
+                    "description": "Target file (must end with .md). Allowed: MEMORY.md, memory.md, or any path under a configured memory root, e.g. memory/work/notes.md or agents/foo/log.md. Intermediate directories are created automatically.",
                     "default": "MEMORY.md"
                 },
                 "append": {
@@ -234,7 +234,7 @@ impl AgentTool for MemoryDeleteTool {
             "properties": {
                 "file": {
                     "type": "string",
-                    "description": "Target file: MEMORY.md, memory.md, or memory/<name>.md"
+                    "description": "Target file (must end with .md). Allowed: MEMORY.md, memory.md, or any path under a configured memory root, e.g. memory/work/notes.md or agents/foo/log.md."
                 },
                 "text": {
                     "type": "string",
@@ -324,7 +324,11 @@ fn resolve_memory_tool_path(manager: &dyn MemoryRuntime, file: &str) -> anyhow::
     let data_dir = manager
         .data_dir()
         .ok_or_else(|| anyhow::anyhow!("memory writes are disabled (no data_dir configured)"))?;
-    Ok(validate_memory_path(data_dir, file)?)
+    Ok(validate_memory_path(
+        data_dir,
+        manager.writable_roots(),
+        file,
+    )?)
 }
 
 async fn checkpoint_memory_path(
@@ -715,6 +719,30 @@ mod tests {
         assert!(content.contains("Notes from 2024-01-15"));
     }
 
+    /// Nested subfolders under memory/ are accepted, intermediate dirs auto-created.
+    #[tokio::test]
+    async fn test_memory_save_nested_subfolders() {
+        let (manager, tmp) = setup_manager().await;
+        let data_dir = tmp.path().to_path_buf();
+        let tool = MemorySaveTool::new(manager.clone());
+
+        let result = tool
+            .execute(json!({
+                "content": "Project alpha kickoff notes.",
+                "file": "memory/work/projects/alpha.md"
+            }))
+            .await
+            .unwrap();
+
+        assert_eq!(result["saved"], json!(true));
+        assert_eq!(result["path"], json!("memory/work/projects/alpha.md"));
+
+        let written = data_dir.join("memory/work/projects/alpha.md");
+        assert!(written.exists(), "nested file should be written");
+        let content = std::fs::read_to_string(&written).unwrap();
+        assert!(content.contains("alpha kickoff"));
+    }
+
     /// Auto-creates memory/ directory if it doesn't exist.
     #[tokio::test]
     async fn test_memory_save_creates_memory_dir() {
@@ -800,12 +828,13 @@ mod tests {
         let tool = MemorySaveTool::new(manager.clone());
 
         let invalid = &[
-            "memory/notes.txt",     // wrong extension
-            "memory/.md",           // empty stem
-            "memory/a b c.md",      // spaces in name
-            "memory/sub/nested.md", // nested subdirectory
-            "random.md",            // not MEMORY.md or memory/
-            "foo/bar.md",           // not in allowed paths
+            "memory/notes.txt",        // wrong extension
+            "memory/.md",              // empty stem
+            "memory/a b c.md",         // spaces in name
+            "memory/sub/.hidden.md",   // hidden segment
+            "memory/sub/../escape.md", // traversal
+            "random.md",               // not MEMORY.md or memory/
+            "foo/bar.md",              // not in allowed paths
         ];
 
         for name in invalid {

--- a/crates/memory/src/writer.rs
+++ b/crates/memory/src/writer.rs
@@ -1,53 +1,175 @@
 //! Path validation and text mutation helpers for memory writes.
 
-use std::path::{Path, PathBuf};
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
 
 const ROOT_MEMORY_FILES: [&str; 2] = ["MEMORY.md", "memory.md"];
-const MEMORY_DIR_PREFIX: &str = "memory/";
+const LEGACY_MEMORY_DIR: &str = "memory";
 
-/// Validate and resolve a memory write path relative to `data_dir`.
+/// Validate and resolve a memory write path.
 ///
-/// Allowed targets:
-/// - `MEMORY.md`
-/// - `memory.md`
-/// - `memory/<name>.md` (single segment only)
-pub fn validate_memory_path(data_dir: &Path, file: &str) -> crate::error::Result<PathBuf> {
+/// `data_dir` is the workspace root. `writable_roots` lists additional roots
+/// (absolute, or relative to `data_dir`) into which writes are allowed; pass
+/// an empty slice for legacy behaviour (only the `memory/` subtree under
+/// `data_dir` plus the root `MEMORY.md`/`memory.md` shortcuts).
+///
+/// Segment rules — every path segment must be non-empty, contain no
+/// whitespace, not equal `.` or `..`, and not begin with `.`. The final
+/// segment must end in `.md` with a non-empty stem. Absolute inputs and
+/// backslash separators are always rejected. After syntactic resolution,
+/// the existing ancestor of the target is canonicalised and must lie under
+/// an allowed root — this catches pre-existing symlinks that would
+/// otherwise escape the workspace.
+pub fn validate_memory_path(
+    data_dir: &Path,
+    writable_roots: &[PathBuf],
+    file: &str,
+) -> crate::error::Result<PathBuf> {
     let path = file.trim();
     if path.is_empty() {
-        return Err(crate::error::Error::Validation(
-            "memory path cannot be empty".into(),
-        ));
+        return Err(invalid("memory path cannot be empty"));
     }
-
     if Path::new(path).is_absolute() {
-        return Err(crate::error::Error::Validation(
-            "memory path must be relative".into(),
-        ));
+        return Err(invalid("memory path must be relative"));
     }
-
     if path.contains('\\') {
-        return Err(crate::error::Error::Validation(
-            "memory path must use '/' separators".into(),
-        ));
+        return Err(invalid("memory path must use '/' separators"));
     }
 
-    if ROOT_MEMORY_FILES.contains(&path) {
-        return Ok(data_dir.join(path));
+    let is_root_file = ROOT_MEMORY_FILES.contains(&path);
+    let segments: Vec<&str> = path.split('/').collect();
+    for (i, seg) in segments.iter().enumerate() {
+        validate_segment(seg, i + 1 == segments.len(), path)?;
     }
 
-    let Some(name) = path.strip_prefix(MEMORY_DIR_PREFIX) else {
-        return Err(crate::error::Error::Validation(format!(
-            "invalid memory path '{path}': allowed targets are MEMORY.md, memory.md, or memory/<name>.md"
+    // We compare a fully-resolved target against fully-resolved roots so
+    // pre-existing symlinks inside the workspace can't be used to escape it.
+    // The caller-facing return path keeps the original `data_dir` spelling.
+    let canon_data_dir = canonicalize_or_self(data_dir);
+    let symlink_safe_target = symlink_safe_resolve(&canon_data_dir.join(path));
+    let allowed = allowed_roots(&canon_data_dir, writable_roots, is_root_file);
+    if !allowed
+        .iter()
+        .any(|root| symlink_safe_target.starts_with(root))
+    {
+        return Err(invalid(format!(
+            "memory path '{}' resolves outside any configured memory root",
+            data_dir.join(path).display()
         )));
+    }
+    Ok(data_dir.join(path))
+}
+
+fn validate_segment(seg: &str, is_last: bool, full: &str) -> crate::error::Result<()> {
+    if seg.is_empty() {
+        return Err(invalid(format!(
+            "invalid memory path '{full}': empty segment"
+        )));
+    }
+    if seg == "." || seg == ".." {
+        return Err(invalid(format!(
+            "invalid memory path '{full}': traversal segment '{seg}'"
+        )));
+    }
+    if seg.chars().any(char::is_whitespace) {
+        return Err(invalid(format!(
+            "invalid memory path '{full}': whitespace in segment '{seg}'"
+        )));
+    }
+    if seg.starts_with('.') {
+        return Err(invalid(format!(
+            "invalid memory path '{full}': segment '{seg}' starts with '.'"
+        )));
+    }
+    if is_last {
+        if !seg.ends_with(".md") {
+            return Err(invalid(format!(
+                "invalid memory path '{full}': last segment must end with .md"
+            )));
+        }
+        let stem = &seg[..seg.len() - 3];
+        if stem.is_empty() {
+            return Err(invalid(format!(
+                "invalid memory path '{full}': empty filename stem"
+            )));
+        }
+    }
+    Ok(())
+}
+
+/// Build the canonical list of permitted roots for a write attempt.
+///
+/// `canon_data_dir` is the already-canonicalised data root. `include_data_dir`
+/// is set only for the root-file shortcuts (`MEMORY.md` / `memory.md`), which
+/// must resolve directly under `data_dir`. For all other paths, only the
+/// legacy `memory/` subtree (when no roots are configured) or the configured
+/// `writable_roots` are permitted.
+fn allowed_roots(
+    canon_data_dir: &Path,
+    writable_roots: &[PathBuf],
+    include_data_dir: bool,
+) -> Vec<PathBuf> {
+    let mut roots: Vec<PathBuf> = Vec::new();
+    let push = |list: &mut Vec<PathBuf>, p: PathBuf| {
+        if !list.iter().any(|existing| existing == &p) {
+            list.push(p);
+        }
     };
 
-    if !is_valid_memory_file_name(name) {
-        return Err(crate::error::Error::Validation(format!(
-            "invalid memory path '{path}': allowed targets are MEMORY.md, memory.md, or memory/<name>.md"
-        )));
+    if include_data_dir {
+        push(&mut roots, canon_data_dir.to_path_buf());
     }
 
-    Ok(data_dir.join(MEMORY_DIR_PREFIX).join(name))
+    if writable_roots.is_empty() {
+        push(&mut roots, canon_data_dir.join(LEGACY_MEMORY_DIR));
+    } else {
+        for root in writable_roots {
+            let abs = if root.is_absolute() {
+                root.clone()
+            } else {
+                canon_data_dir.join(root)
+            };
+            push(&mut roots, canonicalize_or_self(&abs));
+        }
+    }
+    roots
+}
+
+fn canonicalize_or_self(p: &Path) -> PathBuf {
+    fs::canonicalize(p).unwrap_or_else(|_| p.to_path_buf())
+}
+
+/// Resolve `path` to its symlink-safe canonical form, even if the leaf does
+/// not yet exist. Walks up until an ancestor that exists is found,
+/// canonicalises it, then re-attaches the remaining (already-validated)
+/// trailing segments. This catches pre-existing symlinks along the path that
+/// would otherwise allow a write to escape the workspace.
+fn symlink_safe_resolve(path: &Path) -> PathBuf {
+    let mut current = path.to_path_buf();
+    let mut tail: Vec<std::ffi::OsString> = Vec::new();
+    loop {
+        if let Ok(c) = fs::canonicalize(&current) {
+            let mut result = c;
+            for seg in tail.iter().rev() {
+                result.push(seg);
+            }
+            return result;
+        }
+        let Some(name) = current.file_name().map(|n| n.to_os_string()) else {
+            return path.to_path_buf();
+        };
+        tail.push(name);
+        let Some(parent) = current.parent().map(Path::to_path_buf) else {
+            return path.to_path_buf();
+        };
+        current = parent;
+    }
+}
+
+fn invalid(msg: impl Into<String>) -> crate::error::Error {
+    crate::error::Error::Validation(msg.into())
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -114,82 +236,90 @@ fn text_variants(snippet: &str) -> Vec<String> {
     variants
 }
 
-fn is_valid_memory_file_name(name: &str) -> bool {
-    if name.is_empty() {
-        return false;
-    }
-
-    // Exactly one level under memory/.
-    if name.contains('/') {
-        return false;
-    }
-
-    if !name.ends_with(".md") {
-        return false;
-    }
-
-    if name.chars().any(char::is_whitespace) {
-        return false;
-    }
-
-    // Reject empty stem (`.md`) and hidden-ish names (`.foo.md`).
-    let stem = &name[..name.len() - 3];
-    if stem.is_empty() || stem.starts_with('.') {
-        return false;
-    }
-
-    true
-}
-
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 #[cfg(test)]
 mod tests {
-    use std::path::Path;
+    use std::{fs, path::PathBuf};
+
+    use tempfile::TempDir;
 
     use super::{remove_exact_text, validate_memory_path};
 
+    /// Canonicalize a path the same way the validator does so tests work on
+    /// macOS where TempDir paths get `/private` prefixed by realpath(3).
+    fn canon(p: &std::path::Path) -> PathBuf {
+        fs::canonicalize(p).unwrap_or_else(|_| p.to_path_buf())
+    }
+
+    fn tmp_with_memory_dir() -> TempDir {
+        let tmp = TempDir::new().unwrap();
+        fs::create_dir_all(tmp.path().join("memory")).unwrap();
+        tmp
+    }
+
     #[test]
     fn allows_root_memory_files() {
-        let root = Path::new("/tmp/moltis");
+        let tmp = tmp_with_memory_dir();
+        let root = tmp.path();
 
         assert_eq!(
-            validate_memory_path(root, "MEMORY.md").unwrap(),
-            root.join("MEMORY.md")
+            canon(&validate_memory_path(root, &[], "MEMORY.md").unwrap()),
+            canon(&root.join("MEMORY.md"))
         );
         assert_eq!(
-            validate_memory_path(root, "memory.md").unwrap(),
-            root.join("memory.md")
+            canon(&validate_memory_path(root, &[], "memory.md").unwrap()),
+            canon(&root.join("memory.md"))
         );
     }
 
     #[test]
     fn allows_single_level_memory_files() {
-        let root = Path::new("/tmp/moltis");
+        let tmp = tmp_with_memory_dir();
+        let root = tmp.path();
 
         assert_eq!(
-            validate_memory_path(root, "memory/notes.md").unwrap(),
-            root.join("memory").join("notes.md")
+            canon(&validate_memory_path(root, &[], "memory/notes.md").unwrap()),
+            canon(&root.join("memory").join("notes.md"))
         );
         assert_eq!(
-            validate_memory_path(root, "memory/2026-02-14.md").unwrap(),
-            root.join("memory").join("2026-02-14.md")
+            canon(&validate_memory_path(root, &[], "memory/2026-02-14.md").unwrap()),
+            canon(&root.join("memory").join("2026-02-14.md"))
         );
     }
 
     #[test]
+    fn allows_nested_memory_subfolders() {
+        let tmp = tmp_with_memory_dir();
+        let root = tmp.path();
+
+        let resolved = validate_memory_path(root, &[], "memory/work/projects/notes.md").unwrap();
+        assert_eq!(
+            canon(&resolved),
+            canon(&root.join("memory/work/projects/notes.md"))
+        );
+
+        let resolved = validate_memory_path(root, &[], "memory/a/b/c/d.md").unwrap();
+        assert_eq!(canon(&resolved), canon(&root.join("memory/a/b/c/d.md")));
+    }
+
+    #[test]
     fn rejects_invalid_paths() {
-        let root = Path::new("/tmp/moltis");
+        let tmp = tmp_with_memory_dir();
+        let root = tmp.path();
         let invalid = [
             "",
             " ",
             "/etc/passwd",
             "../etc/passwd",
             "memory/../../secret.md",
-            "memory/a/b.md",
+            "memory/./notes.md",
             "memory/.md",
             "memory/.hidden.md",
             "memory/notes.txt",
             "memory/a b.md",
+            "memory/sub/ /notes.md",
+            "memory/sub/.hidden/notes.md",
+            "memory/sub//notes.md",
             "random.md",
             "foo/bar.md",
             "memory\\notes.md",
@@ -197,10 +327,88 @@ mod tests {
 
         for item in invalid {
             assert!(
-                validate_memory_path(root, item).is_err(),
+                validate_memory_path(root, &[], item).is_err(),
                 "expected invalid path: {item}"
             );
         }
+    }
+
+    #[test]
+    fn roots_mode_accepts_paths_under_configured_root() {
+        let tmp = TempDir::new().unwrap();
+        let data_dir = tmp.path();
+        fs::create_dir_all(data_dir.join("agents")).unwrap();
+        let roots = vec![data_dir.join("agents")];
+
+        let resolved = validate_memory_path(data_dir, &roots, "agents/foo/notes.md").unwrap();
+        assert_eq!(
+            canon(&resolved),
+            canon(&data_dir.join("agents/foo/notes.md"))
+        );
+
+        // Multi-segment under the configured root is fine.
+        let resolved = validate_memory_path(data_dir, &roots, "agents/foo/sub/log.md").unwrap();
+        assert_eq!(
+            canon(&resolved),
+            canon(&data_dir.join("agents/foo/sub/log.md"))
+        );
+
+        // Root-file shortcuts still work.
+        let resolved = validate_memory_path(data_dir, &roots, "MEMORY.md").unwrap();
+        assert_eq!(canon(&resolved), canon(&data_dir.join("MEMORY.md")));
+    }
+
+    #[test]
+    fn roots_mode_rejects_paths_outside_roots() {
+        let tmp = TempDir::new().unwrap();
+        let data_dir = tmp.path();
+        fs::create_dir_all(data_dir.join("agents")).unwrap();
+        fs::create_dir_all(data_dir.join("memory")).unwrap();
+        let roots = vec![data_dir.join("agents")];
+
+        // memory/ is no longer implicitly writable when roots are configured.
+        assert!(validate_memory_path(data_dir, &roots, "memory/notes.md").is_err());
+        // Random sibling of an allowed root is rejected.
+        assert!(validate_memory_path(data_dir, &roots, "outside/notes.md").is_err());
+    }
+
+    #[test]
+    fn roots_mode_includes_memory_when_listed() {
+        let tmp = TempDir::new().unwrap();
+        let data_dir = tmp.path();
+        fs::create_dir_all(data_dir.join("memory")).unwrap();
+        fs::create_dir_all(data_dir.join("agents")).unwrap();
+        let roots = vec![data_dir.join("memory"), data_dir.join("agents")];
+
+        assert!(validate_memory_path(data_dir, &roots, "memory/work/notes.md").is_ok());
+        assert!(validate_memory_path(data_dir, &roots, "agents/foo/notes.md").is_ok());
+        assert!(validate_memory_path(data_dir, &roots, "elsewhere/notes.md").is_err());
+    }
+
+    #[test]
+    fn roots_mode_accepts_relative_root_specifier() {
+        let tmp = TempDir::new().unwrap();
+        let data_dir = tmp.path();
+        fs::create_dir_all(data_dir.join("agents")).unwrap();
+        let roots = vec![PathBuf::from("agents")];
+
+        assert!(validate_memory_path(data_dir, &roots, "agents/foo.md").is_ok());
+        assert!(validate_memory_path(data_dir, &roots, "memory/foo.md").is_err());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn rejects_symlink_escape_from_allowed_root() {
+        let tmp = TempDir::new().unwrap();
+        let data_dir = tmp.path();
+        let outside = TempDir::new().unwrap();
+        fs::create_dir_all(data_dir.join("memory")).unwrap();
+        std::os::unix::fs::symlink(outside.path(), data_dir.join("memory/escape")).unwrap();
+
+        // The symlinked subtree points outside the data_dir, so writes there
+        // must be rejected even though the syntactic path looks clean.
+        let result = validate_memory_path(data_dir, &[], "memory/escape/notes.md");
+        assert!(result.is_err(), "symlink escape must be rejected");
     }
 
     #[test]

--- a/crates/qmd/src/runtime.rs
+++ b/crates/qmd/src/runtime.rs
@@ -1,4 +1,7 @@
-use std::{path::Path, sync::Arc};
+use std::{
+    path::{Path, PathBuf},
+    sync::Arc,
+};
 
 use {
     async_trait::async_trait,
@@ -149,6 +152,10 @@ impl MemoryRuntime for QmdMemoryRuntime {
 
     fn data_dir(&self) -> Option<&Path> {
         self.fallback.data_dir()
+    }
+
+    fn writable_roots(&self) -> &[PathBuf] {
+        self.fallback.writable_roots()
     }
 
     fn has_embeddings(&self) -> bool {

--- a/crates/qmd/src/runtime.rs
+++ b/crates/qmd/src/runtime.rs
@@ -158,6 +158,10 @@ impl MemoryRuntime for QmdMemoryRuntime {
         self.fallback.writable_roots()
     }
 
+    fn shared_collection_roots(&self) -> &[PathBuf] {
+        self.fallback.shared_collection_roots()
+    }
+
     fn has_embeddings(&self) -> bool {
         !self.disable_rag
     }


### PR DESCRIPTION
## Summary

`memory_save` / `memory_delete` previously accepted only `MEMORY.md`, `memory.md`, or `memory/<single-name>.md`. With QMD as the backend, collections already support arbitrary directory layouts (`memory/**`, `agents/**`, plus any user-defined collection), but writes couldn't target them — forcing hierarchical memory into flat files.

Two layered relaxations, both backwards-compatible:

* **Layer 1** — multi-segment paths under `memory/` are now accepted (`memory/work/projects/alpha.md`). Each segment is validated independently: non-empty, no whitespace, not `.`/`..`, no leading `.`, last segment must end with `.md` and have a non-empty stem. Intermediate directories are created automatically.

* **Layer 2** — `MemoryConfig` carries two new fields:
  * `writable_roots` — for the global `MemorySaveTool`. Includes `data_dir/memory`, `data_dir/agents`, plus any user-configured QMD collection paths.
  * `shared_collection_roots` — for `AgentScopedMemorySaveTool`. Only user-configured QMD collections, so per-agent isolation isn't accidentally widened by gateway-added defaults. Agents can write to shared collections (`people/foo.md`, `journal/2026-05-17.md`) but still can't cross into another agent's workspace.

Path safety: both the data root and the existing ancestor of the target are canonicalised before the containment check (re-attaching trailing validated segments), so pre-existing symlinks can't be used to escape the allowed roots.

Tool schema descriptions updated to advertise the new layout. Legacy paths keep working — the only flipped negative test was the one asserting `memory/sub/nested.md` is rejected; everything else still rejects what it used to.

## Validation

### Completed
- [x] `cargo test -p moltis-memory` — 116 passed (added: nested-subfolders, roots-mode accept/reject, symlink-escape rejection, relative-root specifier)
- [x] `cargo test -p moltis-qmd` — 12 passed
- [x] `cargo test -p moltis-chat` — 112 passed
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p moltis-memory -p moltis-qmd -p moltis-gateway --no-deps`
- [x] `cargo build -p moltis --no-default-features --features full` (reproduces container release-build lint gate)
- [x] Container deploy + chat-UI smoke test: agent successfully saves `people/<name>.md` to a configured collection root after redeploy

### Remaining
- [ ] CI: full `just lint` / `just test` matrix

## Manual QA

With QMD configured and a collection at `[memory.qmd.collections.people] paths = [\"people\"]`:

1. Ask any agent: \"Use `memory_save` to save 'Hello' at `people/test.md`.\"
   → Expect `saved: true`. Verify file appears at `data_dir/people/test.md`.
2. Repeat with a nested workspace path: `memory/work/projects/test.md`.
   → Expect success, intermediate dirs auto-created.
3. Negative: `memory_save random.md` and `memory_save agents/other/secret.md` should both error with a new \"resolves outside any configured memory root\" message. Cross-agent paths must not appear.
4. `memory_search` for the saved content should return it with a citation.

## Files touched

* `crates/memory/src/{writer,config,manager,runtime,tools}.rs`
* `crates/qmd/src/runtime.rs`
* `crates/chat/src/memory_tools.rs`
* `crates/gateway/src/server/init_memory.rs`

## Notes

Discovered an unrelated QMD wrapper bug while testing this PR's deployment (orphaned QMD child processes on timeout). Filed separately as moltis-org/moltis#1009.