### PR TITLE
Fix sandbox media file reads in Docker

### DIFF
--- a/crates/tools/src/sandbox/docker.rs
+++ b/crates/tools/src/sandbox/docker.rs
@@ -743,15 +743,28 @@ impl Sandbox for DockerSandbox {
         file_path: &str,
         max_bytes: u64,
     ) -> Result<SandboxReadResult> {
-        if let Some(host_path) = self.mounted_host_path(id, file_path) {
-            return native_host_read_file(
-                host_path
-                    .to_str()
-                    .ok_or_else(|| Error::message("mounted host path contains invalid UTF-8"))?,
-                max_bytes,
-            )
-            .await;
+        let Some(host_path) = self.mounted_host_path(id, file_path) else {
+            let container_name = self.container_name(id);
+            return oci_container_read_file(self.cli, &container_name, file_path, max_bytes).await;
+        };
+
+        let host_result = native_host_read_file(
+            host_path
+                .to_str()
+                .ok_or_else(|| Error::message("mounted host path contains invalid UTF-8"))?,
+            max_bytes,
+        )
+        .await?;
+        if matches!(host_result, SandboxReadResult::Ok(_)) {
+            return Ok(host_result);
         }
+
+        debug!(
+            guest_path = file_path,
+            host_path = %host_path.display(),
+            result = ?host_result,
+            "mounted host read failed; falling back to container read"
+        );
 
         let container_name = self.container_name(id);
         oci_container_read_file(self.cli, &container_name, file_path, max_bytes).await

--- a/crates/tools/src/sandbox/docker.rs
+++ b/crates/tools/src/sandbox/docker.rs
@@ -755,7 +755,7 @@ impl Sandbox for DockerSandbox {
             max_bytes,
         )
         .await?;
-        if matches!(host_result, SandboxReadResult::Ok(_)) {
+        if !matches!(host_result, SandboxReadResult::NotFound) {
             return Ok(host_result);
         }
 

--- a/crates/tools/src/sandbox/file_system.rs
+++ b/crates/tools/src/sandbox/file_system.rs
@@ -1050,7 +1050,10 @@ pub async fn oci_container_read_file(
                     .take()
                     .ok_or_else(|| Error::message("failed to open OCI copy stdout"))?;
                 let result = extract_single_file_from_tar_reader(stdout, &file_path, max_bytes);
-                let stop_child = !matches!(result, Ok(SandboxReadResult::Ok(_)));
+                let stop_child = matches!(
+                    result,
+                    Ok(SandboxReadResult::NotRegularFile | SandboxReadResult::TooLarge(_))
+                );
 
                 if stop_child {
                     let _ = child.kill();
@@ -1385,5 +1388,38 @@ mod tests {
         let tar_bytes = build_single_file_tar("/tmp/example.txt", b"hello tar").unwrap();
         let result = extract_single_file_from_tar(&tar_bytes, "/tmp/example.txt", 4).unwrap();
         assert!(matches!(result, SandboxReadResult::TooLarge(9)));
+    }
+
+    #[tokio::test]
+    async fn oci_read_reports_copy_stderr_when_tar_stream_is_empty() {
+        let dir = tempfile::tempdir().unwrap();
+        let cli_path = dir.path().join("fake-oci");
+        std::fs::write(
+            &cli_path,
+            "#!/bin/sh\n\
+             if [ \"$1\" = \"exec\" ]; then printf 'file\\t5\\n'; exit 0; fi\n\
+             if [ \"$1\" = \"cp\" ]; then echo 'Error: no such file or directory' >&2; exit 1; fi\n\
+             exit 2\n",
+        )
+        .unwrap();
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt as _;
+            let mut permissions = std::fs::metadata(&cli_path).unwrap().permissions();
+            permissions.set_mode(0o755);
+            std::fs::set_permissions(&cli_path, permissions).unwrap();
+        }
+
+        let result = oci_container_read_file(
+            cli_path.to_str().unwrap(),
+            "fake-container",
+            "/tmp/example.txt",
+            1024,
+        )
+        .await
+        .unwrap();
+
+        assert!(matches!(result, SandboxReadResult::NotFound));
     }
 }

--- a/crates/tools/src/send_document.rs
+++ b/crates/tools/src/send_document.rs
@@ -75,7 +75,8 @@ impl AgentTool for SendDocumentTool {
 
     fn description(&self) -> &str {
         "Send a local file (PDF, CSV, DOCX, TXT, JSON, ZIP, etc.) to the current \
-         conversation's channel. Use send_image for image files. Maximum size: 20 MB."
+         conversation's channel. In sandboxed sessions, the path is resolved inside \
+         the sandbox. Use send_image for image files. Maximum size: 20 MB."
     }
 
     fn parameters_schema(&self) -> Value {

--- a/crates/tools/src/send_image.rs
+++ b/crates/tools/src/send_image.rs
@@ -52,6 +52,7 @@ impl AgentTool for SendImageTool {
 
     fn description(&self) -> &str {
         "Send a local image file to the current conversation's channel (e.g. Telegram). \
+         In sandboxed sessions, the path is resolved inside the sandbox. \
          Supported formats: PNG, JPEG, GIF, WebP, PPM. Maximum size: 20 MB."
     }
 


### PR DESCRIPTION
## Summary
- Fall back from translated mounted-host reads to container reads when Docker sandbox files are only visible inside the sandbox.
- Preserve and classify `docker cp` stderr so failed sandbox reads do not surface as empty OCI tar streams.
- Clarify `send_image` and `send_document` path resolution for sandboxed sessions.

Fixes #1037.

## Validation
### Completed
- [x] `cargo test -p moltis-tools oci_read_reports_copy_stderr_when_tar_stream_is_empty`
- [x] `cargo test -p moltis-tools test_docker_read_file_uses_mounted_workspace_path`
- [x] `cargo fmt --all -- --check`

### Remaining
- [ ] Full `just test`
- [ ] Full `just lint`

## Manual QA
- Not run locally. Recommended: in a docker-compose Moltis setup with Docker-backed sandboxing, create files under `/home/sandbox` and `/tmp`, then call `send_image` / `send_document` from an agent session.