### PR TITLE
fix(config): preserve explicit defaults on startup

### DIFF
--- a/crates/config/src/loader/config_io.rs
+++ b/crates/config/src/loader/config_io.rs
@@ -81,7 +81,6 @@ pub fn load_config_value(path: &Path) -> crate::Result<serde_json::Value> {
 ///
 /// Performs all write side-effects that prepare the config directory:
 /// - Refreshes Moltis-managed `defaults.toml`
-/// - Auto-compacts user config (strips materialized defaults)
 /// - Writes a default config template on first run
 /// - Persists a randomly generated port so it stays stable
 ///
@@ -92,25 +91,6 @@ pub fn initialize_config() {
         && let Err(e) = crate::defaults::write_defaults_toml(&dir)
     {
         warn!(error = %e, "failed to write defaults.toml");
-    }
-
-    // Auto-compact: strip default values that were materialized by older
-    // versions. Idempotent — no-op when already compact.
-    if find_config_file().is_some() {
-        match compact_config() {
-            Ok((before, after)) if before > after => {
-                info!(
-                    before,
-                    after,
-                    removed = before - after,
-                    "auto-compacted user config (stripped default values)"
-                );
-            },
-            Err(e) => {
-                debug!(error = %e, "auto-compact skipped");
-            },
-            _ => {},
-        }
     }
 
     // Write default user config on first run (when no config file exists).

--- a/crates/config/src/loader/tests/layered.rs
+++ b/crates/config/src/loader/tests/layered.rs
@@ -532,6 +532,46 @@ endpoint = "http://localhost:5002"
 }
 
 #[test]
+fn initialize_config_port_persistence_preserves_explicit_default_coqui_endpoint() {
+    let _guard = CONFIG_DIR_TEST_LOCK.lock().unwrap();
+    let dir = tempfile::tempdir().expect("tempdir");
+    let config_path = dir.path().join("moltis.toml");
+
+    std::fs::write(
+        &config_path,
+        r#"
+[server]
+port = 0
+
+[voice.tts.coqui]
+enabled = true
+endpoint = "http://localhost:5002"
+"#,
+    )
+    .expect("write config");
+
+    set_config_dir(dir.path().to_path_buf());
+    initialize_config();
+
+    let saved = std::fs::read_to_string(&config_path).expect("read saved");
+    let saved_config = parse_config(&saved, &config_path).expect("parse saved config");
+    assert_ne!(
+        saved_config.server.port, 0,
+        "startup initialization should persist a generated port"
+    );
+    assert!(
+        saved.contains("endpoint = \"http://localhost:5002\""),
+        "port persistence must not strip explicit default-valued Coqui endpoint"
+    );
+    assert!(
+        saved.contains("enabled = true"),
+        "port persistence must not strip explicit default-valued Coqui enabled flag"
+    );
+
+    clear_config_dir();
+}
+
+#[test]
 fn strip_default_values_removes_matching_defaults() {
     let effective = r#"
 [server]

--- a/crates/config/src/loader/tests/layered.rs
+++ b/crates/config/src/loader/tests/layered.rs
@@ -497,6 +497,41 @@ disabled = false
 }
 
 #[test]
+fn initialize_config_preserves_explicit_default_coqui_endpoint() {
+    let _guard = CONFIG_DIR_TEST_LOCK.lock().unwrap();
+    let dir = tempfile::tempdir().expect("tempdir");
+    let config_path = dir.path().join("moltis.toml");
+
+    std::fs::write(
+        &config_path,
+        r#"
+[server]
+port = 18789
+
+[voice.tts.coqui]
+enabled = true
+endpoint = "http://localhost:5002"
+"#,
+    )
+    .expect("write config");
+
+    set_config_dir(dir.path().to_path_buf());
+    initialize_config();
+
+    let saved = std::fs::read_to_string(&config_path).expect("read saved");
+    assert!(
+        saved.contains("endpoint = \"http://localhost:5002\""),
+        "startup initialization must not strip explicit default-valued Coqui endpoint"
+    );
+    assert!(
+        saved.contains("enabled = true"),
+        "startup initialization must not strip explicit default-valued Coqui enabled flag"
+    );
+
+    clear_config_dir();
+}
+
+#[test]
 fn strip_default_values_removes_matching_defaults() {
     let effective = r#"
 [server]


### PR DESCRIPTION
## Summary
- Stop startup initialization from auto-compacting user config files.
- Preserve explicit default-valued Coqui TTS settings, including `http://localhost:5002`, while keeping manual config compaction available.
- Add a regression test for issue #1006.

## Validation
### Completed
- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p moltis-config initialize_config_preserves_explicit_default_coqui_endpoint`
- [x] `cargo test -p moltis-config`

### Remaining
- [ ] Full workspace validation not run locally.

## Manual QA
- Not run. Regression coverage verifies startup initialization preserves explicit Coqui defaults.

Fixes #1006