### PR TITLE
fix(voice): return wav metadata for piper audio

### DIFF
--- a/crates/voice/src/stt/elevenlabs.rs
+++ b/crates/voice/src/stt/elevenlabs.rs
@@ -123,7 +123,7 @@ impl ElevenLabsStt {
             AudioFormat::Mp3 => "mp3",
             AudioFormat::Opus => "opus",
             AudioFormat::Aac => "aac",
-            AudioFormat::Pcm => "wav",
+            AudioFormat::Pcm | AudioFormat::Wav => "wav",
             AudioFormat::Webm => "webm",
         }
     }

--- a/crates/voice/src/stt/google.rs
+++ b/crates/voice/src/stt/google.rs
@@ -82,7 +82,7 @@ impl GoogleStt {
             crate::tts::AudioFormat::Mp3 => "MP3",
             crate::tts::AudioFormat::Opus | crate::tts::AudioFormat::Webm => "OGG_OPUS",
             crate::tts::AudioFormat::Aac => "MP3", // Fallback, not directly supported
-            crate::tts::AudioFormat::Pcm => "LINEAR16",
+            crate::tts::AudioFormat::Pcm | crate::tts::AudioFormat::Wav => "LINEAR16",
         }
     }
 }

--- a/crates/voice/src/tts/audio.rs
+++ b/crates/voice/src/tts/audio.rs
@@ -1,0 +1,54 @@
+use {
+    anyhow::{Result, anyhow},
+    bytes::Bytes,
+};
+
+pub(crate) fn wav_from_s16le_mono(pcm: &[u8], sample_rate_hz: u32) -> Result<Bytes> {
+    let data_len = u32::try_from(pcm.len())?;
+    let byte_rate = sample_rate_hz
+        .checked_mul(2)
+        .ok_or_else(|| anyhow!("sample rate is too large for WAV output"))?;
+    let riff_len = 36u32
+        .checked_add(data_len)
+        .ok_or_else(|| anyhow!("audio is too large for WAV output"))?;
+    let mut wav = Vec::with_capacity(44 + pcm.len());
+
+    wav.extend_from_slice(b"RIFF");
+    wav.extend_from_slice(&riff_len.to_le_bytes());
+    wav.extend_from_slice(b"WAVEfmt ");
+    wav.extend_from_slice(&16u32.to_le_bytes());
+    wav.extend_from_slice(&1u16.to_le_bytes());
+    wav.extend_from_slice(&1u16.to_le_bytes());
+    wav.extend_from_slice(&sample_rate_hz.to_le_bytes());
+    wav.extend_from_slice(&byte_rate.to_le_bytes());
+    wav.extend_from_slice(&2u16.to_le_bytes());
+    wav.extend_from_slice(&16u16.to_le_bytes());
+    wav.extend_from_slice(b"data");
+    wav.extend_from_slice(&data_len.to_le_bytes());
+    wav.extend_from_slice(pcm);
+
+    Ok(Bytes::from(wav))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_wav_from_s16le_mono_writes_header_and_payload() -> Result<()> {
+        let pcm = [0x01, 0x02, 0x03, 0x04];
+        let wav = wav_from_s16le_mono(&pcm, 16_000)?;
+
+        assert_eq!(&wav[0..4], b"RIFF");
+        assert_eq!(&wav[8..12], b"WAVE");
+        assert_eq!(&wav[12..16], b"fmt ");
+        assert_eq!(u32::from_le_bytes(wav[24..28].try_into()?), 16_000);
+        assert_eq!(u32::from_le_bytes(wav[28..32].try_into()?), 32_000);
+        assert_eq!(u16::from_le_bytes(wav[32..34].try_into()?), 2);
+        assert_eq!(u16::from_le_bytes(wav[34..36].try_into()?), 16);
+        assert_eq!(&wav[36..40], b"data");
+        assert_eq!(u32::from_le_bytes(wav[40..44].try_into()?), 4);
+        assert_eq!(&wav[44..], &pcm);
+        Ok(())
+    }
+}

--- a/crates/voice/src/tts/coqui.rs
+++ b/crates/voice/src/tts/coqui.rs
@@ -140,7 +140,7 @@ impl TtsProvider for CoquiTts {
         // The response is WAV format
         Ok(AudioOutput {
             data: Bytes::from(audio_data.to_vec()),
-            format: AudioFormat::Pcm, // WAV is essentially PCM with headers
+            format: AudioFormat::Wav,
             duration_ms: None,
         })
     }

--- a/crates/voice/src/tts/elevenlabs.rs
+++ b/crates/voice/src/tts/elevenlabs.rs
@@ -13,7 +13,9 @@ use {
     tracing::{debug, info, warn},
 };
 
-use super::{AudioFormat, AudioOutput, SynthesizeRequest, TtsProvider, Voice, contains_ssml};
+use super::{
+    AudioFormat, AudioOutput, SynthesizeRequest, TtsProvider, Voice, audio, contains_ssml,
+};
 
 /// ElevenLabs API base URL.
 const API_BASE: &str = "https://api.elevenlabs.io/v1";
@@ -117,6 +119,7 @@ impl ElevenLabsTts {
             AudioFormat::Opus => "opus_48000_64", // Good for Telegram voice notes
             AudioFormat::Aac => "aac_44100",
             AudioFormat::Pcm => "pcm_44100",
+            AudioFormat::Wav => "pcm_44100",
             AudioFormat::Webm => "opus_48000_64", // WebM uses Opus codec
         }
     }
@@ -241,20 +244,28 @@ impl TtsProvider for ElevenLabsTts {
             ));
         }
 
-        let data = response
+        let response_data = response
             .bytes()
             .await
             .context("failed to read ElevenLabs TTS response")?;
+        let (data, format) = if request.output_format == AudioFormat::Wav {
+            (
+                audio::wav_from_s16le_mono(&response_data, 44_100)?,
+                AudioFormat::Wav,
+            )
+        } else {
+            (response_data, request.output_format)
+        };
 
         info!(
             audio_bytes = data.len(),
-            format = ?request.output_format,
+            format = ?format,
             "ElevenLabs TTS synthesis complete"
         );
 
         Ok(AudioOutput {
             data,
-            format: request.output_format,
+            format,
             duration_ms: None, // ElevenLabs doesn't return duration in response
         })
     }
@@ -333,6 +344,10 @@ mod tests {
         assert_eq!(
             ElevenLabsTts::output_format_param(AudioFormat::Opus),
             "opus_48000_64"
+        );
+        assert_eq!(
+            ElevenLabsTts::output_format_param(AudioFormat::Wav),
+            "pcm_44100"
         );
     }
 

--- a/crates/voice/src/tts/google.rs
+++ b/crates/voice/src/tts/google.rs
@@ -175,7 +175,7 @@ impl GoogleTts {
             AudioFormat::Mp3 => "MP3",
             AudioFormat::Opus | AudioFormat::Webm => "OGG_OPUS",
             AudioFormat::Aac => "MP3",
-            AudioFormat::Pcm => "LINEAR16",
+            AudioFormat::Pcm | AudioFormat::Wav => "LINEAR16",
         };
 
         let input = if contains_ssml(&request.text) {

--- a/crates/voice/src/tts/mod.rs
+++ b/crates/voice/src/tts/mod.rs
@@ -1,5 +1,6 @@
 //! Text-to-Speech provider abstraction and implementations.
 
+mod audio;
 mod coqui;
 mod elevenlabs;
 mod google;
@@ -46,6 +47,8 @@ pub enum AudioFormat {
     Aac,
     /// PCM (raw audio).
     Pcm,
+    /// WAV container with PCM audio.
+    Wav,
     /// WebM container (browser MediaRecorder default).
     Webm,
 }
@@ -59,6 +62,7 @@ impl AudioFormat {
             Self::Opus => "audio/ogg",
             Self::Aac => "audio/aac",
             Self::Pcm => "audio/pcm",
+            Self::Wav => "audio/wav",
             Self::Webm => "audio/webm",
         }
     }
@@ -71,6 +75,7 @@ impl AudioFormat {
             Self::Opus => "ogg",
             Self::Aac => "aac",
             Self::Pcm => "pcm",
+            Self::Wav => "wav",
             Self::Webm => "webm",
         }
     }
@@ -84,7 +89,8 @@ impl AudioFormat {
             "audio/ogg" | "audio/opus" => Some(Self::Opus),
             "audio/mpeg" | "audio/mp3" => Some(Self::Mp3),
             "audio/aac" | "audio/mp4" | "audio/m4a" => Some(Self::Aac),
-            "audio/pcm" | "audio/wav" | "audio/x-wav" => Some(Self::Pcm),
+            "audio/pcm" => Some(Self::Pcm),
+            "audio/wav" | "audio/x-wav" => Some(Self::Wav),
             _ => None,
         }
     }
@@ -96,7 +102,8 @@ impl AudioFormat {
             "webm" => Self::Webm,
             "opus" | "ogg" => Self::Opus,
             "aac" | "m4a" => Self::Aac,
-            "pcm" | "wav" => Self::Pcm,
+            "pcm" => Self::Pcm,
+            "wav" => Self::Wav,
             _ => Self::Mp3,
         }
     }
@@ -854,6 +861,7 @@ For more details, check the **official documentation** at https://doc.rust-lang.
         assert_eq!(AudioFormat::Webm.mime_type(), "audio/webm");
         assert_eq!(AudioFormat::Aac.mime_type(), "audio/aac");
         assert_eq!(AudioFormat::Pcm.mime_type(), "audio/pcm");
+        assert_eq!(AudioFormat::Wav.mime_type(), "audio/wav");
     }
 
     #[test]
@@ -863,6 +871,7 @@ For more details, check the **official documentation** at https://doc.rust-lang.
         assert_eq!(AudioFormat::Webm.extension(), "webm");
         assert_eq!(AudioFormat::Aac.extension(), "aac");
         assert_eq!(AudioFormat::Pcm.extension(), "pcm");
+        assert_eq!(AudioFormat::Wav.extension(), "wav");
     }
 
     #[test]
@@ -901,7 +910,11 @@ For more details, check the **official documentation** at https://doc.rust-lang.
         );
         assert_eq!(
             AudioFormat::from_content_type("audio/wav"),
-            Some(AudioFormat::Pcm)
+            Some(AudioFormat::Wav)
+        );
+        assert_eq!(
+            AudioFormat::from_content_type("audio/x-wav"),
+            Some(AudioFormat::Wav)
         );
         assert_eq!(AudioFormat::from_content_type("image/png"), None);
         assert_eq!(AudioFormat::from_content_type("text/plain"), None);
@@ -914,7 +927,7 @@ For more details, check the **official documentation** at https://doc.rust-lang.
         assert_eq!(AudioFormat::from_short_name("ogg"), AudioFormat::Opus);
         assert_eq!(AudioFormat::from_short_name("aac"), AudioFormat::Aac);
         assert_eq!(AudioFormat::from_short_name("pcm"), AudioFormat::Pcm);
-        assert_eq!(AudioFormat::from_short_name("wav"), AudioFormat::Pcm);
+        assert_eq!(AudioFormat::from_short_name("wav"), AudioFormat::Wav);
         assert_eq!(AudioFormat::from_short_name("mp3"), AudioFormat::Mp3);
         assert_eq!(AudioFormat::from_short_name("unknown"), AudioFormat::Mp3);
     }

--- a/crates/voice/src/tts/openai.rs
+++ b/crates/voice/src/tts/openai.rs
@@ -103,6 +103,7 @@ impl OpenAiTts {
             AudioFormat::Opus | AudioFormat::Webm => "opus",
             AudioFormat::Aac => "aac",
             AudioFormat::Pcm => "pcm",
+            AudioFormat::Wav => "wav",
         }
     }
 }
@@ -224,6 +225,8 @@ mod tests {
         assert_eq!(OpenAiTts::response_format(AudioFormat::Mp3), "mp3");
         assert_eq!(OpenAiTts::response_format(AudioFormat::Opus), "opus");
         assert_eq!(OpenAiTts::response_format(AudioFormat::Aac), "aac");
+        assert_eq!(OpenAiTts::response_format(AudioFormat::Pcm), "pcm");
+        assert_eq!(OpenAiTts::response_format(AudioFormat::Wav), "wav");
     }
 
     #[test]

--- a/crates/voice/src/tts/piper.rs
+++ b/crates/voice/src/tts/piper.rs
@@ -53,18 +53,20 @@ impl PiperTts {
         path.to_string()
     }
 
-    fn sample_rate_hz(&self, model_path: &str) -> u32 {
+    async fn sample_rate_hz(&self, model_path: &str) -> u32 {
         let config_path = self
             .config_path
             .as_deref()
             .map(Self::expand_path)
             .unwrap_or_else(|| format!("{model_path}.json"));
 
-        Self::read_sample_rate_hz(Path::new(&config_path)).unwrap_or(DEFAULT_SAMPLE_RATE_HZ)
+        Self::read_sample_rate_hz(Path::new(&config_path))
+            .await
+            .unwrap_or(DEFAULT_SAMPLE_RATE_HZ)
     }
 
-    fn read_sample_rate_hz(path: &Path) -> Option<u32> {
-        let config = std::fs::read(path).ok()?;
+    async fn read_sample_rate_hz(path: &Path) -> Option<u32> {
+        let config = tokio::fs::read(path).await.ok()?;
         let value: serde_json::Value = serde_json::from_slice(&config).ok()?;
         let sample_rate = value.pointer("/audio/sample_rate")?.as_u64()?;
         u32::try_from(sample_rate).ok()
@@ -167,7 +169,7 @@ impl TtsProvider for PiperTts {
             | AudioFormat::Aac
             | AudioFormat::Wav
             | AudioFormat::Webm => {
-                let sample_rate_hz = self.sample_rate_hz(&model_path);
+                let sample_rate_hz = self.sample_rate_hz(&model_path).await;
                 (
                     audio::wav_from_s16le_mono(&output.stdout, sample_rate_hz)?,
                     AudioFormat::Wav,
@@ -219,13 +221,13 @@ mod tests {
         assert!(!expanded.starts_with("~/"));
     }
 
-    #[test]
-    fn test_read_sample_rate_hz_from_piper_config() -> Result<()> {
+    #[tokio::test]
+    async fn test_read_sample_rate_hz_from_piper_config() -> Result<()> {
         let dir = tempfile::tempdir()?;
         let path = dir.path().join("voice.onnx.json");
         std::fs::write(&path, r#"{"audio":{"sample_rate":16000}}"#)?;
 
-        assert_eq!(PiperTts::read_sample_rate_hz(&path), Some(16_000));
+        assert_eq!(PiperTts::read_sample_rate_hz(&path).await, Some(16_000));
         Ok(())
     }
 }

--- a/crates/voice/src/tts/piper.rs
+++ b/crates/voice/src/tts/piper.rs
@@ -7,14 +7,16 @@
 use {
     crate::{
         config::PiperTtsConfig,
-        tts::{AudioFormat, AudioOutput, SynthesizeRequest, TtsProvider, Voice},
+        tts::{AudioFormat, AudioOutput, SynthesizeRequest, TtsProvider, Voice, audio},
     },
     anyhow::{Result, anyhow},
     async_trait::async_trait,
     bytes::Bytes,
-    std::process::Stdio,
+    std::{path::Path, process::Stdio},
     tokio::{io::AsyncWriteExt, process::Command},
 };
+
+const DEFAULT_SAMPLE_RATE_HZ: u32 = 22_050;
 
 /// Piper TTS (local) provider.
 pub struct PiperTts {
@@ -50,6 +52,23 @@ impl PiperTts {
         }
         path.to_string()
     }
+
+    fn sample_rate_hz(&self, model_path: &str) -> u32 {
+        let config_path = self
+            .config_path
+            .as_deref()
+            .map(Self::expand_path)
+            .unwrap_or_else(|| format!("{model_path}.json"));
+
+        Self::read_sample_rate_hz(Path::new(&config_path)).unwrap_or(DEFAULT_SAMPLE_RATE_HZ)
+    }
+
+    fn read_sample_rate_hz(path: &Path) -> Option<u32> {
+        let config = std::fs::read(path).ok()?;
+        let value: serde_json::Value = serde_json::from_slice(&config).ok()?;
+        let sample_rate = value.pointer("/audio/sample_rate")?.as_u64()?;
+        u32::try_from(sample_rate).ok()
+    }
 }
 
 #[async_trait]
@@ -70,7 +89,7 @@ impl TtsProvider for PiperTts {
         // Piper doesn't have a dynamic voice list - the voice is determined by the model file
         // Return a single voice representing the configured model
         if let Some(model_path) = &self.model_path {
-            let model_name = std::path::Path::new(model_path)
+            let model_name = Path::new(model_path)
                 .file_stem()
                 .and_then(|s| s.to_str())
                 .unwrap_or("piper-voice");
@@ -140,14 +159,19 @@ impl TtsProvider for PiperTts {
             return Err(anyhow!("Piper failed: {}", stderr));
         }
 
-        // Piper outputs raw 16-bit PCM at 22050 Hz by default
-        // Convert to requested format if needed
+        // Piper outputs raw 16-bit mono PCM; wrap it as WAV unless raw PCM was requested.
         let (data, format) = match request.output_format {
             AudioFormat::Pcm => (Bytes::from(output.stdout), AudioFormat::Pcm),
-            AudioFormat::Mp3 | AudioFormat::Opus | AudioFormat::Aac | AudioFormat::Webm => {
-                // For other formats, we'd need ffmpeg conversion
-                // For now, return PCM and let caller handle conversion
-                (Bytes::from(output.stdout), AudioFormat::Pcm)
+            AudioFormat::Mp3
+            | AudioFormat::Opus
+            | AudioFormat::Aac
+            | AudioFormat::Wav
+            | AudioFormat::Webm => {
+                let sample_rate_hz = self.sample_rate_hz(&model_path);
+                (
+                    audio::wav_from_s16le_mono(&output.stdout, sample_rate_hz)?,
+                    AudioFormat::Wav,
+                )
             },
         };
 
@@ -193,5 +217,15 @@ mod tests {
     fn test_expand_path() {
         let expanded = PiperTts::expand_path("~/test/path");
         assert!(!expanded.starts_with("~/"));
+    }
+
+    #[test]
+    fn test_read_sample_rate_hz_from_piper_config() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+        let path = dir.path().join("voice.onnx.json");
+        std::fs::write(&path, r#"{"audio":{"sample_rate":16000}}"#)?;
+
+        assert_eq!(PiperTts::read_sample_rate_hz(&path), Some(16_000));
+        Ok(())
     }
 }


### PR DESCRIPTION
## Summary
- Add a distinct WAV audio format so raw PCM and WAV-wrapped PCM no longer share `AudioFormat::Pcm`.
- Wrap Piper raw PCM output as WAV for non-PCM requests while preserving raw PCM for explicit `pcm` requests.
- Update provider/STT mappings and tests so WAV MIME types, extensions, and response formats are reported correctly.

## Validation
### Completed
- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p moltis-voice --lib`
- [x] `cargo check -p moltis-voice`

### Remaining
- [ ] Full `just lint`
- [ ] Full `just test`
- [ ] `./scripts/local-validate.sh <PR_NUMBER>`

## Manual QA
- Not run locally with a real Piper model. The WAV header and Piper sample-rate config parsing paths are covered by unit tests.

Closes #1029