### PR TITLE
Support arbitrary chat attachments

### DIFF
--- a/crates/channels/src/plugin.rs
+++ b/crates/channels/src/plugin.rs
@@ -613,6 +613,9 @@ pub struct ChannelDocumentFile {
     pub stored_filename: String,
     /// MIME type reported by the channel.
     pub mime_type: String,
+    /// Attachment size when the channel exposes it.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub size_bytes: Option<u64>,
 }
 
 /// Metadata for an inbound channel file saved to session media.

--- a/crates/chat/src/message.rs
+++ b/crates/chat/src/message.rs
@@ -30,10 +30,15 @@ pub(crate) fn format_user_documents_context(documents: &[UserDocument]) -> Optio
     let mut sections = Vec::with_capacity(documents.len() + 1);
     sections.push("[Inbound documents available]".to_string());
     for document in documents {
+        let size = document
+            .size_bytes
+            .map(|value| format!("\nsize_bytes: {value}"))
+            .unwrap_or_default();
         sections.push(format!(
-            "filename: {}\nmime_type: {}\nlocal_path: {}\nmedia_ref: {}",
+            "filename: {}\nmime_type: {}{}\nlocal_path: {}\nmedia_ref: {}",
             document.display_name,
             document.mime_type,
+            size,
             document
                 .absolute_path
                 .as_deref()
@@ -303,6 +308,7 @@ pub(crate) fn user_documents_from_params(
             display_name,
             stored_filename: stored_filename.to_string(),
             mime_type: mime_type.to_string(),
+            size_bytes: document.size_bytes,
             media_ref: format!("media/{media_dir_key}/{stored_filename}"),
             absolute_path: Some(
                 session_store

--- a/crates/chat/src/types.rs
+++ b/crates/chat/src/types.rs
@@ -38,6 +38,8 @@ pub(crate) struct InputChannelDocumentFile {
     pub display_name: String,
     pub stored_filename: String,
     pub mime_type: String,
+    #[serde(default)]
+    pub size_bytes: Option<u64>,
 }
 
 #[derive(Debug, Deserialize, PartialEq, Eq)]

--- a/crates/sessions/src/message.rs
+++ b/crates/sessions/src/message.rs
@@ -166,6 +166,8 @@ pub struct UserDocument {
     pub display_name: String,
     pub stored_filename: String,
     pub mime_type: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub size_bytes: Option<u64>,
     pub media_ref: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub absolute_path: Option<String>,
@@ -551,6 +553,7 @@ mod tests {
                 display_name: "report.pdf".to_string(),
                 stored_filename: "abc_report.pdf".to_string(),
                 mime_type: "application/pdf".to_string(),
+                size_bytes: Some(12_345),
                 media_ref: "media/main/abc_report.pdf".to_string(),
                 absolute_path: Some("/tmp/main/abc_report.pdf".to_string()),
             }]),
@@ -564,6 +567,7 @@ mod tests {
             json["documents"][0]["media_ref"],
             "media/main/abc_report.pdf"
         );
+        assert_eq!(json["documents"][0]["size_bytes"], 12_345);
     }
 
     #[test]

--- a/crates/telegram/src/handlers/media.rs
+++ b/crates/telegram/src/handlers/media.rs
@@ -222,6 +222,7 @@ pub(super) fn channel_document_file(
             .to_string(),
         stored_filename: saved.filename.clone(),
         mime_type: media_type.to_string(),
+        size_bytes: None,
     }
 }
 

--- a/crates/web/ui/e2e/specs/chat-input.spec.js
+++ b/crates/web/ui/e2e/specs/chat-input.spec.js
@@ -604,7 +604,7 @@ test.describe("Chat input and slash commands", () => {
 						return last?.text || "";
 					}),
 				{ timeout: 5_000 },
-		)
+			)
 			.toBe("/sh echo hello");
 	});
 
@@ -671,6 +671,30 @@ test.describe("Chat input and slash commands", () => {
 				mime_type: "text/calendar",
 				size_bytes: 30,
 			});
+		expect(pageErrors).toEqual([]);
+	});
+
+	test("preserves typed text when attachment upload fails", async ({ page }) => {
+		const pageErrors = watchPageErrors(page);
+		await page.route("**/api/sessions/main/upload", async (route) => {
+			await route.fulfill({
+				status: 500,
+				contentType: "application/json",
+				body: JSON.stringify({ ok: false, error: "upload failed" }),
+			});
+		});
+
+		await page.locator("#attachInput").setInputFiles({
+			name: "broken.ics",
+			mimeType: "text/calendar",
+			buffer: Buffer.from("BEGIN:VCALENDAR\nEND:VCALENDAR\n"),
+		});
+		await page.locator("#chatInput").fill("do not lose this");
+		await page.locator("#chatInput").press("Enter");
+
+		await expect(page.locator(".msg.error")).toContainText("File upload failed");
+		await expect(page.locator("#chatInput")).toHaveValue("do not lose this");
+		await expect(page.locator(".media-preview-item")).toContainText("broken.ics");
 		expect(pageErrors).toEqual([]);
 	});
 

--- a/crates/web/ui/e2e/specs/chat-input.spec.js
+++ b/crates/web/ui/e2e/specs/chat-input.spec.js
@@ -604,8 +604,74 @@ test.describe("Chat input and slash commands", () => {
 						return last?.text || "";
 					}),
 				{ timeout: 5_000 },
-			)
+		)
 			.toBe("/sh echo hello");
+	});
+
+	test("attaches arbitrary files with metadata", async ({ page }) => {
+		const pageErrors = watchPageErrors(page);
+		await page.route("**/api/sessions/main/upload", async (route) => {
+			const request = route.request();
+			const body = request.postDataBuffer() || Buffer.alloc(0);
+			await route.fulfill({
+				status: 200,
+				contentType: "application/json",
+				body: JSON.stringify({
+					ok: true,
+					url: "/api/sessions/main/media/calendar.ics",
+					filename: "calendar.ics",
+					contentType: request.headers()["content-type"] || "text/calendar",
+					size: body.length,
+				}),
+			});
+		});
+		await page.evaluate(() => {
+			window.__fileAttachmentPayloads = [];
+			if (window.__fileAttachmentWsSpyInstalled) return;
+			var originalSend = WebSocket.prototype.send;
+			WebSocket.prototype.send = function (data) {
+				try {
+					var parsed = JSON.parse(data);
+					if (parsed?.method === "chat.send") {
+						window.__fileAttachmentPayloads.push(parsed.params || {});
+					}
+				} catch {
+					// ignore non-JSON payloads
+				}
+				return originalSend.call(this, data);
+			};
+			window.__fileAttachmentWsSpyInstalled = true;
+		});
+
+		await page.locator("#attachInput").setInputFiles({
+			name: "calendar.ics",
+			mimeType: "text/calendar",
+			buffer: Buffer.from("BEGIN:VCALENDAR\nEND:VCALENDAR\n"),
+		});
+		await expect(page.locator(".media-preview-item")).toContainText("calendar.ics");
+		await expect(page.locator(".media-preview-item")).toContainText("30 B");
+
+		await page.locator("#chatInput").fill("please inspect this");
+		await page.locator("#chatInput").press("Enter");
+		await expect(page.locator(".document-container")).toContainText("calendar.ics");
+
+		await expect
+			.poll(
+				async () =>
+					await page.evaluate(() => {
+						var payloads = window.__fileAttachmentPayloads || [];
+						var last = payloads[payloads.length - 1];
+						return last?._document_files?.[0] || null;
+					}),
+				{ timeout: 5_000 },
+			)
+			.toMatchObject({
+				display_name: "calendar.ics",
+				stored_filename: "calendar.ics",
+				mime_type: "text/calendar",
+				size_bytes: 30,
+			});
+		expect(pageErrors).toEqual([]);
 	});
 
 	test("token bar stays visible at zero usage", async ({ page }) => {

--- a/crates/web/ui/input.css
+++ b/crates/web/ui/input.css
@@ -1630,7 +1630,7 @@
     background: var(--accent-subtle);
   }
 
-  /* Image preview strip above input area */
+  /* Attachment preview strip above input area */
   .media-preview-strip {
     display: flex;
     gap: 8px;
@@ -1660,6 +1660,15 @@
     border-radius: 4px;
     flex-shrink: 0;
   }
+  .media-preview-file-icon {
+    width: 32px;
+    height: 32px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 1.25rem;
+    flex-shrink: 0;
+  }
   .media-preview-name {
     font-size: 0.72rem;
     color: var(--muted);
@@ -1667,6 +1676,12 @@
     text-overflow: ellipsis;
     white-space: nowrap;
     min-width: 0;
+  }
+  .media-preview-meta {
+    font-size: 0.68rem;
+    color: var(--muted);
+    white-space: nowrap;
+    flex-shrink: 0;
   }
   .media-preview-remove {
     background: none;

--- a/crates/web/ui/src/chat-ui.ts
+++ b/crates/web/ui/src/chat-ui.ts
@@ -167,7 +167,12 @@ function appendImageAttachments(el: HTMLElement, images: ImageAttachment[]): voi
 
 function appendDocumentAttachments(el: HTMLElement, documents: DocumentAttachment[]): void {
 	for (const doc of documents) {
-		renderDocument(el, doc.url || "#", doc.display_name || doc.stored_filename, doc.mime_type, doc.size_bytes);
+		const mediaSrc =
+			doc.url ||
+			(doc.stored_filename
+				? `/api/sessions/${encodeURIComponent(S.activeSessionKey)}/media/${encodeURIComponent(doc.stored_filename)}`
+				: "#");
+		renderDocument(el, mediaSrc, doc.display_name || doc.stored_filename, doc.mime_type, doc.size_bytes);
 	}
 }
 

--- a/crates/web/ui/src/chat-ui.ts
+++ b/crates/web/ui/src/chat-ui.ts
@@ -1,6 +1,6 @@
 // ── Chat UI ─────────────────────────────────────────────────
 
-import { formatTokens, parseErrorMessage, sendRpc, updateCountdown } from "./helpers";
+import { formatTokens, parseErrorMessage, renderDocument, sendRpc, updateCountdown } from "./helpers";
 import * as S from "./state";
 
 interface ErrorCardData {
@@ -14,6 +14,14 @@ interface ErrorCardData {
 interface ImageAttachment {
 	dataUrl: string;
 	name: string;
+}
+
+export interface DocumentAttachment {
+	display_name: string;
+	stored_filename: string;
+	mime_type: string;
+	size_bytes?: number;
+	url?: string;
 }
 
 function clearChatEmptyState(): void {
@@ -130,30 +138,52 @@ export function chatAddMsgWithImages(
 	htmlContent: string,
 	images: ImageAttachment[],
 ): HTMLDivElement | null {
+	return chatAddMsgWithAttachments(cls, htmlContent, images, []);
+}
+
+function appendHtmlContent(el: HTMLElement, htmlContent: string): void {
+	if (!htmlContent) return;
+	const textDiv = document.createElement("div");
+	// Safe: htmlContent is produced by renderMarkdown which escapes user
+	// input via esc() first, then only adds our own formatting tags.
+	// This is the same pattern used in chatAddMsg above.
+	textDiv.innerHTML = htmlContent; // eslint-disable-line no-unsanitized/property
+	el.appendChild(textDiv);
+}
+
+function appendImageAttachments(el: HTMLElement, images: ImageAttachment[]): void {
+	if (images.length === 0) return;
+	const thumbRow = document.createElement("div");
+	thumbRow.className = "msg-image-row";
+	for (const img of images) {
+		const thumb = document.createElement("img");
+		thumb.className = "msg-image-thumb";
+		thumb.src = img.dataUrl;
+		thumb.alt = img.name;
+		thumbRow.appendChild(thumb);
+	}
+	el.appendChild(thumbRow);
+}
+
+function appendDocumentAttachments(el: HTMLElement, documents: DocumentAttachment[]): void {
+	for (const doc of documents) {
+		renderDocument(el, doc.url || "#", doc.display_name || doc.stored_filename, doc.mime_type, doc.size_bytes);
+	}
+}
+
+export function chatAddMsgWithAttachments(
+	cls: MessageRole,
+	htmlContent: string,
+	images: ImageAttachment[],
+	documents: DocumentAttachment[],
+): HTMLDivElement | null {
 	if (!S.chatMsgBox) return null;
 	clearChatEmptyState();
 	const el = document.createElement("div");
 	el.className = `msg ${cls}`;
-	if (htmlContent) {
-		const textDiv = document.createElement("div");
-		// Safe: htmlContent is produced by renderMarkdown which escapes user
-		// input via esc() first, then only adds our own formatting tags.
-		// This is the same pattern used in chatAddMsg above.
-		textDiv.innerHTML = htmlContent; // eslint-disable-line no-unsanitized/property
-		el.appendChild(textDiv);
-	}
-	if (images && images.length > 0) {
-		const thumbRow = document.createElement("div");
-		thumbRow.className = "msg-image-row";
-		for (const img of images) {
-			const thumb = document.createElement("img");
-			thumb.className = "msg-image-thumb";
-			thumb.src = img.dataUrl;
-			thumb.alt = img.name;
-			thumbRow.appendChild(thumb);
-		}
-		el.appendChild(thumbRow);
-	}
+	appendHtmlContent(el, htmlContent);
+	appendImageAttachments(el, images);
+	appendDocumentAttachments(el, documents);
 	S.chatMsgBox.appendChild(el);
 	if (!S.chatBatchLoading) {
 		if (cls === "user") scrollChatToBottom(true);

--- a/crates/web/ui/src/helpers.ts
+++ b/crates/web/ui/src/helpers.ts
@@ -713,9 +713,13 @@ export function renderScreenshot(container: HTMLElement, imgSrc: string, scale?:
 /**
  * Return an icon string for a given MIME type / filename extension.
  */
-function documentIcon(mimeType?: string, filename?: string): string {
+export function documentIcon(mimeType?: string, filename?: string): string {
 	const ext = (filename || "").split(".").pop()?.toLowerCase() || "";
 	if (mimeType === "application/pdf" || ext === "pdf") return "\uD83D\uDCC4"; // 📄
+	if ((mimeType || "").startsWith("text/") || /^(txt|md|ics|json|xml|log)$/.test(ext)) return "\uD83D\uDCDD"; // 📝
+	if ((mimeType || "").startsWith("image/")) return "\uD83D\uDDBC\uFE0F"; // 🖼️
+	if ((mimeType || "").startsWith("audio/")) return "\uD83C\uDFB5"; // 🎵
+	if ((mimeType || "").startsWith("video/")) return "\uD83C\uDFA5"; // 🎥
 	if (mimeType === "application/zip" || mimeType === "application/gzip" || ext === "zip" || ext === "gz")
 		return "\uD83D\uDCE6"; // 📦
 	if (/spreadsheet|csv|xls/.test(mimeType || "") || /^(csv|xls|xlsx)$/.test(ext)) return "\uD83D\uDCCA"; // 📊
@@ -727,7 +731,7 @@ function documentIcon(mimeType?: string, filename?: string): string {
 /**
  * Format a byte count for display (e.g. "1.2 MB", "345 KB").
  */
-function formatDocSize(bytes: number): string {
+export function formatDocSize(bytes: number): string {
 	if (typeof bytes !== "number" || bytes < 0) return "";
 	if (bytes >= 1048576) return `${(bytes / 1048576).toFixed(1)} MB`;
 	if (bytes >= 1024) return `${(bytes / 1024).toFixed(1)} KB`;

--- a/crates/web/ui/src/media-drop.ts
+++ b/crates/web/ui/src/media-drop.ts
@@ -37,9 +37,10 @@ let boundAttachChange: ((e: Event) => void) | null = null;
 let dragEnterCount = 0;
 
 const MAX_FILE_SIZE = 20 * 1024 * 1024; // 20 MB
+const INLINE_IMAGE_TYPES = new Set<string>(["image/png", "image/jpeg", "image/gif", "image/webp"]);
 
 function isImageFile(file: File): boolean {
-	return file.type.startsWith("image/");
+	return INLINE_IMAGE_TYPES.has(file.type);
 }
 
 function readFileAsDataUrl(file: File): Promise<string> {
@@ -173,6 +174,7 @@ function onPaste(e: ClipboardEvent): void {
 	const items = e.clipboardData?.files;
 	if (!items || items.length === 0) return;
 
+	// Accept any non-empty clipboard file; handleFiles enforces size caps.
 	const pastedFiles: File[] = [];
 	for (const f of items) {
 		if (f.size > 0) pastedFiles.push(f);

--- a/crates/web/ui/src/media-drop.ts
+++ b/crates/web/ui/src/media-drop.ts
@@ -1,17 +1,28 @@
-// ── Media drag-and-drop + paste module ──────────────────────
-// Handles drag-and-drop image upload, clipboard paste, and
-// image preview strip above the chat input area.
+// ── Attachment drag-and-drop + paste module ─────────────────
+// Handles drag-and-drop file upload, clipboard paste, and
+// attachment preview strip above the chat input area.
 
+import { documentIcon, formatDocSize } from "./helpers";
 import { t } from "./i18n";
 import * as S from "./state";
 
-interface PendingImage {
-	dataUrl: string;
-	file: File;
-	name: string;
+export interface UploadedDocumentFile {
+	display_name: string;
+	stored_filename: string;
+	mime_type: string;
+	size_bytes?: number;
+	url?: string;
 }
 
-let pendingImages: PendingImage[] = [];
+export interface PendingAttachment {
+	file: File;
+	name: string;
+	mimeType: string;
+	sizeBytes: number;
+	dataUrl?: string;
+}
+
+let pendingAttachments: PendingAttachment[] = [];
 let previewStrip: HTMLElement | null = null;
 let chatMsgBoxRef: HTMLElement | null = null;
 
@@ -25,11 +36,10 @@ let boundAttachClick: (() => void) | null = null;
 let boundAttachChange: ((e: Event) => void) | null = null;
 let dragEnterCount = 0;
 
-const ACCEPTED_TYPES: string[] = ["image/png", "image/jpeg", "image/gif", "image/webp"];
 const MAX_FILE_SIZE = 20 * 1024 * 1024; // 20 MB
 
 function isImageFile(file: File): boolean {
-	return ACCEPTED_TYPES.indexOf(file.type) !== -1;
+	return file.type.startsWith("image/");
 }
 
 function readFileAsDataUrl(file: File): Promise<string> {
@@ -45,13 +55,19 @@ function readFileAsDataUrl(file: File): Promise<string> {
 	});
 }
 
-function addImage(dataUrl: string, file: File): void {
-	pendingImages.push({ dataUrl: dataUrl, file: file, name: file.name });
+function addAttachment(file: File, dataUrl?: string): void {
+	pendingAttachments.push({
+		file,
+		name: file.name,
+		mimeType: file.type || "application/octet-stream",
+		sizeBytes: file.size,
+		dataUrl,
+	});
 	renderPreview();
 }
 
-function removeImage(index: number): void {
-	pendingImages.splice(index, 1);
+function removeAttachment(index: number): void {
+	pendingAttachments.splice(index, 1);
 	renderPreview();
 }
 
@@ -59,27 +75,41 @@ function renderPreview(): void {
 	if (!previewStrip) return;
 	previewStrip.textContent = "";
 
-	if (pendingImages.length === 0) {
+	if (pendingAttachments.length === 0) {
 		previewStrip.classList.add("hidden");
 		return;
 	}
 
 	previewStrip.classList.remove("hidden");
 
-	for (let i = 0; i < pendingImages.length; i++) {
+	for (let i = 0; i < pendingAttachments.length; i++) {
+		const attachment = pendingAttachments[i];
 		const item = document.createElement("div");
 		item.className = "media-preview-item";
 
-		const img = document.createElement("img");
-		img.className = "media-preview-thumb";
-		img.src = pendingImages[i].dataUrl;
-		img.alt = pendingImages[i].name;
-		item.appendChild(img);
+		if (attachment.dataUrl) {
+			const img = document.createElement("img");
+			img.className = "media-preview-thumb";
+			img.src = attachment.dataUrl;
+			img.alt = attachment.name;
+			item.appendChild(img);
+		} else {
+			const icon = document.createElement("span");
+			icon.className = "media-preview-file-icon";
+			icon.textContent = documentIcon(attachment.mimeType, attachment.name);
+			item.appendChild(icon);
+		}
 
 		const name = document.createElement("span");
 		name.className = "media-preview-name";
-		name.textContent = pendingImages[i].name;
+		name.textContent = attachment.name;
+		name.title = `${attachment.name} \u00b7 ${attachment.mimeType} \u00b7 ${formatDocSize(attachment.sizeBytes)}`;
 		item.appendChild(name);
+
+		const meta = document.createElement("span");
+		meta.className = "media-preview-meta";
+		meta.textContent = formatDocSize(attachment.sizeBytes);
+		item.appendChild(meta);
 
 		const removeBtn = document.createElement("button");
 		removeBtn.className = "media-preview-remove";
@@ -88,7 +118,7 @@ function renderPreview(): void {
 		removeBtn.dataset.idx = String(i);
 		removeBtn.addEventListener("click", (e: MouseEvent): void => {
 			const idx = Number.parseInt((e.currentTarget as HTMLButtonElement).dataset.idx!, 10);
-			removeImage(idx);
+			removeAttachment(idx);
 		});
 		item.appendChild(removeBtn);
 
@@ -98,11 +128,10 @@ function renderPreview(): void {
 
 async function handleFiles(files: FileList | File[]): Promise<void> {
 	for (const file of files) {
-		if (!isImageFile(file)) continue;
 		if (file.size > MAX_FILE_SIZE) continue;
 		try {
-			const dataUrl = await readFileAsDataUrl(file);
-			addImage(dataUrl, file);
+			const dataUrl = isImageFile(file) ? await readFileAsDataUrl(file) : undefined;
+			addAttachment(file, dataUrl);
 		} catch (err) {
 			console.warn("[media-drop] Failed to read file:", err);
 		}
@@ -111,7 +140,7 @@ async function handleFiles(files: FileList | File[]): Promise<void> {
 
 function onDragOver(e: DragEvent): void {
 	e.preventDefault();
-	e.dataTransfer!.dropEffect = "copy";
+	if (e.dataTransfer) e.dataTransfer.dropEffect = "copy";
 }
 
 function onDragEnter(e: DragEvent): void {
@@ -144,13 +173,13 @@ function onPaste(e: ClipboardEvent): void {
 	const items = e.clipboardData?.files;
 	if (!items || items.length === 0) return;
 
-	const imageFiles: File[] = [];
+	const pastedFiles: File[] = [];
 	for (const f of items) {
-		if (isImageFile(f)) imageFiles.push(f);
+		if (f.size > 0) pastedFiles.push(f);
 	}
-	if (imageFiles.length > 0) {
+	if (pastedFiles.length > 0) {
 		e.preventDefault();
-		handleFiles(imageFiles);
+		handleFiles(pastedFiles);
 	}
 }
 
@@ -217,7 +246,7 @@ export function teardownMediaDrop(): void {
 	if (previewStrip?.parentElement) {
 		previewStrip.parentElement.removeChild(previewStrip);
 	}
-	pendingImages = [];
+	pendingAttachments = [];
 	previewStrip = null;
 	chatMsgBoxRef = null;
 	boundDragOver = null;
@@ -230,16 +259,58 @@ export function teardownMediaDrop(): void {
 	dragEnterCount = 0;
 }
 
-export function getPendingImages(): PendingImage[] {
-	return pendingImages;
+export function getPendingAttachments(): PendingAttachment[] {
+	return pendingAttachments;
 }
 
-/** Clear pending images and hide preview strip. */
-export function clearPendingImages(): void {
-	pendingImages = [];
+/** Clear pending attachments and hide preview strip. */
+export function clearPendingAttachments(): void {
+	pendingAttachments = [];
 	renderPreview();
 }
 
-export function hasPendingImages(): boolean {
-	return pendingImages.length > 0;
+export function hasPendingAttachments(): boolean {
+	return pendingAttachments.length > 0;
+}
+
+function safeHeaderFilename(name: string): string {
+	const safe = name.replace(/[^A-Za-z0-9._-]/g, "").replace(/^\.+/, "");
+	return safe || "upload";
+}
+
+export async function uploadDocumentAttachment(
+	attachment: PendingAttachment,
+	sessionKey: string,
+): Promise<UploadedDocumentFile> {
+	const resp = await fetch(`/api/sessions/${encodeURIComponent(sessionKey)}/upload`, {
+		method: "POST",
+		headers: {
+			"Content-Type": attachment.mimeType,
+			"X-Filename": safeHeaderFilename(attachment.name),
+		},
+		body: attachment.file,
+	});
+	const payload: unknown = await resp.json().catch(() => null);
+	if (!isSuccessfulUploadPayload(resp, payload)) {
+		throw new Error("File upload failed");
+	}
+	return {
+		display_name: attachment.name,
+		stored_filename: typeof payload.filename === "string" ? payload.filename : safeHeaderFilename(attachment.name),
+		mime_type: typeof payload.contentType === "string" ? payload.contentType : attachment.mimeType,
+		size_bytes: typeof payload.size === "number" ? payload.size : attachment.sizeBytes,
+		url: typeof payload.url === "string" ? payload.url : undefined,
+	};
+}
+
+interface UploadPayload {
+	ok: true;
+	filename?: unknown;
+	contentType?: unknown;
+	size?: unknown;
+	url?: unknown;
+}
+
+function isSuccessfulUploadPayload(response: Response, payload: unknown): payload is UploadPayload {
+	return response.ok && typeof payload === "object" && payload !== null && "ok" in payload && payload.ok === true;
 }

--- a/crates/web/ui/src/media-drop.ts
+++ b/crates/web/ui/src/media-drop.ts
@@ -37,10 +37,10 @@ let boundAttachChange: ((e: Event) => void) | null = null;
 let dragEnterCount = 0;
 
 const MAX_FILE_SIZE = 20 * 1024 * 1024; // 20 MB
-const INLINE_IMAGE_TYPES = new Set<string>(["image/png", "image/jpeg", "image/gif", "image/webp"]);
+const MAX_INLINE_IMAGE_SIZE = 5 * 1024 * 1024; // 5 MB
 
 function isImageFile(file: File): boolean {
-	return INLINE_IMAGE_TYPES.has(file.type);
+	return file.type.split("/", 1)[0] === "image" && file.size <= MAX_INLINE_IMAGE_SIZE;
 }
 
 function readFileAsDataUrl(file: File): Promise<string> {

--- a/crates/web/ui/src/pages/ChatPage.tsx
+++ b/crates/web/ui/src/pages/ChatPage.tsx
@@ -863,6 +863,8 @@ registerPrefix(
 		S.setChatMsgBox(S.$("messages"));
 		S.setChatInput(S.$("chatInput"));
 		S.setChatSendBtn(S.$("sendBtn"));
+		S.$("attachInput")?.removeAttribute("accept");
+		S.$("attachBtn")?.setAttribute("title", "Attach files");
 		updateCommandInputUI();
 		initializeChatControls();
 

--- a/crates/web/ui/src/pages/chat/chat-send.ts
+++ b/crates/web/ui/src/pages/chat/chat-send.ts
@@ -209,11 +209,11 @@ async function sendChatAsync(): Promise<void> {
 	warmAudioPlayback();
 	try {
 		if (tryHandleLocalSlashCommand(text, hasAttachments)) return;
-		rememberChatHistory(text);
-		resetComposerAfterSend();
 		const outgoingText = normalizeOutgoingText(text, hasAttachments);
 		S.setChatSeq(S.chatSeq + 1);
 		const msg = await buildChatMessage(outgoingText, S.chatSeq, text);
+		rememberChatHistory(text);
+		resetComposerAfterSend();
 		const chatParams = msg.params;
 		const userEl = msg.el;
 		if (userEl) highlightCodeBlocks(userEl);

--- a/crates/web/ui/src/pages/chat/chat-send.ts
+++ b/crates/web/ui/src/pages/chat/chat-send.ts
@@ -1,9 +1,16 @@
 // ── Chat send logic ──────────────────────────────────────────
 
-import { chatAddMsg, chatAddMsgWithImages, setComposerStopButton } from "../../chat-ui";
+import { chatAddMsg, chatAddMsgWithAttachments, setComposerStopButton } from "../../chat-ui";
 import { highlightCodeBlocks } from "../../code-highlight";
 import { renderMarkdown, sendRpc, warmAudioPlayback } from "../../helpers";
-import { clearPendingImages, getPendingImages, hasPendingImages } from "../../media-drop";
+import {
+	clearPendingAttachments,
+	getPendingAttachments,
+	hasPendingAttachments,
+	type PendingAttachment,
+	type UploadedDocumentFile,
+	uploadDocumentAttachment,
+} from "../../media-drop";
 import { setSessionModel } from "../../models";
 import {
 	bumpSessionCount,
@@ -22,11 +29,16 @@ import { handleSlashCommand, parseSlashCommand, shouldHandleSlashLocally, slashH
 export interface ChatSendParams {
 	text?: string;
 	content?: ChatContentPart[];
+	_document_files?: UploadedDocumentFile[];
 	_seq: number;
 	model?: string;
 }
 
 export type ChatContentPart = { type: "text"; text: string } | { type: "image_url"; image_url: { url: string } };
+
+interface PendingImageAttachment extends PendingAttachment {
+	dataUrl: string;
+}
 
 export interface ChatSendPayload {
 	runId?: string;
@@ -43,8 +55,8 @@ function chatAutoResize(): void {
 
 // ── Slash command integration ───────────────────────────────
 
-export function tryHandleLocalSlashCommand(text: string, hasImages: boolean): boolean {
-	if (text.charAt(0) !== "/" || hasImages) return false;
+export function tryHandleLocalSlashCommand(text: string, hasAttachments: boolean): boolean {
+	if (text.charAt(0) !== "/" || hasAttachments) return false;
 	const slash = parseSlashCommand(text);
 	if (!(slash && shouldHandleSlashLocally(slash.name, slash.args))) return false;
 	(S.chatInput as HTMLTextAreaElement).value = "";
@@ -95,8 +107,8 @@ export function resetComposerAfterSend(): void {
 	if (window.innerWidth < 768) S.chatInput?.blur();
 }
 
-export function normalizeOutgoingText(text: string, hasImages: boolean): string {
-	if (!(S.commandModeEnabled && text && !hasImages)) return text;
+export function normalizeOutgoingText(text: string, hasAttachments: boolean): string {
+	if (!(S.commandModeEnabled && text && !hasAttachments)) return text;
 	const parsed = parseSlashCommand(text);
 	if (parsed && parsed.name === "sh") return text;
 	return `/sh ${text}`;
@@ -121,21 +133,26 @@ export function handleChatSendRpcResponse(res: RpcResponse<ChatSendPayload>, use
 	}
 }
 
-export function buildChatMessage(
+export async function buildChatMessage(
 	text: string,
 	seq: number,
 	displayText?: string,
-): { params: ChatSendParams; el: HTMLElement | null } {
+): Promise<{ params: ChatSendParams; el: HTMLElement | null }> {
 	const userText = displayText !== undefined ? displayText : text;
-	const images = hasPendingImages() ? getPendingImages() : [];
-	if (images.length > 0) {
+	const attachments = hasPendingAttachments() ? getPendingAttachments() : [];
+	const images = attachments.filter((attachment): attachment is PendingImageAttachment => Boolean(attachment.dataUrl));
+	const documents = attachments.filter((attachment) => !attachment.dataUrl);
+	if (attachments.length > 0) {
+		const uploadedDocuments = await Promise.all(
+			documents.map((attachment) => uploadDocumentAttachment(attachment, S.activeSessionKey)),
+		);
 		const content: ChatContentPart[] = [];
 		if (text) content.push({ type: "text", text });
-		for (const img of images)
-			content.push({ type: "image_url", image_url: { url: (img as { dataUrl: string }).dataUrl } });
-		const params: ChatSendParams = { content, _seq: seq };
-		const el = chatAddMsgWithImages("user", userText ? renderMarkdown(userText) : "", images);
-		clearPendingImages();
+		for (const img of images) if (img.dataUrl) content.push({ type: "image_url", image_url: { url: img.dataUrl } });
+		const params: ChatSendParams = content.length > 0 ? { content, _seq: seq } : { text, _seq: seq };
+		if (uploadedDocuments.length > 0) params._document_files = uploadedDocuments;
+		const el = chatAddMsgWithAttachments("user", userText ? renderMarkdown(userText) : "", images, uploadedDocuments);
+		clearPendingAttachments();
 		return { params, el };
 	}
 	return { params: { text, _seq: seq }, el: chatAddMsg("user", renderMarkdown(userText), true) };
@@ -177,34 +194,49 @@ export function setMaybeRefreshFullContextFn(fn: () => void): void {
 	maybeRefreshFullContextFn = fn;
 }
 
+let sendInProgress = false;
+
 export function sendChat(): void {
+	void sendChatAsync();
+}
+
+async function sendChatAsync(): Promise<void> {
+	if (sendInProgress) return;
 	const text = (S.chatInput as HTMLTextAreaElement).value.trim();
-	const hasImages = hasPendingImages();
-	if (!((text || hasImages) && S.connected)) return;
+	const hasAttachments = hasPendingAttachments();
+	if (!((text || hasAttachments) && S.connected)) return;
+	sendInProgress = true;
 	warmAudioPlayback();
-	if (tryHandleLocalSlashCommand(text, hasImages)) return;
-	rememberChatHistory(text);
-	resetComposerAfterSend();
-	const outgoingText = normalizeOutgoingText(text, hasImages);
-	S.setChatSeq(S.chatSeq + 1);
-	const msg = buildChatMessage(outgoingText, S.chatSeq, text);
-	const chatParams = msg.params;
-	const userEl = msg.el;
-	if (userEl) highlightCodeBlocks(userEl);
-	applySelectedModelToChatParams(chatParams);
-	bumpSessionCount(S.activeSessionKey, 1);
-	cacheOutgoingUserMessage(S.activeSessionKey, chatParams);
-	seedSessionPreviewFromUserText(S.activeSessionKey, text || outgoingText);
-	setSessionReplying(S.activeSessionKey, true);
-	setComposerStopButton(true, S.activeSessionKey);
-	sendRpc<ChatSendPayload>("chat.send", chatParams)
-		.then((res) => handleChatSendRpcResponse(res, userEl))
-		.catch(() => {
+	try {
+		if (tryHandleLocalSlashCommand(text, hasAttachments)) return;
+		rememberChatHistory(text);
+		resetComposerAfterSend();
+		const outgoingText = normalizeOutgoingText(text, hasAttachments);
+		S.setChatSeq(S.chatSeq + 1);
+		const msg = await buildChatMessage(outgoingText, S.chatSeq, text);
+		const chatParams = msg.params;
+		const userEl = msg.el;
+		if (userEl) highlightCodeBlocks(userEl);
+		applySelectedModelToChatParams(chatParams);
+		bumpSessionCount(S.activeSessionKey, 1);
+		cacheOutgoingUserMessage(S.activeSessionKey, chatParams);
+		seedSessionPreviewFromUserText(S.activeSessionKey, text || outgoingText);
+		setSessionReplying(S.activeSessionKey, true);
+		setComposerStopButton(true, S.activeSessionKey);
+		try {
+			const res = await sendRpc<ChatSendPayload>("chat.send", chatParams);
+			handleChatSendRpcResponse(res, userEl);
+		} catch {
 			setComposerStopButton(false);
 			setSessionReplying(S.activeSessionKey, false);
 			chatAddMsg("error", "Request failed");
-		});
-	maybeRefreshFullContextFn?.();
+		}
+		maybeRefreshFullContextFn?.();
+	} catch (err) {
+		chatAddMsg("error", err instanceof Error ? err.message : "File upload failed");
+	} finally {
+		sendInProgress = false;
+	}
 }
 
 export { chatAutoResize };

--- a/crates/web/ui/src/sessions/session-render.ts
+++ b/crates/web/ui/src/sessions/session-render.ts
@@ -84,6 +84,13 @@ interface AssistantMsg extends HistoryMessage {
 
 interface UserMsg extends Omit<HistoryMessage, "content"> {
 	content?: string | unknown[];
+	documents?: Array<{
+		display_name?: string;
+		stored_filename?: string;
+		mime_type?: string;
+		size_bytes?: number;
+		media_ref?: string;
+	}>;
 	channel?: {
 		channel_type?: string;
 		username?: string;
@@ -189,6 +196,14 @@ function renderHistoryUserMessage(msg: UserMsg): HTMLElement | null {
 		el = chatAddMsgWithImages("user", text ? renderMarkdown(text) : "", images);
 	} else {
 		el = chatAddMsg("user", renderMarkdown(text), true);
+	}
+	if (el && Array.isArray(msg.documents)) {
+		for (const doc of msg.documents) {
+			const storedName = doc.stored_filename || doc.media_ref?.split("/").pop() || "";
+			if (!storedName) continue;
+			const mediaSrc = `/api/sessions/${encodeURIComponent(S.activeSessionKey)}/media/${encodeURIComponent(storedName)}`;
+			renderDocument(el, mediaSrc, doc.display_name || storedName, doc.mime_type, doc.size_bytes);
+		}
 	}
 	if (el && msg.channel) appendChannelFooter(el, msg.channel);
 	return el;


### PR DESCRIPTION
## Summary
- Allow the web chat composer to attach arbitrary files while preserving inline multimodal image handling.
- Upload non-image attachments to session media and pass document metadata, including MIME type and byte size, through chat persistence/context.
- Render attachment/file cards in pending, sent, and historical chat messages with type-aware icons.

## Validation
### Completed
- [x] `biome check --write crates/web/ui/src/` (completed with existing unrelated warnings)
- [x] `cd crates/web/ui && npm run build`
- [x] `cd crates/web/ui && npm run build:css`
- [x] `cd crates/web/ui && npm run build:sw`
- [x] `cd crates/web/ui && npx tsc --noEmit`
- [x] `cargo fmt --all -- --check`
- [x] `cargo check -p moltis-chat -p moltis-sessions -p moltis-channels -p moltis-telegram`
- [x] `cd crates/web/ui && npx playwright test e2e/specs/chat-input.spec.js`

### Remaining
- [ ] Full repository validation not run in this session.

## Manual QA
- Attach a `.ics` file through the chat composer.
- Confirm the pending attachment chip shows filename and size.
- Send the message and confirm a document card appears with metadata and download/open affordance.