### PR TITLE
fix(gateway): register config-declared hooks

### DIFF
--- a/crates/common/src/hooks.rs
+++ b/crates/common/src/hooks.rs
@@ -797,6 +797,17 @@ mod tests {
     }
 
     #[test]
+    fn hook_event_display_and_from_str_roundtrip() {
+        for event in HookEvent::ALL {
+            let parsed = event
+                .to_string()
+                .parse::<HookEvent>()
+                .expect("displayed hook event should parse");
+            assert_eq!(*event, parsed);
+        }
+    }
+
+    #[test]
     fn priority_ordering() {
         let mut registry = HookRegistry::new();
         registry.register(Arc::new(PriorityHandler {

--- a/crates/common/src/hooks.rs
+++ b/crates/common/src/hooks.rs
@@ -7,6 +7,7 @@
 use std::{
     collections::HashMap,
     fmt,
+    str::FromStr,
     sync::{
         Arc,
         atomic::{AtomicBool, AtomicU64, Ordering},
@@ -49,6 +50,33 @@ pub enum HookEvent {
 impl fmt::Display for HookEvent {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{self:?}")
+    }
+}
+
+impl FromStr for HookEvent {
+    type Err = String;
+
+    fn from_str(value: &str) -> std::result::Result<Self, Self::Err> {
+        match value {
+            "BeforeAgentStart" => Ok(Self::BeforeAgentStart),
+            "AgentEnd" => Ok(Self::AgentEnd),
+            "BeforeLLMCall" => Ok(Self::BeforeLLMCall),
+            "AfterLLMCall" => Ok(Self::AfterLLMCall),
+            "BeforeCompaction" => Ok(Self::BeforeCompaction),
+            "AfterCompaction" => Ok(Self::AfterCompaction),
+            "MessageReceived" => Ok(Self::MessageReceived),
+            "MessageSending" => Ok(Self::MessageSending),
+            "MessageSent" => Ok(Self::MessageSent),
+            "BeforeToolCall" => Ok(Self::BeforeToolCall),
+            "AfterToolCall" => Ok(Self::AfterToolCall),
+            "ToolResultPersist" => Ok(Self::ToolResultPersist),
+            "SessionStart" => Ok(Self::SessionStart),
+            "SessionEnd" => Ok(Self::SessionEnd),
+            "GatewayStart" => Ok(Self::GatewayStart),
+            "GatewayStop" => Ok(Self::GatewayStop),
+            "Command" => Ok(Self::Command),
+            other => Err(format!("unknown hook event '{other}'")),
+        }
     }
 }
 

--- a/crates/gateway/src/server/hooks.rs
+++ b/crates/gateway/src/server/hooks.rs
@@ -299,16 +299,25 @@ pub(crate) async fn discover_and_build_hooks(
         }
     }
 
-    let config_hook_count = config
-        .hooks
-        .as_ref()
-        .map_or(0, |hooks_config| hooks_config.hooks.len());
+    let filesystem_hook_names = discovered
+        .iter()
+        .map(|(parsed, _source)| parsed.metadata.name.as_str())
+        .collect::<HashSet<_>>();
+    let mut config_hook_count = 0;
     let config_path = moltis_config::config_dir()
         .map(|path| path.join("moltis.toml").display().to_string())
         .unwrap_or_else(|| "moltis.toml".to_string());
 
     if let Some(hooks_config) = config.hooks.as_ref() {
         for hook in &hooks_config.hooks {
+            if filesystem_hook_names.contains(hook.name.as_str()) {
+                warn!(
+                    hook = %hook.name,
+                    "config hook conflicts with filesystem hook; keeping filesystem hook"
+                );
+                continue;
+            }
+
             let events = hook
                 .events
                 .iter()
@@ -321,6 +330,7 @@ pub(crate) async fn discover_and_build_hooks(
                 })
                 .collect::<Vec<_>>();
             let is_enabled = !disabled.contains(&hook.name) && !events.is_empty();
+            config_hook_count += 1;
 
             info_list.push(crate::state::DiscoveredHookInfo {
                 name: hook.name.clone(),

--- a/crates/gateway/src/server/hooks.rs
+++ b/crates/gateway/src/server/hooks.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashSet, path::PathBuf, sync::Arc};
 
-use tracing::info;
+use tracing::{info, warn};
 
 use moltis_sessions::store::SessionStore;
 
@@ -230,9 +230,10 @@ pub(crate) async fn discover_and_build_hooks(
         shell_hook::ShellHookHandler,
     };
 
+    let config = moltis_config::discover_and_load();
     let discoverer = FsHookDiscoverer::new(FsHookDiscoverer::default_paths());
     let discovered = discoverer.discover().await.unwrap_or_default();
-    let session_export_mode = moltis_config::discover_and_load().memory.session_export;
+    let session_export_mode = config.memory.session_export;
 
     let mut registry = moltis_common::hooks::HookRegistry::new();
     let mut info_list = Vec::with_capacity(discovered.len());
@@ -298,6 +299,65 @@ pub(crate) async fn discover_and_build_hooks(
         }
     }
 
+    let config_hook_count = config
+        .hooks
+        .as_ref()
+        .map_or(0, |hooks_config| hooks_config.hooks.len());
+    let config_path = moltis_config::config_dir()
+        .map(|path| path.join("moltis.toml").display().to_string())
+        .unwrap_or_else(|| "moltis.toml".to_string());
+
+    if let Some(hooks_config) = config.hooks.as_ref() {
+        for hook in &hooks_config.hooks {
+            let events = hook
+                .events
+                .iter()
+                .filter_map(|event| match event.parse::<moltis_common::hooks::HookEvent>() {
+                    Ok(event) => Some(event),
+                    Err(e) => {
+                        warn!(hook = %hook.name, event = %event, error = %e, "skipping invalid config hook event");
+                        None
+                    },
+                })
+                .collect::<Vec<_>>();
+            let is_enabled = !disabled.contains(&hook.name) && !events.is_empty();
+
+            info_list.push(crate::state::DiscoveredHookInfo {
+                name: hook.name.clone(),
+                description: String::new(),
+                emoji: None,
+                events: hook.events.clone(),
+                command: Some(hook.command.clone()),
+                timeout: hook.timeout,
+                priority: 0,
+                source: "config".to_string(),
+                source_path: config_path.clone(),
+                eligible: !events.is_empty(),
+                missing_os: false,
+                missing_bins: vec![],
+                missing_env: vec![],
+                enabled: is_enabled,
+                body: String::new(),
+                body_html: "<p><em>Shell hook declared in moltis.toml.</em></p>".to_string(),
+                call_count: 0,
+                failure_count: 0,
+                avg_latency_ms: 0,
+            });
+
+            if is_enabled {
+                let handler = ShellHookHandler::new(
+                    hook.name.clone(),
+                    hook.command.clone(),
+                    events,
+                    std::time::Duration::from_secs(hook.timeout),
+                    hook.env.clone(),
+                    None,
+                );
+                registry.register(Arc::new(handler));
+            }
+        }
+    }
+
     // ── Built-in hooks (compiled Rust, always active) ──────────────────
     {
         let data = moltis_config::data_dir();
@@ -354,10 +414,11 @@ pub(crate) async fn discover_and_build_hooks(
 
     if !info_list.is_empty() {
         info!(
-            "{} hook(s) discovered ({} shell, {} built-in), {} registered",
+            "{} hook(s) discovered ({} filesystem shell, {} config shell, {} built-in), {} registered",
             info_list.len(),
             discovered.len(),
-            info_list.len() - discovered.len(),
+            config_hook_count,
+            info_list.len() - discovered.len() - config_hook_count,
             registry.handler_names().len()
         );
     }

--- a/crates/gateway/src/server/hooks.rs
+++ b/crates/gateway/src/server/hooks.rs
@@ -307,6 +307,7 @@ pub(crate) async fn discover_and_build_hooks(
     let config_path = moltis_config::config_dir()
         .map(|path| path.join("moltis.toml").display().to_string())
         .unwrap_or_else(|| "moltis.toml".to_string());
+    let mut config_hook_names = HashSet::new();
 
     if let Some(hooks_config) = config.hooks.as_ref() {
         for hook in &hooks_config.hooks {
@@ -314,6 +315,14 @@ pub(crate) async fn discover_and_build_hooks(
                 warn!(
                     hook = %hook.name,
                     "config hook conflicts with filesystem hook; keeping filesystem hook"
+                );
+                continue;
+            }
+
+            if !config_hook_names.insert(hook.name.as_str()) {
+                warn!(
+                    hook = %hook.name,
+                    "duplicate config hook name; keeping first config hook"
                 );
                 continue;
             }

--- a/crates/gateway/src/server/hooks.rs
+++ b/crates/gateway/src/server/hooks.rs
@@ -329,6 +329,7 @@ pub(crate) async fn discover_and_build_hooks(
                     },
                 })
                 .collect::<Vec<_>>();
+            let event_names = events.iter().map(|event| event.to_string()).collect();
             let is_enabled = !disabled.contains(&hook.name) && !events.is_empty();
             config_hook_count += 1;
 
@@ -336,7 +337,7 @@ pub(crate) async fn discover_and_build_hooks(
                 name: hook.name.clone(),
                 description: String::new(),
                 emoji: None,
-                events: hook.events.clone(),
+                events: event_names,
                 command: Some(hook.command.clone()),
                 timeout: hook.timeout,
                 priority: 0,

--- a/crates/gateway/src/server/tests_legacy/hooks.rs
+++ b/crates/gateway/src/server/tests_legacy/hooks.rs
@@ -28,6 +28,24 @@ timeout = 7
     .unwrap();
 }
 
+fn write_filesystem_hook(data_dir: &std::path::Path, name: &str, command: &str) {
+    let hook_dir = data_dir.join("hooks").join(name);
+    std::fs::create_dir_all(&hook_dir).unwrap();
+    std::fs::write(
+        hook_dir.join("HOOK.md"),
+        format!(
+            r#"+++
+name = {name:?}
+command = {command:?}
+events = ["BeforeLLMCall"]
+timeout = 7
++++
+"#
+        ),
+    )
+    .unwrap();
+}
+
 #[tokio::test]
 async fn discover_hooks_registers_builtin_handlers() {
     let _guard = LocalModelConfigTestGuard::new();
@@ -162,6 +180,60 @@ async fn discover_hooks_lists_disabled_config_hooks_without_registering() {
     assert_eq!(hook_info.source, "config");
     assert!(!hook_info.enabled);
     assert!(hook_info.eligible);
+
+    moltis_config::clear_config_dir();
+    moltis_config::clear_data_dir();
+}
+
+#[tokio::test]
+async fn filesystem_hook_takes_precedence_over_same_named_config_hook() {
+    let _guard = LocalModelConfigTestGuard::new();
+    let data_dir = tempfile::tempdir().unwrap();
+    let config_dir = tempfile::tempdir().unwrap();
+    let output_path = data_dir.path().join("collision-output.txt");
+    write_filesystem_hook(
+        data_dir.path(),
+        "config-test-hook",
+        &format!("printf fs > {:?}", output_path),
+    );
+    write_config_hook(
+        config_dir.path(),
+        &format!("printf config > {:?}", output_path),
+        None,
+    );
+    moltis_config::set_data_dir(data_dir.path().to_path_buf());
+    moltis_config::set_config_dir(config_dir.path().to_path_buf());
+
+    let sessions_dir = data_dir.path().join("sessions");
+    std::fs::create_dir_all(&sessions_dir).unwrap();
+    let session_store = Arc::new(moltis_sessions::store::SessionStore::new(sessions_dir));
+    let (registry, info) = discover_and_build_hooks(&HashSet::new(), Some(&session_store)).await;
+    let registry = registry.expect("expected hook registry to be created");
+
+    assert!(
+        info.iter()
+            .any(|hook| hook.name == "config-test-hook" && hook.source == "user")
+    );
+    assert!(
+        !info
+            .iter()
+            .any(|hook| hook.name == "config-test-hook" && hook.source == "config")
+    );
+
+    registry
+        .dispatch(&moltis_common::hooks::HookPayload::BeforeLLMCall {
+            session_key: "config-hook-test".to_string(),
+            provider: "test-provider".to_string(),
+            model: "test-model".to_string(),
+            messages: serde_json::json!([]),
+            tool_count: 0,
+            iteration: 1,
+        })
+        .await
+        .unwrap();
+
+    let captured = std::fs::read_to_string(&output_path).unwrap();
+    assert_eq!(captured, "fs");
 
     moltis_config::clear_config_dir();
     moltis_config::clear_data_dir();

--- a/crates/gateway/src/server/tests_legacy/hooks.rs
+++ b/crates/gateway/src/server/tests_legacy/hooks.rs
@@ -8,6 +8,26 @@ use {
     },
 };
 
+fn write_config_hook(config_dir: &std::path::Path, command: &str, env: Option<(&str, &str)>) {
+    let env_config = env
+        .map(|(key, value)| format!("\n[hooks.hooks.env]\n{key} = {value:?}\n"))
+        .unwrap_or_default();
+    std::fs::write(
+        config_dir.join("moltis.toml"),
+        format!(
+            r#"[hooks]
+
+[[hooks.hooks]]
+name = "config-test-hook"
+command = {command:?}
+events = ["BeforeLLMCall"]
+timeout = 7
+{env_config}"#
+        ),
+    )
+    .unwrap();
+}
+
 #[tokio::test]
 async fn discover_hooks_registers_builtin_handlers() {
     let _guard = LocalModelConfigTestGuard::new();
@@ -77,6 +97,118 @@ async fn discover_hooks_respects_session_export_mode_off() {
 
     std::env::set_current_dir(old_cwd).unwrap();
     moltis_config::clear_config_dir();
+}
+
+#[tokio::test]
+async fn discover_hooks_registers_config_shell_hooks() {
+    let _guard = LocalModelConfigTestGuard::new();
+    let data_dir = tempfile::tempdir().unwrap();
+    let config_dir = tempfile::tempdir().unwrap();
+    write_config_hook(
+        config_dir.path(),
+        "printf ''",
+        Some(("MOLTIS_TEST_HOOK", "1")),
+    );
+    moltis_config::set_data_dir(data_dir.path().to_path_buf());
+    moltis_config::set_config_dir(config_dir.path().to_path_buf());
+
+    let sessions_dir = data_dir.path().join("sessions");
+    std::fs::create_dir_all(&sessions_dir).unwrap();
+    let session_store = Arc::new(moltis_sessions::store::SessionStore::new(sessions_dir));
+
+    let (registry, info) = discover_and_build_hooks(&HashSet::new(), Some(&session_store)).await;
+    let registry = registry.expect("expected hook registry to be created");
+    let handler_names = registry.handler_names();
+
+    assert!(handler_names.iter().any(|n| n == "config-test-hook"));
+    let hook_info = info
+        .iter()
+        .find(|hook| hook.name == "config-test-hook")
+        .expect("config hook should be discovered");
+    assert_eq!(hook_info.source, "config");
+    assert_eq!(hook_info.command.as_deref(), Some("printf ''"));
+    assert_eq!(hook_info.events, vec!["BeforeLLMCall"]);
+    assert_eq!(hook_info.timeout, 7);
+    assert!(hook_info.enabled);
+    assert!(hook_info.eligible);
+
+    moltis_config::clear_config_dir();
+    moltis_config::clear_data_dir();
+}
+
+#[tokio::test]
+async fn discover_hooks_lists_disabled_config_hooks_without_registering() {
+    let _guard = LocalModelConfigTestGuard::new();
+    let data_dir = tempfile::tempdir().unwrap();
+    let config_dir = tempfile::tempdir().unwrap();
+    write_config_hook(config_dir.path(), "printf ''", None);
+    moltis_config::set_data_dir(data_dir.path().to_path_buf());
+    moltis_config::set_config_dir(config_dir.path().to_path_buf());
+
+    let sessions_dir = data_dir.path().join("sessions");
+    std::fs::create_dir_all(&sessions_dir).unwrap();
+    let session_store = Arc::new(moltis_sessions::store::SessionStore::new(sessions_dir));
+    let disabled = HashSet::from(["config-test-hook".to_string()]);
+
+    let (registry, info) = discover_and_build_hooks(&disabled, Some(&session_store)).await;
+    let registry = registry.expect("expected hook registry to be created");
+    let handler_names = registry.handler_names();
+
+    assert!(!handler_names.iter().any(|n| n == "config-test-hook"));
+    let hook_info = info
+        .iter()
+        .find(|hook| hook.name == "config-test-hook")
+        .expect("disabled config hook should still be listed");
+    assert_eq!(hook_info.source, "config");
+    assert!(!hook_info.enabled);
+    assert!(hook_info.eligible);
+
+    moltis_config::clear_config_dir();
+    moltis_config::clear_data_dir();
+}
+
+#[tokio::test]
+async fn config_shell_hook_runs_when_event_dispatches() {
+    let _guard = LocalModelConfigTestGuard::new();
+    let data_dir = tempfile::tempdir().unwrap();
+    let config_dir = tempfile::tempdir().unwrap();
+    let output_path = data_dir.path().join("hook-payload.json");
+    write_config_hook(
+        config_dir.path(),
+        "cat > \"$MOLTIS_TEST_HOOK_OUTPUT\"",
+        Some((
+            "MOLTIS_TEST_HOOK_OUTPUT",
+            output_path.to_string_lossy().as_ref(),
+        )),
+    );
+    moltis_config::set_data_dir(data_dir.path().to_path_buf());
+    moltis_config::set_config_dir(config_dir.path().to_path_buf());
+
+    let sessions_dir = data_dir.path().join("sessions");
+    std::fs::create_dir_all(&sessions_dir).unwrap();
+    let session_store = Arc::new(moltis_sessions::store::SessionStore::new(sessions_dir));
+    let (registry, _info) = discover_and_build_hooks(&HashSet::new(), Some(&session_store)).await;
+    let registry = registry.expect("expected hook registry to be created");
+
+    let action = registry
+        .dispatch(&moltis_common::hooks::HookPayload::BeforeLLMCall {
+            session_key: "config-hook-test".to_string(),
+            provider: "test-provider".to_string(),
+            model: "test-model".to_string(),
+            messages: serde_json::json!([]),
+            tool_count: 0,
+            iteration: 1,
+        })
+        .await
+        .unwrap();
+
+    assert!(matches!(action, moltis_common::hooks::HookAction::Continue));
+    let captured = std::fs::read_to_string(&output_path).unwrap();
+    assert!(captured.contains("BeforeLLMCall"));
+    assert!(captured.contains("config-hook-test"));
+
+    moltis_config::clear_config_dir();
+    moltis_config::clear_data_dir();
 }
 
 #[tokio::test]

--- a/crates/gateway/src/server/tests_legacy/hooks.rs
+++ b/crates/gateway/src/server/tests_legacy/hooks.rs
@@ -186,6 +186,47 @@ async fn discover_hooks_lists_disabled_config_hooks_without_registering() {
 }
 
 #[tokio::test]
+async fn config_hook_info_lists_only_parsed_events() {
+    let _guard = LocalModelConfigTestGuard::new();
+    let data_dir = tempfile::tempdir().unwrap();
+    let config_dir = tempfile::tempdir().unwrap();
+    std::fs::write(
+        config_dir.path().join("moltis.toml"),
+        r#"[hooks]
+
+[[hooks.hooks]]
+name = "config-test-hook"
+command = "printf ''"
+events = ["BeforeLLMCall", "NotARealEvent"]
+timeout = 7
+"#,
+    )
+    .unwrap();
+    moltis_config::set_data_dir(data_dir.path().to_path_buf());
+    moltis_config::set_config_dir(config_dir.path().to_path_buf());
+
+    let sessions_dir = data_dir.path().join("sessions");
+    std::fs::create_dir_all(&sessions_dir).unwrap();
+    let session_store = Arc::new(moltis_sessions::store::SessionStore::new(sessions_dir));
+
+    let (registry, info) = discover_and_build_hooks(&HashSet::new(), Some(&session_store)).await;
+    let registry = registry.expect("expected hook registry to be created");
+    let handler_names = registry.handler_names();
+
+    assert!(handler_names.iter().any(|n| n == "config-test-hook"));
+    let hook_info = info
+        .iter()
+        .find(|hook| hook.name == "config-test-hook")
+        .expect("config hook should be discovered");
+    assert_eq!(hook_info.events, vec!["BeforeLLMCall"]);
+    assert!(hook_info.enabled);
+    assert!(hook_info.eligible);
+
+    moltis_config::clear_config_dir();
+    moltis_config::clear_data_dir();
+}
+
+#[tokio::test]
 async fn filesystem_hook_takes_precedence_over_same_named_config_hook() {
     let _guard = LocalModelConfigTestGuard::new();
     let data_dir = tempfile::tempdir().unwrap();

--- a/crates/gateway/src/server/tests_legacy/hooks.rs
+++ b/crates/gateway/src/server/tests_legacy/hooks.rs
@@ -227,6 +227,69 @@ timeout = 7
 }
 
 #[tokio::test]
+async fn duplicate_config_hook_names_keep_first_entry() {
+    let _guard = LocalModelConfigTestGuard::new();
+    let data_dir = tempfile::tempdir().unwrap();
+    let config_dir = tempfile::tempdir().unwrap();
+    let output_path = data_dir.path().join("duplicate-config-output.txt");
+    let first_command = format!("printf first > {:?}", output_path);
+    let second_command = format!("printf second > {:?}", output_path);
+    std::fs::write(
+        config_dir.path().join("moltis.toml"),
+        format!(
+            r#"[hooks]
+
+[[hooks.hooks]]
+name = "config-test-hook"
+command = {first_command:?}
+events = ["BeforeLLMCall"]
+timeout = 7
+
+[[hooks.hooks]]
+name = "config-test-hook"
+command = {second_command:?}
+events = ["BeforeLLMCall"]
+timeout = 7
+"#
+        ),
+    )
+    .unwrap();
+    moltis_config::set_data_dir(data_dir.path().to_path_buf());
+    moltis_config::set_config_dir(config_dir.path().to_path_buf());
+
+    let sessions_dir = data_dir.path().join("sessions");
+    std::fs::create_dir_all(&sessions_dir).unwrap();
+    let session_store = Arc::new(moltis_sessions::store::SessionStore::new(sessions_dir));
+    let (registry, info) = discover_and_build_hooks(&HashSet::new(), Some(&session_store)).await;
+    let registry = registry.expect("expected hook registry to be created");
+
+    assert_eq!(
+        info.iter()
+            .filter(|hook| hook.name == "config-test-hook" && hook.source == "config")
+            .count(),
+        1
+    );
+
+    registry
+        .dispatch(&moltis_common::hooks::HookPayload::BeforeLLMCall {
+            session_key: "config-hook-test".to_string(),
+            provider: "test-provider".to_string(),
+            model: "test-model".to_string(),
+            messages: serde_json::json!([]),
+            tool_count: 0,
+            iteration: 1,
+        })
+        .await
+        .unwrap();
+
+    let captured = std::fs::read_to_string(&output_path).unwrap();
+    assert_eq!(captured, "first");
+
+    moltis_config::clear_config_dir();
+    moltis_config::clear_data_dir();
+}
+
+#[tokio::test]
 async fn filesystem_hook_takes_precedence_over_same_named_config_hook() {
     let _guard = LocalModelConfigTestGuard::new();
     let data_dir = tempfile::tempdir().unwrap();

--- a/docs/src/hooks.md
+++ b/docs/src/hooks.md
@@ -332,9 +332,10 @@ Hooks are discovered from `HOOK.md` files and `moltis.toml` config entries:
 1. **Project-local**: `<workspace>/.moltis/hooks/<name>/HOOK.md`
 2. **User-global**: `~/.moltis/hooks/<name>/HOOK.md`
 
-Project-local hooks take precedence over global hooks with the same name. Hooks declared in
-`moltis.toml` are registered alongside filesystem hooks and appear with source `config` in the
-hooks UI/status output.
+Project-local hooks take precedence over global hooks with the same name. If a hook declared in
+`moltis.toml` has the same name as a filesystem hook, the filesystem hook takes precedence and the
+config hook is skipped to avoid running the same hook twice. Config hooks appear with source
+`config` in the hooks UI/status output.
 
 ## Configuration in moltis.toml
 

--- a/docs/src/hooks.md
+++ b/docs/src/hooks.md
@@ -327,12 +327,14 @@ exit 0
 
 ## Hook Discovery
 
-Hooks are discovered from `HOOK.md` files in these locations (priority order):
+Hooks are discovered from `HOOK.md` files and `moltis.toml` config entries:
 
 1. **Project-local**: `<workspace>/.moltis/hooks/<name>/HOOK.md`
 2. **User-global**: `~/.moltis/hooks/<name>/HOOK.md`
 
-Project-local hooks take precedence over global hooks with the same name.
+Project-local hooks take precedence over global hooks with the same name. Hooks declared in
+`moltis.toml` are registered alongside filesystem hooks and appear with source `config` in the
+hooks UI/status output.
 
 ## Configuration in moltis.toml
 


### PR DESCRIPTION
## Summary
- Register `[[hooks.hooks]]` entries from `moltis.toml` as shell hook handlers at runtime.
- Surface config hooks in hook discovery/status output and preserve disabled-hook behavior.
- Add regression coverage for discovery, disabled config hooks, and actual dispatch execution.

## Validation
### Completed
- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p moltis-gateway discover_hooks -- --nocapture`
- [x] `cargo test -p moltis-gateway config_shell_hook_runs_when_event_dispatches -- --nocapture`

### Remaining
- [ ] Full CI suite

## Manual QA
- Not run; covered by targeted regression tests that verify config hook registration and shell dispatch.

Fixes #1024.