### PR TITLE
fix(agents): honor BeforeLLMCall hook modifications

### DIFF
--- a/crates/agents/src/model/convert.rs
+++ b/crates/agents/src/model/convert.rs
@@ -82,6 +82,7 @@ pub fn values_to_chat_messages(values: &[serde_json::Value]) -> Vec<ChatMessage>
                             .as_str()
                             .or_else(|| ch["username"].as_str())
                     })
+                    .or_else(|| val["name"].as_str())
                     .map(|s| s.to_string());
 
                 let document_context = val["documents"].as_array().and_then(|documents| {

--- a/crates/agents/src/model/convert.rs
+++ b/crates/agents/src/model/convert.rs
@@ -56,6 +56,22 @@ fn document_absolute_path_from_media_ref(media_ref: &str) -> String {
 /// `outputTokens`, `channel`) are silently dropped — they only exist in
 /// the persisted JSON, not in `ChatMessage`.
 pub fn values_to_chat_messages(values: &[serde_json::Value]) -> Vec<ChatMessage> {
+    values_to_chat_messages_inner(values, true)
+}
+
+/// Convert provider-format JSON messages to typed `ChatMessage`s without
+/// dropping tool results.
+///
+/// Hook-modified LLM payloads are already provider-bound, so preserve their
+/// tool messages exactly instead of applying session-store orphan filtering.
+pub fn provider_values_to_chat_messages(values: &[serde_json::Value]) -> Vec<ChatMessage> {
+    values_to_chat_messages_inner(values, false)
+}
+
+fn values_to_chat_messages_inner(
+    values: &[serde_json::Value],
+    filter_orphan_tool_results: bool,
+) -> Vec<ChatMessage> {
     let mut messages = Vec::with_capacity(values.len());
     // Track tool_call IDs emitted by assistant messages so we only include
     // tool/tool_result messages that have a matching assistant tool_call.
@@ -211,7 +227,8 @@ pub fn values_to_chat_messages(values: &[serde_json::Value]) -> Vec<ChatMessage>
             },
             "tool" => {
                 let tool_call_id = val["tool_call_id"].as_str().unwrap_or("").to_string();
-                if !pending_tool_call_ids.remove(&tool_call_id) {
+                let has_matching_assistant = pending_tool_call_ids.remove(&tool_call_id);
+                if filter_orphan_tool_results && !has_matching_assistant {
                     tracing::debug!(tool_call_id, "skipping orphan tool message");
                     continue;
                 }
@@ -226,7 +243,8 @@ pub fn values_to_chat_messages(values: &[serde_json::Value]) -> Vec<ChatMessage>
             // them to standard tool messages so the LLM sees its own results.
             "tool_result" => {
                 let tool_call_id = val["tool_call_id"].as_str().unwrap_or("").to_string();
-                if !pending_tool_call_ids.remove(&tool_call_id) {
+                let has_matching_assistant = pending_tool_call_ids.remove(&tool_call_id);
+                if filter_orphan_tool_results && !has_matching_assistant {
                     tracing::debug!(tool_call_id, "skipping orphan tool_result message");
                     continue;
                 }

--- a/crates/agents/src/model/mod.rs
+++ b/crates/agents/src/model/mod.rs
@@ -14,7 +14,9 @@ mod chat;
 pub use chat::{ChatMessage, ContentPart, UserContent};
 
 mod convert;
-pub use convert::{extract_tool_call_metadata, values_to_chat_messages};
+pub use convert::{
+    extract_tool_call_metadata, provider_values_to_chat_messages, values_to_chat_messages,
+};
 
 mod stream;
 pub use stream::{LlmProvider, StreamEvent};
@@ -647,6 +649,32 @@ mod tests {
         assert_eq!(msgs.len(), 2);
         assert!(matches!(&msgs[0], ChatMessage::User { .. }));
         assert!(matches!(&msgs[1], ChatMessage::Assistant { .. }));
+    }
+
+    #[test]
+    fn provider_conversion_preserves_orphan_tool_messages() {
+        let values = vec![
+            serde_json::json!({"role": "user", "content": "run ls"}),
+            serde_json::json!({
+                "role": "tool",
+                "tool_call_id": "call_orphan",
+                "content": "result data"
+            }),
+            serde_json::json!({"role": "assistant", "content": "done"}),
+        ];
+
+        let session_msgs = values_to_chat_messages(&values);
+        assert_eq!(session_msgs.len(), 2);
+
+        let provider_msgs = provider_values_to_chat_messages(&values);
+        assert_eq!(provider_msgs.len(), 3);
+        assert!(matches!(
+            &provider_msgs[1],
+            ChatMessage::Tool {
+                tool_call_id,
+                content
+            } if tool_call_id == "call_orphan" && content == "result data"
+        ));
     }
 
     #[test]

--- a/crates/agents/src/runner/helpers.rs
+++ b/crates/agents/src/runner/helpers.rs
@@ -9,7 +9,7 @@ use moltis_common::hooks::{ChannelBinding, HookAction, HookPayload, HookRegistry
 use crate::{
     model::{
         ChatMessage, ToolCall, ToolCallArgumentDiagnostic, ToolCallArgumentSource, Usage,
-        UserContent,
+        UserContent, values_to_chat_messages,
     },
     response_sanitizer::clean_response,
     tool_loop_detector::{
@@ -264,6 +264,26 @@ pub(crate) fn log_tool_argument_diagnostic(
             "tool call arguments decoded with diagnostics"
         ),
     }
+}
+
+pub(crate) fn apply_before_llm_call_modify_payload(
+    messages: &mut Vec<ChatMessage>,
+    modified_payload: serde_json::Value,
+) {
+    let Some(modified_messages) = modified_payload
+        .get("messages")
+        .and_then(serde_json::Value::as_array)
+        .or_else(|| modified_payload.as_array())
+    else {
+        warn!("BeforeLLMCall ModifyPayload missing messages array");
+        return;
+    };
+
+    *messages = values_to_chat_messages(modified_messages);
+    tracing::debug!(
+        messages_count = messages.len(),
+        "BeforeLLMCall ModifyPayload applied"
+    );
 }
 
 pub(crate) async fn dispatch_after_llm_call_hook(

--- a/crates/agents/src/runner/helpers.rs
+++ b/crates/agents/src/runner/helpers.rs
@@ -9,7 +9,7 @@ use moltis_common::hooks::{ChannelBinding, HookAction, HookPayload, HookRegistry
 use crate::{
     model::{
         ChatMessage, ToolCall, ToolCallArgumentDiagnostic, ToolCallArgumentSource, Usage,
-        UserContent, values_to_chat_messages,
+        UserContent, provider_values_to_chat_messages,
     },
     response_sanitizer::clean_response,
     tool_loop_detector::{
@@ -279,7 +279,13 @@ pub(crate) fn apply_before_llm_call_modify_payload(
         return;
     };
 
-    *messages = values_to_chat_messages(modified_messages);
+    let parsed = provider_values_to_chat_messages(modified_messages);
+    if parsed.is_empty() {
+        warn!("BeforeLLMCall ModifyPayload produced no valid messages; keeping original");
+        return;
+    }
+
+    *messages = parsed;
     tracing::debug!(
         messages_count = messages.len(),
         "BeforeLLMCall ModifyPayload applied"

--- a/crates/agents/src/runner/mod.rs
+++ b/crates/agents/src/runner/mod.rs
@@ -32,11 +32,11 @@ pub type SteerInbox = std::sync::Arc<tokio::sync::Mutex<Vec<String>>>;
 // (`non_streaming`, `streaming`) can continue to import via `super::item_name`.
 pub(crate) use helpers::{
     AUTO_CONTINUE_NUDGE, MALFORMED_TOOL_RETRY_PROMPT, UsageAccumulator,
-    apply_loop_detector_intervention, channel_binding_from_tool_context,
-    dispatch_after_llm_call_hook, empty_tool_name_retry_prompt, enforce_tool_result_context_budget,
-    explicit_shell_command_from_user_content, find_empty_tool_name_call, finish_agent_run,
-    has_named_tool_call, is_substantive_answer_text, log_tool_argument_diagnostic,
-    record_answer_text, resolve_tool_lookup, sanitize_tool_name,
+    apply_before_llm_call_modify_payload, apply_loop_detector_intervention,
+    channel_binding_from_tool_context, dispatch_after_llm_call_hook, empty_tool_name_retry_prompt,
+    enforce_tool_result_context_budget, explicit_shell_command_from_user_content,
+    find_empty_tool_name_call, finish_agent_run, has_named_tool_call, is_substantive_answer_text,
+    log_tool_argument_diagnostic, record_answer_text, resolve_tool_lookup, sanitize_tool_name,
     streaming_tool_call_message_content,
 };
 

--- a/crates/agents/src/runner/non_streaming.rs
+++ b/crates/agents/src/runner/non_streaming.rs
@@ -22,8 +22,9 @@ use crate::{
 
 use super::{
     AUTO_CONTINUE_NUDGE, AgentRunError, AgentRunResult, MALFORMED_TOOL_RETRY_PROMPT, OnEvent,
-    RunnerEvent, UsageAccumulator, apply_loop_detector_intervention,
-    channel_binding_from_tool_context, dispatch_after_llm_call_hook, empty_tool_name_retry_prompt,
+    RunnerEvent, UsageAccumulator, apply_before_llm_call_modify_payload,
+    apply_loop_detector_intervention, channel_binding_from_tool_context,
+    dispatch_after_llm_call_hook, empty_tool_name_retry_prompt,
     explicit_shell_command_from_user_content, find_empty_tool_name_call, finish_agent_run,
     has_named_tool_call, is_substantive_answer_text, log_tool_argument_diagnostic,
     record_answer_text, resolve_tool_lookup,
@@ -207,8 +208,8 @@ pub async fn run_agent_loop_with_context(
                         "blocked by BeforeLLMCall hook: {reason}"
                     )));
                 },
-                Ok(HookAction::ModifyPayload(_)) => {
-                    debug!("BeforeLLMCall ModifyPayload ignored (messages are typed)");
+                Ok(HookAction::ModifyPayload(modified_payload)) => {
+                    apply_before_llm_call_modify_payload(&mut messages, modified_payload);
                 },
                 Ok(HookAction::Continue) => {},
                 Err(e) => {

--- a/crates/agents/src/runner/streaming.rs
+++ b/crates/agents/src/runner/streaming.rs
@@ -30,8 +30,9 @@ use crate::{
 
 use super::{
     AUTO_CONTINUE_NUDGE, AgentRunError, AgentRunResult, MALFORMED_TOOL_RETRY_PROMPT, OnEvent,
-    RunnerEvent, UsageAccumulator, apply_loop_detector_intervention,
-    channel_binding_from_tool_context, dispatch_after_llm_call_hook, empty_tool_name_retry_prompt,
+    RunnerEvent, UsageAccumulator, apply_before_llm_call_modify_payload,
+    apply_loop_detector_intervention, channel_binding_from_tool_context,
+    dispatch_after_llm_call_hook, empty_tool_name_retry_prompt,
     explicit_shell_command_from_user_content, find_empty_tool_name_call, finish_agent_run,
     has_named_tool_call, is_substantive_answer_text, log_tool_argument_diagnostic,
     resolve_tool_lookup,
@@ -203,8 +204,8 @@ pub async fn run_agent_loop_streaming(
                         "blocked by BeforeLLMCall hook: {reason}"
                     )));
                 },
-                Ok(HookAction::ModifyPayload(_)) => {
-                    debug!("BeforeLLMCall ModifyPayload ignored (messages are typed)");
+                Ok(HookAction::ModifyPayload(modified_payload)) => {
+                    apply_before_llm_call_modify_payload(&mut messages, modified_payload);
                 },
                 Ok(HookAction::Continue) => {},
                 Err(e) => {

--- a/crates/agents/src/runner/tests/basic.rs
+++ b/crates/agents/src/runner/tests/basic.rs
@@ -276,6 +276,22 @@ async fn test_before_llm_call_modify_payload_updates_streaming_messages() {
     ));
 }
 
+#[test]
+fn test_before_llm_call_modify_payload_keeps_original_when_invalid() {
+    let mut messages = vec![ChatMessage::system("original system")];
+
+    apply_before_llm_call_modify_payload(
+        &mut messages,
+        serde_json::json!({"messages": [{"role": "invalid", "content": "ignored"}]}),
+    );
+
+    assert_eq!(messages.len(), 1);
+    assert!(matches!(
+        messages.first(),
+        Some(ChatMessage::System { content }) if content == "original system"
+    ));
+}
+
 struct StreamingUsageProvider;
 
 #[async_trait]

--- a/crates/agents/src/runner/tests/basic.rs
+++ b/crates/agents/src/runner/tests/basic.rs
@@ -10,7 +10,7 @@ use {
     },
     anyhow::Result,
     async_trait::async_trait,
-    moltis_common::hooks::HookRegistry,
+    moltis_common::hooks::{HookAction, HookEvent, HookHandler, HookPayload, HookRegistry},
     std::pin::Pin,
     tokio_stream::Stream,
 };
@@ -133,6 +133,147 @@ async fn test_simple_text_response() {
     assert_eq!(result.text, "Hello!");
     assert_eq!(result.iterations, 1);
     assert_eq!(result.tool_calls_made, 0);
+}
+
+struct InjectBeforeLlmSystemHook;
+
+#[async_trait]
+impl HookHandler for InjectBeforeLlmSystemHook {
+    fn name(&self) -> &str {
+        "inject-before-llm-system-hook"
+    }
+
+    fn events(&self) -> &[HookEvent] {
+        static EVENTS: [HookEvent; 1] = [HookEvent::BeforeLLMCall];
+        &EVENTS
+    }
+
+    async fn handle(
+        &self,
+        _event: HookEvent,
+        payload: &HookPayload,
+    ) -> moltis_common::error::Result<HookAction> {
+        let HookPayload::BeforeLLMCall { messages, .. } = payload else {
+            return Ok(HookAction::Continue);
+        };
+        let mut messages = messages.as_array().cloned().unwrap_or_default();
+        messages.insert(
+            0,
+            serde_json::json!({"role": "system", "content": "hook-injected system"}),
+        );
+        Ok(HookAction::ModifyPayload(
+            serde_json::json!({"messages": messages}),
+        ))
+    }
+}
+
+struct RecordingMessagesProvider {
+    messages: Arc<std::sync::Mutex<Vec<ChatMessage>>>,
+}
+
+#[async_trait]
+impl LlmProvider for RecordingMessagesProvider {
+    fn name(&self) -> &str {
+        "recording-messages"
+    }
+
+    fn id(&self) -> &str {
+        "recording-messages-model"
+    }
+
+    async fn complete(
+        &self,
+        messages: &[ChatMessage],
+        _tools: &[serde_json::Value],
+    ) -> Result<CompletionResponse> {
+        *self.messages.lock().unwrap() = messages.to_vec();
+        Ok(CompletionResponse {
+            text: Some("ok".into()),
+            tool_calls: vec![],
+            usage: Usage::default(),
+        })
+    }
+
+    fn stream(
+        &self,
+        _messages: Vec<ChatMessage>,
+    ) -> Pin<Box<dyn Stream<Item = StreamEvent> + Send + '_>> {
+        Box::pin(tokio_stream::empty())
+    }
+
+    fn stream_with_tools(
+        &self,
+        messages: Vec<ChatMessage>,
+        _tools: Vec<serde_json::Value>,
+    ) -> Pin<Box<dyn Stream<Item = StreamEvent> + Send + '_>> {
+        *self.messages.lock().unwrap() = messages;
+        Box::pin(tokio_stream::iter(vec![StreamEvent::Delta("ok".into())]))
+    }
+}
+
+#[tokio::test]
+async fn test_before_llm_call_modify_payload_updates_non_streaming_messages() {
+    let recorded_messages = Arc::new(std::sync::Mutex::new(Vec::new()));
+    let provider = Arc::new(RecordingMessagesProvider {
+        messages: Arc::clone(&recorded_messages),
+    });
+    let tools = ToolRegistry::new();
+    let mut hooks = HookRegistry::new();
+    hooks.register(Arc::new(InjectBeforeLlmSystemHook));
+
+    let result = run_agent_loop_with_context(
+        provider,
+        &tools,
+        "original system",
+        &UserContent::text("hello"),
+        None,
+        None,
+        None,
+        Some(Arc::new(hooks)),
+        None,
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(result.text, "ok");
+    let messages = recorded_messages.lock().unwrap();
+    assert!(matches!(
+        messages.first(),
+        Some(ChatMessage::System { content }) if content == "hook-injected system"
+    ));
+}
+
+#[tokio::test]
+async fn test_before_llm_call_modify_payload_updates_streaming_messages() {
+    let recorded_messages = Arc::new(std::sync::Mutex::new(Vec::new()));
+    let provider = Arc::new(RecordingMessagesProvider {
+        messages: Arc::clone(&recorded_messages),
+    });
+    let tools = ToolRegistry::new();
+    let mut hooks = HookRegistry::new();
+    hooks.register(Arc::new(InjectBeforeLlmSystemHook));
+
+    let result = run_agent_loop_streaming(
+        provider,
+        &tools,
+        "original system",
+        &UserContent::text("hello"),
+        None,
+        None,
+        None,
+        Some(Arc::new(hooks)),
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(result.text, "ok");
+    let messages = recorded_messages.lock().unwrap();
+    assert!(matches!(
+        messages.first(),
+        Some(ChatMessage::System { content }) if content == "hook-injected system"
+    ));
 }
 
 struct StreamingUsageProvider;

--- a/crates/agents/src/runner/tests/helpers.rs
+++ b/crates/agents/src/runner/tests/helpers.rs
@@ -16,9 +16,9 @@ use {
 pub(super) use {
     super::super::{
         AgentRunError, AgentRunResult, OnEvent, RunnerEvent, TOOL_RESULT_COMPACTION_PLACEHOLDER,
-        compact_tool_results_oldest_first_in_place, enforce_tool_result_context_budget,
-        explicit_shell_command_from_user_content, is_substantive_answer_text,
-        legacy_public_tool_alias, resolve_tool_lookup,
+        apply_before_llm_call_modify_payload, compact_tool_results_oldest_first_in_place,
+        enforce_tool_result_context_budget, explicit_shell_command_from_user_content,
+        is_substantive_answer_text, legacy_public_tool_alias, resolve_tool_lookup,
         retry::*,
         run_agent_loop, run_agent_loop_with_context, sanitize_tool_name, sanitize_tool_result,
         streaming::run_agent_loop_streaming,


### PR DESCRIPTION
## Summary
- Applies `BeforeLLMCall` hook `modify` responses to the typed message list before provider calls.
- Supports modified payloads as either `{ "messages": [...] }` or raw message arrays for both streaming and non-streaming runners.
- Adds regression coverage proving modified messages reach the provider request.

## Validation
### Completed
- [x] `cargo fmt --all`
- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p moltis-agents before_llm_call_modify_payload`
- [x] `cargo test -p moltis-agents`

### Remaining
- [ ] Full workspace validation not run.

## Manual QA
- Not run; covered by automated runner regression tests.

Closes #1013.