### PR TITLE
fix(web): restore light mode syntax highlighting

### DIFF
--- a/crates/web/src/assets/css/chat.css
+++ b/crates/web/src/assets/css/chat.css
@@ -500,10 +500,9 @@
   background-color: transparent !important;
 }
 
-/* Light mode uses default --shiki-light colors */
+/* Light mode uses Shiki's inline default theme colors. */
 [data-theme="light"] .shiki,
 [data-theme="light"] .shiki span {
-  color: var(--shiki-light) !important;
   background-color: transparent !important;
 }
 

--- a/crates/web/ui/e2e/specs/code-highlight.spec.js
+++ b/crates/web/ui/e2e/specs/code-highlight.spec.js
@@ -81,6 +81,7 @@ test.describe("Code block syntax highlighting", () => {
 			document.documentElement.setAttribute("data-theme", "light");
 			document.documentElement.style.colorScheme = "light";
 			var appScript = document.querySelector('script[type="module"][src*="js/app.js"]');
+			if (!appScript) throw new Error("app module script not found");
 			var appUrl = new URL(appScript.src, window.location.origin);
 			var prefix = appUrl.href.slice(0, appUrl.href.length - "js/app.js".length);
 			var helpers = await import(`${prefix}js/helpers.js`);
@@ -99,10 +100,12 @@ test.describe("Code block syntax highlighting", () => {
 
 		var colorInfo = await page.locator("#e2e-shiki-light-fixture code.shiki").evaluate((codeEl) => {
 			var codeColor = getComputedStyle(codeEl).color;
-			var tokenColors = Array.from(codeEl.querySelectorAll("span")).map((span) => getComputedStyle(span).color);
+			var tokenColors = Array.from(codeEl.querySelectorAll("span"))
+				.map((span) => getComputedStyle(span).color)
+				.filter((color) => color !== codeColor && color !== "rgb(0, 0, 0)");
 			return { codeColor, tokenColors };
 		});
-		expect(colorInfo.tokenColors.some((color) => color !== colorInfo.codeColor)).toBe(true);
+		expect(new Set(colorInfo.tokenColors).size).toBeGreaterThanOrEqual(2);
 
 		expect(pageErrors).toEqual([]);
 	});

--- a/crates/web/ui/e2e/specs/code-highlight.spec.js
+++ b/crates/web/ui/e2e/specs/code-highlight.spec.js
@@ -72,4 +72,38 @@ test.describe("Code block syntax highlighting", () => {
 
 		expect(pageErrors).toEqual([]);
 	});
+
+	test("light theme keeps computed syntax colors", async ({ page }) => {
+		const pageErrors = await navigateAndWait(page, "/");
+		await waitForWsConnected(page);
+
+		await page.evaluate(async () => {
+			document.documentElement.setAttribute("data-theme", "light");
+			document.documentElement.style.colorScheme = "light";
+			var appScript = document.querySelector('script[type="module"][src*="js/app.js"]');
+			var appUrl = new URL(appScript.src, window.location.origin);
+			var prefix = appUrl.href.slice(0, appUrl.href.length - "js/app.js".length);
+			var helpers = await import(`${prefix}js/helpers.js`);
+			var codeHighlight = await import(`${prefix}js/code-highlight.js`);
+			await codeHighlight.initHighlighter();
+			var markdown = "```javascript\nconst x = 42;\n```";
+			var existing = document.getElementById("e2e-shiki-light-fixture");
+			if (existing) existing.remove();
+			var fixture = document.createElement("div");
+			fixture.id = "e2e-shiki-light-fixture";
+			fixture.className = "msg assistant";
+			fixture.innerHTML = helpers.renderMarkdown(markdown); // eslint-disable-line no-unsanitized/property
+			document.body.appendChild(fixture);
+			await codeHighlight.highlightCodeBlocks(fixture);
+		});
+
+		var colorInfo = await page.locator("#e2e-shiki-light-fixture code.shiki").evaluate((codeEl) => {
+			var codeColor = getComputedStyle(codeEl).color;
+			var tokenColors = Array.from(codeEl.querySelectorAll("span")).map((span) => getComputedStyle(span).color);
+			return { codeColor, tokenColors };
+		});
+		expect(colorInfo.tokenColors.some((color) => color !== colorInfo.codeColor)).toBe(true);
+
+		expect(pageErrors).toEqual([]);
+	});
 });


### PR DESCRIPTION
## Summary
- Restore Shiki light-mode syntax highlighting by allowing inline light theme token colors to apply.
- Keep code block backgrounds transparent in both themes so existing chat styling remains consistent.
- Add a Playwright regression test for light-mode computed syntax colors.

## Validation
### Completed
- [x] `biome check --write crates/web/ui/e2e/specs/code-highlight.spec.js`
- [x] `cd crates/web/ui && npm run build`
- [x] `cd crates/web/ui && npx tsc --noEmit`
- [x] `cd crates/web/ui && npx playwright test e2e/specs/code-highlight.spec.js`

### Remaining
- [ ] Full CI suite

## Manual QA
- Not performed manually; covered by targeted Playwright regression test for light-mode highlighted code blocks.

Closes #1045