### PR TITLE
fix(sandbox): update slacrawl go module path

### DIFF
--- a/crates/skills/src/assets/messaging/slacrawl/SKILL.md
+++ b/crates/skills/src/assets/messaging/slacrawl/SKILL.md
@@ -11,7 +11,7 @@ requires:
       bins: [slacrawl]
       os: [darwin]
     - kind: go
-      module: "github.com/vincentkoc/slacrawl/cmd/slacrawl@latest"
+      module: "github.com/openclaw/slacrawl/cmd/slacrawl@latest"
       bins: [slacrawl]
 origin:
   source: moltis

--- a/crates/skills/src/assets/messaging/slacrawl/SKILL.md
+++ b/crates/skills/src/assets/messaging/slacrawl/SKILL.md
@@ -2,12 +2,12 @@
 name: slacrawl
 description: Archive and search Slack workspace messages, threads, and channels via the slacrawl CLI. Supports API sync, Slack export ZIP import, local desktop cache import, and full-text search.
 platforms: [linux, macos]
-homepage: https://github.com/vincentkoc/slacrawl
+homepage: https://github.com/openclaw/slacrawl
 requires:
   bins: [slacrawl]
   install:
     - kind: brew
-      formula: vincentkoc/tap/slacrawl
+      formula: openclaw/tap/slacrawl
       bins: [slacrawl]
       os: [darwin]
     - kind: go

--- a/crates/skills/src/bundled.rs
+++ b/crates/skills/src/bundled.rs
@@ -764,7 +764,7 @@ mod tests {
     }
 
     #[test]
-    fn slacrawl_go_install_uses_declared_module_path() {
+    fn slacrawl_install_metadata_uses_openclaw_sources() {
         let skills = store().discover();
         let slacrawl = skills
             .iter()
@@ -778,7 +778,30 @@ mod tests {
             .filter_map(|install| install.module.as_deref())
             .collect();
 
+        assert_eq!(
+            slacrawl.homepage.as_deref(),
+            Some("https://github.com/openclaw/slacrawl")
+        );
+        assert!(
+            slacrawl
+                .requires
+                .install
+                .iter()
+                .any(|install| install.formula.as_deref() == Some("openclaw/tap/slacrawl"))
+        );
         assert!(modules.contains(&"github.com/openclaw/slacrawl/cmd/slacrawl@latest"));
+        assert!(
+            !slacrawl
+                .homepage
+                .as_deref()
+                .is_some_and(|homepage| { homepage.contains("github.com/vincentkoc/slacrawl") })
+        );
+        assert!(!slacrawl.requires.install.iter().any(|install| {
+            install
+                .formula
+                .as_deref()
+                .is_some_and(|formula| formula.contains("vincentkoc/tap/slacrawl"))
+        }));
         assert!(
             !modules
                 .iter()

--- a/crates/skills/src/bundled.rs
+++ b/crates/skills/src/bundled.rs
@@ -764,6 +764,29 @@ mod tests {
     }
 
     #[test]
+    fn slacrawl_go_install_uses_declared_module_path() {
+        let skills = store().discover();
+        let slacrawl = skills
+            .iter()
+            .find(|s| s.name == "slacrawl")
+            .expect("slacrawl should be bundled");
+
+        let modules: Vec<&str> = slacrawl
+            .requires
+            .install
+            .iter()
+            .filter_map(|install| install.module.as_deref())
+            .collect();
+
+        assert!(modules.contains(&"github.com/openclaw/slacrawl/cmd/slacrawl@latest"));
+        assert!(
+            !modules
+                .iter()
+                .any(|module| module.contains("github.com/vincentkoc/slacrawl"))
+        );
+    }
+
+    #[test]
     fn webhook_subscriptions_is_moltis_native() {
         let s = store();
         let body = s.read_skill("webhook-subscriptions").expect("should exist");

--- a/crates/tools/src/sandbox/tests/docker_router.rs
+++ b/crates/tools/src/sandbox/tests/docker_router.rs
@@ -591,6 +591,8 @@ fn test_sandbox_image_dockerfile_installs_crawl_tools() {
     let dockerfile = sandbox_image_dockerfile("ubuntu:25.10", &["curl".into()]);
     assert!(dockerfile.contains("go install github.com/openclaw/discrawl/cmd/discrawl@latest"));
     assert!(!dockerfile.contains("github.com/steipete/discrawl"));
+    assert!(dockerfile.contains("go install github.com/openclaw/slacrawl/cmd/slacrawl@latest"));
+    assert!(!dockerfile.contains("github.com/vincentkoc/slacrawl"));
     for (module, version, _bin) in GO_TOOL_INSTALLS {
         assert!(
             dockerfile.contains(&format!("go install {module}@{version}")),

--- a/crates/tools/src/sandbox/types.rs
+++ b/crates/tools/src/sandbox/types.rs
@@ -577,7 +577,7 @@ pub(crate) const GO_TOOL_INSTALLS: &[(&str, &str, &str)] = &[
         "discrawl",
     ),
     (
-        "github.com/vincentkoc/slacrawl/cmd/slacrawl",
+        "github.com/openclaw/slacrawl/cmd/slacrawl",
         "latest",
         "slacrawl",
     ),


### PR DESCRIPTION
## Summary
- Update the bundled sandbox `slacrawl` Go install path to the module declared upstream.
- Keep embedded `slacrawl` skill install metadata in sync with the sandbox image path, homepage, and Homebrew formula.
- Add regression coverage preventing stale `github.com/vincentkoc/slacrawl` and `vincentkoc/tap/slacrawl` metadata from returning.

Fixes #1020

## Validation
### Completed
- [x] `cargo test -p moltis-tools test_sandbox_image_dockerfile_installs_crawl_tools`
- [x] `cargo test -p moltis-skills --features bundled-skills slacrawl_install_metadata_uses_openclaw_sources`
- [x] `cargo fmt --all -- --check`

### Remaining
- [ ] `./scripts/local-validate.sh 1021` failed on pre-existing file-size violations: `crates/agents/src/runner/tests/basic.rs` is 1678 lines and `crates/tools/src/approval.rs` is 1543 lines; neither file is touched by this PR.
- [ ] Full `just lint`
- [ ] Full `just test`

## Manual QA
- Verified `openclaw/homebrew-tap` exists and includes a `slacrawl` formula pointing at `https://github.com/openclaw/slacrawl` release artifacts.