### PR TITLE
Allow disabling vault encryption at rest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7593,6 +7593,7 @@ dependencies = [
  "secrecy 0.8.0",
  "serde",
  "serde_json",
+ "serial_test",
  "sha2 0.10.9",
  "sqlx",
  "sysinfo",

--- a/crates/auth/src/credential_store.rs
+++ b/crates/auth/src/credential_store.rs
@@ -39,4 +39,6 @@ pub struct CredentialStore {
     /// Encryption-at-rest vault for environment variables.
     #[cfg(feature = "vault")]
     vault: Option<Arc<Vault>>,
+    #[cfg(feature = "vault")]
+    vault_encryption_enabled: AtomicBool,
 }

--- a/crates/auth/src/credential_store/env_vars.rs
+++ b/crates/auth/src/credential_store/env_vars.rs
@@ -37,8 +37,10 @@ impl CredentialStore {
     pub async fn set_env_var(&self, key: &str, value: &str) -> Result<i64> {
         #[cfg(feature = "vault")]
         let (store_value, encrypted) = {
-            if let Some(ref vault) = self.vault {
-                if vault.is_unsealed().await {
+            if self.is_vault_encryption_enabled() {
+                if let Some(ref vault) = self.vault
+                    && vault.is_unsealed().await
+                {
                     let aad = format!("env:{key}");
                     let enc = vault
                         .encrypt_string(value, &aad)

--- a/crates/auth/src/credential_store/sessions.rs
+++ b/crates/auth/src/credential_store/sessions.rs
@@ -74,6 +74,8 @@ impl CredentialStore {
             auth_disabled: std::sync::atomic::AtomicBool::new(false),
             #[cfg(feature = "vault")]
             vault: None,
+            #[cfg(feature = "vault")]
+            vault_encryption_enabled: std::sync::atomic::AtomicBool::new(false),
         };
         store.init().await?;
         let has = store.has_password().await? || store.has_passkeys().await?;
@@ -105,6 +107,7 @@ impl CredentialStore {
             setup_complete: std::sync::atomic::AtomicBool::new(false),
             auth_disabled: std::sync::atomic::AtomicBool::new(false),
             vault,
+            vault_encryption_enabled: std::sync::atomic::AtomicBool::new(auth_config.vault_enabled),
         };
         store.init().await?;
         let has = store.has_password().await? || store.has_passkeys().await?;
@@ -638,6 +641,17 @@ impl CredentialStore {
     #[cfg(feature = "vault")]
     pub fn vault(&self) -> Option<&Arc<Vault>> {
         self.vault.as_ref()
+    }
+
+    #[cfg(feature = "vault")]
+    pub fn is_vault_encryption_enabled(&self) -> bool {
+        self.vault_encryption_enabled.load(Ordering::Relaxed)
+    }
+
+    #[cfg(feature = "vault")]
+    pub fn disable_vault_encryption(&self) {
+        self.vault_encryption_enabled
+            .store(false, Ordering::Relaxed);
     }
 
     /// Get a reference to the underlying database pool.

--- a/crates/auth/src/credential_store/ssh.rs
+++ b/crates/auth/src/credential_store/ssh.rs
@@ -69,8 +69,10 @@ impl CredentialStore {
 
         #[cfg(feature = "vault")]
         let (store_private_key, encrypted) = {
-            if let Some(ref vault) = self.vault {
-                if vault.is_unsealed().await {
+            if self.is_vault_encryption_enabled() {
+                if let Some(ref vault) = self.vault
+                    && vault.is_unsealed().await
+                {
                     let aad = format!("ssh-key:{name}");
                     let enc = vault
                         .encrypt_string(private_key, &aad)

--- a/crates/auth/src/credential_store/tests.rs
+++ b/crates/auth/src/credential_store/tests.rs
@@ -730,6 +730,28 @@ async fn test_env_var_encryption_when_vault_unsealed() {
 
 #[cfg(feature = "vault")]
 #[tokio::test]
+async fn test_env_var_plaintext_when_vault_encryption_disabled() {
+    let vault_password = generate_token();
+    let visible_value = fixture_secret("vault-env-disabled-visible");
+    let (store, _vault) = vault_store(&vault_password).await;
+    store.disable_vault_encryption();
+
+    store
+        .set_env_var("DISABLED_KEY", &visible_value)
+        .await
+        .unwrap();
+
+    let row: (String, i64) =
+        sqlx::query_as("SELECT value, encrypted FROM env_variables WHERE key = 'DISABLED_KEY'")
+            .fetch_one(store.db_pool())
+            .await
+            .unwrap();
+    assert_eq!(row.1, 0);
+    assert_eq!(row.0, visible_value);
+}
+
+#[cfg(feature = "vault")]
+#[tokio::test]
 async fn test_env_var_plaintext_when_vault_sealed() {
     let vault_password = generate_token();
     let visible_value = fixture_secret("vault-env-plaintext-visible");

--- a/crates/config/src/loader/tests/core.rs
+++ b/crates/config/src/loader/tests/core.rs
@@ -60,6 +60,7 @@ fn apply_env_overrides_auth_disabled() {
     let vars = vec![("MOLTIS_AUTH__DISABLED".into(), "true".into())];
     let config = MoltisConfig::default();
     assert!(!config.auth.disabled);
+    assert!(config.auth.vault_enabled);
     let config = apply_env_overrides_with(config, vars.into_iter());
     assert!(config.auth.disabled);
 }

--- a/crates/config/src/schema/runtime.rs
+++ b/crates/config/src/schema/runtime.rs
@@ -10,6 +10,10 @@ use {
 pub struct AuthConfig {
     /// When true, authentication is explicitly disabled (no login required).
     pub disabled: bool,
+
+    /// When true, stored secrets are encrypted at rest using the password-backed vault.
+    #[serde(default = "default_true")]
+    pub vault_enabled: bool,
 }
 
 /// Runtime GraphQL server configuration.

--- a/crates/config/src/schema/runtime.rs
+++ b/crates/config/src/schema/runtime.rs
@@ -5,7 +5,7 @@ use {
 };
 
 /// Authentication configuration.
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
 pub struct AuthConfig {
     /// When true, authentication is explicitly disabled (no login required).
@@ -14,6 +14,15 @@ pub struct AuthConfig {
     /// When true, stored secrets are encrypted at rest using the password-backed vault.
     #[serde(default = "default_true")]
     pub vault_enabled: bool,
+}
+
+impl Default for AuthConfig {
+    fn default() -> Self {
+        Self {
+            disabled: false,
+            vault_enabled: true,
+        }
+    }
 }
 
 /// Runtime GraphQL server configuration.

--- a/crates/config/src/template.rs
+++ b/crates/config/src/template.rs
@@ -65,6 +65,8 @@ port = {port}                           # Port number (auto-generated for this i
 # [auth]
 # disabled = false                  # true = disable auth entirely (DANGEROUS if exposed)
                                     # When disabled, anyone with network access can use moltis
+# vault_enabled = true              # true = encrypt stored secrets at rest using the password vault
+#                                   # Set false to keep password auth without requiring vault unlocks after restart.
 
 # ══════════════════════════════════════════════════════════════════════════════
 # GRAPHQL

--- a/crates/config/src/validate/schema_map.rs
+++ b/crates/config/src/validate/schema_map.rs
@@ -472,7 +472,10 @@ pub(super) fn build_schema_map() -> KnownKeys {
                 ("http_redirect_port", Leaf),
             ])),
         ),
-        ("auth", Struct(HashMap::from([("disabled", Leaf)]))),
+        (
+            "auth",
+            Struct(HashMap::from([("disabled", Leaf), ("vault_enabled", Leaf)])),
+        ),
         ("graphql", Struct(HashMap::from([("enabled", Leaf)]))),
         (
             "metrics",

--- a/crates/gateway/Cargo.toml
+++ b/crates/gateway/Cargo.toml
@@ -215,6 +215,7 @@ web-ui = ["dep:include_dir", "dep:portable-pty", "dep:which", "moltis-chat/web-u
 whatsapp = ["dep:moltis-whatsapp", "dep:qrcode", "moltis-whatsapp/metrics"]
 
 [dev-dependencies]
+serial_test = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/gateway/src/channel_store.rs
+++ b/crates/gateway/src/channel_store.rs
@@ -117,6 +117,10 @@ impl VaultChannelStore {
             return Ok(StoredChannel { config, ..channel });
         }
 
+        if !crate::vault_lifecycle::is_vault_encryption_runtime_enabled() {
+            return Ok(StoredChannel { config, ..channel });
+        }
+
         let Some(vault) = self.vault.as_ref() else {
             return Ok(StoredChannel { config, ..channel });
         };

--- a/crates/gateway/src/channel_store.rs
+++ b/crates/gateway/src/channel_store.rs
@@ -451,7 +451,9 @@ mod tests {
 
     #[cfg(feature = "vault")]
     #[tokio::test]
+    #[serial_test::serial(vault_runtime)]
     async fn vault_store_encrypts_and_decrypts_secret_fields() {
+        crate::vault_lifecycle::set_vault_encryption_runtime_enabled(true);
         let pool = test_pool().await;
         let vault = test_vault(pool.clone()).await;
         let inner: Arc<dyn ChannelStore> = Arc::new(SqliteChannelStore::new(pool.clone()));

--- a/crates/gateway/src/server/prepare_core.rs
+++ b/crates/gateway/src/server/prepare_core.rs
@@ -445,9 +445,11 @@ pub async fn prepare_gateway_core(
     #[cfg(feature = "vault")]
     let (vault, auto_unsealed_vault): (Option<Arc<moltis_vault::Vault>>, bool) = {
         if !config.auth.vault_enabled {
+            crate::vault_lifecycle::set_vault_encryption_runtime_enabled(false);
             info!("vault disabled by auth.vault_enabled=false");
             (None, false)
         } else {
+            crate::vault_lifecycle::set_vault_encryption_runtime_enabled(true);
             match moltis_vault::Vault::new(db_pool.clone()).await {
                 Ok(v) => {
                     info!(status = ?v.status().await, "vault ready");

--- a/crates/gateway/src/server/prepare_core.rs
+++ b/crates/gateway/src/server/prepare_core.rs
@@ -444,22 +444,28 @@ pub async fn prepare_gateway_core(
 
     #[cfg(feature = "vault")]
     let (vault, auto_unsealed_vault): (Option<Arc<moltis_vault::Vault>>, bool) = {
-        match moltis_vault::Vault::new(db_pool.clone()).await {
-            Ok(v) => {
-                info!(status = ?v.status().await, "vault ready");
-                let vault = Arc::new(v);
-                let auto_unseal_result = crate::vault_lifecycle::auto_unseal_from_env(&vault).await;
-                let auto_unsealed = matches!(
-                    auto_unseal_result,
-                    crate::vault_lifecycle::AutoUnsealResult::Unsealed
-                        | crate::vault_lifecycle::AutoUnsealResult::AlreadyUnsealed
-                );
-                (Some(vault), auto_unsealed)
-            },
-            Err(e) => {
-                warn!(error = %e, "vault init failed, encryption disabled");
-                (None, false)
-            },
+        if !config.auth.vault_enabled {
+            info!("vault disabled by auth.vault_enabled=false");
+            (None, false)
+        } else {
+            match moltis_vault::Vault::new(db_pool.clone()).await {
+                Ok(v) => {
+                    info!(status = ?v.status().await, "vault ready");
+                    let vault = Arc::new(v);
+                    let auto_unseal_result =
+                        crate::vault_lifecycle::auto_unseal_from_env(&vault).await;
+                    let auto_unsealed = matches!(
+                        auto_unseal_result,
+                        crate::vault_lifecycle::AutoUnsealResult::Unsealed
+                            | crate::vault_lifecycle::AutoUnsealResult::AlreadyUnsealed
+                    );
+                    (Some(vault), auto_unsealed)
+                },
+                Err(e) => {
+                    warn!(error = %e, "vault init failed, encryption disabled");
+                    (None, false)
+                },
+            }
         }
     };
 

--- a/crates/gateway/src/vault_lifecycle.rs
+++ b/crates/gateway/src/vault_lifecycle.rs
@@ -282,7 +282,18 @@ async fn decrypt_channels(
     for (channel_type, account_id, config_json) in rows {
         let channel_type_enum = match channel_type.parse::<moltis_channels::plugin::ChannelType>() {
             Ok(channel_type) => channel_type,
-            Err(_) => continue,
+            Err(_) => {
+                let config: serde_json::Value =
+                    serde_json::from_str(&config_json).with_context(|| {
+                        format!("invalid channel config for {channel_type}:{account_id}")
+                    })?;
+                if contains_vault_encrypted_secret(&config) {
+                    anyhow::bail!(
+                        "cannot disable vault: channel {channel_type}:{account_id} has encrypted secrets but the channel type is unavailable"
+                    );
+                }
+                continue;
+            },
         };
         let secret_fields = channel_type_enum.secret_fields();
         if secret_fields.is_empty() {
@@ -310,6 +321,17 @@ async fn decrypt_channels(
         changed += 1;
     }
     Ok(changed)
+}
+
+fn contains_vault_encrypted_secret(value: &serde_json::Value) -> bool {
+    match value {
+        serde_json::Value::Object(map) => {
+            map.get("kind").and_then(serde_json::Value::as_str) == Some("vault_encrypted")
+                || map.values().any(contains_vault_encrypted_secret)
+        },
+        serde_json::Value::Array(values) => values.iter().any(contains_vault_encrypted_secret),
+        _ => false,
+    }
 }
 
 async fn decrypt_webhooks(
@@ -548,7 +570,8 @@ mod tests {
     use {
         crate::vault_lifecycle::{
             AutoUnsealResult, AutoUnsealSecret, AutoUnsealSourceKind, auto_unseal_with_secret,
-            disable_vault_and_decrypt_all, set_vault_encryption_runtime_enabled,
+            disable_vault_and_decrypt_all, is_vault_encryption_runtime_enabled,
+            set_vault_encryption_runtime_enabled,
         },
         secrecy::Secret,
         sqlx::SqlitePool,
@@ -742,6 +765,43 @@ mod tests {
                 .unwrap();
         let channel_json: serde_json::Value = serde_json::from_str(&channel.0).unwrap();
         assert_eq!(channel_json["token"], "Bot discord-token");
+    }
+
+    #[tokio::test]
+    #[serial_test::serial(vault_runtime)]
+    async fn disable_vault_fails_on_unknown_channel_with_encrypted_secret() {
+        let _runtime_flag = VaultRuntimeFlagGuard::enabled();
+        let config_dir = tempfile::tempdir().unwrap();
+        moltis_config::set_config_dir(config_dir.path().to_path_buf());
+        let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        moltis_vault::run_migrations(&pool).await.unwrap();
+        create_disable_test_tables(&pool).await;
+        let vault = Arc::new(moltis_vault::Vault::new(pool.clone()).await.unwrap());
+        vault.initialize(&test_password()).await.unwrap();
+
+        let config = serde_json::json!({
+            "token": {
+                "kind": "vault_encrypted",
+                "ciphertext": "unavailable-channel-ciphertext"
+            }
+        });
+        sqlx::query("INSERT INTO channels (channel_type, account_id, config, created_at, updated_at) VALUES ('future-channel', 'main', ?, 1, 1)")
+            .bind(serde_json::to_string(&config).unwrap())
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        set_vault_encryption_runtime_enabled(true);
+        let error = disable_vault_and_decrypt_all(&vault, &pool)
+            .await
+            .unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("channel future-channel:main has encrypted secrets")
+        );
+        assert!(is_vault_encryption_runtime_enabled());
     }
 
     async fn create_disable_test_tables(pool: &SqlitePool) {

--- a/crates/gateway/src/vault_lifecycle.rs
+++ b/crates/gateway/src/vault_lifecycle.rs
@@ -411,17 +411,42 @@ async fn decrypt_provider_keys(vault: &moltis_vault::Vault) -> anyhow::Result<bo
 }
 
 async fn write_secret_file(path: &std::path::Path, content: &str) -> anyhow::Result<()> {
-    tokio::fs::write(path, content)
+    let path = path.to_path_buf();
+    let content = content.to_owned();
+    tokio::task::spawn_blocking(move || write_secret_file_blocking(&path, &content))
         .await
-        .with_context(|| format!("failed to write {}", path.display()))?;
+        .context("secret file write task failed")?
+}
+
+fn write_secret_file_blocking(path: &std::path::Path, content: &str) -> anyhow::Result<()> {
+    use std::io::Write;
+
+    let mut options = std::fs::OpenOptions::new();
+    options.create(true).truncate(true).write(true);
+
     #[cfg(unix)]
     {
-        use std::os::unix::fs::PermissionsExt;
-        tokio::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))
-            .await
+        use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+        options.mode(0o600);
+        let mut file = options
+            .open(path)
+            .with_context(|| format!("failed to open {}", path.display()))?;
+        file.set_permissions(std::fs::Permissions::from_mode(0o600))
             .with_context(|| format!("failed to chmod {}", path.display()))?;
+        file.write_all(content.as_bytes())
+            .with_context(|| format!("failed to write {}", path.display()))?;
+        return Ok(());
     }
-    Ok(())
+
+    #[cfg(not(unix))]
+    {
+        let mut file = options
+            .open(path)
+            .with_context(|| format!("failed to open {}", path.display()))?;
+        file.write_all(content.as_bytes())
+            .with_context(|| format!("failed to write {}", path.display()))?;
+        Ok(())
+    }
 }
 
 fn webhook_auth_secret_fields(auth_mode: &str) -> &'static [&'static str] {

--- a/crates/gateway/src/vault_lifecycle.rs
+++ b/crates/gateway/src/vault_lifecycle.rs
@@ -2,10 +2,7 @@ use {
     crate::{auth::CredentialStore, state::GatewayState},
     anyhow::Context,
     secrecy::{ExposeSecret, Secret},
-    std::{
-        path::{Path, PathBuf},
-        sync::Arc,
-    },
+    std::{path::PathBuf, sync::Arc},
 };
 
 pub const AUTO_UNSEAL_KEY_ENV: &str = "MOLTIS_VAULT_AUTO_UNSEAL_KEY";
@@ -309,8 +306,9 @@ async fn decrypt_webhooks(
     .await?;
     let mut changed = 0;
     for (id, auth_mode, auth_config_json, source_profile, source_config_json) in rows {
-        let mut row_changed = false;
-        let auth_config = if let Some(config_json) = auth_config_json {
+        let mut auth_config_update = None;
+        let mut source_config_update = None;
+        if let Some(config_json) = auth_config_json {
             let mut config: serde_json::Value = serde_json::from_str(&config_json)
                 .with_context(|| format!("invalid auth_config_json for webhook {id}"))?;
             let fields = webhook_auth_secret_fields(&auth_mode);
@@ -324,13 +322,10 @@ async fn decrypt_webhooks(
                     vault,
                 )
                 .await?;
-                row_changed = true;
+                auth_config_update = Some(serde_json::to_string(&config)?);
             }
-            Some(serde_json::to_string(&config)?)
-        } else {
-            None
-        };
-        let source_config = if let Some(config_json) = source_config_json {
+        }
+        if let Some(config_json) = source_config_json {
             let mut config: serde_json::Value = serde_json::from_str(&config_json)
                 .with_context(|| format!("invalid source_config_json for webhook {id}"))?;
             let fields = webhook_source_secret_fields(&source_profile);
@@ -342,20 +337,37 @@ async fn decrypt_webhooks(
                     vault,
                 )
                 .await?;
-                row_changed = true;
+                source_config_update = Some(serde_json::to_string(&config)?);
             }
-            Some(serde_json::to_string(&config)?)
-        } else {
-            None
-        };
-        if row_changed {
-            sqlx::query("UPDATE webhooks SET auth_config_json = ?, source_config_json = ?, updated_at = datetime('now') WHERE id = ?")
-                .bind(auth_config)
-                .bind(source_config)
-                .bind(id)
-                .execute(pool)
-                .await?;
-            changed += 1;
+        }
+
+        match (auth_config_update, source_config_update) {
+            (Some(auth_config), Some(source_config)) => {
+                sqlx::query("UPDATE webhooks SET auth_config_json = ?, source_config_json = ?, updated_at = datetime('now') WHERE id = ?")
+                    .bind(auth_config)
+                    .bind(source_config)
+                    .bind(id)
+                    .execute(pool)
+                    .await?;
+                changed += 1;
+            },
+            (Some(auth_config), None) => {
+                sqlx::query("UPDATE webhooks SET auth_config_json = ?, updated_at = datetime('now') WHERE id = ?")
+                    .bind(auth_config)
+                    .bind(id)
+                    .execute(pool)
+                    .await?;
+                changed += 1;
+            },
+            (None, Some(source_config)) => {
+                sqlx::query("UPDATE webhooks SET source_config_json = ?, updated_at = datetime('now') WHERE id = ?")
+                    .bind(source_config)
+                    .bind(id)
+                    .execute(pool)
+                    .await?;
+                changed += 1;
+            },
+            (None, None) => {},
         }
     }
     Ok(changed)
@@ -370,21 +382,26 @@ async fn decrypt_provider_keys(vault: &moltis_vault::Vault) -> anyhow::Result<bo
     if !enc_path.exists() {
         return Ok(false);
     }
-    let encrypted = std::fs::read_to_string(&enc_path)
+    let encrypted = tokio::fs::read_to_string(&enc_path)
+        .await
         .with_context(|| format!("failed to read {}", enc_path.display()))?;
     let plaintext = vault.decrypt_string(&encrypted, "provider_keys").await?;
-    write_secret_file(&path, &plaintext)?;
-    std::fs::remove_file(&enc_path)
+    write_secret_file(&path, &plaintext).await?;
+    tokio::fs::remove_file(&enc_path)
+        .await
         .with_context(|| format!("failed to remove {}", enc_path.display()))?;
     Ok(true)
 }
 
-fn write_secret_file(path: &Path, content: &str) -> anyhow::Result<()> {
-    std::fs::write(path, content).with_context(|| format!("failed to write {}", path.display()))?;
+async fn write_secret_file(path: &std::path::Path, content: &str) -> anyhow::Result<()> {
+    tokio::fs::write(path, content)
+        .await
+        .with_context(|| format!("failed to write {}", path.display()))?;
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
-        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))
+        tokio::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))
+            .await
             .with_context(|| format!("failed to chmod {}", path.display()))?;
     }
     Ok(())
@@ -503,10 +520,17 @@ mod tests {
         Arc::new(moltis_vault::Vault::new(pool).await.unwrap())
     }
 
+    fn test_password() -> String {
+        format!(
+            "test-password-{}",
+            time::OffsetDateTime::now_utc().unix_timestamp_nanos()
+        )
+    }
+
     #[tokio::test]
     async fn auto_unseal_with_recovery_key_unseals_vault() {
         let vault = test_vault().await;
-        let recovery_key = vault.initialize("test-password-123").await.unwrap();
+        let recovery_key = vault.initialize(&test_password()).await.unwrap();
         let recovery_phrase = recovery_key.phrase().to_owned();
         vault.seal().await;
 
@@ -526,7 +550,7 @@ mod tests {
     #[tokio::test]
     async fn auto_unseal_already_unsealed_is_successful_noop() {
         let vault = test_vault().await;
-        let recovery_key = vault.initialize("test-password-123").await.unwrap();
+        let recovery_key = vault.initialize(&test_password()).await.unwrap();
         let recovery_phrase = recovery_key.phrase().to_owned();
 
         let result = auto_unseal_with_secret(&vault, AutoUnsealSecret {
@@ -545,7 +569,7 @@ mod tests {
     #[tokio::test]
     async fn auto_unseal_rejects_wrong_recovery_key() {
         let vault = test_vault().await;
-        vault.initialize("test-password-123").await.unwrap();
+        vault.initialize(&test_password()).await.unwrap();
         vault.seal().await;
 
         let result = auto_unseal_with_secret(&vault, AutoUnsealSecret {
@@ -564,7 +588,7 @@ mod tests {
     #[tokio::test]
     async fn auto_unseal_empty_secret_is_noop() {
         let vault = test_vault().await;
-        vault.initialize("test-password-123").await.unwrap();
+        vault.initialize(&test_password()).await.unwrap();
         vault.seal().await;
 
         let result = auto_unseal_with_secret(&vault, AutoUnsealSecret {
@@ -588,7 +612,7 @@ mod tests {
         moltis_vault::run_migrations(&pool).await.unwrap();
         create_disable_test_tables(&pool).await;
         let vault = Arc::new(moltis_vault::Vault::new(pool.clone()).await.unwrap());
-        vault.initialize("test-password-123").await.unwrap();
+        vault.initialize(&test_password()).await.unwrap();
 
         let env_ciphertext = vault
             .encrypt_string("env-secret", "env:API_KEY")

--- a/crates/gateway/src/vault_lifecycle.rs
+++ b/crates/gateway/src/vault_lifecycle.rs
@@ -2,11 +2,27 @@ use {
     crate::{auth::CredentialStore, state::GatewayState},
     anyhow::Context,
     secrecy::{ExposeSecret, Secret},
-    std::{path::PathBuf, sync::Arc},
+    std::{
+        path::PathBuf,
+        sync::{
+            Arc,
+            atomic::{AtomicBool, Ordering},
+        },
+    },
 };
 
 pub const AUTO_UNSEAL_KEY_ENV: &str = "MOLTIS_VAULT_AUTO_UNSEAL_KEY";
 pub const AUTO_UNSEAL_KEY_FILE_ENV: &str = "MOLTIS_VAULT_AUTO_UNSEAL_KEY_FILE";
+
+static VAULT_ENCRYPTION_RUNTIME_ENABLED: AtomicBool = AtomicBool::new(true);
+
+pub fn set_vault_encryption_runtime_enabled(enabled: bool) {
+    VAULT_ENCRYPTION_RUNTIME_ENABLED.store(enabled, Ordering::Relaxed);
+}
+
+pub fn is_vault_encryption_runtime_enabled() -> bool {
+    VAULT_ENCRYPTION_RUNTIME_ENABLED.load(Ordering::Relaxed)
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AutoUnsealResult {
@@ -204,6 +220,7 @@ pub async fn disable_vault_and_decrypt_all(
         config.auth.vault_enabled = false;
     })
     .context("failed to persist auth.vault_enabled=false")?;
+    set_vault_encryption_runtime_enabled(false);
 
     tracing::info!(?report, "vault disabled after decrypting stored secrets");
     Ok(report)

--- a/crates/gateway/src/vault_lifecycle.rs
+++ b/crates/gateway/src/vault_lifecycle.rs
@@ -316,13 +316,12 @@ async fn decrypt_webhooks(
     vault: &moltis_vault::Vault,
     pool: &sqlx::SqlitePool,
 ) -> anyhow::Result<usize> {
-    let rows: Vec<(i64, String, Option<String>, String, Option<String>)> = sqlx::query_as(
-        "SELECT id, auth_mode, auth_config_json, source_profile, source_config_json FROM webhooks",
-    )
-    .fetch_all(pool)
-    .await?;
+    let rows: Vec<(i64, String, Option<String>, Option<String>)> =
+        sqlx::query_as("SELECT id, auth_mode, auth_config_json, source_config_json FROM webhooks")
+            .fetch_all(pool)
+            .await?;
     let mut changed = 0;
-    for (id, auth_mode, auth_config_json, source_profile, source_config_json) in rows {
+    for (id, auth_mode, auth_config_json, source_config_json) in rows {
         let mut auth_config_update = None;
         let mut source_config_update = None;
         if let Some(config_json) = auth_config_json {
@@ -345,7 +344,7 @@ async fn decrypt_webhooks(
         if let Some(config_json) = source_config_json {
             let mut config: serde_json::Value = serde_json::from_str(&config_json)
                 .with_context(|| format!("invalid source_config_json for webhook {id}"))?;
-            let fields = webhook_source_secret_fields(&source_profile);
+            let fields = webhook_source_secret_fields();
             if moltis_secret_store::has_encrypted_secret_fields(&config, fields)? {
                 moltis_secret_store::decrypt_secret_fields(
                     &mut config,
@@ -462,7 +461,7 @@ fn webhook_auth_secret_fields(auth_mode: &str) -> &'static [&'static str] {
     }
 }
 
-fn webhook_source_secret_fields(_source_profile: &str) -> &'static [&'static str] {
+fn webhook_source_secret_fields() -> &'static [&'static str] {
     &[
         "access_token",
         "api_key",
@@ -562,6 +561,21 @@ mod tests {
         Arc::new(moltis_vault::Vault::new(pool).await.unwrap())
     }
 
+    struct VaultRuntimeFlagGuard;
+
+    impl VaultRuntimeFlagGuard {
+        fn enabled() -> Self {
+            set_vault_encryption_runtime_enabled(true);
+            Self
+        }
+    }
+
+    impl Drop for VaultRuntimeFlagGuard {
+        fn drop(&mut self) {
+            set_vault_encryption_runtime_enabled(true);
+        }
+    }
+
     fn test_password() -> String {
         format!(
             "test-password-{}",
@@ -649,7 +663,7 @@ mod tests {
     #[tokio::test]
     #[serial_test::serial(vault_runtime)]
     async fn disable_vault_decrypts_stored_secrets_before_flipping_config() {
-        set_vault_encryption_runtime_enabled(true);
+        let _runtime_flag = VaultRuntimeFlagGuard::enabled();
         let config_dir = tempfile::tempdir().unwrap();
         moltis_config::set_config_dir(config_dir.path().to_path_buf());
         let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
@@ -708,6 +722,7 @@ mod tests {
             .await
             .unwrap();
 
+        set_vault_encryption_runtime_enabled(true);
         let report = disable_vault_and_decrypt_all(&vault, &pool).await.unwrap();
         assert_eq!(report.env_vars, 1);
         assert_eq!(report.ssh_keys, 1);
@@ -727,7 +742,6 @@ mod tests {
                 .unwrap();
         let channel_json: serde_json::Value = serde_json::from_str(&channel.0).unwrap();
         assert_eq!(channel_json["token"], "Bot discord-token");
-        set_vault_encryption_runtime_enabled(true);
     }
 
     async fn create_disable_test_tables(pool: &SqlitePool) {

--- a/crates/gateway/src/vault_lifecycle.rs
+++ b/crates/gateway/src/vault_lifecycle.rs
@@ -1,7 +1,11 @@
 use {
     crate::{auth::CredentialStore, state::GatewayState},
+    anyhow::Context,
     secrecy::{ExposeSecret, Secret},
-    std::{path::PathBuf, sync::Arc},
+    std::{
+        path::{Path, PathBuf},
+        sync::Arc,
+    },
 };
 
 pub const AUTO_UNSEAL_KEY_ENV: &str = "MOLTIS_VAULT_AUTO_UNSEAL_KEY";
@@ -169,6 +173,254 @@ pub async fn run_vault_env_migration(credential_store: &CredentialStore) {
     }
 }
 
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct VaultDisableReport {
+    pub env_vars: usize,
+    pub ssh_keys: usize,
+    pub channels: usize,
+    pub webhooks: usize,
+    pub provider_keys: bool,
+}
+
+/// Decrypt all known vault-backed data and disable vault use in config.
+///
+/// This must only run while the vault is unsealed. The config flag is written
+/// after all decryptions succeed, so a partial failure leaves vault mode intact.
+#[tracing::instrument(skip(vault, pool))]
+pub async fn disable_vault_and_decrypt_all(
+    vault: &moltis_vault::Vault,
+    pool: &sqlx::SqlitePool,
+) -> anyhow::Result<VaultDisableReport> {
+    if !vault.is_unsealed().await {
+        anyhow::bail!("vault must be unlocked before disabling encryption at rest");
+    }
+
+    let report = VaultDisableReport {
+        env_vars: decrypt_env_vars(vault, pool).await?,
+        ssh_keys: decrypt_ssh_keys(vault, pool).await?,
+        channels: decrypt_channels(vault, pool).await?,
+        webhooks: decrypt_webhooks(vault, pool).await?,
+        provider_keys: decrypt_provider_keys(vault).await?,
+    };
+
+    moltis_config::update_config(|config| {
+        config.auth.vault_enabled = false;
+    })
+    .context("failed to persist auth.vault_enabled=false")?;
+
+    tracing::info!(?report, "vault disabled after decrypting stored secrets");
+    Ok(report)
+}
+
+async fn decrypt_env_vars(
+    vault: &moltis_vault::Vault,
+    pool: &sqlx::SqlitePool,
+) -> anyhow::Result<usize> {
+    let rows: Vec<(i64, String, String)> =
+        sqlx::query_as("SELECT id, key, value FROM env_variables WHERE encrypted = 1")
+            .fetch_all(pool)
+            .await?;
+    let count = rows.len();
+    for (id, key, ciphertext) in rows {
+        let plaintext = vault
+            .decrypt_string(&ciphertext, &format!("env:{key}"))
+            .await?;
+        sqlx::query("UPDATE env_variables SET value = ?, encrypted = 0, updated_at = datetime('now') WHERE id = ?")
+            .bind(plaintext)
+            .bind(id)
+            .execute(pool)
+            .await?;
+    }
+    Ok(count)
+}
+
+async fn decrypt_ssh_keys(
+    vault: &moltis_vault::Vault,
+    pool: &sqlx::SqlitePool,
+) -> anyhow::Result<usize> {
+    let rows: Vec<(i64, String, String)> =
+        sqlx::query_as("SELECT id, name, private_key FROM ssh_keys WHERE encrypted = 1")
+            .fetch_all(pool)
+            .await?;
+    let count = rows.len();
+    for (id, name, ciphertext) in rows {
+        let plaintext = vault
+            .decrypt_string(&ciphertext, &format!("ssh-key:{name}"))
+            .await?;
+        sqlx::query("UPDATE ssh_keys SET private_key = ?, encrypted = 0, updated_at = datetime('now') WHERE id = ?")
+            .bind(plaintext)
+            .bind(id)
+            .execute(pool)
+            .await?;
+    }
+    Ok(count)
+}
+
+async fn decrypt_channels(
+    vault: &moltis_vault::Vault,
+    pool: &sqlx::SqlitePool,
+) -> anyhow::Result<usize> {
+    let rows: Vec<(String, String, String)> =
+        sqlx::query_as("SELECT channel_type, account_id, config FROM channels")
+            .fetch_all(pool)
+            .await?;
+    let mut changed = 0;
+    for (channel_type, account_id, config_json) in rows {
+        let channel_type_enum = match channel_type.parse::<moltis_channels::plugin::ChannelType>() {
+            Ok(channel_type) => channel_type,
+            Err(_) => continue,
+        };
+        let secret_fields = channel_type_enum.secret_fields();
+        if secret_fields.is_empty() {
+            continue;
+        }
+        let mut config: serde_json::Value = serde_json::from_str(&config_json)
+            .with_context(|| format!("invalid channel config for {channel_type}:{account_id}"))?;
+        if !moltis_secret_store::has_encrypted_secret_fields(&config, secret_fields)? {
+            continue;
+        }
+        moltis_secret_store::decrypt_secret_fields(
+            &mut config,
+            secret_fields,
+            &format!("channel:{channel_type}:{account_id}"),
+            vault,
+        )
+        .await?;
+        sqlx::query("UPDATE channels SET config = ?, updated_at = ? WHERE channel_type = ? AND account_id = ?")
+            .bind(serde_json::to_string(&config)?)
+            .bind(unix_now_i64())
+            .bind(&channel_type)
+            .bind(&account_id)
+            .execute(pool)
+            .await?;
+        changed += 1;
+    }
+    Ok(changed)
+}
+
+async fn decrypt_webhooks(
+    vault: &moltis_vault::Vault,
+    pool: &sqlx::SqlitePool,
+) -> anyhow::Result<usize> {
+    let rows: Vec<(i64, String, Option<String>, String, Option<String>)> = sqlx::query_as(
+        "SELECT id, auth_mode, auth_config_json, source_profile, source_config_json FROM webhooks",
+    )
+    .fetch_all(pool)
+    .await?;
+    let mut changed = 0;
+    for (id, auth_mode, auth_config_json, source_profile, source_config_json) in rows {
+        let mut row_changed = false;
+        let auth_config = if let Some(config_json) = auth_config_json {
+            let mut config: serde_json::Value = serde_json::from_str(&config_json)
+                .with_context(|| format!("invalid auth_config_json for webhook {id}"))?;
+            let fields = webhook_auth_secret_fields(&auth_mode);
+            if !fields.is_empty()
+                && moltis_secret_store::has_encrypted_secret_fields(&config, fields)?
+            {
+                moltis_secret_store::decrypt_secret_fields(
+                    &mut config,
+                    fields,
+                    "webhook:config",
+                    vault,
+                )
+                .await?;
+                row_changed = true;
+            }
+            Some(serde_json::to_string(&config)?)
+        } else {
+            None
+        };
+        let source_config = if let Some(config_json) = source_config_json {
+            let mut config: serde_json::Value = serde_json::from_str(&config_json)
+                .with_context(|| format!("invalid source_config_json for webhook {id}"))?;
+            let fields = webhook_source_secret_fields(&source_profile);
+            if moltis_secret_store::has_encrypted_secret_fields(&config, fields)? {
+                moltis_secret_store::decrypt_secret_fields(
+                    &mut config,
+                    fields,
+                    "webhook:config",
+                    vault,
+                )
+                .await?;
+                row_changed = true;
+            }
+            Some(serde_json::to_string(&config)?)
+        } else {
+            None
+        };
+        if row_changed {
+            sqlx::query("UPDATE webhooks SET auth_config_json = ?, source_config_json = ?, updated_at = datetime('now') WHERE id = ?")
+                .bind(auth_config)
+                .bind(source_config)
+                .bind(id)
+                .execute(pool)
+                .await?;
+            changed += 1;
+        }
+    }
+    Ok(changed)
+}
+
+async fn decrypt_provider_keys(vault: &moltis_vault::Vault) -> anyhow::Result<bool> {
+    let Some(config_dir) = moltis_config::config_dir() else {
+        return Ok(false);
+    };
+    let path = config_dir.join("provider_keys.json");
+    let enc_path = path.with_extension("json.enc");
+    if !enc_path.exists() {
+        return Ok(false);
+    }
+    let encrypted = std::fs::read_to_string(&enc_path)
+        .with_context(|| format!("failed to read {}", enc_path.display()))?;
+    let plaintext = vault.decrypt_string(&encrypted, "provider_keys").await?;
+    write_secret_file(&path, &plaintext)?;
+    std::fs::remove_file(&enc_path)
+        .with_context(|| format!("failed to remove {}", enc_path.display()))?;
+    Ok(true)
+}
+
+fn write_secret_file(path: &Path, content: &str) -> anyhow::Result<()> {
+    std::fs::write(path, content).with_context(|| format!("failed to write {}", path.display()))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))
+            .with_context(|| format!("failed to chmod {}", path.display()))?;
+    }
+    Ok(())
+}
+
+fn webhook_auth_secret_fields(auth_mode: &str) -> &'static [&'static str] {
+    match auth_mode {
+        "static_header" => &["value"],
+        "bearer" | "gitlab_token" => &["token"],
+        "github_hmac_sha256"
+        | "stripe_webhook_signature"
+        | "linear_webhook_signature"
+        | "pagerduty_v2_signature"
+        | "sentry_webhook_signature" => &["secret"],
+        _ => &[],
+    }
+}
+
+fn webhook_source_secret_fields(_source_profile: &str) -> &'static [&'static str] {
+    &[
+        "access_token",
+        "api_key",
+        "api_token",
+        "bearer_token",
+        "client_secret",
+        "secret",
+        "signing_secret",
+        "token",
+        "webhook_secret",
+    ]
+}
+
+fn unix_now_i64() -> i64 {
+    time::OffsetDateTime::now_utc().unix_timestamp()
+}
+
 /// Start stored channel accounts after vault unseal.
 ///
 /// When the vault is unsealed, previously encrypted channel configs become
@@ -238,6 +490,7 @@ mod tests {
     use {
         crate::vault_lifecycle::{
             AutoUnsealResult, AutoUnsealSecret, AutoUnsealSourceKind, auto_unseal_with_secret,
+            disable_vault_and_decrypt_all,
         },
         secrecy::Secret,
         sqlx::SqlitePool,
@@ -325,5 +578,97 @@ mod tests {
             vault.status().await.unwrap(),
             moltis_vault::VaultStatus::Sealed
         );
+    }
+
+    #[tokio::test]
+    async fn disable_vault_decrypts_stored_secrets_before_flipping_config() {
+        let config_dir = tempfile::tempdir().unwrap();
+        moltis_config::set_config_dir(config_dir.path().to_path_buf());
+        let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        moltis_vault::run_migrations(&pool).await.unwrap();
+        create_disable_test_tables(&pool).await;
+        let vault = Arc::new(moltis_vault::Vault::new(pool.clone()).await.unwrap());
+        vault.initialize("test-password-123").await.unwrap();
+
+        let env_ciphertext = vault
+            .encrypt_string("env-secret", "env:API_KEY")
+            .await
+            .unwrap();
+        sqlx::query("INSERT INTO env_variables (id, key, value, encrypted, updated_at) VALUES (1, 'API_KEY', ?, 1, datetime('now'))")
+            .bind(env_ciphertext)
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        let ssh_ciphertext = vault
+            .encrypt_string("private-key", "ssh-key:deploy")
+            .await
+            .unwrap();
+        sqlx::query("INSERT INTO ssh_keys (id, name, private_key, encrypted, updated_at) VALUES (1, 'deploy', ?, 1, datetime('now'))")
+            .bind(ssh_ciphertext)
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        let mut channel_config = serde_json::json!({ "token": "Bot discord-token" });
+        moltis_secret_store::encrypt_secret_fields(
+            &mut channel_config,
+            &["token"],
+            "channel:discord:main",
+            vault.as_ref(),
+        )
+        .await
+        .unwrap();
+        sqlx::query("INSERT INTO channels (channel_type, account_id, config, created_at, updated_at) VALUES ('discord', 'main', ?, 1, 1)")
+            .bind(serde_json::to_string(&channel_config).unwrap())
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        let mut webhook_config = serde_json::json!({ "token": "webhook-token" });
+        moltis_secret_store::encrypt_secret_fields(
+            &mut webhook_config,
+            &["token"],
+            "webhook:config",
+            vault.as_ref(),
+        )
+        .await
+        .unwrap();
+        sqlx::query("INSERT INTO webhooks (id, auth_mode, auth_config_json, source_profile, source_config_json, updated_at) VALUES (1, 'bearer', ?, 'generic', NULL, datetime('now'))")
+            .bind(serde_json::to_string(&webhook_config).unwrap())
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        let report = disable_vault_and_decrypt_all(&vault, &pool).await.unwrap();
+        assert_eq!(report.env_vars, 1);
+        assert_eq!(report.ssh_keys, 1);
+        assert_eq!(report.channels, 1);
+        assert_eq!(report.webhooks, 1);
+
+        let env: (String, i64) =
+            sqlx::query_as("SELECT value, encrypted FROM env_variables WHERE key = 'API_KEY'")
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(env, ("env-secret".to_owned(), 0));
+        let channel: (String,) =
+            sqlx::query_as("SELECT config FROM channels WHERE account_id = 'main'")
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        let channel_json: serde_json::Value = serde_json::from_str(&channel.0).unwrap();
+        assert_eq!(channel_json["token"], "Bot discord-token");
+    }
+
+    async fn create_disable_test_tables(pool: &SqlitePool) {
+        for sql in [
+            "CREATE TABLE env_variables (id INTEGER PRIMARY KEY, key TEXT NOT NULL, value TEXT NOT NULL, encrypted INTEGER NOT NULL DEFAULT 0, updated_at TEXT)",
+            "CREATE TABLE ssh_keys (id INTEGER PRIMARY KEY, name TEXT NOT NULL, private_key TEXT NOT NULL, encrypted INTEGER NOT NULL DEFAULT 0, updated_at TEXT)",
+            "CREATE TABLE channels (channel_type TEXT NOT NULL, account_id TEXT NOT NULL, config TEXT NOT NULL, created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL, PRIMARY KEY (channel_type, account_id))",
+            "CREATE TABLE webhooks (id INTEGER PRIMARY KEY, auth_mode TEXT NOT NULL, auth_config_json TEXT, source_profile TEXT NOT NULL, source_config_json TEXT, updated_at TEXT)",
+        ] {
+            sqlx::query(sql).execute(pool).await.unwrap();
+        }
     }
 }

--- a/crates/gateway/src/vault_lifecycle.rs
+++ b/crates/gateway/src/vault_lifecycle.rs
@@ -549,7 +549,7 @@ mod tests {
     use {
         crate::vault_lifecycle::{
             AutoUnsealResult, AutoUnsealSecret, AutoUnsealSourceKind, auto_unseal_with_secret,
-            disable_vault_and_decrypt_all,
+            disable_vault_and_decrypt_all, set_vault_encryption_runtime_enabled,
         },
         secrecy::Secret,
         sqlx::SqlitePool,
@@ -647,7 +647,9 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial(vault_runtime)]
     async fn disable_vault_decrypts_stored_secrets_before_flipping_config() {
+        set_vault_encryption_runtime_enabled(true);
         let config_dir = tempfile::tempdir().unwrap();
         moltis_config::set_config_dir(config_dir.path().to_path_buf());
         let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
@@ -725,6 +727,7 @@ mod tests {
                 .unwrap();
         let channel_json: serde_json::Value = serde_json::from_str(&channel.0).unwrap();
         assert_eq!(channel_json["token"], "Bot discord-token");
+        set_vault_encryption_runtime_enabled(true);
     }
 
     async fn create_disable_test_tables(pool: &SqlitePool) {

--- a/crates/gateway/src/webhooks.rs
+++ b/crates/gateway/src/webhooks.rs
@@ -74,6 +74,10 @@ async fn encrypt_secret_config(
         return Ok(());
     };
 
+    if !crate::vault_lifecycle::is_vault_encryption_runtime_enabled() {
+        return Ok(());
+    }
+
     let Some(vault) = vault else {
         return Ok(());
     };

--- a/crates/gateway/src/webhooks.rs
+++ b/crates/gateway/src/webhooks.rs
@@ -531,6 +531,7 @@ mod tests {
         Arc<moltis_webhooks::store::SqliteWebhookStore>,
         Arc<moltis_vault::Vault>,
     ) {
+        crate::vault_lifecycle::set_vault_encryption_runtime_enabled(true);
         let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
         moltis_webhooks::run_migrations(&pool).await.unwrap();
         let raw = Arc::new(moltis_webhooks::store::SqliteWebhookStore::with_pool(
@@ -543,6 +544,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial(vault_runtime)]
     async fn vault_store_encrypts_webhook_secret_configs() {
         let (store, raw, vault) = make_store().await;
 
@@ -601,6 +603,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial(vault_runtime)]
     async fn sealed_vault_rejects_plaintext_secret_updates() {
         let (store, _raw, vault) = make_store().await;
         let webhook = store

--- a/crates/httpd/src/auth_middleware.rs
+++ b/crates/httpd/src/auth_middleware.rs
@@ -475,7 +475,10 @@ mod tests {
     async fn auth_disabled_still_requires_setup_for_remote_requests()
     -> Result<(), Box<dyn std::error::Error>> {
         let pool = SqlitePool::connect("sqlite::memory:").await?;
-        let auth_config = moltis_config::AuthConfig { disabled: true };
+        let auth_config = moltis_config::AuthConfig {
+            disabled: true,
+            ..Default::default()
+        };
         let store = CredentialStore::with_config(pool, &auth_config).await?;
         let headers = HeaderMap::new();
 

--- a/crates/httpd/src/auth_routes.rs
+++ b/crates/httpd/src/auth_routes.rs
@@ -97,6 +97,7 @@ fn vault_routes() -> axum::Router<AuthState> {
         .route("/vault/status", get(vault::vault_status_handler))
         .route("/vault/unlock", post(vault::vault_unlock_handler))
         .route("/vault/recovery", post(vault::vault_recovery_handler))
+        .route("/vault/disable", post(vault::vault_disable_handler))
 }
 
 #[cfg(not(feature = "vault"))]

--- a/crates/httpd/src/auth_routes/vault.rs
+++ b/crates/httpd/src/auth_routes/vault.rs
@@ -85,6 +85,61 @@ pub(super) async fn vault_recovery_handler(
     }
 }
 
+#[cfg(feature = "vault")]
+#[derive(serde::Deserialize)]
+pub(super) struct VaultDisableRequest {
+    password: Option<String>,
+}
+
+#[cfg(feature = "vault")]
+pub(super) async fn vault_disable_handler(
+    _session: crate::auth_middleware::AuthSession,
+    State(state): State<AuthState>,
+    Json(body): Json<VaultDisableRequest>,
+) -> impl IntoResponse {
+    let Some(ref vault) = state.gateway_state.vault else {
+        return (StatusCode::NOT_FOUND, "vault not available").into_response();
+    };
+
+    if !vault.is_unsealed().await {
+        let Some(password) = body
+            .password
+            .as_deref()
+            .filter(|password| !password.is_empty())
+        else {
+            return (StatusCode::LOCKED, "unlock the vault before disabling it").into_response();
+        };
+        if let Err(error) = vault.unseal(password).await {
+            return match error {
+                moltis_vault::VaultError::BadCredential => {
+                    (StatusCode::LOCKED, "invalid password").into_response()
+                },
+                other => (StatusCode::INTERNAL_SERVER_ERROR, other.to_string()).into_response(),
+            };
+        }
+    }
+
+    match moltis_gateway::vault_lifecycle::disable_vault_and_decrypt_all(
+        vault,
+        state.credential_store.db_pool(),
+    )
+    .await
+    {
+        Ok(report) => Json(serde_json::json!({
+            "ok": true,
+            "report": {
+                "env_vars": report.env_vars,
+                "ssh_keys": report.ssh_keys,
+                "channels": report.channels,
+                "webhooks": report.webhooks,
+                "provider_keys": report.provider_keys,
+            }
+        }))
+        .into_response(),
+        Err(error) => (StatusCode::INTERNAL_SERVER_ERROR, error.to_string()).into_response(),
+    }
+}
+
 /// Migrate plaintext secrets to encrypted storage after vault unseal.
 #[cfg(feature = "vault")]
 pub(super) async fn run_vault_env_migration(state: &AuthState) {

--- a/crates/httpd/src/auth_routes/vault.rs
+++ b/crates/httpd/src/auth_routes/vault.rs
@@ -125,17 +125,20 @@ pub(super) async fn vault_disable_handler(
     )
     .await
     {
-        Ok(report) => Json(serde_json::json!({
-            "ok": true,
-            "report": {
-                "env_vars": report.env_vars,
-                "ssh_keys": report.ssh_keys,
-                "channels": report.channels,
-                "webhooks": report.webhooks,
-                "provider_keys": report.provider_keys,
-            }
-        }))
-        .into_response(),
+        Ok(report) => {
+            state.credential_store.disable_vault_encryption();
+            Json(serde_json::json!({
+                "ok": true,
+                "report": {
+                    "env_vars": report.env_vars,
+                    "ssh_keys": report.ssh_keys,
+                    "channels": report.channels,
+                    "webhooks": report.webhooks,
+                    "provider_keys": report.provider_keys,
+                }
+            }))
+            .into_response()
+        },
         Err(error) => (StatusCode::INTERNAL_SERVER_ERROR, error.to_string()).into_response(),
     }
 }

--- a/crates/httpd/src/auth_routes/vault.rs
+++ b/crates/httpd/src/auth_routes/vault.rs
@@ -20,7 +20,9 @@ use moltis_gateway::{auth::CredentialStore, state::GatewayState};
 
 #[cfg(feature = "vault")]
 pub(super) async fn vault_status_handler(State(state): State<AuthState>) -> impl IntoResponse {
-    let status = if let Some(ref vault) = state.gateway_state.vault {
+    let status = if !moltis_gateway::vault_lifecycle::is_vault_encryption_runtime_enabled() {
+        "disabled".to_owned()
+    } else if let Some(ref vault) = state.gateway_state.vault {
         match vault.status().await {
             Ok(s) => format!("{s:?}").to_lowercase(),
             Err(_) => "error".to_owned(),
@@ -42,6 +44,9 @@ pub(super) async fn vault_unlock_handler(
     State(state): State<AuthState>,
     Json(body): Json<VaultUnlockRequest>,
 ) -> impl IntoResponse {
+    if !moltis_gateway::vault_lifecycle::is_vault_encryption_runtime_enabled() {
+        return (StatusCode::NOT_FOUND, "vault not available").into_response();
+    }
     let Some(ref vault) = state.gateway_state.vault else {
         return (StatusCode::NOT_FOUND, "vault not available").into_response();
     };
@@ -69,6 +74,9 @@ pub(super) async fn vault_recovery_handler(
     State(state): State<AuthState>,
     Json(body): Json<VaultRecoveryRequest>,
 ) -> impl IntoResponse {
+    if !moltis_gateway::vault_lifecycle::is_vault_encryption_runtime_enabled() {
+        return (StatusCode::NOT_FOUND, "vault not available").into_response();
+    }
     let Some(ref vault) = state.gateway_state.vault else {
         return (StatusCode::NOT_FOUND, "vault not available").into_response();
     };
@@ -97,6 +105,9 @@ pub(super) async fn vault_disable_handler(
     State(state): State<AuthState>,
     Json(body): Json<VaultDisableRequest>,
 ) -> impl IntoResponse {
+    if !moltis_gateway::vault_lifecycle::is_vault_encryption_runtime_enabled() {
+        return (StatusCode::NOT_FOUND, "vault not available").into_response();
+    }
     let Some(ref vault) = state.gateway_state.vault else {
         return (StatusCode::NOT_FOUND, "vault not available").into_response();
     };
@@ -126,6 +137,7 @@ pub(super) async fn vault_disable_handler(
     .await
     {
         Ok(report) => {
+            vault.seal().await;
             state.credential_store.disable_vault_encryption();
             Json(serde_json::json!({
                 "ok": true,

--- a/crates/web/ui/src/pages/sections/VaultSection.tsx
+++ b/crates/web/ui/src/pages/sections/VaultSection.tsx
@@ -8,6 +8,193 @@ import { refresh as refreshGon } from "../../gon";
 import { targetValue } from "../../typed-events";
 import { rerender } from "./_shared";
 
+interface DisabledVaultStateProps {
+	error: string | null;
+	success: string | null;
+}
+
+function DisabledVaultState({ error, success }: DisabledVaultStateProps): VNode {
+	return (
+		<div className="flex-1 flex flex-col min-w-0 p-4 gap-4 overflow-y-auto">
+			<SectionHeading title="Encryption" />
+			<p className="text-xs text-[var(--muted)]">Encryption at rest is disabled or not available in this build.</p>
+			<StatusMessage error={error} success={success} />
+		</div>
+	);
+}
+
+interface DisableVaultFormProps {
+	vaultStatus: string;
+	onDisabled: (message: string) => void;
+	onError: (message: string) => void;
+}
+
+function DisableVaultForm({ vaultStatus, onDisabled, onError }: DisableVaultFormProps): VNode {
+	const [disablePw, setDisablePw] = useState("");
+	const [disabling, setDisabling] = useState(false);
+	const needsPassword = vaultStatus === "sealed";
+
+	function onDisableVault(e: Event): void {
+		e.preventDefault();
+		setDisabling(true);
+		rerender();
+		fetch("/api/auth/vault/disable", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ password: disablePw || undefined }),
+		})
+			.then((r) => {
+				if (r.ok) {
+					setDisablePw("");
+					onDisabled(
+						"Vault disabled. Stored secrets were decrypted; restart Moltis to fully remove vault startup behavior.",
+					);
+					return;
+				}
+				return r.text().then((t) => onError(t || "Disable failed"));
+			})
+			.catch((error: Error) => onError(error.message))
+			.finally(() => {
+				setDisabling(false);
+				rerender();
+			});
+	}
+
+	return (
+		<form onSubmit={onDisableVault} className="mt-6 rounded border border-red-900/50 bg-red-950/20 p-3">
+			<div className="text-sm font-semibold text-red-200">Disable encryption at rest</div>
+			<p className="my-2 text-xs leading-relaxed text-[var(--muted)]">
+				This decrypts stored provider, channel, webhook, environment, and SSH secrets so password login no longer
+				requires unlocking the vault after restart.
+			</p>
+			{needsPassword ? (
+				<input
+					type="password"
+					className="provider-key-input mb-2 w-full"
+					value={disablePw}
+					onInput={(event: Event) => setDisablePw(targetValue(event))}
+					placeholder="Vault password required while locked"
+				/>
+			) : null}
+			<button
+				type="submit"
+				className="provider-btn provider-btn-danger"
+				disabled={disabling || (needsPassword && !disablePw.trim())}
+			>
+				{disabling ? "Disabling..." : "Decrypt secrets and disable vault"}
+			</button>
+		</form>
+	);
+}
+
+interface UnlockFormsProps {
+	unlockPw: string;
+	recoveryKey: string;
+	unlockingPw: boolean;
+	unlockingRk: boolean;
+	onUnlockPw: (event: Event) => void;
+	onUnlockRecovery: (event: Event) => void;
+	onUnlockPwInput: (value: string) => void;
+	onRecoveryKeyInput: (value: string) => void;
+}
+
+function UnlockForms({
+	unlockPw,
+	recoveryKey,
+	unlockingPw,
+	unlockingRk,
+	onUnlockPw,
+	onUnlockRecovery,
+	onUnlockPwInput,
+	onRecoveryKeyInput,
+}: UnlockFormsProps): VNode {
+	return (
+		<div style={{ display: "flex", flexDirection: "column", gap: "12px" }}>
+			<form onSubmit={onUnlockPw} style={{ display: "flex", flexDirection: "column", gap: "6px" }}>
+				<div className="text-xs text-[var(--muted)]">Unlock with password</div>
+				<div style={{ display: "flex", gap: "8px", alignItems: "center" }}>
+					<input
+						type="password"
+						className="provider-key-input"
+						style={{ flex: 1 }}
+						value={unlockPw}
+						onInput={(e: Event) => onUnlockPwInput(targetValue(e))}
+						placeholder="Your password"
+					/>
+					<button type="submit" className="provider-btn" disabled={unlockingPw || !unlockPw.trim()}>
+						{unlockingPw ? "Unlocking..." : "Unlock"}
+					</button>
+				</div>
+			</form>
+			<div style={{ display: "flex", alignItems: "center", gap: "8px" }}>
+				<div style={{ flex: 1, borderTop: "1px solid var(--border)" }} />
+				<span className="text-xs text-[var(--muted)]">or</span>
+				<div style={{ flex: 1, borderTop: "1px solid var(--border)" }} />
+			</div>
+			<form onSubmit={onUnlockRecovery} style={{ display: "flex", flexDirection: "column", gap: "6px" }}>
+				<div className="text-xs text-[var(--muted)]">Unlock with recovery key</div>
+				<div style={{ display: "flex", gap: "8px", alignItems: "center" }}>
+					<input
+						type="password"
+						className="provider-key-input"
+						style={{ flex: 1, fontFamily: "var(--font-mono)", fontSize: ".78rem" }}
+						value={recoveryKey}
+						onInput={(e: Event) => onRecoveryKeyInput(targetValue(e))}
+						placeholder="XXXX-XXXX-XXXX-XXXX-XXXX-XXXX-XXXX-XXXX"
+					/>
+					<button type="submit" className="provider-btn" disabled={unlockingRk || !recoveryKey.trim()}>
+						{unlockingRk ? "Unlocking..." : "Unlock"}
+					</button>
+				</div>
+			</form>
+		</div>
+	);
+}
+
+function VaultIntro(): VNode {
+	return (
+		<div className="rounded border border-[var(--border)] bg-[var(--surface2)] p-3 mb-4">
+			<p className="text-xs text-[var(--muted)] leading-relaxed m-0 mb-1.5">
+				Your API keys and secrets are encrypted at rest using{" "}
+				<strong className="text-[var(--text)]">XChaCha20-Poly1305</strong> AEAD with keys derived from your password via{" "}
+				<strong className="text-[var(--text)]">Argon2id</strong>.
+			</p>
+			<p className="text-xs text-[var(--muted)] leading-relaxed m-0 mb-1.5">
+				The vault uses a two-layer key hierarchy: your password derives a Key Encryption Key (KEK) which unwraps a
+				random 256-bit Data Encryption Key (DEK). Changing your password only re-wraps the DEK; all encrypted data stays
+				intact. A recovery key (shown once at setup) provides emergency access if you forget your password.
+			</p>
+			<p className="text-xs text-[var(--muted)] leading-relaxed m-0">
+				The vault locks automatically when the server restarts and unlocks when you log in.
+			</p>
+		</div>
+	);
+}
+
+interface VaultStatusRowProps {
+	vaultStatus: string;
+}
+
+function VaultStatusRow({ vaultStatus }: VaultStatusRowProps): VNode {
+	const label = vaultStatus === "unsealed" ? "Unlocked" : vaultStatus === "sealed" ? "Locked" : "Off";
+	const detail =
+		vaultStatus === "unsealed"
+			? "Your API keys and secrets are encrypted in the database. Everything is working."
+			: vaultStatus === "sealed"
+				? "Log in or unlock below to access your encrypted keys."
+				: "Set a password in Authentication settings to start encrypting your stored keys.";
+	return (
+		<div style={{ display: "flex", alignItems: "center", gap: "8px", marginBottom: "12px" }}>
+			<span
+				className={`provider-item-badge ${vaultStatus === "unsealed" ? "configured" : vaultStatus === "sealed" ? "warning" : "muted"}`}
+			>
+				{label}
+			</span>
+			<span className="text-xs text-[var(--muted)]">{detail}</span>
+		</div>
+	);
+}
+
 export function VaultSection(): VNode {
 	const [vaultStatus, setVaultStatus] = useState(gon.get("vault_status") || null);
 	const [unlockPw, setUnlockPw] = useState("");
@@ -70,12 +257,18 @@ export function VaultSection(): VNode {
 	}
 
 	if (!vaultStatus || vaultStatus === "disabled") {
-		return (
-			<div className="flex-1 flex flex-col min-w-0 p-4 gap-4 overflow-y-auto">
-				<SectionHeading title="Encryption" />
-				<p className="text-xs text-[var(--muted)]">Encryption at rest is not available in this build.</p>
-			</div>
-		);
+		return <DisabledVaultState error={err} success={msg} />;
+	}
+
+	function onVaultDisabled(message: string): void {
+		setErr(null);
+		setMsg(message);
+		setVaultStatus("disabled");
+	}
+
+	function onVaultDisableError(message: string): void {
+		setMsg(null);
+		setErr(message);
 	}
 
 	return (
@@ -83,79 +276,20 @@ export function VaultSection(): VNode {
 			<SectionHeading title="Encryption" />
 
 			<div style={{ maxWidth: "600px" }}>
-				<div className="rounded border border-[var(--border)] bg-[var(--surface2)] p-3 mb-4">
-					<p className="text-xs text-[var(--muted)] leading-relaxed m-0 mb-1.5">
-						Your API keys and secrets are encrypted at rest using{" "}
-						<strong className="text-[var(--text)]">XChaCha20-Poly1305</strong> AEAD with keys derived from your password
-						via <strong className="text-[var(--text)]">Argon2id</strong>.
-					</p>
-					<p className="text-xs text-[var(--muted)] leading-relaxed m-0 mb-1.5">
-						The vault uses a two-layer key hierarchy: your password derives a Key Encryption Key (KEK) which unwraps a
-						random 256-bit Data Encryption Key (DEK). Changing your password only re-wraps the DEK {"\u2014"} all
-						encrypted data stays intact. A recovery key (shown once at setup) provides emergency access if you forget
-						your password.
-					</p>
-					<p className="text-xs text-[var(--muted)] leading-relaxed m-0">
-						The vault locks automatically when the server restarts and unlocks when you log in.
-					</p>
-				</div>
-
-				<div style={{ display: "flex", alignItems: "center", gap: "8px", marginBottom: "12px" }}>
-					<span
-						className={`provider-item-badge ${vaultStatus === "unsealed" ? "configured" : vaultStatus === "sealed" ? "warning" : "muted"}`}
-					>
-						{vaultStatus === "unsealed" ? "Unlocked" : vaultStatus === "sealed" ? "Locked" : "Off"}
-					</span>
-					<span className="text-xs text-[var(--muted)]">
-						{vaultStatus === "unsealed"
-							? "Your API keys and secrets are encrypted in the database. Everything is working."
-							: vaultStatus === "sealed"
-								? "Log in or unlock below to access your encrypted keys."
-								: "Set a password in Authentication settings to start encrypting your stored keys."}
-					</span>
-				</div>
+				<VaultIntro />
+				<VaultStatusRow vaultStatus={vaultStatus} />
 
 				{vaultStatus === "sealed" ? (
-					<div style={{ display: "flex", flexDirection: "column", gap: "12px" }}>
-						<form onSubmit={onUnlockPw} style={{ display: "flex", flexDirection: "column", gap: "6px" }}>
-							<div className="text-xs text-[var(--muted)]">Unlock with password</div>
-							<div style={{ display: "flex", gap: "8px", alignItems: "center" }}>
-								<input
-									type="password"
-									className="provider-key-input"
-									style={{ flex: 1 }}
-									value={unlockPw}
-									onInput={(e: Event) => setUnlockPw(targetValue(e))}
-									placeholder="Your password"
-								/>
-								<button type="submit" className="provider-btn" disabled={unlockingPw || !unlockPw.trim()}>
-									{unlockingPw ? "Unlocking\u2026" : "Unlock"}
-								</button>
-							</div>
-						</form>
-						<div style={{ display: "flex", alignItems: "center", gap: "8px" }}>
-							<div style={{ flex: 1, borderTop: "1px solid var(--border)" }} />
-							<span className="text-xs text-[var(--muted)]">or</span>
-							<div style={{ flex: 1, borderTop: "1px solid var(--border)" }} />
-						</div>
-						<form onSubmit={onUnlockRecovery} style={{ display: "flex", flexDirection: "column", gap: "6px" }}>
-							<div className="text-xs text-[var(--muted)]">Unlock with recovery key</div>
-							<div style={{ display: "flex", gap: "8px", alignItems: "center" }}>
-								<input
-									type="password"
-									className="provider-key-input"
-									style={{ flex: 1, fontFamily: "var(--font-mono)", fontSize: ".78rem" }}
-									value={recoveryKey}
-									onInput={(e: Event) => setRecoveryKey(targetValue(e))}
-									placeholder="XXXX-XXXX-XXXX-XXXX-XXXX-XXXX-XXXX-XXXX"
-								/>
-								<button type="submit" className="provider-btn" disabled={unlockingRk || !recoveryKey.trim()}>
-									{unlockingRk ? "Unlocking\u2026" : "Unlock"}
-								</button>
-							</div>
-						</form>
-						<StatusMessage error={err} success={msg} />
-					</div>
+					<UnlockForms
+						unlockPw={unlockPw}
+						recoveryKey={recoveryKey}
+						unlockingPw={unlockingPw}
+						unlockingRk={unlockingRk}
+						onUnlockPw={onUnlockPw}
+						onUnlockRecovery={onUnlockRecovery}
+						onUnlockPwInput={setUnlockPw}
+						onRecoveryKeyInput={setRecoveryKey}
+					/>
 				) : null}
 
 				{vaultStatus === "uninitialized" ? (
@@ -169,6 +303,12 @@ export function VaultSection(): VNode {
 						</a>
 					</div>
 				) : null}
+
+				{vaultStatus === "unsealed" || vaultStatus === "sealed" ? (
+					<DisableVaultForm vaultStatus={vaultStatus} onDisabled={onVaultDisabled} onError={onVaultDisableError} />
+				) : null}
+
+				<StatusMessage error={err} success={msg} />
 			</div>
 		</div>
 	);

--- a/docs/src/configuration-reference.md
+++ b/docs/src/configuration-reference.md
@@ -143,6 +143,7 @@ Authentication configuration.
 | Key | Type | Default | Description |
 |---|---|---|---|
 | `disabled` | bool | `false` | When `true`, authentication is explicitly disabled (no login required). |
+| `vault_enabled` | bool | `true` | When `true`, stored secrets are encrypted at rest using the password-backed vault. Set `false` to keep password auth without vault unlocks after restart. |
 
 
 ### `tls` — TlsConfig

--- a/docs/src/vault.md
+++ b/docs/src/vault.md
@@ -9,6 +9,10 @@ The vault is enabled by default (the `vault` cargo feature) and requires
 no configuration. It initializes automatically when you set your first
 password (during setup or later in **Settings > Authentication**).
 
+Set `auth.vault_enabled = false` to keep password authentication without
+encrypting stored secrets at rest. Existing installs keep vault behavior on
+upgrade because the default is `true`.
+
 ## Key Hierarchy
 
 The vault uses a two-layer key hierarchy to separate the encryption key
@@ -166,6 +170,8 @@ Currently encrypted:
 |------|---------|-----|
 | Environment variables (`env_variables` table) | SQLite | `env:{key}` |
 | Managed SSH private keys (`ssh_keys` table) | SQLite | `ssh-key:{name}` |
+| Channel account secrets, including Discord bot tokens | SQLite | `channel:{type}:{account_id}:{field}` |
+| Webhook auth/source secrets | SQLite | `webhook:config:{field}` |
 | Provider API keys (`provider_keys.json.enc`) | File | `provider_keys` |
 
 The `encrypted` column in `env_variables` and `ssh_keys` tracks whether each
@@ -216,14 +222,28 @@ Allowed through regardless of vault state:
 
 ## API Endpoints
 
-All vault endpoints are under `/api/auth/vault/` and require no session
-(they are on the public auth allowlist):
+Vault unlock endpoints are under `/api/auth/vault/`. Unlock and recovery are
+available before login so a sealed vault can be opened during authentication.
+Disabling the vault requires an authenticated session.
 
 | Method | Path | Purpose |
 |--------|------|---------|
 | `GET` | `/api/auth/vault/status` | Returns `{"status": "uninitialized"\|"sealed"\|"unsealed"\|"disabled"}` |
 | `POST` | `/api/auth/vault/unlock` | Unseal with password: `{"password": "..."}` |
 | `POST` | `/api/auth/vault/recovery` | Unseal with recovery key: `{"recovery_key": "..."}` |
+| `POST` | `/api/auth/vault/disable` | Decrypt stored secrets and set `auth.vault_enabled = false`; accepts `{"password":"..."}` when sealed. |
+
+## Disabling The Vault
+
+Use **Settings > Encryption > Disable encryption at rest** to opt out of the
+vault while keeping password login. Moltis decrypts all known vault-backed data
+before writing `auth.vault_enabled = false`; if any decrypt step fails, the flag
+is not changed.
+
+After disabling, restart Moltis so startup no longer wires the vault into auth,
+channel, webhook, env-var, and SSH secret storage. Local secrets remain on disk
+as plaintext, so only use this mode on trusted machines with appropriate file
+and disk protections.
 
 Error responses:
 

--- a/docs/src/vault.md
+++ b/docs/src/vault.md
@@ -241,9 +241,11 @@ before writing `auth.vault_enabled = false`; if any decrypt step fails, the flag
 is not changed.
 
 After disabling, restart Moltis so startup no longer wires the vault into auth,
-channel, webhook, env-var, and SSH secret storage. Local secrets remain on disk
-as plaintext, so only use this mode on trusted machines with appropriate file
-and disk protections.
+channel, webhook, env-var, and SSH secret storage. The running process also
+stops encrypting new secret writes immediately after a successful disable, so
+secrets added before the restart remain readable in no-vault mode. Local secrets
+remain on disk as plaintext, so only use this mode on trusted machines with
+appropriate file and disk protections.
 
 Error responses:
 


### PR DESCRIPTION
## Summary
- Add `auth.vault_enabled` as an opt-out switch so password authentication can run without wiring the vault on startup.
- Add an authenticated vault-disable API and Settings UI action that decrypts env vars, SSH keys, channel secrets, webhook secrets, and provider key copies before flipping the config flag.
- Document the tradeoff and update config schema/template/reference coverage.

## Validation
### Completed
- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p moltis-gateway vault_lifecycle --features vault,discord`
- [x] `cargo check -p moltis-httpd --features vault,discord`
- [x] `cargo check -p moltis-httpd`
- [x] `cargo check -p moltis-config`
- [x] `cd crates/web/ui && npm run build`
- [x] `cd crates/web/ui && npx tsc --noEmit`
- [x] `biome check --write crates/web/ui/src/pages/sections/VaultSection.tsx`

### Remaining
- [ ] `biome check --write crates/web/ui/src/` is blocked by existing warnings across unrelated files (for example `chat-ui.ts`, `SessionHeader.tsx`, `SessionList.tsx`). The touched file passes targeted Biome.
- [ ] Full Playwright E2E suite not run locally.

## Manual QA
- Not run. Suggested QA: create a vault-backed install with a stored Discord account, env var, SSH key, webhook secret, and provider key; unlock vault; use Settings > Encryption > Disable encryption at rest; restart; verify Discord starts without vault unlock and stored secrets are readable as plaintext.