### PR TITLE
fix(sandbox): reap docker sandbox zombies

### DIFF
--- a/crates/tools/src/sandbox/docker.rs
+++ b/crates/tools/src/sandbox/docker.rs
@@ -273,6 +273,7 @@ impl DockerSandbox {
         // root, causing the mount (and container startup) to fail.  Podman
         // already masks /sys/firmware via its built-in OCI MaskedPaths.
         if kind != BackendKind::Podman {
+            args.push("--init".to_string());
             for path in sysfs_paths_to_mask() {
                 args.extend(["--tmpfs".to_string(), format!("{path}:ro,nosuid")]);
             }

--- a/crates/tools/src/sandbox/tests/core.rs
+++ b/crates/tools/src/sandbox/tests/core.rs
@@ -268,6 +268,21 @@ fn test_docker_workspace_args_uses_host_data_dir_override() {
 }
 
 #[test]
+fn test_docker_hardening_args_enable_init_reaper() {
+    let args = DockerSandbox::hardening_args(true, BackendKind::Docker);
+    assert!(
+        args.contains(&"--init".to_string()),
+        "Docker sandboxes must run with an init process so orphaned children are reaped"
+    );
+}
+
+#[test]
+fn test_podman_hardening_args_do_not_require_host_init_binary() {
+    let args = DockerSandbox::hardening_args(true, BackendKind::Podman);
+    assert!(!args.contains(&"--init".to_string()));
+}
+
+#[test]
 fn test_docker_workspace_args_none() {
     let config = SandboxConfig {
         workspace_mount: WorkspaceMount::None,


### PR DESCRIPTION
## Summary
- Run Docker-backed sandbox containers with Docker's `--init` process so orphaned children are reaped instead of accumulating as zombies.
- Add regression coverage for Docker enabling `--init` while leaving Podman hardening args unchanged.

## Validation
### Completed
- [x] `cargo test -p moltis-tools sandbox::tests::core -- --nocapture`
- [x] `cargo test -p moltis-tools sandbox::tests::network -- --nocapture`
- [x] `cargo fmt --all -- --check`

### Remaining
- [ ] Full workspace validation not run for this targeted sandbox fix.

## Manual QA
- Reviewed issue #423 against current sandbox code.
- Confirmed Docker-in-Docker path mapping and trusted/bypass network behavior already have existing implementation and targeted tests.