### PR TITLE
fix(gateway): use mp3 for chat voice generation

### DIFF
--- a/crates/gateway/src/session.rs
+++ b/crates/gateway/src/session.rs
@@ -96,7 +96,16 @@ pub(crate) async fn dispatch_command_hook(
 struct TtsStatusPayload {
     enabled: bool,
     #[serde(default)]
+    provider: Option<String>,
+    #[serde(default)]
     max_text_length: Option<usize>,
+}
+
+fn session_voice_format(status: &TtsStatusPayload) -> &'static str {
+    match status.provider.as_deref() {
+        Some("openai") => "mp3",
+        _ => "ogg",
+    }
 }
 
 #[derive(Debug, Deserialize)]

--- a/crates/gateway/src/session.rs
+++ b/crates/gateway/src/session.rs
@@ -18,7 +18,7 @@ use {
         store::SessionStore,
     },
     moltis_tools::sandbox::SandboxRouter,
-    moltis_voice::TtsProviderId,
+    moltis_voice::{AudioFormat, TtsProviderId},
 };
 
 #[allow(unused_imports)]
@@ -102,10 +102,10 @@ struct TtsStatusPayload {
     max_text_length: Option<usize>,
 }
 
-fn session_voice_format(status: &TtsStatusPayload) -> &'static str {
+fn session_voice_format(status: &TtsStatusPayload) -> AudioFormat {
     match status.provider {
-        Some(TtsProviderId::OpenAi) => "mp3",
-        _ => "ogg",
+        Some(TtsProviderId::OpenAi) => AudioFormat::Mp3,
+        _ => AudioFormat::Opus,
     }
 }
 

--- a/crates/gateway/src/session.rs
+++ b/crates/gateway/src/session.rs
@@ -18,6 +18,7 @@ use {
         store::SessionStore,
     },
     moltis_tools::sandbox::SandboxRouter,
+    moltis_voice::TtsProviderId,
 };
 
 #[allow(unused_imports)]
@@ -96,14 +97,14 @@ pub(crate) async fn dispatch_command_hook(
 struct TtsStatusPayload {
     enabled: bool,
     #[serde(default)]
-    provider: Option<String>,
+    provider: Option<TtsProviderId>,
     #[serde(default)]
     max_text_length: Option<usize>,
 }
 
 fn session_voice_format(status: &TtsStatusPayload) -> &'static str {
-    match status.provider.as_deref() {
-        Some("openai") => "mp3",
+    match status.provider {
+        Some(TtsProviderId::OpenAi) => "mp3",
         _ => "ogg",
     }
 }

--- a/crates/gateway/src/session/tests.rs
+++ b/crates/gateway/src/session/tests.rs
@@ -683,7 +683,75 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn voice_generate_creates_and_persists_mp3_audio() {
+    async fn voice_generate_uses_mp3_for_openai_compatible_tts() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Arc::new(SessionStore::new(dir.path().to_path_buf()));
+        let pool = sqlite_pool().await;
+        let metadata = Arc::new(SqliteSessionMetadata::new(pool));
+
+        store
+            .append(
+                "main",
+                &serde_json::json!({ "role": "user", "content": "hello" }),
+            )
+            .await
+            .expect("append user");
+        store
+            .append(
+                "main",
+                &serde_json::json!({
+                    "role": "assistant",
+                    "content": "here is the reply",
+                    "run_id": "run-generate",
+                }),
+            )
+            .await
+            .expect("append assistant");
+
+        let audio_bytes = b"ID3new".to_vec();
+        let mock_tts = Arc::new(MockTtsService::new(
+            serde_json::json!({ "enabled": true, "provider": "openai", "maxTextLength": 8000 }),
+            Some(serde_json::json!({
+                "audio": general_purpose::STANDARD.encode(&audio_bytes),
+                "provider": "openai",
+            })),
+        ));
+        let service = LiveSessionService::new(Arc::clone(&store), metadata)
+            .with_tts_service(Arc::clone(&mock_tts) as Arc<dyn TtsService>);
+
+        let result = service
+            .voice_generate(serde_json::json!({ "key": "main", "runId": "run-generate" }))
+            .await
+            .expect("voice generate");
+
+        assert_eq!(result["reused"], false);
+        let audio_path = result["audio"].as_str().unwrap_or_default().to_string();
+        assert_eq!(audio_path, "media/main/voice-msg-1.mp3");
+        assert_eq!(result["ttsProvider"].as_str(), Some("openai"));
+        assert_eq!(mock_tts.convert_calls.load(Ordering::SeqCst), 1);
+        let convert_params = mock_tts
+            .last_convert_params
+            .lock()
+            .unwrap()
+            .clone()
+            .unwrap_or_default();
+        assert_eq!(convert_params["format"].as_str(), Some("mp3"));
+        assert_eq!(convert_params["text"].as_str(), Some("here is the reply"));
+
+        let history = store.read("main").await.expect("read history");
+        assert_eq!(history[1]["audio"].as_str(), Some(audio_path.as_str()));
+        assert_eq!(history[1]["tts_provider"].as_str(), Some("openai"));
+
+        let filename = media_filename(&audio_path).expect("filename");
+        let saved = store
+            .read_media("main", filename)
+            .await
+            .expect("read media");
+        assert_eq!(saved, audio_bytes);
+    }
+
+    #[tokio::test]
+    async fn voice_generate_keeps_ogg_for_non_openai_tts() {
         let dir = tempfile::tempdir().unwrap();
         let store = Arc::new(SessionStore::new(dir.path().to_path_buf()));
         let pool = sqlite_pool().await;
@@ -710,7 +778,7 @@ mod tests {
 
         let audio_bytes = b"OggSnew".to_vec();
         let mock_tts = Arc::new(MockTtsService::new(
-            serde_json::json!({ "enabled": true, "maxTextLength": 8000 }),
+            serde_json::json!({ "enabled": true, "provider": "elevenlabs", "maxTextLength": 8000 }),
             Some(serde_json::json!({
                 "audio": general_purpose::STANDARD.encode(&audio_bytes),
                 "provider": "elevenlabs",
@@ -726,28 +794,15 @@ mod tests {
 
         assert_eq!(result["reused"], false);
         let audio_path = result["audio"].as_str().unwrap_or_default().to_string();
-        assert_eq!(audio_path, "media/main/voice-msg-1.mp3");
+        assert_eq!(audio_path, "media/main/voice-msg-1.ogg");
         assert_eq!(result["ttsProvider"].as_str(), Some("elevenlabs"));
-        assert_eq!(mock_tts.convert_calls.load(Ordering::SeqCst), 1);
         let convert_params = mock_tts
             .last_convert_params
             .lock()
             .unwrap()
             .clone()
             .unwrap_or_default();
-        assert_eq!(convert_params["format"].as_str(), Some("mp3"));
-        assert_eq!(convert_params["text"].as_str(), Some("here is the reply"));
-
-        let history = store.read("main").await.expect("read history");
-        assert_eq!(history[1]["audio"].as_str(), Some(audio_path.as_str()));
-        assert_eq!(history[1]["tts_provider"].as_str(), Some("elevenlabs"));
-
-        let filename = media_filename(&audio_path).expect("filename");
-        let saved = store
-            .read_media("main", filename)
-            .await
-            .expect("read media");
-        assert_eq!(saved, audio_bytes);
+        assert_eq!(convert_params["format"].as_str(), Some("ogg"));
     }
 
     #[tokio::test]

--- a/crates/gateway/src/session/tests.rs
+++ b/crates/gateway/src/session/tests.rs
@@ -573,6 +573,7 @@ mod tests {
         convert_payload: Option<Value>,
         convert_error: Option<String>,
         convert_calls: AtomicU32,
+        last_convert_params: std::sync::Mutex<Option<Value>>,
     }
 
     impl MockTtsService {
@@ -582,6 +583,7 @@ mod tests {
                 convert_payload,
                 convert_error: None,
                 convert_calls: AtomicU32::new(0),
+                last_convert_params: std::sync::Mutex::new(None),
             }
         }
 
@@ -591,6 +593,7 @@ mod tests {
                 convert_payload: None,
                 convert_error: Some(error.to_string()),
                 convert_calls: AtomicU32::new(0),
+                last_convert_params: std::sync::Mutex::new(None),
             }
         }
     }
@@ -613,8 +616,9 @@ mod tests {
             Ok(serde_json::json!({}))
         }
 
-        async fn convert(&self, _params: Value) -> ServiceResult {
+        async fn convert(&self, params: Value) -> ServiceResult {
             self.convert_calls.fetch_add(1, Ordering::SeqCst);
+            *self.last_convert_params.lock().unwrap() = Some(params);
             if let Some(ref error) = self.convert_error {
                 return Err(error.clone().into());
             }
@@ -679,7 +683,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn voice_generate_creates_and_persists_audio() {
+    async fn voice_generate_creates_and_persists_mp3_audio() {
         let dir = tempfile::tempdir().unwrap();
         let store = Arc::new(SessionStore::new(dir.path().to_path_buf()));
         let pool = sqlite_pool().await;
@@ -722,9 +726,17 @@ mod tests {
 
         assert_eq!(result["reused"], false);
         let audio_path = result["audio"].as_str().unwrap_or_default().to_string();
-        assert_eq!(audio_path, "media/main/voice-msg-1.ogg");
+        assert_eq!(audio_path, "media/main/voice-msg-1.mp3");
         assert_eq!(result["ttsProvider"].as_str(), Some("elevenlabs"));
         assert_eq!(mock_tts.convert_calls.load(Ordering::SeqCst), 1);
+        let convert_params = mock_tts
+            .last_convert_params
+            .lock()
+            .unwrap()
+            .clone()
+            .unwrap_or_default();
+        assert_eq!(convert_params["format"].as_str(), Some("mp3"));
+        assert_eq!(convert_params["text"].as_str(), Some("here is the reply"));
 
         let history = store.read("main").await.expect("read history");
         assert_eq!(history[1]["audio"].as_str(), Some(audio_path.as_str()));

--- a/crates/gateway/src/session/tests.rs
+++ b/crates/gateway/src/session/tests.rs
@@ -802,7 +802,7 @@ mod tests {
             .unwrap()
             .clone()
             .unwrap_or_default();
-        assert_eq!(convert_params["format"].as_str(), Some("ogg"));
+        assert_eq!(convert_params["format"].as_str(), Some("opus"));
     }
 
     #[tokio::test]

--- a/crates/gateway/src/session/voice.rs
+++ b/crates/gateway/src/session/voice.rs
@@ -79,7 +79,7 @@ impl LiveSessionService {
         // session agent's voice_persona_id → global active persona.
         let mut convert_params = serde_json::json!({
             "text": sanitized,
-            "format": "ogg",
+            "format": "mp3",
         });
         if let Some(ref vp_store) = self.voice_persona_store {
             let persona = crate::voice_persona::resolve_persona(
@@ -109,7 +109,7 @@ impl LiveSessionService {
                 ServiceError::message("invalid base64 audio payload returned by TTS provider")
             })?;
 
-        let filename = format!("voice-msg-{target_index}.ogg");
+        let filename = format!("voice-msg-{target_index}.mp3");
         let audio_path = self
             .store
             .save_media(key, &filename, &audio_bytes)

--- a/crates/gateway/src/session/voice.rs
+++ b/crates/gateway/src/session/voice.rs
@@ -110,7 +110,7 @@ impl LiveSessionService {
                 ServiceError::message("invalid base64 audio payload returned by TTS provider")
             })?;
 
-        let filename = format!("voice-msg-{target_index}.{format}");
+        let filename = format!("voice-msg-{target_index}.{}", format.extension());
         let audio_path = self
             .store
             .save_media(key, &filename, &audio_bytes)

--- a/crates/gateway/src/session/voice.rs
+++ b/crates/gateway/src/session/voice.rs
@@ -77,9 +77,10 @@ impl LiveSessionService {
 
         // Resolve voice persona through the full chain:
         // session agent's voice_persona_id → global active persona.
+        let format = session_voice_format(&status);
         let mut convert_params = serde_json::json!({
             "text": sanitized,
-            "format": "mp3",
+            "format": format,
         });
         if let Some(ref vp_store) = self.voice_persona_store {
             let persona = crate::voice_persona::resolve_persona(
@@ -109,7 +110,7 @@ impl LiveSessionService {
                 ServiceError::message("invalid base64 audio payload returned by TTS provider")
             })?;
 
-        let filename = format!("voice-msg-{target_index}.mp3");
+        let filename = format!("voice-msg-{target_index}.{format}");
         let audio_path = self
             .store
             .save_media(key, &filename, &audio_bytes)


### PR DESCRIPTION
## Summary
- Use MP3 for chat Voice It TTS generation when the resolved TTS provider is OpenAI/OpenAI-compatible, so servers like Speaches do not receive unsupported `response_format: opus`.
- Preserve OGG/Opus generation for non-OpenAI TTS providers to avoid unnecessary quality/size regressions.
- Add regression coverage asserting OpenAI-compatible chat voice uses `format: mp3` while non-OpenAI chat voice keeps `format: ogg`.

Fixes #1030

## Validation
### Completed
- [x] `cargo test -p moltis-gateway voice_generate_`
- [x] `cargo fmt --all -- --check`

### Remaining
- [ ] Full CI suite

## Manual QA
- Not run locally. Expected flow: configure OpenAI TTS with a Speaches `/v1` endpoint, confirm Settings > Voice > Text To Speech > Test works, then use Voice It on a chat response and confirm audio is generated without a 422 `response_format: opus` error.