### PR TITLE
fix(telephony): dispatch Twilio gather speech

### DIFF
--- a/crates/httpd/src/server/gateway.rs
+++ b/crates/httpd/src/server/gateway.rs
@@ -72,6 +72,31 @@ fn telephony_webhook_url(
     ))
 }
 
+#[cfg(feature = "telephony")]
+fn telnyx_payload_string(payload: &serde_json::Value, field: &str) -> Option<String> {
+    payload[field]
+        .as_str()
+        .or_else(|| payload[field]["phone_number"].as_str())
+        .map(ToOwned::to_owned)
+}
+
+#[cfg(feature = "telephony")]
+fn telnyx_call_fields(body: &[u8]) -> (String, String, String) {
+    let payload = serde_json::from_slice::<serde_json::Value>(body)
+        .ok()
+        .and_then(|value| value["data"]["payload"].as_object().cloned())
+        .map(serde_json::Value::Object)
+        .unwrap_or_default();
+
+    let call_control_id = payload["call_control_id"]
+        .as_str()
+        .unwrap_or("")
+        .to_string();
+    let from = telnyx_payload_string(&payload, "from").unwrap_or_else(|| "unknown".to_string());
+    let to = telnyx_payload_string(&payload, "to").unwrap_or_else(|| "unknown".to_string());
+    (call_control_id, from, to)
+}
+
 /// Prepare the full gateway: load config, run migrations, wire services,
 /// spawn background tasks, and return the composed axum application.
 ///
@@ -634,7 +659,7 @@ pub async fn prepare_gateway(
             ),
         );
 
-        // Answer URL — Twilio fetches TwiML from here when a call connects
+        // Answer URL — providers fetch call instructions here when a call connects.
         let telephony_answer_plugin = Arc::clone(&telephony_webhook_plugin);
         let telephony_config_for_answer = config.clone();
         app = app.route(
@@ -674,6 +699,122 @@ pub async fn prepare_gateway(
                                 tracing::warn!(account_id = %account_id, "telephony answer webhook verification failed: {e}");
                                 return (StatusCode::UNAUTHORIZED, "signature verification failed").into_response();
                             }
+                        }
+
+                        if manager.provider().read().await.id() == "telnyx" {
+                            let provider = manager.provider().read().await;
+                            let event = match provider.parse_webhook_event(&headers, &body) {
+                                Ok(event) => event,
+                                Err(e) => {
+                                    tracing::warn!(account_id = %account_id, "telephony Telnyx answer webhook parse error: {e}");
+                                    return (StatusCode::BAD_REQUEST, Json(serde_json::json!({"ok": false, "error": e.to_string()}))).into_response();
+                                },
+                            };
+
+                            match event {
+                                moltis_telephony::types::CallEvent::Initiated {
+                                    ref provider_call_id,
+                                } => {
+                                    let (_, caller, called) = telnyx_call_fields(&body);
+                                    let existing_call = manager
+                                        .resolve_call_id(provider_call_id)
+                                        .and_then(|call_id| manager.get_call(&call_id));
+                                    if let Some(config_view) = plugin_guard.account_config(&account_id)
+                                    {
+                                        let policy = config_view.dm_policy();
+                                        let rejected = match policy {
+                                            moltis_channels::gating::DmPolicy::Disabled => true,
+                                            moltis_channels::gating::DmPolicy::Allowlist => {
+                                                !moltis_channels::gating::is_allowed(
+                                                    &caller,
+                                                    config_view.allowlist(),
+                                                )
+                                            },
+                                            moltis_channels::gating::DmPolicy::Open => false,
+                                        };
+                                        if rejected {
+                                            tracing::info!(account_id = %account_id, caller = %caller, "rejecting Telnyx inbound call");
+                                            let _ = provider.hangup_call(provider_call_id).await;
+                                            return (StatusCode::OK, Json(serde_json::json!({"ok": true}))).into_response();
+                                        }
+                                    }
+
+                                    if existing_call.is_none() {
+                                        manager.register_inbound(
+                                            provider_call_id,
+                                            &caller,
+                                            &called,
+                                            &account_id,
+                                        );
+                                    }
+
+                                    let is_conversation = existing_call
+                                        .as_ref()
+                                        .map(|call| {
+                                            matches!(
+                                                call.mode,
+                                                moltis_telephony::types::CallMode::Conversation
+                                            )
+                                        })
+                                        .unwrap_or(true);
+                                    let greeting = existing_call
+                                        .as_ref()
+                                        .and_then(|call| call.initial_message.as_deref())
+                                        .unwrap_or(
+                                            "Hello, you've reached the AI assistant. How can I help you?",
+                                        );
+
+                                    if let Err(e) = provider.answer_call(provider_call_id).await {
+                                        tracing::warn!(account_id = %account_id, provider_call_id = %provider_call_id, "failed to answer Telnyx call: {e}");
+                                    }
+                                    if let Err(e) = provider.play_tts(provider_call_id, greeting, None, None).await {
+                                        tracing::warn!(account_id = %account_id, provider_call_id = %provider_call_id, "failed to greet Telnyx call: {e}");
+                                    }
+                                    if is_conversation && let Err(e) = provider.start_transcription(provider_call_id).await {
+                                        tracing::warn!(account_id = %account_id, provider_call_id = %provider_call_id, "failed to start Telnyx transcription: {e}");
+                                    }
+                                },
+                                moltis_telephony::types::CallEvent::Speech {
+                                    ref provider_call_id,
+                                    ref text,
+                                    ..
+                                } => {
+                                    drop(provider);
+                                    manager.handle_event(&event);
+                                    let call_id = manager
+                                        .resolve_call_id(provider_call_id)
+                                        .unwrap_or_default();
+                                    if call_id.is_empty() {
+                                        tracing::warn!(account_id = %account_id, provider_call_id = %provider_call_id, "Telnyx transcription for unknown call");
+                                        return (StatusCode::OK, Json(serde_json::json!({"ok": true}))).into_response();
+                                    }
+                                    let caller = manager
+                                        .get_call(&call_id)
+                                        .map(|r| r.from.clone())
+                                        .unwrap_or_default();
+                                    let account_id_owned = account_id.clone();
+                                    let call_id_owned = call_id.clone();
+                                    let text_owned = text.clone();
+                                    let plugin_for_dispatch = Arc::clone(&plugin);
+                                    tokio::spawn(async move {
+                                        let pg = plugin_for_dispatch.read().await;
+                                        pg.dispatch_speech(
+                                            &account_id_owned,
+                                            &call_id_owned,
+                                            &caller,
+                                            &text_owned,
+                                        )
+                                        .await;
+                                    });
+                                },
+                                ref other => {
+                                    tracing::debug!(account_id = %account_id, event = ?other, "handling Telnyx telephony event");
+                                    manager.handle_event(other);
+                                },
+                            }
+
+                            return (StatusCode::OK, Json(serde_json::json!({"ok": true})))
+                                .into_response();
                         }
 
                         // Parse inbound call info from body

--- a/crates/httpd/src/server/gateway.rs
+++ b/crates/httpd/src/server/gateway.rs
@@ -1026,14 +1026,22 @@ pub async fn prepare_gateway(
                                             provider_call_id = %provider_call_id,
                                             "telephony gather speech for unknown call"
                                         );
-                                    } else {
-                                        tracing::debug!(
-                                            account_id = %account_id,
-                                            provider_call_id = %provider_call_id,
-                                            call_id = %call_id,
-                                            "telephony gather dispatching speech"
-                                        );
+                                        let provider = manager.provider().read().await;
+                                        let twiml = provider.build_gather_response(None, &webhook_url);
+                                        return (
+                                            StatusCode::OK,
+                                            [(axum::http::header::CONTENT_TYPE, "text/xml")],
+                                            twiml,
+                                        )
+                                            .into_response();
                                     }
+
+                                    tracing::debug!(
+                                        account_id = %account_id,
+                                        provider_call_id = %provider_call_id,
+                                        call_id = %call_id,
+                                        "telephony gather dispatching speech"
+                                    );
 
                                     // Look up the caller from the call record.
                                     let caller = manager

--- a/crates/httpd/src/server/gateway.rs
+++ b/crates/httpd/src/server/gateway.rs
@@ -838,6 +838,33 @@ pub async fn prepare_gateway(
 
                         match provider.parse_webhook_event(&headers, &body) {
                             Ok(event) => {
+                                match &event {
+                                    moltis_telephony::types::CallEvent::Speech {
+                                        provider_call_id,
+                                        text,
+                                        confidence,
+                                    } => tracing::debug!(
+                                        account_id = %account_id,
+                                        provider_call_id = %provider_call_id,
+                                        speech_len = text.len(),
+                                        confidence = ?confidence,
+                                        "telephony gather received speech"
+                                    ),
+                                    moltis_telephony::types::CallEvent::Dtmf {
+                                        provider_call_id,
+                                        ..
+                                    } => tracing::debug!(
+                                        account_id = %account_id,
+                                        provider_call_id = %provider_call_id,
+                                        "telephony gather received DTMF"
+                                    ),
+                                    other => tracing::debug!(
+                                        account_id = %account_id,
+                                        event = ?other,
+                                        "telephony gather parsed non-input event"
+                                    ),
+                                }
+
                                 drop(provider);
                                 manager.handle_event(&event);
 
@@ -851,6 +878,21 @@ pub async fn prepare_gateway(
                                     let call_id = manager
                                         .resolve_call_id(provider_call_id)
                                         .unwrap_or_default();
+
+                                    if call_id.is_empty() {
+                                        tracing::warn!(
+                                            account_id = %account_id,
+                                            provider_call_id = %provider_call_id,
+                                            "telephony gather speech for unknown call"
+                                        );
+                                    } else {
+                                        tracing::debug!(
+                                            account_id = %account_id,
+                                            provider_call_id = %provider_call_id,
+                                            call_id = %call_id,
+                                            "telephony gather dispatching speech"
+                                        );
+                                    }
 
                                     // Look up the caller from the call record.
                                     let caller = manager

--- a/crates/telephony/src/plugin.rs
+++ b/crates/telephony/src/plugin.rs
@@ -305,7 +305,77 @@ impl ChannelPlugin for TelephonyPlugin {
 
 #[cfg(test)]
 mod tests {
-    use {super::*, crate::providers::mock::MockProvider};
+    use {
+        super::*,
+        crate::providers::mock::MockProvider,
+        async_trait::async_trait,
+        moltis_channels::{ChannelEvent, ChannelMessageMeta, ChannelReplyTarget, ChannelType},
+        std::sync::Mutex,
+    };
+
+    #[derive(Clone)]
+    struct CapturedDispatch {
+        text: String,
+        reply_to: ChannelReplyTarget,
+        meta: ChannelMessageMeta,
+    }
+
+    struct CapturingSink {
+        dispatches: Mutex<Vec<CapturedDispatch>>,
+    }
+
+    impl CapturingSink {
+        fn new() -> Self {
+            Self {
+                dispatches: Mutex::new(Vec::new()),
+            }
+        }
+
+        fn dispatches(&self) -> Vec<CapturedDispatch> {
+            self.dispatches
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .clone()
+        }
+    }
+
+    #[async_trait]
+    impl ChannelEventSink for CapturingSink {
+        async fn emit(&self, _event: ChannelEvent) {}
+
+        async fn dispatch_to_chat(
+            &self,
+            text: &str,
+            reply_to: ChannelReplyTarget,
+            meta: ChannelMessageMeta,
+        ) {
+            self.dispatches
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .push(CapturedDispatch {
+                    text: text.to_string(),
+                    reply_to,
+                    meta,
+                });
+        }
+
+        async fn dispatch_command(
+            &self,
+            _command: &str,
+            _reply_to: ChannelReplyTarget,
+            _sender_id: Option<&str>,
+        ) -> moltis_channels::Result<String> {
+            Ok(String::new())
+        }
+
+        async fn request_disable_account(
+            &self,
+            _channel_type: &str,
+            _account_id: &str,
+            _reason: &str,
+        ) {
+        }
+    }
 
     fn twilio_config(from_number: &str) -> serde_json::Value {
         serde_json::json!({
@@ -393,5 +463,49 @@ mod tests {
             plugin.routing_outbound.gather_url(account_id).as_deref(),
             Some("https://calls.example.com/base/api/channels/telephony/default/gather")
         );
+    }
+
+    #[tokio::test]
+    async fn dispatch_speech_sends_voice_message_to_event_sink() {
+        let account_id = "default";
+        let sink = Arc::new(CapturingSink::new());
+        let manager = Arc::new(RwLock::new(CallManager::new(
+            Box::new(MockProvider::new()),
+            60,
+        )));
+        let mut plugin = TelephonyPlugin::new().with_event_sink(sink.clone());
+        plugin.set_test_account(
+            account_id.to_string(),
+            TelephonyAccountConfig {
+                from_number: "+15550000002".to_string(),
+                model: Some("anthropic/claude-test".to_string()),
+                agent_id: Some("phone-agent".to_string()),
+                ..TelephonyAccountConfig::default()
+            },
+            manager,
+        );
+
+        plugin
+            .dispatch_speech(account_id, "call-123", "+15551112222", "hello world")
+            .await;
+
+        let dispatches = sink.dispatches();
+        assert_eq!(dispatches.len(), 1);
+        let captured = &dispatches[0];
+        assert_eq!(captured.text, "hello world");
+        assert_eq!(captured.reply_to.channel_type, ChannelType::Telephony);
+        assert_eq!(captured.reply_to.account_id, account_id);
+        assert_eq!(captured.reply_to.chat_id, "call-123");
+        assert_eq!(captured.meta.channel_type, ChannelType::Telephony);
+        assert_eq!(captured.meta.sender_id.as_deref(), Some("+15551112222"));
+        assert!(matches!(
+            captured.meta.message_kind,
+            Some(moltis_channels::ChannelMessageKind::Voice)
+        ));
+        assert_eq!(
+            captured.meta.model.as_deref(),
+            Some("anthropic/claude-test")
+        );
+        assert_eq!(captured.meta.agent_id.as_deref(), Some("phone-agent"));
     }
 }

--- a/crates/telephony/src/provider.rs
+++ b/crates/telephony/src/provider.rs
@@ -70,6 +70,16 @@ pub trait TelephonyProvider: Send + Sync {
     /// Send DTMF digits to the remote party.
     async fn send_dtmf(&self, provider_call_id: &str, digits: &str) -> anyhow::Result<()>;
 
+    /// Answer an inbound call when the provider requires an API call instead of response XML.
+    async fn answer_call(&self, _provider_call_id: &str) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    /// Start provider-side transcription for an answered call when required.
+    async fn start_transcription(&self, _provider_call_id: &str) -> anyhow::Result<()> {
+        Ok(())
+    }
+
     /// Query the provider for current call status.
     async fn get_call_status(&self, provider_call_id: &str) -> anyhow::Result<ProviderCallStatus>;
 

--- a/crates/telephony/src/providers/plivo.rs
+++ b/crates/telephony/src/providers/plivo.rs
@@ -332,7 +332,7 @@ impl TelephonyProvider for PlivoProvider {
         if let Some(url) = gather_url {
             let url = xml_escape(url);
             xml.push_str(&format!(
-                r#"<GetInput action="{url}" method="POST" inputType="speech" speechEndTimeout="auto">"#
+                r#"<GetInput action="{url}" method="POST" inputType="dtmf speech" speechEndTimeout="auto">"#
             ));
             if let Some(msg) = message {
                 xml.push_str(&format!(
@@ -357,7 +357,7 @@ impl TelephonyProvider for PlivoProvider {
         let mut xml = String::from(r#"<?xml version="1.0" encoding="UTF-8"?><Response>"#);
         let action_url = xml_escape(action_url);
         xml.push_str(&format!(
-            r#"<GetInput action="{action_url}" method="POST" inputType="speech" speechEndTimeout="auto">"#
+            r#"<GetInput action="{action_url}" method="POST" inputType="dtmf speech" speechEndTimeout="auto">"#
         ));
         if let Some(p) = prompt {
             xml.push_str(&format!(
@@ -522,6 +522,7 @@ mod tests {
             provider.build_answer_response(Some("Hello"), Some("https://example.com/gather"));
         let xml = std::str::from_utf8(&resp).unwrap_or("");
         assert!(xml.contains("<GetInput"));
+        assert!(xml.contains(r#"inputType="dtmf speech""#));
         assert!(xml.contains("Hello"));
         assert!(xml.contains("https://example.com/gather"));
     }
@@ -538,6 +539,7 @@ mod tests {
 
         let gather = provider.build_gather_response(None, url);
         let gather_xml = std::str::from_utf8(&gather).unwrap_or("");
+        assert!(gather_xml.contains(r#"inputType="dtmf speech""#));
         assert!(gather_xml.contains("foo=1&amp;bar=&quot;two&quot;"));
         assert!(!gather_xml.contains("foo=1&bar=\"two\""));
     }

--- a/crates/telephony/src/providers/telnyx.rs
+++ b/crates/telephony/src/providers/telnyx.rs
@@ -201,6 +201,50 @@ impl TelephonyProvider for TelnyxProvider {
         Ok(())
     }
 
+    async fn answer_call(&self, provider_call_id: &str) -> anyhow::Result<()> {
+        let url = format!("{}/calls/{provider_call_id}/actions/answer", self.base_url);
+
+        let resp = self
+            .client
+            .post(&url)
+            .header("Authorization", self.auth_header())
+            .header("Content-Type", "application/json")
+            .json(&serde_json::json!({ "command_id": uuid::Uuid::new_v4().to_string() }))
+            .send()
+            .await?;
+
+        if !resp.status().is_success() {
+            let text = resp.text().await.unwrap_or_default();
+            anyhow::bail!("Telnyx answer failed: {text}");
+        }
+        Ok(())
+    }
+
+    async fn start_transcription(&self, provider_call_id: &str) -> anyhow::Result<()> {
+        let url = format!(
+            "{}/calls/{provider_call_id}/actions/transcription_start",
+            self.base_url
+        );
+
+        let resp = self
+            .client
+            .post(&url)
+            .header("Authorization", self.auth_header())
+            .header("Content-Type", "application/json")
+            .json(&serde_json::json!({
+                "command_id": uuid::Uuid::new_v4().to_string(),
+                "language": "en",
+            }))
+            .send()
+            .await?;
+
+        if !resp.status().is_success() {
+            let text = resp.text().await.unwrap_or_default();
+            anyhow::bail!("Telnyx transcription_start failed: {text}");
+        }
+        Ok(())
+    }
+
     async fn get_call_status(&self, provider_call_id: &str) -> anyhow::Result<ProviderCallStatus> {
         let url = format!("{}/calls/{provider_call_id}", self.base_url);
 
@@ -599,5 +643,29 @@ mod tests {
         let message = error.to_string();
         assert!(message.contains("Telnyx API error 404"));
         assert!(message.contains("not found"));
+    }
+
+    #[tokio::test]
+    async fn answer_call_accepts_success_response() {
+        let base_url = serve_telnyx_response("200 OK", r#"{"data":{"result":"ok"}}"#).await;
+        let provider =
+            TelnyxProvider::new(Secret::new("key".into()), "conn".into()).with_base_url(base_url);
+
+        provider
+            .answer_call("call-123")
+            .await
+            .unwrap_or_else(|error| panic!("answer should succeed: {error}"));
+    }
+
+    #[tokio::test]
+    async fn start_transcription_accepts_success_response() {
+        let base_url = serve_telnyx_response("200 OK", r#"{"data":{"result":"ok"}}"#).await;
+        let provider =
+            TelnyxProvider::new(Secret::new("key".into()), "conn".into()).with_base_url(base_url);
+
+        provider
+            .start_transcription("call-123")
+            .await
+            .unwrap_or_else(|error| panic!("transcription start should succeed: {error}"));
     }
 }

--- a/crates/telephony/src/providers/twilio.rs
+++ b/crates/telephony/src/providers/twilio.rs
@@ -268,6 +268,21 @@ impl TelephonyProvider for TwilioProvider {
 
         let call_sid = params.get("CallSid").cloned().unwrap_or_default();
 
+        if let Some(speech) = params.get("SpeechResult") {
+            let confidence = params.get("Confidence").and_then(|c| c.parse::<f32>().ok());
+            return Ok(CallEvent::Speech {
+                provider_call_id: call_sid,
+                text: speech.clone(),
+                confidence,
+            });
+        }
+        if let Some(digits) = params.get("Digits") {
+            return Ok(CallEvent::Dtmf {
+                provider_call_id: call_sid,
+                digits: digits.clone(),
+            });
+        }
+
         let status = params.get("CallStatus").map(String::as_str).unwrap_or("");
 
         match status {
@@ -297,21 +312,6 @@ impl TelephonyProvider for TwilioProvider {
                 reason: CallEndReason::Error,
             }),
             other => {
-                // Check for speech result from <Gather>.
-                if let Some(speech) = params.get("SpeechResult") {
-                    let confidence = params.get("Confidence").and_then(|c| c.parse::<f32>().ok());
-                    return Ok(CallEvent::Speech {
-                        provider_call_id: call_sid,
-                        text: speech.clone(),
-                        confidence,
-                    });
-                }
-                if let Some(digits) = params.get("Digits") {
-                    return Ok(CallEvent::Dtmf {
-                        provider_call_id: call_sid,
-                        digits: digits.clone(),
-                    });
-                }
                 debug!(status = %other, "unrecognized Twilio status, treating as error");
                 Ok(CallEvent::Error {
                     provider_call_id: call_sid,
@@ -543,6 +543,29 @@ mod tests {
     }
 
     #[test]
+    fn parse_webhook_speech_result_with_in_progress_status() {
+        let provider = TwilioProvider::new("AC_TEST".into(), Secret::new("TOKEN".into()));
+        let body =
+            b"CallSid=CA456&CallStatus=in-progress&SpeechResult=hello%20world&Confidence=0.92";
+        let headers = HeaderMap::new();
+        let event = provider
+            .parse_webhook_event(&headers, body)
+            .unwrap_or_else(|e| panic!("{e}"));
+        match event {
+            CallEvent::Speech {
+                provider_call_id,
+                text,
+                confidence,
+            } => {
+                assert_eq!(provider_call_id, "CA456");
+                assert_eq!(text, "hello world");
+                assert!((confidence.unwrap_or(0.0) - 0.92).abs() < 0.01);
+            },
+            other => panic!("unexpected event: {other:?}"),
+        }
+    }
+
+    #[test]
     fn parse_webhook_dtmf_digits() {
         let provider = TwilioProvider::new("AC_TEST".into(), Secret::new("TOKEN".into()));
         let body = b"CallSid=CA789&Digits=123";
@@ -552,6 +575,26 @@ mod tests {
             .unwrap_or_else(|e| panic!("{e}"));
         match event {
             CallEvent::Dtmf { digits, .. } => assert_eq!(digits, "123"),
+            other => panic!("unexpected event: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_webhook_dtmf_digits_with_in_progress_status() {
+        let provider = TwilioProvider::new("AC_TEST".into(), Secret::new("TOKEN".into()));
+        let body = b"CallSid=CA789&CallStatus=in-progress&Digits=123";
+        let headers = HeaderMap::new();
+        let event = provider
+            .parse_webhook_event(&headers, body)
+            .unwrap_or_else(|e| panic!("{e}"));
+        match event {
+            CallEvent::Dtmf {
+                provider_call_id,
+                digits,
+            } => {
+                assert_eq!(provider_call_id, "CA789");
+                assert_eq!(digits, "123");
+            },
             other => panic!("unexpected event: {other:?}"),
         }
     }

--- a/crates/telephony/src/providers/twilio.rs
+++ b/crates/telephony/src/providers/twilio.rs
@@ -327,7 +327,7 @@ impl TelephonyProvider for TwilioProvider {
         if let Some(url) = gather_url {
             let url = xml_escape(url);
             twiml.push_str(&format!(
-                r#"<Gather input="speech" action="{url}" speechTimeout="auto">"#
+                r#"<Gather input="speech dtmf" action="{url}" speechTimeout="auto">"#
             ));
             if let Some(msg) = message {
                 twiml.push_str(&format!(
@@ -352,7 +352,7 @@ impl TelephonyProvider for TwilioProvider {
         let mut twiml = String::from(r#"<?xml version="1.0" encoding="UTF-8"?><Response>"#);
         let action_url = xml_escape(action_url);
         twiml.push_str(&format!(
-            r#"<Gather input="speech" action="{action_url}" speechTimeout="auto">"#
+            r#"<Gather input="speech dtmf" action="{action_url}" speechTimeout="auto">"#
         ));
         if let Some(p) = prompt {
             twiml.push_str(&format!(
@@ -384,7 +384,7 @@ fn build_say_gather_twiml(text: &str, voice: Option<&str>, gather_url: Option<&s
         .unwrap_or_default();
 
     format!(
-        r#"<Response><Say voice="{voice_attr}">{text}</Say><Gather input="speech"{gather_action} speechTimeout="auto" timeout="30"/><Pause length="120"/></Response>"#
+        r#"<Response><Say voice="{voice_attr}">{text}</Say><Gather input="speech dtmf"{gather_action} speechTimeout="auto" timeout="30"/><Pause length="120"/></Response>"#
     )
 }
 
@@ -448,6 +448,7 @@ mod tests {
             .build_answer_response(Some("Hello caller"), Some("https://example.com/gather"));
         let twiml = std::str::from_utf8(&resp).unwrap_or("");
         assert!(twiml.contains("<Gather"));
+        assert!(twiml.contains(r#"input="speech dtmf""#));
         assert!(twiml.contains("Hello caller"));
         assert!(twiml.contains("https://example.com/gather"));
     }
@@ -464,6 +465,7 @@ mod tests {
 
         let gather = provider.build_gather_response(None, url);
         let gather_twiml = std::str::from_utf8(&gather).unwrap_or("");
+        assert!(gather_twiml.contains(r#"input="speech dtmf""#));
         assert!(gather_twiml.contains("foo=1&amp;bar=&quot;two&quot;"));
         assert!(!gather_twiml.contains("foo=1&bar=\"two\""));
     }
@@ -477,6 +479,7 @@ mod tests {
         );
 
         assert!(twiml.contains(r#"voice="voice&quot;attr""#));
+        assert!(twiml.contains(r#"input="speech dtmf""#));
         assert!(twiml.contains("hello &amp; goodbye"));
         assert!(
             twiml.contains(r#"action="https://example.com/gather?foo=1&amp;bar=&quot;two&quot;""#)

--- a/docs/src/channels/telephony.md
+++ b/docs/src/channels/telephony.md
@@ -7,8 +7,8 @@ Moltis can make and receive phone calls, enabling voice-based AI conversations o
 | Provider | Status | Features |
 |----------|--------|----------|
 | **Twilio** | Supported | Outbound calls, inbound calls, TTS, speech recognition, DTMF |
-| **Telnyx** | Supported | Outbound calls, inbound calls |
-| **Plivo** | Supported | Outbound calls, inbound calls |
+| **Telnyx** | Supported | Outbound calls, inbound calls, TTS, transcription events, DTMF events |
+| **Plivo** | Supported | Outbound calls, inbound calls, TTS, speech recognition, DTMF |
 
 ## Quick Start
 
@@ -127,11 +127,11 @@ When configured with a public `webhook_url`, the gateway exposes:
 | `POST /api/channels/telephony/{account}/answer` | TwiML for answered calls |
 | `POST /api/channels/telephony/{account}/gather` | Speech/DTMF result handler |
 
-Configure these in your Twilio phone number settings, or they are set automatically when initiating outbound calls.
+Configure these in your provider's phone number or call-control settings, or they are set automatically when initiating outbound calls. Twilio and Plivo use XML responses from `/answer` and `/gather`; Telnyx uses Call Control commands from the `/answer` webhook and sends transcription events back to the same webhook URL.
 
 ## Security
 
-- **Webhook verification**: Twilio webhooks are verified using HMAC-SHA1 signature validation
+- **Webhook verification**: Twilio webhooks are verified using HMAC-SHA1 signature validation; Plivo and Telnyx verification are used when their signature credentials are configured
 - **Inbound access control**: Phone numbers can be restricted via allowlist
 - **Credential storage**: Provider credentials are stored in the credential store when configured from Settings > Phone
 - **Max duration**: Calls are automatically terminated after the configured max duration
@@ -139,7 +139,7 @@ Configure these in your Twilio phone number settings, or they are set automatica
 ## Audio Pipeline
 
 ```
-User Speech -> Twilio STT -> Text -> Agent (LLM) -> Text -> TTS -> mu-law 8kHz -> Caller
+User Speech -> Provider STT/transcription -> Text -> Agent (LLM) -> Text -> Provider TTS -> Caller
 ```
 
 The telephony audio pipeline converts between PSTN-standard mu-law encoding (8 kHz, ITU-T G.711) and the PCM audio used by TTS providers.


### PR DESCRIPTION
## Summary
- Fix Twilio gather parsing so `SpeechResult` and `Digits` are handled before `CallStatus=in-progress`.
- Add regression coverage for realistic Twilio gather payloads and telephony speech dispatch metadata.
- Add gather-path debug logging for received input, dispatch, and unknown-call cases.
- Extend follow-up provider coverage: Twilio/Plivo speech+DTMF gathers, Telnyx Call Control answer/greet/transcription handling, and telephony docs updates.

## Validation
### Completed
- [x] `cargo test -p moltis-telephony`
- [x] `cargo fmt --all -- --check`
- [x] `cargo check -p moltis-httpd --features telephony`

### Remaining
- [ ] Full `just lint`
- [ ] Full `just test`

## Manual QA
- Not run locally; covered by provider and dispatch regression tests.

Closes #1032