### PR TITLE
Expose local Moltis docs to agents

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7142,6 +7142,7 @@ dependencies = [
  "axum",
  "futures",
  "http 1.4.0",
+ "include_dir",
  "moltis-common",
  "moltis-config",
  "moltis-metrics",

--- a/crates/agents/Cargo.toml
+++ b/crates/agents/Cargo.toml
@@ -12,6 +12,7 @@ anyhow          = { workspace = true }
 async-stream    = { workspace = true }
 async-trait     = { workspace = true }
 futures         = { workspace = true }
+include_dir     = { workspace = true }
 moltis-common   = { workspace = true }
 moltis-config   = { workspace = true }
 moltis-sessions = { workspace = true }
@@ -21,7 +22,7 @@ secrecy         = { workspace = true }
 serde           = { workspace = true }
 serde_json      = { workspace = true }
 thiserror       = { workspace = true }
-time            = { workspace = true, features = ["macros"] }
+time            = { features = ["macros"], workspace = true }
 tokio           = { workspace = true }
 tokio-stream    = { workspace = true }
 tracing         = { workspace = true }

--- a/crates/agents/src/docs.rs
+++ b/crates/agents/src/docs.rs
@@ -3,6 +3,7 @@
 use std::{
     fs,
     path::{Component, Path, PathBuf},
+    sync::OnceLock,
 };
 
 use {
@@ -19,7 +20,15 @@ static BUNDLED_DOCS: Dir<'_> = include_dir!("$CARGO_MANIFEST_DIR/../../docs/src"
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MoltisDocsReference {
     pub docs_dir: PathBuf,
-    pub config_template_path: PathBuf,
+    pub config_template_path: Option<PathBuf>,
+}
+
+static DOCS_REFERENCE: OnceLock<Option<MoltisDocsReference>> = OnceLock::new();
+
+pub fn cached_moltis_docs_reference(data_dir: &Path, port: u16) -> Option<MoltisDocsReference> {
+    DOCS_REFERENCE
+        .get_or_init(|| resolve_moltis_docs_reference(data_dir, port))
+        .clone()
 }
 
 #[must_use]
@@ -68,7 +77,7 @@ pub fn resolve_moltis_docs_reference(data_dir: &Path, port: u16) -> Option<Molti
     })
 }
 
-fn write_config_template(data_dir: &Path, port: u16) -> PathBuf {
+fn write_config_template(data_dir: &Path, port: u16) -> Option<PathBuf> {
     let path = data_dir
         .join(BUNDLED_DOCS_RELATIVE_DIR)
         .join(CONFIG_TEMPLATE_DOC);
@@ -78,8 +87,11 @@ fn write_config_template(data_dir: &Path, port: u16) -> PathBuf {
     );
     let mut updated = 0usize;
     let mut errors = 0usize;
-    write_if_changed(&path, config_template.as_bytes(), &mut updated, &mut errors);
-    path
+    if write_if_changed(&path, config_template.as_bytes(), &mut updated, &mut errors) {
+        Some(path)
+    } else {
+        None
+    }
 }
 
 fn ensure_embedded_moltis_docs_dir(data_dir: &Path) -> Option<PathBuf> {
@@ -140,29 +152,52 @@ fn safe_relative_path(path: &Path) -> Option<PathBuf> {
     (!cleaned.as_os_str().is_empty()).then_some(cleaned)
 }
 
-fn write_if_changed(path: &Path, content: &[u8], updated: &mut usize, errors: &mut usize) {
+fn write_if_changed(path: &Path, content: &[u8], updated: &mut usize, errors: &mut usize) -> bool {
     if fs::read(path).is_ok_and(|existing| existing == content) {
-        return;
+        return true;
     }
     if let Some(parent) = path.parent()
         && let Err(error) = fs::create_dir_all(parent)
     {
         *errors += 1;
         warn!(path = %parent.display(), error = %error, "failed to create bundled doc parent directory");
-        return;
+        return false;
     }
     match fs::write(path, content) {
-        Ok(()) => *updated += 1,
+        Ok(()) => {
+            *updated += 1;
+            true
+        },
         Err(error) => {
             *errors += 1;
             warn!(path = %path.display(), error = %error, "failed to write bundled Moltis doc");
+            false
         },
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Mutex;
+
     use super::*;
+
+    static SHARE_DIR_TEST_LOCK: Mutex<()> = Mutex::new(());
+
+    struct ShareDirOverrideGuard;
+
+    impl ShareDirOverrideGuard {
+        fn set(path: PathBuf) -> Self {
+            moltis_config::set_share_dir(path);
+            Self
+        }
+    }
+
+    impl Drop for ShareDirOverrideGuard {
+        fn drop(&mut self) {
+            moltis_config::clear_share_dir();
+        }
+    }
 
     #[test]
     fn materializes_bundled_docs_and_config_template() {
@@ -172,7 +207,10 @@ mod tests {
             .unwrap_or_else(|| panic!("docs reference was not resolved"));
 
         assert!(reference.docs_dir.join("SUMMARY.md").is_file());
-        let config_template = fs::read_to_string(reference.config_template_path)
+        let config_template_path = reference
+            .config_template_path
+            .unwrap_or_else(|| panic!("config template path was not resolved"));
+        let config_template = fs::read_to_string(config_template_path)
             .unwrap_or_else(|error| panic!("read config template failed: {error}"));
         assert!(config_template.contains("# Moltis configuration template"));
         assert!(config_template.contains("port = 18789"));
@@ -180,6 +218,9 @@ mod tests {
 
     #[test]
     fn prefers_external_docs_dir_when_available() {
+        let _guard = SHARE_DIR_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
         let data = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir failed: {error}"));
         let share = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir failed: {error}"));
         let docs = share.path().join("docs");
@@ -187,13 +228,15 @@ mod tests {
         fs::write(docs.join("SUMMARY.md"), "# Summary\n")
             .unwrap_or_else(|error| panic!("write summary failed: {error}"));
 
-        moltis_config::set_share_dir(share.path().to_path_buf());
+        let _share_dir = ShareDirOverrideGuard::set(share.path().to_path_buf());
         let reference = resolve_moltis_docs_reference(data.path(), 18789)
             .unwrap_or_else(|| panic!("docs reference was not resolved"));
-        moltis_config::clear_share_dir();
 
         assert_eq!(reference.docs_dir, docs);
-        assert!(reference.config_template_path.starts_with(data.path()));
+        let config_template_path = reference
+            .config_template_path
+            .unwrap_or_else(|| panic!("config template path was not resolved"));
+        assert!(config_template_path.starts_with(data.path()));
     }
 
     #[test]

--- a/crates/agents/src/docs.rs
+++ b/crates/agents/src/docs.rs
@@ -1,0 +1,208 @@
+//! Moltis documentation exposed to agent prompts.
+
+use std::{
+    fs,
+    path::{Component, Path, PathBuf},
+};
+
+use {
+    include_dir::{Dir, DirEntry, include_dir},
+    tracing::{debug, warn},
+};
+
+pub const MOLTIS_DOCS_URL: &str = "https://docs.moltis.org";
+pub const BUNDLED_DOCS_RELATIVE_DIR: &str = "docs/moltis";
+pub const CONFIG_TEMPLATE_DOC: &str = "config-template.md";
+
+static BUNDLED_DOCS: Dir<'_> = include_dir!("$CARGO_MANIFEST_DIR/../../docs/src");
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MoltisDocsReference {
+    pub docs_dir: PathBuf,
+    pub config_template_path: PathBuf,
+}
+
+#[must_use]
+pub fn is_usable_moltis_docs_dir(path: &Path) -> bool {
+    path.join("SUMMARY.md").is_file()
+}
+
+pub fn resolve_moltis_docs_reference(data_dir: &Path, port: u16) -> Option<MoltisDocsReference> {
+    let config_template_path = write_config_template(data_dir, port);
+
+    if let Some(dir) = std::env::var("MOLTIS_DOCS_DIR")
+        .ok()
+        .map(PathBuf::from)
+        .filter(|dir| is_usable_moltis_docs_dir(dir))
+    {
+        debug!(path = %dir.display(), "using Moltis docs from MOLTIS_DOCS_DIR");
+        return Some(MoltisDocsReference {
+            docs_dir: dir,
+            config_template_path,
+        });
+    }
+
+    if let Some(dir) = moltis_config::share_dir()
+        .map(|share| share.join("docs"))
+        .filter(|dir| is_usable_moltis_docs_dir(dir))
+    {
+        debug!(path = %dir.display(), "using Moltis docs from external share dir");
+        return Some(MoltisDocsReference {
+            docs_dir: dir,
+            config_template_path,
+        });
+    }
+
+    let source_docs = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../docs/src");
+    if is_usable_moltis_docs_dir(&source_docs) {
+        debug!(path = %source_docs.display(), "using Moltis docs from source tree");
+        return Some(MoltisDocsReference {
+            docs_dir: source_docs,
+            config_template_path,
+        });
+    }
+
+    ensure_embedded_moltis_docs_dir(data_dir).map(|docs_dir| MoltisDocsReference {
+        docs_dir,
+        config_template_path,
+    })
+}
+
+fn write_config_template(data_dir: &Path, port: u16) -> PathBuf {
+    let path = data_dir
+        .join(BUNDLED_DOCS_RELATIVE_DIR)
+        .join(CONFIG_TEMPLATE_DOC);
+    let config_template = format!(
+        "# Moltis configuration template\n\n```toml\n{}\n```\n",
+        moltis_config::template::default_config_template(port)
+    );
+    let mut updated = 0usize;
+    let mut errors = 0usize;
+    write_if_changed(&path, config_template.as_bytes(), &mut updated, &mut errors);
+    path
+}
+
+fn ensure_embedded_moltis_docs_dir(data_dir: &Path) -> Option<PathBuf> {
+    let docs_dir = data_dir.join(BUNDLED_DOCS_RELATIVE_DIR);
+    if let Err(error) = fs::create_dir_all(&docs_dir) {
+        warn!(path = %docs_dir.display(), error = %error, "failed to create bundled Moltis docs directory");
+        return None;
+    }
+
+    let mut updated = 0usize;
+    let mut errors = 0usize;
+    write_dir_entries(&docs_dir, BUNDLED_DOCS.entries(), &mut updated, &mut errors);
+
+    if errors > 0 {
+        warn!(path = %docs_dir.display(), errors, "failed to write some bundled Moltis docs");
+    } else if updated > 0 {
+        debug!(path = %docs_dir.display(), updated, "bundled Moltis docs refreshed");
+    }
+
+    is_usable_moltis_docs_dir(&docs_dir).then_some(docs_dir)
+}
+
+fn write_dir_entries(
+    target_root: &Path,
+    entries: &[DirEntry<'_>],
+    updated: &mut usize,
+    errors: &mut usize,
+) {
+    for entry in entries {
+        match entry {
+            DirEntry::Dir(dir) => write_dir_entries(target_root, dir.entries(), updated, errors),
+            DirEntry::File(file) => {
+                let Some(relative_path) = safe_relative_path(file.path()) else {
+                    *errors += 1;
+                    warn!(path = %file.path().display(), "skipping bundled doc with unsafe path");
+                    continue;
+                };
+                write_if_changed(
+                    &target_root.join(relative_path),
+                    file.contents(),
+                    updated,
+                    errors,
+                );
+            },
+        }
+    }
+}
+
+fn safe_relative_path(path: &Path) -> Option<PathBuf> {
+    let mut cleaned = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::Normal(part) => cleaned.push(part),
+            Component::CurDir => {},
+            Component::ParentDir | Component::RootDir | Component::Prefix(_) => return None,
+        }
+    }
+    (!cleaned.as_os_str().is_empty()).then_some(cleaned)
+}
+
+fn write_if_changed(path: &Path, content: &[u8], updated: &mut usize, errors: &mut usize) {
+    if fs::read(path).is_ok_and(|existing| existing == content) {
+        return;
+    }
+    if let Some(parent) = path.parent()
+        && let Err(error) = fs::create_dir_all(parent)
+    {
+        *errors += 1;
+        warn!(path = %parent.display(), error = %error, "failed to create bundled doc parent directory");
+        return;
+    }
+    match fs::write(path, content) {
+        Ok(()) => *updated += 1,
+        Err(error) => {
+            *errors += 1;
+            warn!(path = %path.display(), error = %error, "failed to write bundled Moltis doc");
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn materializes_bundled_docs_and_config_template() {
+        let temp = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir failed: {error}"));
+
+        let reference = resolve_moltis_docs_reference(temp.path(), 18789)
+            .unwrap_or_else(|| panic!("docs reference was not resolved"));
+
+        assert!(reference.docs_dir.join("SUMMARY.md").is_file());
+        let config_template = fs::read_to_string(reference.config_template_path)
+            .unwrap_or_else(|error| panic!("read config template failed: {error}"));
+        assert!(config_template.contains("# Moltis configuration template"));
+        assert!(config_template.contains("port = 18789"));
+    }
+
+    #[test]
+    fn prefers_external_docs_dir_when_available() {
+        let data = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir failed: {error}"));
+        let share = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir failed: {error}"));
+        let docs = share.path().join("docs");
+        fs::create_dir_all(&docs).unwrap_or_else(|error| panic!("create docs failed: {error}"));
+        fs::write(docs.join("SUMMARY.md"), "# Summary\n")
+            .unwrap_or_else(|error| panic!("write summary failed: {error}"));
+
+        moltis_config::set_share_dir(share.path().to_path_buf());
+        let reference = resolve_moltis_docs_reference(data.path(), 18789)
+            .unwrap_or_else(|| panic!("docs reference was not resolved"));
+        moltis_config::clear_share_dir();
+
+        assert_eq!(reference.docs_dir, docs);
+        assert!(reference.config_template_path.starts_with(data.path()));
+    }
+
+    #[test]
+    fn usable_docs_dir_requires_summary() {
+        let temp = tempfile::tempdir().unwrap_or_else(|error| panic!("tempdir failed: {error}"));
+        assert!(!is_usable_moltis_docs_dir(temp.path()));
+
+        fs::write(temp.path().join("SUMMARY.md"), "# Summary\n")
+            .unwrap_or_else(|error| panic!("write summary failed: {error}"));
+        assert!(is_usable_moltis_docs_dir(temp.path()));
+    }
+}

--- a/crates/agents/src/lib.rs
+++ b/crates/agents/src/lib.rs
@@ -1,6 +1,7 @@
 //! LLM agent runtime: model selection, prompt building, tool execution, streaming.
 
 pub mod auth_profiles;
+pub mod docs;
 pub mod json_repair;
 pub mod memory_writer;
 pub mod model;

--- a/crates/agents/src/prompt/builder.rs
+++ b/crates/agents/src/prompt/builder.rs
@@ -339,7 +339,7 @@ fn append_documentation_section(
                 "For config template examples, read `{config_path}`.\n\n"
             ));
         } else {
-            prompt.push_str("For config template examples, read `config-template.md` in the Moltis docs directory.\n\n");
+            prompt.push('\n');
         }
     } else {
         prompt.push_str(&format!("Moltis docs: {MOLTIS_DOCS_URL}\n"));

--- a/crates/agents/src/prompt/builder.rs
+++ b/crates/agents/src/prompt/builder.rs
@@ -1,5 +1,6 @@
 use {
     crate::{
+        docs::MOLTIS_DOCS_URL,
         model::{ContentPart, UserContent},
         prompt::{
             formatting::{
@@ -296,6 +297,7 @@ fn build_system_prompt_full(
     append_boot_section(&mut prompt, boot_text);
     append_project_context(&mut prompt, project_context);
     append_runtime_section(&mut prompt, runtime_context, include_tools);
+    append_documentation_section(&mut prompt, runtime_context);
     append_skills_section(
         &mut prompt,
         include_tools,
@@ -313,6 +315,35 @@ fn build_system_prompt_full(
     PromptBuildOutput {
         prompt,
         metadata: PromptBuildMetadata { workspace_files },
+    }
+}
+
+fn append_documentation_section(
+    prompt: &mut String,
+    runtime_context: Option<&PromptRuntimeContext>,
+) {
+    let docs_path = runtime_context
+        .and_then(|ctx| ctx.host.docs_path.as_deref())
+        .filter(|value| !value.is_empty());
+    let config_template_path = runtime_context
+        .and_then(|ctx| ctx.host.config_template_path.as_deref())
+        .filter(|value| !value.is_empty());
+
+    prompt.push_str("## Documentation\n\n");
+    if let Some(path) = docs_path {
+        prompt.push_str(&format!("Moltis docs: {path}\n"));
+        prompt.push_str(&format!("Mirror: {MOLTIS_DOCS_URL}\n"));
+        prompt.push_str("For Moltis behavior, commands, config, channels, or architecture: consult local docs first.\n");
+        if let Some(config_path) = config_template_path {
+            prompt.push_str(&format!(
+                "For config template examples, read `{config_path}`.\n\n"
+            ));
+        } else {
+            prompt.push_str("For config template examples, read `config-template.md` in the Moltis docs directory.\n\n");
+        }
+    } else {
+        prompt.push_str(&format!("Moltis docs: {MOLTIS_DOCS_URL}\n"));
+        prompt.push_str("For Moltis behavior, commands, config, channels, or architecture: consult the docs first.\n\n");
     }
 }
 

--- a/crates/agents/src/prompt/formatting.rs
+++ b/crates/agents/src/prompt/formatting.rs
@@ -158,6 +158,8 @@ pub(crate) fn format_host_runtime_line(host: &PromptHostRuntimeContext) -> Optio
         ("channel_chat_id", host.channel_chat_id.as_deref()),
         ("channel_chat_type", host.channel_chat_type.as_deref()),
         ("data_dir", host.data_dir.as_deref()),
+        ("docs_path", host.docs_path.as_deref()),
+        ("config_template", host.config_template_path.as_deref()),
     ] {
         push_non_empty_runtime_field(&mut parts, key, value);
     }

--- a/crates/agents/src/prompt/tests.rs
+++ b/crates/agents/src/prompt/tests.rs
@@ -132,6 +132,61 @@ fn test_no_skills_block_when_empty() {
 }
 
 #[test]
+fn test_documentation_section_includes_local_docs_path() {
+    let tools = ToolRegistry::new();
+    let runtime = PromptRuntimeContext {
+        host: PromptHostRuntimeContext {
+            docs_path: Some("/tmp/moltis/docs/moltis".into()),
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+
+    let prompt = build_system_prompt_with_session_runtime(
+        &tools,
+        true,
+        None,
+        &[],
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        Some(&runtime),
+        None,
+        None,
+    );
+
+    assert!(prompt.contains("## Documentation"));
+    assert!(prompt.contains("Moltis docs: /tmp/moltis/docs/moltis"));
+    assert!(prompt.contains("consult local docs first"));
+    assert!(prompt.contains("config-template.md"));
+}
+
+#[test]
+fn test_documentation_section_falls_back_to_public_docs() {
+    let tools = ToolRegistry::new();
+    let prompt = build_system_prompt_with_session_runtime(
+        &tools,
+        true,
+        None,
+        &[],
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+    );
+
+    assert!(prompt.contains("Moltis docs: https://docs.moltis.org"));
+}
+
+#[test]
 fn test_identity_injected_into_prompt() {
     let tools = ToolRegistry::new();
     let identity = AgentIdentity {
@@ -302,6 +357,8 @@ fn test_runtime_context_injected_when_provided() {
             channel_chat_type: None,
             channel_sender_id: None,
             data_dir: Some("/home/moltis/.moltis".into()),
+            docs_path: None,
+            config_template_path: None,
             sudo_non_interactive: Some(true),
             sudo_status: Some("passwordless".into()),
             timezone: Some("Europe/Paris".into()),

--- a/crates/agents/src/prompt/tests.rs
+++ b/crates/agents/src/prompt/tests.rs
@@ -137,6 +137,7 @@ fn test_documentation_section_includes_local_docs_path() {
     let runtime = PromptRuntimeContext {
         host: PromptHostRuntimeContext {
             docs_path: Some("/tmp/moltis/docs/moltis".into()),
+            config_template_path: Some("/tmp/moltis/docs/moltis/config-template.md".into()),
             ..Default::default()
         },
         ..Default::default()

--- a/crates/agents/src/prompt/types.rs
+++ b/crates/agents/src/prompt/types.rs
@@ -55,6 +55,8 @@ pub struct PromptHostRuntimeContext {
     pub channel_chat_type: Option<String>,
     pub channel_sender_id: Option<String>,
     pub data_dir: Option<String>,
+    pub docs_path: Option<String>,
+    pub config_template_path: Option<String>,
     pub sudo_non_interactive: Option<bool>,
     pub sudo_status: Option<String>,
     pub timezone: Option<String>,

--- a/crates/chat/src/prompt.rs
+++ b/crates/chat/src/prompt.rs
@@ -381,7 +381,7 @@ pub(crate) async fn build_prompt_runtime_context(
     let data_dir = moltis_config::data_dir();
     let data_dir_display = data_dir.display().to_string();
     let docs_reference =
-        moltis_agents::docs::resolve_moltis_docs_reference(&data_dir, config.server.port);
+        moltis_agents::docs::cached_moltis_docs_reference(&data_dir, config.server.port);
 
     let sudo_fut = detect_host_sudo_access();
     let sandbox_fut = async {
@@ -452,7 +452,8 @@ pub(crate) async fn build_prompt_runtime_context(
             .map(|reference| reference.docs_dir.display().to_string()),
         config_template_path: docs_reference
             .as_ref()
-            .map(|reference| reference.config_template_path.display().to_string()),
+            .and_then(|reference| reference.config_template_path.as_ref())
+            .map(|path| path.display().to_string()),
         sudo_non_interactive,
         sudo_status,
         timezone,

--- a/crates/chat/src/prompt.rs
+++ b/crates/chat/src/prompt.rs
@@ -373,12 +373,15 @@ pub(crate) fn build_tool_context(
 
 pub(crate) async fn build_prompt_runtime_context(
     state: &Arc<dyn ChatRuntime>,
+    config: &moltis_config::MoltisConfig,
     provider: &Arc<dyn moltis_agents::model::LlmProvider>,
     session_key: &str,
     session_entry: Option<&SessionEntry>,
 ) -> PromptRuntimeContext {
     let data_dir = moltis_config::data_dir();
     let data_dir_display = data_dir.display().to_string();
+    let docs_reference =
+        moltis_agents::docs::resolve_moltis_docs_reference(&data_dir, config.server.port);
 
     let sudo_fut = detect_host_sudo_access();
     let sandbox_fut = async {
@@ -444,6 +447,12 @@ pub(crate) async fn build_prompt_runtime_context(
         channel_chat_id: channel_context.chat_id,
         channel_chat_type: channel_context.chat_type,
         data_dir: Some(data_dir_display),
+        docs_path: docs_reference
+            .as_ref()
+            .map(|reference| reference.docs_dir.display().to_string()),
+        config_template_path: docs_reference
+            .as_ref()
+            .map(|reference| reference.config_template_path.display().to_string()),
         sudo_non_interactive,
         sudo_status,
         timezone,

--- a/crates/chat/src/service/chat_impl.rs
+++ b/crates/chat/src/service/chat_impl.rs
@@ -161,6 +161,7 @@ impl ChatService for LiveChatService {
         .await;
         let mut runtime_context = build_prompt_runtime_context(
             &self.state,
+            &persona.config,
             &provider,
             &session_key,
             session_entry.as_ref(),
@@ -989,6 +990,7 @@ impl ChatService for LiveChatService {
         .await;
         let mut runtime_context = build_prompt_runtime_context(
             &self.state,
+            &persona.config,
             &provider,
             &session_key,
             session_entry.as_ref(),
@@ -1119,6 +1121,7 @@ impl ChatService for LiveChatService {
         .await;
         let mut runtime_context = build_prompt_runtime_context(
             &self.state,
+            &persona.config,
             &provider,
             &session_key,
             session_entry.as_ref(),

--- a/crates/chat/src/service/chat_impl/send.rs
+++ b/crates/chat/src/service/chat_impl/send.rs
@@ -877,6 +877,7 @@ impl LiveChatService {
         );
         let mut runtime_context = build_prompt_runtime_context(
             &self.state,
+            &persona.config,
             &provider,
             &session_key,
             session_entry.as_ref(),

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -20,6 +20,11 @@ assets = [
     "644",
   ],
   [
+    "../../docs/src/**/*",
+    "usr/share/moltis/docs/",
+    "644",
+  ],
+  [
     "target/release/moltis_wasm_calc.wasm",
     "usr/share/moltis/wasm/",
     "644",
@@ -45,6 +50,7 @@ section = "net"
 [package.metadata.generate-rpm]
 assets = [
   { dest = "/usr/bin/moltis", mode = "0755", source = "target/release/moltis" },
+  { dest = "/usr/share/moltis/docs/", mode = "0644", source = "docs/src/**/*" },
   { dest = "/usr/share/moltis/wasm/", mode = "0644", source = "target/wasm32-wasip2/release/moltis_wasm_calc.wasm" },
   { dest = "/usr/share/moltis/wasm/", mode = "0644", source = "target/wasm32-wasip2/release/moltis_wasm_web_fetch.wasm" },
   { dest = "/usr/share/moltis/wasm/", mode = "0644", source = "target/wasm32-wasip2/release/moltis_wasm_web_search.wasm" },

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -53,6 +53,20 @@ implementation. Moltis regenerates `defaults.toml` from those built-in defaults
 on startup, while `moltis.toml` should contain only values you intentionally
 override.
 
+## Agent-Readable Docs
+
+Moltis packages the documentation as local markdown files when the install
+format supports external share files, such as `.deb`, `.rpm`, Homebrew, and
+similar system packages. Agents are pointed at those local files through the
+system prompt so they can read setup, configuration, channel, and
+troubleshooting docs without needing web access.
+
+Resolution order is `MOLTIS_DOCS_DIR`, the packaged share docs directory
+(`<share>/docs`), the source checkout docs in development, then an embedded
+fallback copied to `~/.moltis/docs/moltis/`. Moltis also writes a generated
+`config-template.md` under `~/.moltis/docs/moltis/` for the current server port
+and points agents at it separately.
+
 ## Basic Settings
 
 ```toml


### PR DESCRIPTION
## Summary
- Add agent prompt documentation guidance that points agents at local Moltis docs before falling back to the public docs site.
- Resolve docs from `MOLTIS_DOCS_DIR`, packaged share docs, source docs, or an embedded fallback, and generate a local config template reference.
- Package docs into Debian/RPM share directories and document the resolution behavior.

## Validation
### Completed
- [x] `cargo fmt --all -- --check`
- [x] `taplo fmt --check crates/agents/Cargo.toml crates/cli/Cargo.toml`
- [x] `cargo test -p moltis-agents docs::tests`
- [x] `cargo test -p moltis-agents documentation_section`
- [x] `cargo check -p moltis-chat`

### Remaining
- [ ] Full `just test`
- [ ] Full `just lint`

## Manual QA
- Not run. The focused tests cover docs resolution and prompt injection.