### PR TITLE
fix(providers): parse thought reasoning tags

### DIFF
--- a/crates/providers/src/openai_compat/provider.rs
+++ b/crates/providers/src/openai_compat/provider.rs
@@ -555,17 +555,17 @@ pub fn parse_openai_compat_usage_from_payload(payload: &serde_json::Value) -> Op
     usage_object_from_payload(payload).map(parse_openai_compat_usage)
 }
 
-/// Strip `<think>...</think>` tags from content, returning `(visible, thinking)`.
+/// Strip reasoning tags from content, returning `(visible, thinking)`.
 ///
 /// Models like DeepSeek R1, QwQ, and MiniMax embed chain-of-thought reasoning
-/// inside `<think>` tags in the `content` field rather than using a separate
+/// inside tags like `<think>` or `<thought>` in the `content` field rather than using a separate
 /// `reasoning_content` field.  This helper splits content into the visible
 /// answer text and the thinking text so callers can handle them appropriately.
 ///
 /// Edge cases handled:
-/// - Multiple `<think>` blocks interspersed with answer text
-/// - Unclosed `<think>` tag (remainder treated as reasoning)
-/// - Empty `<think></think>` blocks
+/// - Multiple reasoning blocks interspersed with answer text
+/// - Unclosed reasoning tag (remainder treated as reasoning)
+/// - Empty reasoning blocks
 /// - Nested angle brackets inside thinking text
 pub fn strip_think_tags(content: &str) -> (String, String) {
     let mut visible = String::new();
@@ -573,18 +573,18 @@ pub fn strip_think_tags(content: &str) -> (String, String) {
     let mut remaining = content;
 
     loop {
-        match remaining.find("<think>") {
-            Some(start) => {
+        match find_next_open_tag(remaining) {
+            Some((start, tag)) => {
                 // Text before <think> is visible
                 visible.push_str(&remaining[..start]);
-                let after_open = &remaining[start + "<think>".len()..];
-                match after_open.find("</think>") {
+                let after_open = &remaining[start + tag.open().len()..];
+                match after_open.find(tag.close()) {
                     Some(end) => {
                         thinking.push_str(&after_open[..end]);
-                        remaining = &after_open[end + "</think>".len()..];
+                        remaining = &after_open[end + tag.close().len()..];
                     },
                     None => {
-                        // Unclosed <think> — treat rest as reasoning
+                        // Unclosed reasoning tag — treat rest as reasoning
                         thinking.push_str(after_open);
                         break;
                     },
@@ -603,6 +603,42 @@ pub fn strip_think_tags(content: &str) -> (String, String) {
     )
 }
 
+#[derive(Clone, Copy)]
+enum ReasoningTag {
+    Think,
+    Thought,
+}
+
+impl ReasoningTag {
+    fn open(self) -> &'static str {
+        match self {
+            Self::Think => "<think>",
+            Self::Thought => "<thought>",
+        }
+    }
+
+    fn close(self) -> &'static str {
+        match self {
+            Self::Think => "</think>",
+            Self::Thought => "</thought>",
+        }
+    }
+}
+
+fn find_next_open_tag(text: &str) -> Option<(usize, ReasoningTag)> {
+    [ReasoningTag::Think, ReasoningTag::Thought]
+        .into_iter()
+        .filter_map(|tag| text.find(tag.open()).map(|pos| (pos, tag)))
+        .min_by_key(|(pos, _)| *pos)
+}
+
+fn longest_reasoning_tag_suffix(text: &str, tags: &[&str]) -> usize {
+    tags.iter()
+        .map(|tag| longest_tag_suffix(text, tag))
+        .max()
+        .unwrap_or_default()
+}
+
 /// State for tracking streaming tool calls.
 #[derive(Default)]
 pub struct StreamingToolState {
@@ -614,6 +650,8 @@ pub struct StreamingToolState {
     pub cache_write_tokens: u32,
     /// Whether we are currently inside a `<think>` block in streamed content.
     in_think_block: bool,
+    /// Which reasoning tag opened the current block.
+    current_reasoning_tag: Option<ReasoningTag>,
     /// Whether we are still stripping leading whitespace at the start of a
     /// think block. Set to `true` when entering `<think>`, cleared once
     /// non-whitespace reasoning content is emitted.
@@ -678,9 +716,9 @@ fn emit_visible(text: String, strip_leading_ws: &mut bool, events: &mut Vec<Stre
     events.push(StreamEvent::Delta(emitted));
 }
 
-/// Process streamed content through the `<think>` tag state machine.
+/// Process streamed content through the reasoning-tag state machine.
 ///
-/// Content arriving inside `<think>...</think>` is emitted as
+/// Content arriving inside `<think>...</think>` or `<thought>...</thought>` is emitted as
 /// `ReasoningDelta`; content outside is emitted as `Delta`.
 /// Tags may be split across SSE chunks — `tag_buffer` accumulates
 /// partial tag fragments until they can be resolved.
@@ -694,21 +732,27 @@ fn process_content_think_tags(
 
     loop {
         if state.in_think_block {
-            // Look for </think> to exit think mode
-            match state.tag_buffer.find("</think>") {
+            let Some(current_tag) = state.current_reasoning_tag else {
+                state.in_think_block = false;
+                continue;
+            };
+            let close_tag = current_tag.close();
+            // Look for the matching close tag to exit reasoning mode.
+            match state.tag_buffer.find(close_tag) {
                 Some(pos) => {
                     let thinking = state.tag_buffer[..pos].to_string();
                     emit_reasoning(thinking, &mut state.think_strip_leading_ws, events);
                     state.in_think_block = false;
+                    state.current_reasoning_tag = None;
                     state.visible_strip_leading_ws = true;
-                    let rest = state.tag_buffer[pos + "</think>".len()..].to_string();
+                    let rest = state.tag_buffer[pos + close_tag.len()..].to_string();
                     state.tag_buffer = rest;
                     // Continue loop to process remaining content
                 },
                 None => {
-                    // Check if buffer ends with a prefix of "</think>"
+                    // Check if buffer ends with a prefix of the closing tag
                     // to avoid emitting partial tag as reasoning text.
-                    let suffix_match = longest_tag_suffix(&state.tag_buffer, "</think>");
+                    let suffix_match = longest_tag_suffix(&state.tag_buffer, close_tag);
                     if suffix_match > 0 {
                         let safe = state.tag_buffer.len() - suffix_match;
                         let emit = state.tag_buffer[..safe].to_string();
@@ -724,20 +768,22 @@ fn process_content_think_tags(
                 },
             }
         } else {
-            // Look for <think> to enter think mode
-            match state.tag_buffer.find("<think>") {
-                Some(pos) => {
+            // Look for an opening reasoning tag to enter reasoning mode.
+            match find_next_open_tag(&state.tag_buffer) {
+                Some((pos, tag)) => {
                     let visible = state.tag_buffer[..pos].to_string();
                     emit_visible(visible, &mut state.visible_strip_leading_ws, events);
                     state.in_think_block = true;
+                    state.current_reasoning_tag = Some(tag);
                     state.think_strip_leading_ws = true;
-                    let rest = state.tag_buffer[pos + "<think>".len()..].to_string();
+                    let rest = state.tag_buffer[pos + tag.open().len()..].to_string();
                     state.tag_buffer = rest;
                     // Continue loop to process remaining content
                 },
                 None => {
-                    // Check if buffer ends with a prefix of "<think>"
-                    let suffix_match = longest_tag_suffix(&state.tag_buffer, "<think>");
+                    // Check if buffer ends with a prefix of any opening reasoning tag.
+                    let suffix_match =
+                        longest_reasoning_tag_suffix(&state.tag_buffer, &["<think>", "<thought>"]);
                     if suffix_match > 0 {
                         let safe = state.tag_buffer.len() - suffix_match;
                         let emit = state.tag_buffer[..safe].to_string();

--- a/crates/providers/src/openai_compat/provider.rs
+++ b/crates/providers/src/openai_compat/provider.rs
@@ -610,6 +610,8 @@ enum ReasoningTag {
 }
 
 impl ReasoningTag {
+    const ALL: [Self; 2] = [Self::Think, Self::Thought];
+
     fn open(self) -> &'static str {
         match self {
             Self::Think => "<think>",
@@ -626,15 +628,16 @@ impl ReasoningTag {
 }
 
 fn find_next_open_tag(text: &str) -> Option<(usize, ReasoningTag)> {
-    [ReasoningTag::Think, ReasoningTag::Thought]
+    ReasoningTag::ALL
         .into_iter()
         .filter_map(|tag| text.find(tag.open()).map(|pos| (pos, tag)))
         .min_by_key(|(pos, _)| *pos)
 }
 
-fn longest_reasoning_tag_suffix(text: &str, tags: &[&str]) -> usize {
-    tags.iter()
-        .map(|tag| longest_tag_suffix(text, tag))
+fn longest_reasoning_open_tag_suffix(text: &str) -> usize {
+    ReasoningTag::ALL
+        .into_iter()
+        .map(|tag| longest_tag_suffix(text, tag.open()))
         .max()
         .unwrap_or_default()
 }
@@ -648,19 +651,19 @@ pub struct StreamingToolState {
     pub output_tokens: u32,
     pub cache_read_tokens: u32,
     pub cache_write_tokens: u32,
-    /// Whether we are currently inside a `<think>` block in streamed content.
+    /// Whether we are currently inside a reasoning tag block in streamed content.
     in_think_block: bool,
     /// Which reasoning tag opened the current block.
     current_reasoning_tag: Option<ReasoningTag>,
     /// Whether we are still stripping leading whitespace at the start of a
-    /// think block. Set to `true` when entering `<think>`, cleared once
+    /// reasoning block. Set to `true` when entering a reasoning tag, cleared once
     /// non-whitespace reasoning content is emitted.
     think_strip_leading_ws: bool,
     /// Whether we are still stripping leading whitespace from visible content
-    /// after exiting a `</think>` block. Models often emit `\n\n` between
-    /// `</think>` and the actual answer.
+    /// after exiting a reasoning tag block. Models often emit `\n\n` between
+    /// reasoning and the actual answer.
     visible_strip_leading_ws: bool,
-    /// Buffer for detecting `<think>` / `</think>` tags that may be split
+    /// Buffer for detecting reasoning tags that may be split
     /// across SSE chunk boundaries.
     tag_buffer: String,
 }
@@ -722,7 +725,7 @@ fn emit_visible(text: String, strip_leading_ws: &mut bool, events: &mut Vec<Stre
 /// `ReasoningDelta`; content outside is emitted as `Delta`.
 /// Tags may be split across SSE chunks — `tag_buffer` accumulates
 /// partial tag fragments until they can be resolved.
-/// Leading whitespace at the start of each think block is stripped.
+/// Leading whitespace at the start of each reasoning block is stripped.
 fn process_content_think_tags(
     content: &str,
     state: &mut StreamingToolState,
@@ -782,8 +785,7 @@ fn process_content_think_tags(
                 },
                 None => {
                     // Check if buffer ends with a prefix of any opening reasoning tag.
-                    let suffix_match =
-                        longest_reasoning_tag_suffix(&state.tag_buffer, &["<think>", "<thought>"]);
+                    let suffix_match = longest_reasoning_open_tag_suffix(&state.tag_buffer);
                     if suffix_match > 0 {
                         let safe = state.tag_buffer.len() - suffix_match;
                         let emit = state.tag_buffer[..safe].to_string();

--- a/crates/providers/src/openai_compat/tests/schema_normalization.rs
+++ b/crates/providers/src/openai_compat/tests/schema_normalization.rs
@@ -1,13 +1,13 @@
 use {
     super::assert_no_orphaned_required,
     crate::openai_compat::{
-        SseLineResult, StreamingToolState, parse_tool_calls, process_openai_sse_line,
-        sanitize_schema_for_openai_compat,
+        SseLineResult, StreamingToolState, finalize_stream, parse_tool_calls,
+        process_openai_sse_line, sanitize_schema_for_openai_compat,
         schema_normalization::{
             collapse_schema_unions_for_non_strict_tools, strip_null_from_typed_enums,
         },
         strict_mode::patch_schema_for_strict_mode,
-        to_openai_tools, to_responses_api_tools,
+        strip_think_tags, to_openai_tools, to_responses_api_tools,
     },
     moltis_agents::model::StreamEvent,
 };
@@ -328,6 +328,94 @@ fn parse_tool_calls_extracts_metadata() {
             .is_some_and(|m| m["thought_signature"] == "sig_abc"),
         "should extract thought_signature into metadata"
     );
+}
+
+/// Issue #1007: Gemma via Google emits internal reasoning in `<thought>` tags.
+/// The provider parser must route it to `ReasoningDelta` rather than visible text.
+#[test]
+fn streaming_content_extracts_thought_tags_as_reasoning() {
+    let data = serde_json::json!({
+        "choices": [{
+            "delta": {
+                "content": "<thought>private reasoning</thought>\n\nvisible answer"
+            }
+        }]
+    })
+    .to_string();
+
+    let mut state = StreamingToolState::default();
+    let result = process_openai_sse_line(&data, &mut state);
+    let SseLineResult::Events(events) = result else {
+        panic!("expected Events");
+    };
+
+    assert!(
+        events
+            .iter()
+            .any(|event| matches!(event, StreamEvent::ReasoningDelta(delta) if delta == "private reasoning")),
+        "<thought> content should be emitted as reasoning: {events:?}"
+    );
+    assert!(
+        events
+            .iter()
+            .any(|event| matches!(event, StreamEvent::Delta(delta) if delta == "visible answer")),
+        "content after </thought> should remain visible: {events:?}"
+    );
+    assert!(
+        !events
+            .iter()
+            .any(|event| matches!(event, StreamEvent::Delta(delta) if delta.contains("thought"))),
+        "visible deltas must not include thought tags: {events:?}"
+    );
+}
+
+#[test]
+fn streaming_content_handles_thought_tag_split_across_chunks() {
+    let mut state = StreamingToolState::default();
+    let chunks = [
+        "<tho",
+        "ught>private",
+        " reasoning</thou",
+        "ght>\n\nvisible answer",
+    ];
+
+    let mut events = Vec::new();
+    for content in chunks {
+        let data = serde_json::json!({
+            "choices": [{ "delta": { "content": content } }]
+        })
+        .to_string();
+        match process_openai_sse_line(&data, &mut state) {
+            SseLineResult::Events(chunk_events) => events.extend(chunk_events),
+            SseLineResult::Skip | SseLineResult::Done => {},
+        }
+    }
+    events.extend(finalize_stream(&mut state));
+
+    let reasoning = events.iter().fold(String::new(), |mut acc, event| {
+        if let StreamEvent::ReasoningDelta(delta) = event {
+            acc.push_str(delta);
+        }
+        acc
+    });
+    let visible = events.iter().fold(String::new(), |mut acc, event| {
+        if let StreamEvent::Delta(delta) = event {
+            acc.push_str(delta);
+        }
+        acc
+    });
+
+    assert_eq!(reasoning, "private reasoning");
+    assert_eq!(visible, "visible answer");
+}
+
+#[test]
+fn non_streaming_content_strips_thought_tags() {
+    let (visible, reasoning) =
+        strip_think_tags("<thought>private reasoning</thought>\n\nvisible answer");
+
+    assert_eq!(reasoning, "private reasoning");
+    assert_eq!(visible, "visible answer");
 }
 
 /// Issue #712: enum-only schemas (no `type` key) must also get null


### PR DESCRIPTION
## Summary
- Treat `<thought>...</thought>` as provider reasoning content alongside `<think>...</think>`.
- Preserve split-SSE-chunk handling so Gemma/Google reasoning tags do not leak into visible assistant text or TTS.
- Add provider parser regression coverage for streaming, split streaming, and non-streaming responses.

## Validation
### Completed
- [x] `cargo test -p moltis-providers openai_compat::tests::schema_normalization`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p moltis-providers --all-targets -- -D warnings`

### Remaining
- [ ] `cargo clippy -p moltis-providers --all-targets --all-features -- -D warnings` could not complete on this macOS host because all features enable CUDA/Vulkan local LLM build paths and CUDA is unavailable.

## Manual QA
- Not run; covered by provider parser regression tests for issue #1007.