### PR TITLE
fix(agents): dispatch before agent start hooks

### DIFF
--- a/crates/agents/src/runner/helpers.rs
+++ b/crates/agents/src/runner/helpers.rs
@@ -309,6 +309,39 @@ pub(crate) async fn dispatch_after_llm_call_hook(
     }
 }
 
+pub(crate) async fn dispatch_before_agent_start_hook(
+    hook_registry: Option<&std::sync::Arc<HookRegistry>>,
+    session_key: &str,
+    model: &str,
+) -> Result<(), AgentRunError> {
+    let Some(hooks) = hook_registry else {
+        return Ok(());
+    };
+
+    let payload = HookPayload::BeforeAgentStart {
+        session_key: session_key.to_string(),
+        model: model.to_string(),
+    };
+
+    match hooks.dispatch(&payload).await {
+        Ok(HookAction::Block(reason)) => {
+            warn!(reason = %reason, "agent start blocked by BeforeAgentStart hook");
+            Err(AgentRunError::Other(anyhow::anyhow!(
+                "blocked by BeforeAgentStart hook: {reason}"
+            )))
+        },
+        Ok(HookAction::ModifyPayload(_)) => {
+            tracing::debug!("BeforeAgentStart ModifyPayload ignored (startup state is typed)");
+            Ok(())
+        },
+        Ok(HookAction::Continue) => Ok(()),
+        Err(e) => {
+            warn!(error = %e, "BeforeAgentStart hook dispatch failed");
+            Ok(())
+        },
+    }
+}
+
 pub(crate) fn finish_agent_run(
     final_text: String,
     iterations: usize,

--- a/crates/agents/src/runner/helpers.rs
+++ b/crates/agents/src/runner/helpers.rs
@@ -331,7 +331,7 @@ pub(crate) async fn dispatch_before_agent_start_hook(
             )))
         },
         Ok(HookAction::ModifyPayload(_)) => {
-            tracing::debug!("BeforeAgentStart ModifyPayload ignored (startup state is typed)");
+            warn!("BeforeAgentStart ModifyPayload ignored (startup state is typed)");
             Ok(())
         },
         Ok(HookAction::Continue) => Ok(()),

--- a/crates/agents/src/runner/mod.rs
+++ b/crates/agents/src/runner/mod.rs
@@ -33,10 +33,10 @@ pub type SteerInbox = std::sync::Arc<tokio::sync::Mutex<Vec<String>>>;
 pub(crate) use helpers::{
     AUTO_CONTINUE_NUDGE, MALFORMED_TOOL_RETRY_PROMPT, UsageAccumulator,
     apply_loop_detector_intervention, channel_binding_from_tool_context,
-    dispatch_after_llm_call_hook, empty_tool_name_retry_prompt, enforce_tool_result_context_budget,
-    explicit_shell_command_from_user_content, find_empty_tool_name_call, finish_agent_run,
-    has_named_tool_call, is_substantive_answer_text, log_tool_argument_diagnostic,
-    record_answer_text, resolve_tool_lookup, sanitize_tool_name,
+    dispatch_after_llm_call_hook, dispatch_before_agent_start_hook, empty_tool_name_retry_prompt,
+    enforce_tool_result_context_budget, explicit_shell_command_from_user_content,
+    find_empty_tool_name_call, finish_agent_run, has_named_tool_call, is_substantive_answer_text,
+    log_tool_argument_diagnostic, record_answer_text, resolve_tool_lookup, sanitize_tool_name,
     streaming_tool_call_message_content,
 };
 

--- a/crates/agents/src/runner/non_streaming.rs
+++ b/crates/agents/src/runner/non_streaming.rs
@@ -23,7 +23,8 @@ use crate::{
 use super::{
     AUTO_CONTINUE_NUDGE, AgentRunError, AgentRunResult, MALFORMED_TOOL_RETRY_PROMPT, OnEvent,
     RunnerEvent, UsageAccumulator, apply_loop_detector_intervention,
-    channel_binding_from_tool_context, dispatch_after_llm_call_hook, empty_tool_name_retry_prompt,
+    channel_binding_from_tool_context, dispatch_after_llm_call_hook,
+    dispatch_before_agent_start_hook, empty_tool_name_retry_prompt,
     explicit_shell_command_from_user_content, find_empty_tool_name_call, finish_agent_run,
     has_named_tool_call, is_substantive_answer_text, log_tool_argument_diagnostic,
     record_answer_text, resolve_tool_lookup,
@@ -124,6 +125,13 @@ pub async fn run_agent_loop_with_context(
         .to_string();
     let channel_for_hooks =
         channel_binding_from_tool_context(&session_key_for_hooks, tool_context.as_ref());
+
+    dispatch_before_agent_start_hook(
+        hook_registry.as_ref(),
+        &session_key_for_hooks,
+        provider.id(),
+    )
+    .await?;
 
     let mut iterations = 0;
     let mut total_tool_calls = 0;

--- a/crates/agents/src/runner/streaming.rs
+++ b/crates/agents/src/runner/streaming.rs
@@ -31,7 +31,8 @@ use crate::{
 use super::{
     AUTO_CONTINUE_NUDGE, AgentRunError, AgentRunResult, MALFORMED_TOOL_RETRY_PROMPT, OnEvent,
     RunnerEvent, UsageAccumulator, apply_loop_detector_intervention,
-    channel_binding_from_tool_context, dispatch_after_llm_call_hook, empty_tool_name_retry_prompt,
+    channel_binding_from_tool_context, dispatch_after_llm_call_hook,
+    dispatch_before_agent_start_hook, empty_tool_name_retry_prompt,
     explicit_shell_command_from_user_content, find_empty_tool_name_call, finish_agent_run,
     has_named_tool_call, is_substantive_answer_text, log_tool_argument_diagnostic,
     resolve_tool_lookup,
@@ -112,6 +113,13 @@ pub async fn run_agent_loop_streaming(
         .to_string();
     let channel_for_hooks =
         channel_binding_from_tool_context(&session_key_for_hooks, tool_context.as_ref());
+
+    dispatch_before_agent_start_hook(
+        hook_registry.as_ref(),
+        &session_key_for_hooks,
+        provider.id(),
+    )
+    .await?;
 
     let mut iterations = 0;
     let mut total_tool_calls = 0;

--- a/crates/agents/src/runner/tests/basic.rs
+++ b/crates/agents/src/runner/tests/basic.rs
@@ -10,7 +10,7 @@ use {
     },
     anyhow::Result,
     async_trait::async_trait,
-    moltis_common::hooks::HookRegistry,
+    moltis_common::hooks::{HookPayload, HookRegistry},
     std::pin::Pin,
     tokio_stream::Stream,
 };
@@ -135,6 +135,42 @@ async fn test_simple_text_response() {
     assert_eq!(result.tool_calls_made, 0);
 }
 
+#[tokio::test]
+async fn test_non_streaming_runner_dispatches_before_agent_start_hook() {
+    let provider = Arc::new(MockProvider {
+        response_text: "Hello!".into(),
+    });
+    let tools = ToolRegistry::new();
+    let payloads = Arc::new(std::sync::Mutex::new(Vec::new()));
+    let mut hooks = HookRegistry::new();
+    hooks.register(Arc::new(AgentStartRecordingHook {
+        payloads: Arc::clone(&payloads),
+    }));
+
+    let result = run_agent_loop_with_context(
+        provider,
+        &tools,
+        "You are a test bot.",
+        &UserContent::text("Hi"),
+        None,
+        None,
+        Some(serde_json::json!({"_session_key": "session-123"})),
+        Some(Arc::new(hooks)),
+        None,
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(result.text, "Hello!");
+    let payloads = payloads.lock().unwrap();
+    assert_eq!(payloads.len(), 1);
+    assert!(matches!(
+        &payloads[0],
+        HookPayload::BeforeAgentStart { session_key, model }
+            if session_key == "session-123" && model == "mock-model"
+    ));
+}
+
 struct StreamingUsageProvider;
 
 #[async_trait]
@@ -215,6 +251,41 @@ async fn test_streaming_runner_preserves_cache_usage() {
     assert_eq!(result.request_usage.output_tokens, 17);
     assert_eq!(result.request_usage.cache_read_tokens, 12_800);
     assert_eq!(result.request_usage.cache_write_tokens, 64);
+}
+
+#[tokio::test]
+async fn test_streaming_runner_dispatches_before_agent_start_hook() {
+    let provider = Arc::new(StreamingUsageProvider);
+    let tools = ToolRegistry::new();
+    let payloads = Arc::new(std::sync::Mutex::new(Vec::new()));
+    let mut hooks = HookRegistry::new();
+    hooks.register(Arc::new(AgentStartRecordingHook {
+        payloads: Arc::clone(&payloads),
+    }));
+
+    let result = run_agent_loop_streaming(
+        provider,
+        &tools,
+        "You are a test bot.",
+        &UserContent::text("Hi"),
+        None,
+        None,
+        Some(serde_json::json!({"_session_key": "stream-session-123"})),
+        Some(Arc::new(hooks)),
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(result.text, "cached reply");
+    let payloads = payloads.lock().unwrap();
+    assert_eq!(payloads.len(), 1);
+    assert!(matches!(
+        &payloads[0],
+        HookPayload::BeforeAgentStart { session_key, model }
+            if session_key == "stream-session-123" && model == "streaming-usage-model"
+    ));
 }
 
 struct NonStreamingUsageProvider {

--- a/crates/agents/src/runner/tests/helpers.rs
+++ b/crates/agents/src/runner/tests/helpers.rs
@@ -81,6 +81,31 @@ impl HookHandler for RewriteToolArgsHook {
     }
 }
 
+pub(super) struct AgentStartRecordingHook {
+    pub payloads: Arc<std::sync::Mutex<Vec<HookPayload>>>,
+}
+
+#[async_trait]
+impl HookHandler for AgentStartRecordingHook {
+    fn name(&self) -> &str {
+        "agent-start-recording-hook"
+    }
+
+    fn events(&self) -> &[HookEvent] {
+        static EVENTS: [HookEvent; 1] = [HookEvent::BeforeAgentStart];
+        &EVENTS
+    }
+
+    async fn handle(
+        &self,
+        _event: HookEvent,
+        payload: &HookPayload,
+    ) -> moltis_common::error::Result<HookAction> {
+        self.payloads.lock().unwrap().push(payload.clone());
+        Ok(HookAction::Continue)
+    }
+}
+
 // ── Mock providers ──────────────────────────────────────────────────────
 
 /// A mock provider that returns text on the first call.


### PR DESCRIPTION
## Summary
- Restores `BeforeAgentStart` hook dispatch at the start of both streaming and non-streaming agent loops.
- Adds regression coverage that verifies each runner emits the documented payload exactly once with the session key and model.
- Fixes #1012.

## Validation

### Completed
- [x] `cargo fmt --all`
- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p moltis-agents before_agent_start`

### Remaining
- [ ] Full workspace validation not run in this session.

## Manual QA
- Not run; covered by targeted unit regression tests for both runner paths.