### PR TITLE
fix(web): avoid false websocket disconnect timeouts

### DIFF
--- a/crates/web/ui/e2e/specs/websocket.spec.js
+++ b/crates/web/ui/e2e/specs/websocket.spec.js
@@ -203,15 +203,23 @@ test.describe("WebSocket connection lifecycle", () => {
 			const prefix = appUrl.href.slice(0, appUrl.href.length - "js/app.js".length);
 			const helpers = await import(`${prefix}js/helpers.js`);
 			const state = await import(`${prefix}js/state.js`);
+			const originalWs = state.ws;
+			const originalTimeout = window.__moltisTestRpcTimeoutMs;
 
-			state.setWs({
-				readyState: WebSocket.OPEN,
-				send() {
-					// Intentionally never resolves; this exercises the client timeout path.
-				},
-			});
+			try {
+				window.__moltisTestRpcTimeoutMs = 1_000;
+				state.setWs({
+					readyState: WebSocket.OPEN,
+					send() {
+						// Intentionally never resolves; this exercises the client timeout path.
+					},
+				});
 
-			return helpers.sendRpc("test.slow_method", {});
+				return await helpers.sendRpc("test.slow_method", {});
+			} finally {
+				state.setWs(originalWs);
+				window.__moltisTestRpcTimeoutMs = originalTimeout;
+			}
 		});
 
 		expect(res).toMatchObject({

--- a/crates/web/ui/e2e/specs/websocket.spec.js
+++ b/crates/web/ui/e2e/specs/websocket.spec.js
@@ -186,8 +186,12 @@ test.describe("WebSocket connection lifecycle", () => {
 		expect(resp.ok()).toBeTruthy();
 	});
 
-	test("long-running RPC responses do not show a false disconnect", async ({ page }) => {
+	test("RPC timeouts identify the slow method instead of reporting disconnect", async ({ page }) => {
 		const pageErrors = watchPageErrors(page);
+		const warnings = [];
+		page.on("console", (msg) => {
+			if (msg.type() === "warning") warnings.push(msg.text());
+		});
 		await page.goto("/");
 		await waitForWsConnected(page);
 
@@ -202,22 +206,24 @@ test.describe("WebSocket connection lifecycle", () => {
 
 			state.setWs({
 				readyState: WebSocket.OPEN,
-				send(rawPayload) {
-					const frame = JSON.parse(String(rawPayload));
-					setTimeout(() => {
-						const resolver = state.pending?.[frame.id];
-						if (typeof resolver === "function") {
-							delete state.pending[frame.id];
-							resolver({ ok: true, payload: { completed: true } });
-						}
-					}, 5_100);
+				send() {
+					// Intentionally never resolves; this exercises the client timeout path.
 				},
 			});
 
-			return helpers.sendRpc("test.long_running", {});
+			return helpers.sendRpc("test.slow_method", {});
 		});
 
-		expect(res).toEqual({ ok: true, payload: { completed: true } });
+		expect(res).toMatchObject({
+			ok: false,
+			error: {
+				code: "TIMEOUT",
+			},
+		});
+		expect(res.error.message).toContain("test.slow_method");
+		expect(res.error.message).not.toContain("WebSocket disconnected");
+		expect(warnings.some((warning) => warning.includes("RPC request timed out"))).toBeTruthy();
+		expect(warnings.some((warning) => warning.includes("test.slow_method"))).toBeTruthy();
 		expect(pageErrors).toEqual([]);
 	});
 

--- a/crates/web/ui/e2e/specs/websocket.spec.js
+++ b/crates/web/ui/e2e/specs/websocket.spec.js
@@ -186,6 +186,41 @@ test.describe("WebSocket connection lifecycle", () => {
 		expect(resp.ok()).toBeTruthy();
 	});
 
+	test("long-running RPC responses do not show a false disconnect", async ({ page }) => {
+		const pageErrors = watchPageErrors(page);
+		await page.goto("/");
+		await waitForWsConnected(page);
+
+		const res = await page.evaluate(async () => {
+			const appScript = document.querySelector('script[type="module"][src*="js/app.js"]');
+			if (!appScript) throw new Error("app module script not found");
+
+			const appUrl = new URL(appScript.src, window.location.origin);
+			const prefix = appUrl.href.slice(0, appUrl.href.length - "js/app.js".length);
+			const helpers = await import(`${prefix}js/helpers.js`);
+			const state = await import(`${prefix}js/state.js`);
+
+			state.setWs({
+				readyState: WebSocket.OPEN,
+				send(rawPayload) {
+					const frame = JSON.parse(String(rawPayload));
+					setTimeout(() => {
+						const resolver = state.pending?.[frame.id];
+						if (typeof resolver === "function") {
+							delete state.pending[frame.id];
+							resolver({ ok: true, payload: { completed: true } });
+						}
+					}, 5_100);
+				},
+			});
+
+			return helpers.sendRpc("test.long_running", {});
+		});
+
+		expect(res).toEqual({ ok: true, payload: { completed: true } });
+		expect(pageErrors).toEqual([]);
+	});
+
 	test("final chat text is kept when it includes tool output plus analysis", async ({ page }) => {
 		const pageErrors = watchPageErrors(page);
 		await page.goto("/chats/main");
@@ -891,7 +926,9 @@ test.describe("WebSocket connection lifecycle", () => {
 					this.sent.push(JSON.parse(data));
 				}
 
-				close() {}
+				close() {
+					// Fake WebSocket used only for unit-style module testing.
+				}
 			}
 
 			const originalWebSocket = window.WebSocket;

--- a/crates/web/ui/src/helpers.ts
+++ b/crates/web/ui/src/helpers.ts
@@ -268,7 +268,7 @@ mdRenderer.link = ({ href, text }) => {
 mdRenderer.html = ({ text }) => esc(text);
 
 const markedInstance = new Marked({ renderer: mdRenderer, breaks: true, gfm: true, async: false });
-const RPC_TIMEOUT_MS = 10 * 60_000;
+const RPC_TIMEOUT_MS = 5_000;
 
 export function renderMarkdown(raw: string): string {
 	// Extract ASCII tables as placeholders before marked processes the text.
@@ -298,11 +298,13 @@ export function sendRpc<T = unknown>(method: string, params: unknown): Promise<R
 		const timer = setTimeout(() => {
 			if (S.pending[id]) {
 				delete S.pending[id];
+				const message = `${localizedRpcErrorMessage({ code: "TIMEOUT", message: "RPC request timed out" })} (${method})`;
+				console.warn("RPC request timed out", { method, timeoutMs: RPC_TIMEOUT_MS });
 				resolve({
 					ok: false,
 					error: {
 						code: "TIMEOUT",
-						message: localizedRpcErrorMessage({ code: "TIMEOUT", message: "Request timed out" }),
+						message,
 					},
 				} as unknown as RpcResponse<T>);
 			}

--- a/crates/web/ui/src/helpers.ts
+++ b/crates/web/ui/src/helpers.ts
@@ -268,7 +268,7 @@ mdRenderer.link = ({ href, text }) => {
 mdRenderer.html = ({ text }) => esc(text);
 
 const markedInstance = new Marked({ renderer: mdRenderer, breaks: true, gfm: true, async: false });
-const RPC_TIMEOUT_MS = 5_000;
+const RPC_TIMEOUT_MS = 10 * 60_000;
 
 export function renderMarkdown(raw: string): string {
 	// Extract ASCII tables as placeholders before marked processes the text.
@@ -300,7 +300,10 @@ export function sendRpc<T = unknown>(method: string, params: unknown): Promise<R
 				delete S.pending[id];
 				resolve({
 					ok: false,
-					error: { code: "TIMEOUT", message: "WebSocket disconnected" },
+					error: {
+						code: "TIMEOUT",
+						message: localizedRpcErrorMessage({ code: "TIMEOUT", message: "Request timed out" }),
+					},
 				} as unknown as RpcResponse<T>);
 			}
 		}, RPC_TIMEOUT_MS);

--- a/crates/web/ui/src/helpers.ts
+++ b/crates/web/ui/src/helpers.ts
@@ -8,6 +8,7 @@ import type { RpcResponse } from "./types";
 declare global {
 	interface Window {
 		webkitAudioContext?: typeof AudioContext;
+		__moltisTestRpcTimeoutMs?: number;
 	}
 }
 
@@ -270,6 +271,10 @@ mdRenderer.html = ({ text }) => esc(text);
 const markedInstance = new Marked({ renderer: mdRenderer, breaks: true, gfm: true, async: false });
 const RPC_TIMEOUT_MS = 5_000;
 
+function rpcTimeoutMs(): number {
+	return window.__moltisTestRpcTimeoutMs ?? RPC_TIMEOUT_MS;
+}
+
 export function renderMarkdown(raw: string): string {
 	// Extract ASCII tables as placeholders before marked processes the text.
 	// Re-insert after marked is done so the HTML doesn't get escaped.
@@ -295,11 +300,12 @@ export function sendRpc<T = unknown>(method: string, params: unknown): Promise<R
 			return;
 		}
 		const id = nextId();
+		const timeoutMs = rpcTimeoutMs();
 		const timer = setTimeout(() => {
 			if (S.pending[id]) {
 				delete S.pending[id];
 				const message = `${localizedRpcErrorMessage({ code: "TIMEOUT", message: "RPC request timed out" })} (${method})`;
-				console.warn("RPC request timed out", { method, timeoutMs: RPC_TIMEOUT_MS });
+				console.warn("RPC request timed out", { method, timeoutMs });
 				resolve({
 					ok: false,
 					error: {
@@ -308,7 +314,7 @@ export function sendRpc<T = unknown>(method: string, params: unknown): Promise<R
 					},
 				} as unknown as RpcResponse<T>);
 			}
-		}, RPC_TIMEOUT_MS);
+		}, timeoutMs);
 		S.pending[id] = ((res: RpcResponse) => {
 			clearTimeout(timer);
 			resolve(res as RpcResponse<T>);


### PR DESCRIPTION
## Summary
- Keep the existing 5-second client RPC timeout, but stop reporting timeout failures as "WebSocket disconnected".
- Include the timed-out RPC method in the user-facing timeout message and browser warning log so slow endpoints can be identified.
- Add a Playwright regression test for the timeout diagnostic path.

## Validation
### Completed
- [x] `biome check --write crates/web/ui/src/helpers.ts crates/web/ui/e2e/specs/websocket.spec.js`
- [x] `npm run build`
- [x] `npx tsc --noEmit`
- [x] `npm run build:all`
- [x] `cargo build --bin moltis`
- [x] `npx playwright test e2e/specs/websocket.spec.js`

### Remaining
- [ ] `biome check --write crates/web/ui/src/` currently reports unrelated pre-existing warnings outside this change.

## Manual QA
- Verified with a browser-side mocked RPC that never responds: the UI receives a timeout containing the RPC method and logs a warning containing the method, without saying the WebSocket disconnected.

Fixes #1022