### PR TITLE
fix(vault): keep auth password changes in sync

### DIFF
--- a/crates/auth/src/credential_store.rs
+++ b/crates/auth/src/credential_store.rs
@@ -26,6 +26,9 @@ pub use {
     util::is_loopback,
 };
 
+#[cfg(feature = "vault")]
+pub use sessions::PasswordVaultChangeError;
+
 /// Single-user credential store backed by SQLite.
 pub struct CredentialStore {
     pool: SqlitePool,

--- a/crates/auth/src/credential_store/sessions.rs
+++ b/crates/auth/src/credential_store/sessions.rs
@@ -307,6 +307,18 @@ impl CredentialStore {
         Ok(())
     }
 
+    /// Set the first auth password and initialize/rewrap the vault atomically when present.
+    #[cfg(feature = "vault")]
+    pub async fn set_initial_password_and_prepare_vault(
+        &self,
+        password: &str,
+    ) -> std::result::Result<Option<moltis_vault::RecoveryKey>, PasswordVaultChangeError> {
+        if self.is_setup_complete() {
+            return Err(Error::Validation("password already set".into()).into());
+        }
+        self.insert_password_and_prepare_vault(password).await
+    }
+
     /// Add a password when none exists yet (e.g. after passkey-only setup).
     ///
     /// This marks setup complete so auth is enforced immediately.
@@ -321,6 +333,78 @@ impl CredentialStore {
             .await?;
         self.mark_setup_complete().await?;
         Ok(())
+    }
+
+    /// Add an auth password and initialize/rewrap the vault atomically when present.
+    #[cfg(feature = "vault")]
+    pub async fn add_password_and_prepare_vault(
+        &self,
+        password: &str,
+    ) -> std::result::Result<Option<moltis_vault::RecoveryKey>, PasswordVaultChangeError> {
+        self.insert_password_and_prepare_vault(password).await
+    }
+
+    #[cfg(feature = "vault")]
+    async fn insert_password_and_prepare_vault(
+        &self,
+        password: &str,
+    ) -> std::result::Result<Option<moltis_vault::RecoveryKey>, PasswordVaultChangeError> {
+        let Some(ref vault) = self.vault else {
+            self.add_password(password).await?;
+            return Ok(None);
+        };
+
+        if matches!(vault.status().await?, moltis_vault::VaultStatus::Sealed) {
+            vault
+                .unseal(password)
+                .await
+                .map_err(map_vault_password_change_error)?;
+        }
+
+        let mut tx = self.pool.begin().await?;
+        let has_password: Option<(i64,)> =
+            sqlx::query_as("SELECT id FROM auth_password WHERE id = 1")
+                .fetch_optional(&mut *tx)
+                .await?;
+        if has_password.is_some() {
+            return Err(Error::Validation("password already set".into()).into());
+        }
+
+        let recovery_key = match vault.status().await? {
+            moltis_vault::VaultStatus::Uninitialized => {
+                Some(vault.initialize_in_transaction(password, &mut tx).await?)
+            },
+            moltis_vault::VaultStatus::Sealed => {
+                return Err(PasswordVaultChangeError::VaultStateChanged);
+            },
+            moltis_vault::VaultStatus::Unsealed => {
+                vault
+                    .rewrap_unsealed_in_transaction(password, &mut tx)
+                    .await
+                    .map_err(map_vault_password_change_error)?;
+                None
+            },
+        };
+
+        let hash = hash_password(password)?;
+        sqlx::query("INSERT INTO auth_password (id, password_hash) VALUES (1, ?)")
+            .bind(&hash)
+            .execute(&mut *tx)
+            .await?;
+        sqlx::query(
+            "INSERT INTO auth_state (id, auth_disabled, updated_at)
+             VALUES (1, 0, datetime('now'))
+             ON CONFLICT(id) DO UPDATE
+             SET auth_disabled = 0, updated_at = excluded.updated_at",
+        )
+        .execute(&mut *tx)
+        .await?;
+
+        tx.commit().await?;
+        self.setup_complete.store(true, Ordering::Relaxed);
+        self.auth_disabled.store(false, Ordering::Relaxed);
+        moltis_config::update_config(|c| c.auth.disabled = false).map_err(Error::from)?;
+        Ok(recovery_key)
     }
 
     /// Mark initial setup as complete without setting a password (e.g. passkey-only setup).

--- a/crates/auth/src/credential_store/sessions.rs
+++ b/crates/auth/src/credential_store/sessions.rs
@@ -484,13 +484,6 @@ impl CredentialStore {
             return Ok(());
         };
 
-        if matches!(vault.status().await?, moltis_vault::VaultStatus::Sealed) {
-            vault
-                .unseal(current)
-                .await
-                .map_err(map_vault_password_change_error)?;
-        }
-
         let mut tx = self.pool.begin().await?;
         let row: Option<(String,)> =
             sqlx::query_as("SELECT password_hash FROM auth_password WHERE id = 1")
@@ -501,6 +494,13 @@ impl CredentialStore {
         };
         if !verify_password(current, &current_hash) {
             return Err(PasswordVaultChangeError::IncorrectCurrentPassword);
+        }
+
+        if matches!(vault.status().await?, moltis_vault::VaultStatus::Sealed) {
+            vault
+                .unseal(current)
+                .await
+                .map_err(map_vault_password_change_error)?;
         }
 
         match vault.status().await? {

--- a/crates/auth/src/credential_store/sessions.rs
+++ b/crates/auth/src/credential_store/sessions.rs
@@ -401,6 +401,12 @@ impl CredentialStore {
         .await?;
 
         tx.commit().await?;
+        if recovery_key.is_some() {
+            vault
+                .unseal(password)
+                .await
+                .map_err(map_vault_password_change_error)?;
+        }
         self.setup_complete.store(true, Ordering::Relaxed);
         self.auth_disabled.store(false, Ordering::Relaxed);
         moltis_config::update_config(|c| c.auth.disabled = false).map_err(Error::from)?;

--- a/crates/auth/src/credential_store/sessions.rs
+++ b/crates/auth/src/credential_store/sessions.rs
@@ -16,6 +16,34 @@ use crate::{
     },
 };
 
+#[cfg(feature = "vault")]
+#[derive(Debug, thiserror::Error)]
+pub enum PasswordVaultChangeError {
+    #[error("current password is incorrect")]
+    IncorrectCurrentPassword,
+    #[error(
+        "vault password does not match current password; unlock with recovery key before changing password"
+    )]
+    VaultBadCredential,
+    #[error("vault state changed while changing password; retry the password change")]
+    VaultStateChanged,
+    #[error(transparent)]
+    Database(#[from] sqlx::Error),
+    #[error(transparent)]
+    Auth(#[from] Error),
+    #[error(transparent)]
+    Vault(#[from] moltis_vault::VaultError),
+}
+
+#[cfg(feature = "vault")]
+fn map_vault_password_change_error(error: moltis_vault::VaultError) -> PasswordVaultChangeError {
+    match error {
+        moltis_vault::VaultError::BadCredential => PasswordVaultChangeError::VaultBadCredential,
+        moltis_vault::VaultError::Sealed => PasswordVaultChangeError::VaultStateChanged,
+        other => PasswordVaultChangeError::Vault(other),
+    }
+}
+
 impl CredentialStore {
     /// Maximum number of concurrent active sessions. Oldest sessions are evicted when the cap is reached.
     const MAX_SESSIONS: i64 = 10;
@@ -357,6 +385,75 @@ impl CredentialStore {
             .execute(&self.pool)
             .await?;
 
+        Ok(())
+    }
+
+    /// Change the auth password and rotate the vault wrapper atomically.
+    #[cfg(feature = "vault")]
+    pub async fn change_password_and_rotate_vault(
+        &self,
+        current: &str,
+        new_password: &str,
+    ) -> std::result::Result<(), PasswordVaultChangeError> {
+        let Some(ref vault) = self.vault else {
+            self.change_password(current, new_password).await?;
+            return Ok(());
+        };
+
+        if matches!(vault.status().await?, moltis_vault::VaultStatus::Sealed) {
+            vault
+                .unseal(current)
+                .await
+                .map_err(map_vault_password_change_error)?;
+        }
+
+        let mut tx = self.pool.begin().await?;
+        let row: Option<(String,)> =
+            sqlx::query_as("SELECT password_hash FROM auth_password WHERE id = 1")
+                .fetch_optional(&mut *tx)
+                .await?;
+        let Some((current_hash,)) = row else {
+            return Err(PasswordVaultChangeError::IncorrectCurrentPassword);
+        };
+        if !verify_password(current, &current_hash) {
+            return Err(PasswordVaultChangeError::IncorrectCurrentPassword);
+        }
+
+        match vault.status().await? {
+            moltis_vault::VaultStatus::Uninitialized => {},
+            moltis_vault::VaultStatus::Sealed => {
+                return Err(PasswordVaultChangeError::VaultStateChanged);
+            },
+            moltis_vault::VaultStatus::Unsealed => {
+                match vault
+                    .change_password_in_transaction(current, new_password, &mut tx)
+                    .await
+                {
+                    Ok(()) => {},
+                    Err(moltis_vault::VaultError::BadCredential) => {
+                        vault
+                            .rewrap_unsealed_in_transaction(new_password, &mut tx)
+                            .await
+                            .map_err(map_vault_password_change_error)?;
+                    },
+                    Err(error) => return Err(map_vault_password_change_error(error)),
+                }
+            },
+        }
+
+        let hash = hash_password(new_password)?;
+        sqlx::query(
+            "UPDATE auth_password SET password_hash = ?, updated_at = datetime('now') WHERE id = 1",
+        )
+        .bind(&hash)
+        .execute(&mut *tx)
+        .await?;
+
+        sqlx::query("DELETE FROM auth_sessions")
+            .execute(&mut *tx)
+            .await?;
+
+        tx.commit().await?;
         Ok(())
     }
 

--- a/crates/httpd/src/auth_routes.rs
+++ b/crates/httpd/src/auth_routes.rs
@@ -263,6 +263,22 @@ async fn setup_handler(
             )
                 .into_response();
         }
+        #[cfg(feature = "vault")]
+        if let Some(ref vault) = state.gateway_state.vault {
+            match prepare_vault_for_new_auth_password(vault, &password).await {
+                Ok(()) => {},
+                Err(moltis_vault::VaultError::BadCredential) => {
+                    return (
+                        StatusCode::LOCKED,
+                        "password must match the existing vault password; unlock with recovery key before setting a different password",
+                    )
+                    .into_response();
+                },
+                Err(e) => {
+                    return (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response();
+                },
+            }
+        }
         if let Err(e) = state.credential_store.set_initial_password(&password).await {
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,
@@ -483,6 +499,23 @@ async fn change_password_handler(
     let has_password = state.credential_store.has_password().await.unwrap_or(false);
 
     if !has_password {
+        #[cfg(feature = "vault")]
+        if let Some(ref vault) = state.gateway_state.vault {
+            match prepare_vault_for_new_auth_password(vault, &body.new_password).await {
+                Ok(()) => {},
+                Err(moltis_vault::VaultError::BadCredential) => {
+                    return (
+                        StatusCode::LOCKED,
+                        "password must match the existing vault password; unlock with recovery key before setting a different password",
+                    )
+                    .into_response();
+                },
+                Err(e) => {
+                    return (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response();
+                },
+            }
+        }
+
         // No password set yet — add one (works even after passkey-only setup).
         return match state
             .credential_store
@@ -501,8 +534,7 @@ async fn change_password_handler(
                             Some(rk.phrase().to_owned())
                         },
                         Err(moltis_vault::VaultError::AlreadyInitialized) => {
-                            tracing::debug!("vault already initialized, unsealing");
-                            let _ = vault.unseal(&body.new_password).await;
+                            tracing::debug!("vault already initialized for first password set");
                             None
                         },
                         Err(e) => {
@@ -540,6 +572,40 @@ async fn change_password_handler(
     }
 
     let current_password = body.current_password.unwrap_or_default();
+    if !state
+        .credential_store
+        .verify_password(&current_password)
+        .await
+        .unwrap_or(false)
+    {
+        state
+            .login_guard
+            .record_failure(client_ip, PASSWORD_CHANGE_ACCOUNT);
+        return (StatusCode::FORBIDDEN, "current password is incorrect").into_response();
+    }
+
+    #[cfg(feature = "vault")]
+    if let Some(ref vault) = state.gateway_state.vault {
+        match rotate_vault_password(vault, &current_password, &body.new_password).await {
+            Ok(()) => {},
+            Err(moltis_vault::VaultError::BadCredential) => {
+                return (
+                    StatusCode::LOCKED,
+                    "vault password does not match current password; unlock with recovery key before changing password",
+                )
+                    .into_response();
+            },
+            Err(moltis_vault::VaultError::Sealed) => {
+                return (
+                    StatusCode::LOCKED,
+                    "vault is sealed; unlock it before changing password",
+                )
+                    .into_response();
+            },
+            Err(e) => return (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
+        }
+    }
+
     match state
         .credential_store
         .change_password(&current_password, &body.new_password)
@@ -547,17 +613,6 @@ async fn change_password_handler(
     {
         Ok(()) => {
             state.login_guard.record_success(client_ip);
-            // Best-effort vault password rotation.
-            #[cfg(feature = "vault")]
-            if let Some(ref vault) = state.gateway_state.vault {
-                match vault
-                    .change_password(&current_password, &body.new_password)
-                    .await
-                {
-                    Ok(()) => tracing::info!("vault password rotated"),
-                    Err(e) => tracing::warn!(error = %e, "vault password rotation failed"),
-                }
-            }
             state
                 .gateway_state
                 .disconnect_all_clients("password_changed")
@@ -575,6 +630,48 @@ async fn change_password_handler(
                 (StatusCode::INTERNAL_SERVER_ERROR, msg).into_response()
             }
         },
+    }
+}
+
+#[cfg(feature = "vault")]
+async fn rotate_vault_password(
+    vault: &moltis_vault::Vault,
+    current_password: &str,
+    new_password: &str,
+) -> Result<(), moltis_vault::VaultError> {
+    match vault.status().await? {
+        moltis_vault::VaultStatus::Uninitialized => Ok(()),
+        moltis_vault::VaultStatus::Sealed => {
+            vault.unseal(current_password).await?;
+            vault
+                .change_password(current_password, new_password)
+                .await?;
+            tracing::info!("vault password rotated");
+            Ok(())
+        },
+        moltis_vault::VaultStatus::Unsealed => {
+            match vault.change_password(current_password, new_password).await {
+                Ok(()) => {},
+                Err(moltis_vault::VaultError::BadCredential) => {
+                    vault.rewrap_unsealed(new_password).await?;
+                },
+                Err(e) => return Err(e),
+            }
+            tracing::info!("vault password rotated");
+            Ok(())
+        },
+    }
+}
+
+#[cfg(feature = "vault")]
+async fn prepare_vault_for_new_auth_password(
+    vault: &moltis_vault::Vault,
+    password: &str,
+) -> Result<(), moltis_vault::VaultError> {
+    match vault.status().await? {
+        moltis_vault::VaultStatus::Uninitialized => Ok(()),
+        moltis_vault::VaultStatus::Sealed => vault.unseal(password).await,
+        moltis_vault::VaultStatus::Unsealed => vault.rewrap_unsealed(password).await,
     }
 }
 

--- a/crates/httpd/src/auth_routes.rs
+++ b/crates/httpd/src/auth_routes.rs
@@ -572,38 +572,43 @@ async fn change_password_handler(
     }
 
     let current_password = body.current_password.unwrap_or_default();
-    if !state
-        .credential_store
-        .verify_password(&current_password)
-        .await
-        .unwrap_or(false)
-    {
-        state
-            .login_guard
-            .record_failure(client_ip, PASSWORD_CHANGE_ACCOUNT);
-        return (StatusCode::FORBIDDEN, "current password is incorrect").into_response();
-    }
-
     #[cfg(feature = "vault")]
-    if let Some(ref vault) = state.gateway_state.vault {
-        match rotate_vault_password(vault, &current_password, &body.new_password).await {
-            Ok(()) => {},
-            Err(moltis_vault::VaultError::BadCredential) => {
-                return (
+    if state.gateway_state.vault.is_some() {
+        return match state
+            .credential_store
+            .change_password_and_rotate_vault(&current_password, &body.new_password)
+            .await
+        {
+            Ok(()) => {
+                state.login_guard.record_success(client_ip);
+                state
+                    .gateway_state
+                    .disconnect_all_clients("password_changed")
+                    .await;
+                Json(serde_json::json!({ "ok": true })).into_response()
+            },
+            Err(moltis_gateway::auth::PasswordVaultChangeError::IncorrectCurrentPassword) => {
+                state
+                    .login_guard
+                    .record_failure(client_ip, PASSWORD_CHANGE_ACCOUNT);
+                (StatusCode::FORBIDDEN, "current password is incorrect").into_response()
+            },
+            Err(moltis_gateway::auth::PasswordVaultChangeError::VaultBadCredential) => {
+                (
                     StatusCode::LOCKED,
                     "vault password does not match current password; unlock with recovery key before changing password",
                 )
-                    .into_response();
+                    .into_response()
             },
-            Err(moltis_vault::VaultError::Sealed) => {
-                return (
-                    StatusCode::LOCKED,
-                    "vault is sealed; unlock it before changing password",
+            Err(moltis_gateway::auth::PasswordVaultChangeError::VaultStateChanged) => {
+                (
+                    StatusCode::CONFLICT,
+                    "vault state changed while changing password; retry the password change",
                 )
-                    .into_response();
+                    .into_response()
             },
             Err(e) => return (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
-        }
+        };
     }
 
     match state
@@ -629,36 +634,6 @@ async fn change_password_handler(
             } else {
                 (StatusCode::INTERNAL_SERVER_ERROR, msg).into_response()
             }
-        },
-    }
-}
-
-#[cfg(feature = "vault")]
-async fn rotate_vault_password(
-    vault: &moltis_vault::Vault,
-    current_password: &str,
-    new_password: &str,
-) -> Result<(), moltis_vault::VaultError> {
-    match vault.status().await? {
-        moltis_vault::VaultStatus::Uninitialized => Ok(()),
-        moltis_vault::VaultStatus::Sealed => {
-            vault.unseal(current_password).await?;
-            vault
-                .change_password(current_password, new_password)
-                .await?;
-            tracing::info!("vault password rotated");
-            Ok(())
-        },
-        moltis_vault::VaultStatus::Unsealed => {
-            match vault.change_password(current_password, new_password).await {
-                Ok(()) => {},
-                Err(moltis_vault::VaultError::BadCredential) => {
-                    vault.rewrap_unsealed(new_password).await?;
-                },
-                Err(e) => return Err(e),
-            }
-            tracing::info!("vault password rotated");
-            Ok(())
         },
     }
 }

--- a/crates/httpd/src/auth_routes.rs
+++ b/crates/httpd/src/auth_routes.rs
@@ -244,6 +244,8 @@ async fn setup_handler(
     }
 
     let password = body.password.unwrap_or_default();
+    #[cfg(feature = "vault")]
+    let mut vault_recovery_key = None;
 
     let is_local = is_local_connection(&headers, addr, state.gateway_state.behind_proxy);
     if password.is_empty() && is_local {
@@ -264,21 +266,47 @@ async fn setup_handler(
                 .into_response();
         }
         #[cfg(feature = "vault")]
-        if let Some(ref vault) = state.gateway_state.vault {
-            match prepare_vault_for_new_auth_password(vault, &password).await {
-                Ok(()) => {},
-                Err(moltis_vault::VaultError::BadCredential) => {
+        if state.gateway_state.vault.is_some() {
+            match state
+                .credential_store
+                .set_initial_password_and_prepare_vault(&password)
+                .await
+            {
+                Ok(recovery_key) => {
+                    vault_recovery_key = recovery_key.map(|key| key.phrase().to_owned());
+                    run_vault_env_migration(&state).await;
+                    start_stored_channels_on_vault_unseal(&state).await;
+                },
+                Err(moltis_gateway::auth::PasswordVaultChangeError::VaultBadCredential) => {
                     return (
                         StatusCode::LOCKED,
                         "password must match the existing vault password; unlock with recovery key before setting a different password",
                     )
                     .into_response();
                 },
+                Err(moltis_gateway::auth::PasswordVaultChangeError::VaultStateChanged) => {
+                    return (
+                        StatusCode::CONFLICT,
+                        "vault state changed while setting password; retry the setup",
+                    )
+                        .into_response();
+                },
                 Err(e) => {
                     return (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response();
                 },
             }
         }
+        #[cfg(feature = "vault")]
+        if state.gateway_state.vault.is_none()
+            && let Err(e) = state.credential_store.set_initial_password(&password).await
+        {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("failed to set password: {e}"),
+            )
+                .into_response();
+        }
+        #[cfg(not(feature = "vault"))]
         if let Err(e) = state.credential_store.set_initial_password(&password).await {
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,
@@ -287,33 +315,6 @@ async fn setup_handler(
                 .into_response();
         }
     }
-
-    // Initialize the vault when a password was set.
-    #[cfg(feature = "vault")]
-    let vault_recovery_key = if !password.is_empty() {
-        if let Some(ref vault) = state.gateway_state.vault {
-            match vault.initialize(&password).await {
-                Ok(rk) => {
-                    tracing::info!("vault initialized");
-                    run_vault_env_migration(&state).await;
-                    start_stored_channels_on_vault_unseal(&state).await;
-                    Some(rk.phrase().to_owned())
-                },
-                Err(moltis_vault::VaultError::AlreadyInitialized) => {
-                    tracing::debug!("vault already initialized, skipping");
-                    None
-                },
-                Err(e) => {
-                    tracing::warn!(error = %e, "vault initialization failed");
-                    None
-                },
-            }
-        } else {
-            None
-        }
-    } else {
-        None
-    };
 
     // Disconnect pre-setup WebSocket clients and clear setup code.
     state
@@ -500,20 +501,45 @@ async fn change_password_handler(
 
     if !has_password {
         #[cfg(feature = "vault")]
-        if let Some(ref vault) = state.gateway_state.vault {
-            match prepare_vault_for_new_auth_password(vault, &body.new_password).await {
-                Ok(()) => {},
-                Err(moltis_vault::VaultError::BadCredential) => {
-                    return (
+        if state.gateway_state.vault.is_some() {
+            return match state
+                .credential_store
+                .add_password_and_prepare_vault(&body.new_password)
+                .await
+            {
+                Ok(recovery_key) => {
+                    run_vault_env_migration(&state).await;
+                    start_stored_channels_on_vault_unseal(&state).await;
+                    state
+                        .gateway_state
+                        .disconnect_all_clients("password_changed")
+                        .await;
+                    if let Some(rk) = recovery_key {
+                        return Json(
+                            serde_json::json!({ "ok": true, "recovery_key": rk.phrase() }),
+                        )
+                        .into_response();
+                    }
+                    Json(serde_json::json!({ "ok": true })).into_response()
+                },
+                Err(moltis_gateway::auth::PasswordVaultChangeError::VaultBadCredential) => {
+                    (
                         StatusCode::LOCKED,
                         "password must match the existing vault password; unlock with recovery key before setting a different password",
                     )
-                    .into_response();
+                    .into_response()
+                },
+                Err(moltis_gateway::auth::PasswordVaultChangeError::VaultStateChanged) => {
+                    (
+                        StatusCode::CONFLICT,
+                        "vault state changed while setting password; retry the password change",
+                    )
+                    .into_response()
                 },
                 Err(e) => {
                     return (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response();
                 },
-            }
+            };
         }
 
         // No password set yet — add one (works even after passkey-only setup).
@@ -635,18 +661,6 @@ async fn change_password_handler(
                 (StatusCode::INTERNAL_SERVER_ERROR, msg).into_response()
             }
         },
-    }
-}
-
-#[cfg(feature = "vault")]
-async fn prepare_vault_for_new_auth_password(
-    vault: &moltis_vault::Vault,
-    password: &str,
-) -> Result<(), moltis_vault::VaultError> {
-    match vault.status().await? {
-        moltis_vault::VaultStatus::Uninitialized => Ok(()),
-        moltis_vault::VaultStatus::Sealed => vault.unseal(password).await,
-        moltis_vault::VaultStatus::Unsealed => vault.rewrap_unsealed(password).await,
     }
 }
 

--- a/crates/httpd/src/auth_routes.rs
+++ b/crates/httpd/src/auth_routes.rs
@@ -549,37 +549,10 @@ async fn change_password_handler(
             .await
         {
             Ok(()) => {
-                // Initialize the vault now that we have a password.
-                #[cfg(feature = "vault")]
-                let vault_recovery_key = if let Some(ref vault) = state.gateway_state.vault {
-                    match vault.initialize(&body.new_password).await {
-                        Ok(rk) => {
-                            tracing::info!("vault initialized on first password set");
-                            run_vault_env_migration(&state).await;
-                            start_stored_channels_on_vault_unseal(&state).await;
-                            Some(rk.phrase().to_owned())
-                        },
-                        Err(moltis_vault::VaultError::AlreadyInitialized) => {
-                            tracing::debug!("vault already initialized for first password set");
-                            None
-                        },
-                        Err(e) => {
-                            tracing::warn!(error = %e, "vault initialization failed");
-                            None
-                        },
-                    }
-                } else {
-                    None
-                };
                 state
                     .gateway_state
                     .disconnect_all_clients("password_changed")
                     .await;
-                #[cfg(feature = "vault")]
-                if let Some(rk) = vault_recovery_key {
-                    return Json(serde_json::json!({ "ok": true, "recovery_key": rk }))
-                        .into_response();
-                }
                 Json(serde_json::json!({ "ok": true })).into_response()
             },
             Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
@@ -607,6 +580,8 @@ async fn change_password_handler(
         {
             Ok(()) => {
                 state.login_guard.record_success(client_ip);
+                run_vault_env_migration(&state).await;
+                start_stored_channels_on_vault_unseal(&state).await;
                 state
                     .gateway_state
                     .disconnect_all_clients("password_changed")

--- a/crates/httpd/tests/auth_middleware/more.rs
+++ b/crates/httpd/tests/auth_middleware/more.rs
@@ -406,6 +406,107 @@ pub(super) async fn password_change_on_initialized_vault_no_recovery_key() {
     );
 
     assert!(store.has_password().await.unwrap());
+    vault.seal().await;
+    assert!(vault.unseal(&new_password).await.is_ok());
+}
+
+/// After auth reset, setting a different auth password while the existing vault
+/// is sealed would create a password/vault mismatch. Reject it instead.
+#[cfg(all(feature = "web-ui", feature = "vault"))]
+#[tokio::test]
+pub(super) async fn first_password_rejects_sealed_vault_password_mismatch() {
+    let (addr, store, _state, vault) = start_localhost_server_with_vault().await;
+    let vault_password = generated_password();
+    let new_password = different_password(&vault_password);
+
+    let _rk = vault.initialize(&vault_password).await.unwrap();
+    vault.seal().await;
+
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(format!("http://{addr}/api/auth/password/change"))
+        .header("Content-Type", "application/json")
+        .body(json_new_password(&new_password))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 423);
+
+    assert!(!store.has_password().await.unwrap());
+    assert!(vault.unseal(&vault_password).await.is_ok());
+}
+
+/// Changing the auth password while the vault is sealed should first unseal and
+/// re-wrap the vault DEK, keeping the login and vault passwords in sync.
+#[cfg(all(feature = "web-ui", feature = "vault"))]
+#[tokio::test]
+pub(super) async fn password_change_rotates_sealed_vault_password() {
+    let (addr, store, _state, vault) = start_localhost_server_with_vault().await;
+    let current_password = generated_password();
+    let new_password = generated_password();
+
+    store.set_initial_password(&current_password).await.unwrap();
+    let token = store.create_session().await.unwrap();
+    let _rk = vault.initialize(&current_password).await.unwrap();
+    vault.seal().await;
+
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(format!("http://{addr}/api/auth/password/change"))
+        .header("Content-Type", "application/json")
+        .header("Cookie", format!("moltis_session={token}"))
+        .body(
+            serde_json::json!({
+                "current_password": current_password,
+                "new_password": new_password,
+            })
+            .to_string(),
+        )
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+
+    assert!(store.verify_password(&new_password).await.unwrap());
+    vault.seal().await;
+    assert!(vault.unseal(&new_password).await.is_ok());
+}
+
+/// If auth and vault passwords are already out of sync, changing the auth
+/// password must fail instead of making the split-brain state worse.
+#[cfg(all(feature = "web-ui", feature = "vault"))]
+#[tokio::test]
+pub(super) async fn password_change_rejects_mismatched_vault_password() {
+    let (addr, store, _state, vault) = start_localhost_server_with_vault().await;
+    let auth_password = generated_password();
+    let vault_password = different_password(&auth_password);
+    let new_password = generated_password();
+
+    store.set_initial_password(&auth_password).await.unwrap();
+    let token = store.create_session().await.unwrap();
+    let _rk = vault.initialize(&vault_password).await.unwrap();
+    vault.seal().await;
+
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(format!("http://{addr}/api/auth/password/change"))
+        .header("Content-Type", "application/json")
+        .header("Cookie", format!("moltis_session={token}"))
+        .body(
+            serde_json::json!({
+                "current_password": auth_password,
+                "new_password": new_password,
+            })
+            .to_string(),
+        )
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 423);
+
+    assert!(store.verify_password(&auth_password).await.unwrap());
+    assert!(!store.verify_password(&new_password).await.unwrap());
+    assert!(vault.unseal(&vault_password).await.is_ok());
 }
 
 /// Bootstrap remains available when the vault is sealed because it does not

--- a/crates/vault/src/vault.rs
+++ b/crates/vault/src/vault.rs
@@ -1,6 +1,11 @@
 //! Vault state machine: initialization, seal/unseal, encrypt/decrypt.
 
-use {base64::Engine, sqlx::SqlitePool, tokio::sync::RwLock, zeroize::Zeroizing};
+use {
+    base64::Engine,
+    sqlx::{Sqlite, SqlitePool, Transaction},
+    tokio::sync::RwLock,
+    zeroize::Zeroizing,
+};
 
 use crate::{
     error::VaultError,
@@ -185,6 +190,24 @@ impl<C: Cipher> Vault<C> {
     ///
     /// The vault must already be unsealed (DEK in memory).
     pub async fn change_password(&self, old: &str, new: &str) -> Result<(), VaultError> {
+        let mut tx = self.pool.begin().await?;
+        self.change_password_in_transaction(old, new, &mut tx)
+            .await?;
+        tx.commit().await?;
+
+        #[cfg(feature = "tracing")]
+        tracing::info!("vault password changed (DEK re-wrapped)");
+
+        Ok(())
+    }
+
+    /// Change the password as part of a caller-owned SQLite transaction.
+    pub async fn change_password_in_transaction(
+        &self,
+        old: &str,
+        new: &str,
+        tx: &mut Transaction<'_, Sqlite>,
+    ) -> Result<(), VaultError> {
         let row = self
             .load_metadata()
             .await?
@@ -218,11 +241,8 @@ impl<C: Cipher> Vault<C> {
         .bind(&new_salt_b64)
         .bind(&params_json)
         .bind(&new_wrapped)
-        .execute(&self.pool)
+        .execute(&mut **tx)
         .await?;
-
-        #[cfg(feature = "tracing")]
-        tracing::info!("vault password changed (DEK re-wrapped)");
 
         Ok(())
     }
@@ -233,6 +253,22 @@ impl<C: Cipher> Vault<C> {
     /// recovery-key unlock, where possession of the in-memory DEK is the proof
     /// needed to rotate the password wrapper.
     pub async fn rewrap_unsealed(&self, new: &str) -> Result<(), VaultError> {
+        let mut tx = self.pool.begin().await?;
+        self.rewrap_unsealed_in_transaction(new, &mut tx).await?;
+        tx.commit().await?;
+
+        #[cfg(feature = "tracing")]
+        tracing::info!("vault password wrapper rekeyed from unsealed DEK");
+
+        Ok(())
+    }
+
+    /// Re-wrap the DEK with a new password as part of a caller-owned SQLite transaction.
+    pub async fn rewrap_unsealed_in_transaction(
+        &self,
+        new: &str,
+        tx: &mut Transaction<'_, Sqlite>,
+    ) -> Result<(), VaultError> {
         let row = self
             .load_metadata()
             .await?
@@ -256,11 +292,8 @@ impl<C: Cipher> Vault<C> {
         .bind(&new_salt_b64)
         .bind(&params_json)
         .bind(&new_wrapped)
-        .execute(&self.pool)
+        .execute(&mut **tx)
         .await?;
-
-        #[cfg(feature = "tracing")]
-        tracing::info!("vault password wrapper rekeyed from unsealed DEK");
 
         Ok(())
     }
@@ -358,6 +391,10 @@ mod tests {
         .await
         .unwrap();
         pool
+    }
+
+    fn test_password(label: &str) -> String {
+        format!("vault-test-{label}-{}", rand::random::<u64>())
     }
 
     #[tokio::test]
@@ -501,8 +538,10 @@ mod tests {
         let vault = Vault::with_cipher(pool, XChaCha20Poly1305Cipher)
             .await
             .unwrap();
+        let old_password = test_password("old");
+        let new_password = test_password("new");
 
-        let recovery_key = vault.initialize("oldpass").await.unwrap();
+        let recovery_key = vault.initialize(&old_password).await.unwrap();
         let encrypted = vault.encrypt_string("secret", "test").await.unwrap();
         vault.seal().await;
         vault
@@ -510,14 +549,14 @@ mod tests {
             .await
             .unwrap();
 
-        vault.rewrap_unsealed("newpass").await.unwrap();
+        vault.rewrap_unsealed(&new_password).await.unwrap();
         vault.seal().await;
-        vault.unseal("newpass").await.unwrap();
+        vault.unseal(&new_password).await.unwrap();
         let decrypted = vault.decrypt_string(&encrypted, "test").await.unwrap();
         assert_eq!(decrypted, "secret");
 
         vault.seal().await;
-        let result = vault.unseal("oldpass").await;
+        let result = vault.unseal(&old_password).await;
         assert!(matches!(result, Err(VaultError::BadCredential)));
     }
 
@@ -527,11 +566,13 @@ mod tests {
         let vault = Vault::with_cipher(pool, XChaCha20Poly1305Cipher)
             .await
             .unwrap();
+        let old_password = test_password("old");
+        let new_password = test_password("new");
 
-        vault.initialize("oldpass").await.unwrap();
+        vault.initialize(&old_password).await.unwrap();
         vault.seal().await;
 
-        let result = vault.rewrap_unsealed("newpass").await;
+        let result = vault.rewrap_unsealed(&new_password).await;
         assert!(matches!(result, Err(VaultError::Sealed)));
     }
 

--- a/crates/vault/src/vault.rs
+++ b/crates/vault/src/vault.rs
@@ -449,8 +449,9 @@ mod tests {
         let vault = Vault::with_cipher(pool, XChaCha20Poly1305Cipher)
             .await
             .unwrap();
+        let password = test_password("initialize");
 
-        let rk = vault.initialize("testpassword123").await.unwrap();
+        let rk = vault.initialize(&password).await.unwrap();
         assert!(!rk.phrase().is_empty());
         assert_eq!(vault.status().await.unwrap(), VaultStatus::Unsealed);
 
@@ -459,7 +460,7 @@ mod tests {
         assert_eq!(vault.status().await.unwrap(), VaultStatus::Sealed);
 
         // Unseal with password.
-        vault.unseal("testpassword123").await.unwrap();
+        vault.unseal(&password).await.unwrap();
         assert_eq!(vault.status().await.unwrap(), VaultStatus::Unsealed);
     }
 
@@ -469,11 +470,13 @@ mod tests {
         let vault = Vault::with_cipher(pool, XChaCha20Poly1305Cipher)
             .await
             .unwrap();
+        let correct_password = test_password("correct");
+        let wrong_password = test_password("wrong");
 
-        vault.initialize("correctpassword").await.unwrap();
+        vault.initialize(&correct_password).await.unwrap();
         vault.seal().await;
 
-        let result = vault.unseal("wrongpassword").await;
+        let result = vault.unseal(&wrong_password).await;
         assert!(matches!(result, Err(VaultError::BadCredential)));
     }
 
@@ -483,8 +486,9 @@ mod tests {
         let vault = Vault::with_cipher(pool, XChaCha20Poly1305Cipher)
             .await
             .unwrap();
+        let password = test_password("recovery");
 
-        let rk = vault.initialize("testpassword123").await.unwrap();
+        let rk = vault.initialize(&password).await.unwrap();
         let phrase = rk.phrase().to_string();
         vault.seal().await;
 
@@ -498,8 +502,9 @@ mod tests {
         let vault = Vault::with_cipher(pool, XChaCha20Poly1305Cipher)
             .await
             .unwrap();
+        let password = test_password("encrypt");
 
-        vault.initialize("password").await.unwrap();
+        vault.initialize(&password).await.unwrap();
 
         let encrypted = vault
             .encrypt_string("my secret api key", "env:OPENAI_API_KEY")
@@ -518,8 +523,9 @@ mod tests {
         let vault = Vault::with_cipher(pool, XChaCha20Poly1305Cipher)
             .await
             .unwrap();
+        let password = test_password("sealed");
 
-        vault.initialize("password").await.unwrap();
+        vault.initialize(&password).await.unwrap();
         vault.seal().await;
 
         let result = vault.encrypt_string("data", "aad").await;
@@ -532,8 +538,9 @@ mod tests {
         let vault = Vault::with_cipher(pool, XChaCha20Poly1305Cipher)
             .await
             .unwrap();
+        let password = test_password("aad");
 
-        vault.initialize("password").await.unwrap();
+        vault.initialize(&password).await.unwrap();
 
         let encrypted = vault.encrypt_string("secret", "env:KEY1").await.unwrap();
         let result = vault.decrypt_string(&encrypted, "env:KEY2").await;
@@ -546,18 +553,23 @@ mod tests {
         let vault = Vault::with_cipher(pool, XChaCha20Poly1305Cipher)
             .await
             .unwrap();
+        let old_password = test_password("old");
+        let new_password = test_password("new");
 
-        vault.initialize("oldpass").await.unwrap();
+        vault.initialize(&old_password).await.unwrap();
 
         // Encrypt something with the old key.
         let encrypted = vault.encrypt_string("secret", "test").await.unwrap();
 
         // Change password.
-        vault.change_password("oldpass", "newpass").await.unwrap();
+        vault
+            .change_password(&old_password, &new_password)
+            .await
+            .unwrap();
 
         // Seal and unseal with new password.
         vault.seal().await;
-        vault.unseal("newpass").await.unwrap();
+        vault.unseal(&new_password).await.unwrap();
 
         // Old data should still be decryptable (same DEK).
         let decrypted = vault.decrypt_string(&encrypted, "test").await.unwrap();
@@ -565,7 +577,7 @@ mod tests {
 
         // Old password should no longer work.
         vault.seal().await;
-        let result = vault.unseal("oldpass").await;
+        let result = vault.unseal(&old_password).await;
         assert!(matches!(result, Err(VaultError::BadCredential)));
     }
 
@@ -619,9 +631,11 @@ mod tests {
         let vault = Vault::with_cipher(pool, XChaCha20Poly1305Cipher)
             .await
             .unwrap();
+        let first_password = test_password("first");
+        let second_password = test_password("second");
 
-        vault.initialize("pass1").await.unwrap();
-        let result = vault.initialize("pass2").await;
+        vault.initialize(&first_password).await.unwrap();
+        let result = vault.initialize(&second_password).await;
         assert!(matches!(result, Err(VaultError::AlreadyInitialized)));
     }
 
@@ -631,8 +645,9 @@ mod tests {
         let vault = Vault::with_cipher(pool, XChaCha20Poly1305Cipher)
             .await
             .unwrap();
+        let password = test_password("missing");
 
-        let result = vault.unseal("password").await;
+        let result = vault.unseal(&password).await;
         assert!(matches!(result, Err(VaultError::NotInitialized)));
     }
 }

--- a/crates/vault/src/vault.rs
+++ b/crates/vault/src/vault.rs
@@ -91,6 +91,7 @@ impl<C: Cipher> Vault<C> {
         let mut tx = self.pool.begin().await?;
         let recovery_key = self.initialize_in_transaction(password, &mut tx).await?;
         tx.commit().await?;
+        self.unseal(password).await?;
 
         #[cfg(feature = "tracing")]
         tracing::info!("vault initialized");
@@ -99,6 +100,9 @@ impl<C: Cipher> Vault<C> {
     }
 
     /// Initialize the vault as part of a caller-owned SQLite transaction.
+    ///
+    /// The vault remains sealed until the caller commits and explicitly unseals
+    /// it, so rolled-back transactions cannot leave an in-memory DEK live.
     pub async fn initialize_in_transaction(
         &self,
         password: &str,
@@ -140,9 +144,6 @@ impl<C: Cipher> Vault<C> {
         .bind(&recovery_hash)
         .execute(&mut **tx)
         .await?;
-
-        // Hold DEK in memory (vault is now unsealed).
-        *self.dek.write().await = Some(dek);
 
         Ok(recovery_key)
     }

--- a/crates/vault/src/vault.rs
+++ b/crates/vault/src/vault.rs
@@ -88,8 +88,24 @@ impl<C: Cipher> Vault<C> {
     /// generates a recovery key, and stores everything in the database.
     /// Returns the recovery key (shown to the user exactly once).
     pub async fn initialize(&self, password: &str) -> Result<RecoveryKey, VaultError> {
+        let mut tx = self.pool.begin().await?;
+        let recovery_key = self.initialize_in_transaction(password, &mut tx).await?;
+        tx.commit().await?;
+
+        #[cfg(feature = "tracing")]
+        tracing::info!("vault initialized");
+
+        Ok(recovery_key)
+    }
+
+    /// Initialize the vault as part of a caller-owned SQLite transaction.
+    pub async fn initialize_in_transaction(
+        &self,
+        password: &str,
+        tx: &mut Transaction<'_, Sqlite>,
+    ) -> Result<RecoveryKey, VaultError> {
         // Ensure vault doesn't already exist.
-        if self.load_metadata().await?.is_some() {
+        if self.load_metadata_in_transaction(tx).await?.is_some() {
             return Err(VaultError::AlreadyInitialized);
         }
 
@@ -122,14 +138,11 @@ impl<C: Cipher> Vault<C> {
         .bind(&wrapped_dek)
         .bind(&recovery_wrapped)
         .bind(&recovery_hash)
-        .execute(&self.pool)
+        .execute(&mut **tx)
         .await?;
 
         // Hold DEK in memory (vault is now unsealed).
         *self.dek.write().await = Some(dek);
-
-        #[cfg(feature = "tracing")]
-        tracing::info!("vault initialized");
 
         Ok(recovery_key)
     }
@@ -209,7 +222,7 @@ impl<C: Cipher> Vault<C> {
         tx: &mut Transaction<'_, Sqlite>,
     ) -> Result<(), VaultError> {
         let row = self
-            .load_metadata()
+            .load_metadata_in_transaction(tx)
             .await?
             .ok_or(VaultError::NotInitialized)?;
 
@@ -270,7 +283,7 @@ impl<C: Cipher> Vault<C> {
         tx: &mut Transaction<'_, Sqlite>,
     ) -> Result<(), VaultError> {
         let row = self
-            .load_metadata()
+            .load_metadata_in_transaction(tx)
             .await?
             .ok_or(VaultError::NotInitialized)?;
 
@@ -351,6 +364,30 @@ impl<C: Cipher> Vault<C> {
                  FROM vault_metadata WHERE id = 1",
         )
         .fetch_optional(&self.pool)
+        .await?;
+
+        Ok(row.map(
+            |(kdf_salt, kdf_params, wrapped_dek, recovery_wrapped_dek, recovery_key_hash)| {
+                VaultRow {
+                    kdf_salt,
+                    kdf_params,
+                    wrapped_dek,
+                    recovery_wrapped_dek,
+                    recovery_key_hash,
+                }
+            },
+        ))
+    }
+
+    async fn load_metadata_in_transaction(
+        &self,
+        tx: &mut Transaction<'_, Sqlite>,
+    ) -> Result<Option<VaultRow>, VaultError> {
+        let row: Option<(String, String, String, Option<String>, Option<String>)> = sqlx::query_as(
+            "SELECT kdf_salt, kdf_params, wrapped_dek, recovery_wrapped_dek, recovery_key_hash
+                 FROM vault_metadata WHERE id = 1",
+        )
+        .fetch_optional(&mut **tx)
         .await?;
 
         Ok(row.map(

--- a/crates/vault/src/vault.rs
+++ b/crates/vault/src/vault.rs
@@ -431,8 +431,9 @@ mod tests {
         pool
     }
 
-    fn test_password(label: &str) -> String {
-        format!("vault-test-{label}-{}", rand::random::<u64>())
+    fn test_password() -> String {
+        let token = rand::random::<u64>();
+        format!("vault-test-{token}")
     }
 
     #[tokio::test]
@@ -450,7 +451,7 @@ mod tests {
         let vault = Vault::with_cipher(pool, XChaCha20Poly1305Cipher)
             .await
             .unwrap();
-        let password = test_password("initialize");
+        let password = test_password();
 
         let rk = vault.initialize(&password).await.unwrap();
         assert!(!rk.phrase().is_empty());
@@ -471,8 +472,8 @@ mod tests {
         let vault = Vault::with_cipher(pool, XChaCha20Poly1305Cipher)
             .await
             .unwrap();
-        let correct_password = test_password("correct");
-        let wrong_password = test_password("wrong");
+        let correct_password = test_password();
+        let wrong_password = test_password();
 
         vault.initialize(&correct_password).await.unwrap();
         vault.seal().await;
@@ -487,7 +488,7 @@ mod tests {
         let vault = Vault::with_cipher(pool, XChaCha20Poly1305Cipher)
             .await
             .unwrap();
-        let password = test_password("recovery");
+        let password = test_password();
 
         let rk = vault.initialize(&password).await.unwrap();
         let phrase = rk.phrase().to_string();
@@ -503,7 +504,7 @@ mod tests {
         let vault = Vault::with_cipher(pool, XChaCha20Poly1305Cipher)
             .await
             .unwrap();
-        let password = test_password("encrypt");
+        let password = test_password();
 
         vault.initialize(&password).await.unwrap();
 
@@ -524,7 +525,7 @@ mod tests {
         let vault = Vault::with_cipher(pool, XChaCha20Poly1305Cipher)
             .await
             .unwrap();
-        let password = test_password("sealed");
+        let password = test_password();
 
         vault.initialize(&password).await.unwrap();
         vault.seal().await;
@@ -539,7 +540,7 @@ mod tests {
         let vault = Vault::with_cipher(pool, XChaCha20Poly1305Cipher)
             .await
             .unwrap();
-        let password = test_password("aad");
+        let password = test_password();
 
         vault.initialize(&password).await.unwrap();
 
@@ -554,8 +555,8 @@ mod tests {
         let vault = Vault::with_cipher(pool, XChaCha20Poly1305Cipher)
             .await
             .unwrap();
-        let old_password = test_password("old");
-        let new_password = test_password("new");
+        let old_password = test_password();
+        let new_password = test_password();
 
         vault.initialize(&old_password).await.unwrap();
 
@@ -588,8 +589,8 @@ mod tests {
         let vault = Vault::with_cipher(pool, XChaCha20Poly1305Cipher)
             .await
             .unwrap();
-        let old_password = test_password("old");
-        let new_password = test_password("new");
+        let old_password = test_password();
+        let new_password = test_password();
 
         let recovery_key = vault.initialize(&old_password).await.unwrap();
         let encrypted = vault.encrypt_string("secret", "test").await.unwrap();
@@ -616,8 +617,8 @@ mod tests {
         let vault = Vault::with_cipher(pool, XChaCha20Poly1305Cipher)
             .await
             .unwrap();
-        let old_password = test_password("old");
-        let new_password = test_password("new");
+        let old_password = test_password();
+        let new_password = test_password();
 
         vault.initialize(&old_password).await.unwrap();
         vault.seal().await;
@@ -632,8 +633,8 @@ mod tests {
         let vault = Vault::with_cipher(pool, XChaCha20Poly1305Cipher)
             .await
             .unwrap();
-        let first_password = test_password("first");
-        let second_password = test_password("second");
+        let first_password = test_password();
+        let second_password = test_password();
 
         vault.initialize(&first_password).await.unwrap();
         let result = vault.initialize(&second_password).await;
@@ -646,7 +647,7 @@ mod tests {
         let vault = Vault::with_cipher(pool, XChaCha20Poly1305Cipher)
             .await
             .unwrap();
-        let password = test_password("missing");
+        let password = test_password();
 
         let result = vault.unseal(&password).await;
         assert!(matches!(result, Err(VaultError::NotInitialized)));

--- a/crates/vault/src/vault.rs
+++ b/crates/vault/src/vault.rs
@@ -227,6 +227,44 @@ impl<C: Cipher> Vault<C> {
         Ok(())
     }
 
+    /// Re-wrap the DEK with a new password without requiring the old password.
+    ///
+    /// This is only available while the vault is already unsealed, such as after
+    /// recovery-key unlock, where possession of the in-memory DEK is the proof
+    /// needed to rotate the password wrapper.
+    pub async fn rewrap_unsealed(&self, new: &str) -> Result<(), VaultError> {
+        let row = self
+            .load_metadata()
+            .await?
+            .ok_or(VaultError::NotInitialized)?;
+
+        let params: KdfParams = serde_json::from_str(&row.kdf_params)?;
+        let guard = self.dek.read().await;
+        let dek = guard.as_ref().ok_or(VaultError::Sealed)?;
+
+        let new_salt_b64 = kdf::generate_salt();
+        let new_salt = kdf::decode_salt(&new_salt_b64)?;
+        let new_kek = kdf::derive_key(new.as_bytes(), &new_salt, &params)?;
+        let new_wrapped = key_wrap::wrap_dek(&self.cipher, &new_kek, dek)?;
+        let params_json = serde_json::to_string(&params)?;
+
+        drop(guard);
+
+        sqlx::query(
+            "UPDATE vault_metadata SET kdf_salt = ?, kdf_params = ?, wrapped_dek = ?, updated_at = datetime('now') WHERE id = 1",
+        )
+        .bind(&new_salt_b64)
+        .bind(&params_json)
+        .bind(&new_wrapped)
+        .execute(&self.pool)
+        .await?;
+
+        #[cfg(feature = "tracing")]
+        tracing::info!("vault password wrapper rekeyed from unsealed DEK");
+
+        Ok(())
+    }
+
     /// Encrypt a string and return a versioned base64 blob.
     ///
     /// The AAD (additional authenticated data) should identify the context,
@@ -455,6 +493,46 @@ mod tests {
         vault.seal().await;
         let result = vault.unseal("oldpass").await;
         assert!(matches!(result, Err(VaultError::BadCredential)));
+    }
+
+    #[tokio::test]
+    async fn rewrap_unsealed_changes_password_without_old_password() {
+        let pool = test_pool().await;
+        let vault = Vault::with_cipher(pool, XChaCha20Poly1305Cipher)
+            .await
+            .unwrap();
+
+        let recovery_key = vault.initialize("oldpass").await.unwrap();
+        let encrypted = vault.encrypt_string("secret", "test").await.unwrap();
+        vault.seal().await;
+        vault
+            .unseal_with_recovery(recovery_key.phrase())
+            .await
+            .unwrap();
+
+        vault.rewrap_unsealed("newpass").await.unwrap();
+        vault.seal().await;
+        vault.unseal("newpass").await.unwrap();
+        let decrypted = vault.decrypt_string(&encrypted, "test").await.unwrap();
+        assert_eq!(decrypted, "secret");
+
+        vault.seal().await;
+        let result = vault.unseal("oldpass").await;
+        assert!(matches!(result, Err(VaultError::BadCredential)));
+    }
+
+    #[tokio::test]
+    async fn rewrap_unsealed_fails_when_sealed() {
+        let pool = test_pool().await;
+        let vault = Vault::with_cipher(pool, XChaCha20Poly1305Cipher)
+            .await
+            .unwrap();
+
+        vault.initialize("oldpass").await.unwrap();
+        vault.seal().await;
+
+        let result = vault.rewrap_unsealed("newpass").await;
+        assert!(matches!(result, Err(VaultError::Sealed)));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- Keep auth password changes atomic with vault password rotation instead of best-effort logging.
- Reject first-password/reset flows that would create an auth/vault password mismatch for an existing sealed vault.
- Add regression coverage for sealed vault rotation, mismatch rejection, and recovery-unlocked vault rewrapping.

## Validation
### Completed
- [x] `cargo test -p moltis-vault`
- [x] `cargo test -p moltis-httpd --test auth_middleware first_password_rejects_sealed_vault_password_mismatch --features web-ui,vault`
- [x] `cargo test -p moltis-httpd --test auth_middleware password_change_rotates_sealed_vault_password --features web-ui,vault`
- [x] `cargo test -p moltis-httpd --test auth_middleware password_change_rejects_mismatched_vault_password --features web-ui,vault`
- [x] `cargo test -p moltis-httpd --test auth_middleware password_change_on_initialized_vault_no_recovery_key --features web-ui,vault`
- [x] `cargo fmt --all -- --check`

### Remaining
- [ ] Full `just test` / `just lint` CI sweep.

## Manual QA
- Not run locally; covered by targeted integration tests for the reported password/vault regression.