### PR TITLE
feat: agents as capability boundaries (MCP, sandbox, skills)

### DIFF
--- a/crates/agents/src/lazy_tools.rs
+++ b/crates/agents/src/lazy_tools.rs
@@ -284,7 +284,7 @@ mod tests {
                 "mcp__vmcp-ha__homeassistant_ha_get_state",
                 "Get current status, state, and attributes from Home Assistant",
             )),
-            "vmcp-ha".to_string(),
+            moltis_config::schema::McpServerId::from("vmcp-ha"),
         );
         registry
     }

--- a/crates/agents/src/tool_registry.rs
+++ b/crates/agents/src/tool_registry.rs
@@ -1,6 +1,7 @@
 use {
     anyhow::Result,
     async_trait::async_trait,
+    moltis_config::schema::McpServerId,
     std::{
         collections::HashMap,
         sync::{Arc, Mutex},
@@ -27,7 +28,7 @@ pub enum ToolSource {
     /// Built-in tool shipped with the binary.
     Builtin,
     /// Tool provided by an MCP server.
-    Mcp { server: String },
+    Mcp { server: McpServerId },
     /// Tool provided by a precompiled WASM component.
     Wasm { component_hash: [u8; 32] },
 }
@@ -89,7 +90,7 @@ impl ToolRegistry {
     }
 
     /// Register a tool from an MCP server. Warns (and overwrites) on name collision.
-    pub fn register_mcp(&mut self, tool: Box<dyn AgentTool>, server: String) {
+    pub fn register_mcp(&mut self, tool: Box<dyn AgentTool>, server: McpServerId) {
         let name = tool.name().to_string();
         let new_source = ToolSource::Mcp { server };
         if let Some(existing) = self.tools.get(&name) {
@@ -311,7 +312,7 @@ fn entry_to_schema(e: &ToolEntry) -> serde_json::Value {
         },
         ToolSource::Mcp { server } => {
             schema["source"] = serde_json::json!("mcp");
-            schema["mcpServer"] = serde_json::json!(server);
+            schema["mcpServer"] = serde_json::json!(server.as_str());
         },
         ToolSource::Wasm { component_hash } => {
             schema["source"] = serde_json::json!("wasm");
@@ -406,13 +407,13 @@ mod tests {
             Box::new(DummyTool {
                 name: "mcp__github__search".to_string(),
             }),
-            "github".to_string(),
+            McpServerId::from("github"),
         );
         registry.register_mcp(
             Box::new(DummyTool {
                 name: "mcp__memory__store".to_string(),
             }),
-            "memory".to_string(),
+            McpServerId::from("memory"),
         );
 
         let filtered = registry.clone_without_mcp();
@@ -432,13 +433,13 @@ mod tests {
             Box::new(DummyTool {
                 name: "mcp__github__search".to_string(),
             }),
-            "github".to_string(),
+            McpServerId::from("github"),
         );
         registry.register_mcp(
             Box::new(DummyTool {
                 name: "mcp__memory__store".to_string(),
             }),
-            "memory".to_string(),
+            McpServerId::from("memory"),
         );
 
         let removed = registry.unregister_mcp();
@@ -457,7 +458,7 @@ mod tests {
             Box::new(DummyTool {
                 name: "mcp__github__search".to_string(),
             }),
-            "github".to_string(),
+            McpServerId::from("github"),
         );
         registry.register_wasm(
             Box::new(DummyTool {
@@ -582,7 +583,7 @@ mod tests {
             Box::new(DummyTool {
                 name: "Read".to_string(),
             }),
-            "filesystem".to_string(),
+            McpServerId::from("filesystem"),
         );
         // Source should now be Mcp even though the builtin was registered first.
         let src = registry.get_source("Read").unwrap();

--- a/crates/agents/src/tool_registry.rs
+++ b/crates/agents/src/tool_registry.rs
@@ -278,10 +278,18 @@ impl ToolRegistry {
     where
         F: FnMut(&str) -> bool,
     {
+        self.clone_allowed_entries(|name, _| predicate(name))
+    }
+
+    /// Clone the registry keeping only tools whose name and source metadata match `predicate`.
+    pub fn clone_allowed_entries<F>(&self, mut predicate: F) -> ToolRegistry
+    where
+        F: FnMut(&str, &ToolSource) -> bool,
+    {
         let tools = self
             .tools
             .iter()
-            .filter(|(name, _)| predicate(name))
+            .filter(|(name, entry)| predicate(name, &entry.source))
             .map(|(name, entry)| {
                 (name.clone(), ToolEntry {
                     tool: Arc::clone(&entry.tool),

--- a/crates/chat/src/prompt.rs
+++ b/crates/chat/src/prompt.rs
@@ -58,133 +58,6 @@ pub(crate) async fn clear_prompt_memory_snapshot(
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    struct DummyTool(&'static str);
-
-    #[async_trait::async_trait]
-    impl moltis_agents::tool_registry::AgentTool for DummyTool {
-        fn name(&self) -> &str {
-            self.0
-        }
-
-        fn description(&self) -> &str {
-            "test tool"
-        }
-
-        fn parameters_schema(&self) -> Value {
-            serde_json::json!({"type": "object"})
-        }
-
-        async fn execute(&self, _params: Value) -> anyhow::Result<Value> {
-            Ok(serde_json::json!({}))
-        }
-    }
-
-    fn registry_with_mcp_tools() -> moltis_agents::tool_registry::ToolRegistry {
-        let mut registry = moltis_agents::tool_registry::ToolRegistry::new();
-        registry.register(Box::new(DummyTool("exec")));
-        registry.register(Box::new(DummyTool("mcp__github__builtin_named_like_mcp")));
-        registry.register_mcp(Box::new(DummyTool("mcp__github__search")), "github".into());
-        registry.register_mcp(Box::new(DummyTool("mcp__memory__store")), "memory".into());
-        registry
-    }
-
-    fn unrestricted_policy_context(agent_id: &str) -> PolicyContext {
-        PolicyContext {
-            agent_id: agent_id.to_string(),
-            ..Default::default()
-        }
-    }
-
-    #[test]
-    fn mcp_allow_empty_denies_all_mcp_tools_only() {
-        let mut config = moltis_config::MoltisConfig::default();
-        config.tools.policy.allow = vec!["*".into()];
-        config
-            .agents
-            .presets
-            .insert("locked".into(), moltis_config::schema::AgentPreset {
-                mcp: moltis_config::schema::PresetMcpPolicy::Allow(vec![]),
-                ..Default::default()
-            });
-
-        let filtered = apply_runtime_tool_filters(
-            &registry_with_mcp_tools(),
-            &config,
-            &[],
-            false,
-            &unrestricted_policy_context("locked"),
-        );
-
-        assert!(filtered.get("exec").is_some());
-        assert!(
-            filtered
-                .get("mcp__github__builtin_named_like_mcp")
-                .is_some()
-        );
-        assert!(filtered.get("mcp__github__search").is_none());
-        assert!(filtered.get("mcp__memory__store").is_none());
-    }
-
-    #[test]
-    fn mcp_allow_keeps_only_listed_mcp_server() {
-        let mut config = moltis_config::MoltisConfig::default();
-        config.tools.policy.allow = vec!["*".into()];
-        config
-            .agents
-            .presets
-            .insert("github-only".into(), moltis_config::schema::AgentPreset {
-                mcp: moltis_config::schema::PresetMcpPolicy::Allow(vec!["github".into()]),
-                ..Default::default()
-            });
-
-        let filtered = apply_runtime_tool_filters(
-            &registry_with_mcp_tools(),
-            &config,
-            &[],
-            false,
-            &unrestricted_policy_context("github-only"),
-        );
-
-        assert!(filtered.get("exec").is_some());
-        assert!(filtered.get("mcp__github__search").is_some());
-        assert!(filtered.get("mcp__memory__store").is_none());
-    }
-
-    #[test]
-    fn skill_policy_allows_then_denies_by_name_or_category() {
-        let skills = vec![
-            moltis_skills::types::SkillMetadata {
-                name: "web-search".into(),
-                category: Some("research".into()),
-                ..Default::default()
-            },
-            moltis_skills::types::SkillMetadata {
-                name: "games".into(),
-                category: Some("gaming".into()),
-                ..Default::default()
-            },
-            moltis_skills::types::SkillMetadata {
-                name: "writer".into(),
-                category: Some("creative".into()),
-                ..Default::default()
-            },
-        ];
-        let policy = moltis_config::schema::PresetSkillPolicy {
-            allow: Some(vec!["research".into(), "writer".into()]),
-            deny: Some(vec!["writer".into()]),
-        };
-
-        let filtered = filter_skills_for_agent(skills, &policy);
-
-        assert_eq!(filtered.len(), 1);
-        assert_eq!(filtered[0].name, "web-search");
-    }
-}
-
 pub(crate) fn prompt_memory_status(
     style: MemoryStyle,
     mode: PromptMemoryMode,
@@ -753,5 +626,132 @@ pub(crate) fn build_policy_context(
         sandboxed: runtime_context
             .and_then(|rc| rc.sandbox.as_ref())
             .is_some_and(|s| s.exec_sandboxed),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct DummyTool(&'static str);
+
+    #[async_trait::async_trait]
+    impl moltis_agents::tool_registry::AgentTool for DummyTool {
+        fn name(&self) -> &str {
+            self.0
+        }
+
+        fn description(&self) -> &str {
+            "test tool"
+        }
+
+        fn parameters_schema(&self) -> Value {
+            serde_json::json!({"type": "object"})
+        }
+
+        async fn execute(&self, _params: Value) -> anyhow::Result<Value> {
+            Ok(serde_json::json!({}))
+        }
+    }
+
+    fn registry_with_mcp_tools() -> moltis_agents::tool_registry::ToolRegistry {
+        let mut registry = moltis_agents::tool_registry::ToolRegistry::new();
+        registry.register(Box::new(DummyTool("exec")));
+        registry.register(Box::new(DummyTool("mcp__github__builtin_named_like_mcp")));
+        registry.register_mcp(Box::new(DummyTool("mcp__github__search")), "github".into());
+        registry.register_mcp(Box::new(DummyTool("mcp__memory__store")), "memory".into());
+        registry
+    }
+
+    fn unrestricted_policy_context(agent_id: &str) -> PolicyContext {
+        PolicyContext {
+            agent_id: agent_id.to_string(),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn mcp_allow_empty_denies_all_mcp_tools_only() {
+        let mut config = moltis_config::MoltisConfig::default();
+        config.tools.policy.allow = vec!["*".into()];
+        config
+            .agents
+            .presets
+            .insert("locked".into(), moltis_config::schema::AgentPreset {
+                mcp: moltis_config::schema::PresetMcpPolicy::Allow(vec![]),
+                ..Default::default()
+            });
+
+        let filtered = apply_runtime_tool_filters(
+            &registry_with_mcp_tools(),
+            &config,
+            &[],
+            false,
+            &unrestricted_policy_context("locked"),
+        );
+
+        assert!(filtered.get("exec").is_some());
+        assert!(
+            filtered
+                .get("mcp__github__builtin_named_like_mcp")
+                .is_some()
+        );
+        assert!(filtered.get("mcp__github__search").is_none());
+        assert!(filtered.get("mcp__memory__store").is_none());
+    }
+
+    #[test]
+    fn mcp_allow_keeps_only_listed_mcp_server() {
+        let mut config = moltis_config::MoltisConfig::default();
+        config.tools.policy.allow = vec!["*".into()];
+        config
+            .agents
+            .presets
+            .insert("github-only".into(), moltis_config::schema::AgentPreset {
+                mcp: moltis_config::schema::PresetMcpPolicy::Allow(vec!["github".into()]),
+                ..Default::default()
+            });
+
+        let filtered = apply_runtime_tool_filters(
+            &registry_with_mcp_tools(),
+            &config,
+            &[],
+            false,
+            &unrestricted_policy_context("github-only"),
+        );
+
+        assert!(filtered.get("exec").is_some());
+        assert!(filtered.get("mcp__github__search").is_some());
+        assert!(filtered.get("mcp__memory__store").is_none());
+    }
+
+    #[test]
+    fn skill_policy_allows_then_denies_by_name_or_category() {
+        let skills = vec![
+            moltis_skills::types::SkillMetadata {
+                name: "web-search".into(),
+                category: Some("research".into()),
+                ..Default::default()
+            },
+            moltis_skills::types::SkillMetadata {
+                name: "games".into(),
+                category: Some("gaming".into()),
+                ..Default::default()
+            },
+            moltis_skills::types::SkillMetadata {
+                name: "writer".into(),
+                category: Some("creative".into()),
+                ..Default::default()
+            },
+        ];
+        let policy = moltis_config::schema::PresetSkillPolicy {
+            allow: Some(vec!["research".into(), "writer".into()]),
+            deny: Some(vec!["writer".into()]),
+        };
+
+        let filtered = filter_skills_for_agent(skills, &policy);
+
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(filtered[0].name, "web-search");
     }
 }

--- a/crates/chat/src/prompt.rs
+++ b/crates/chat/src/prompt.rs
@@ -326,20 +326,24 @@ pub(crate) fn filter_skills_for_agent(
     skills
         .into_iter()
         .filter(|s| {
-            // If allow is non-empty, must match by name or category.
-            if !policy.allow.is_empty()
-                && !policy
-                    .allow
+            // If allow is Some, must match by name or category.
+            // Some(vec![]) means "no skills allowed" — filters everything.
+            if let Some(ref allow) = policy.allow
+                && !allow
                     .iter()
                     .any(|a| a == &s.name || s.category.as_deref().is_some_and(|cat| a == cat))
             {
                 return false;
             }
-            // Deny by name or category.
-            !policy
-                .deny
-                .iter()
-                .any(|d| d == &s.name || s.category.as_deref().is_some_and(|cat| d == cat))
+            // Deny by name or category (if present).
+            if let Some(ref deny) = policy.deny
+                && deny
+                    .iter()
+                    .any(|d| d == &s.name || s.category.as_deref().is_some_and(|cat| d == cat))
+            {
+                return false;
+            }
+            true
         })
         .collect()
 }

--- a/crates/chat/src/prompt.rs
+++ b/crates/chat/src/prompt.rs
@@ -328,18 +328,18 @@ pub(crate) fn filter_skills_for_agent(
         .filter(|s| {
             // If allow is non-empty, must match by name or category.
             if !policy.allow.is_empty()
-                && !policy.allow.iter().any(|a| {
-                    a == &s.name
-                        || s.category.as_deref().is_some_and(|cat| a == cat)
-                })
+                && !policy
+                    .allow
+                    .iter()
+                    .any(|a| a == &s.name || s.category.as_deref().is_some_and(|cat| a == cat))
             {
                 return false;
             }
             // Deny by name or category.
-            !policy.deny.iter().any(|d| {
-                d == &s.name
-                    || s.category.as_deref().is_some_and(|cat| d == cat)
-            })
+            !policy
+                .deny
+                .iter()
+                .any(|d| d == &s.name || s.category.as_deref().is_some_and(|cat| d == cat))
         })
         .collect()
 }

--- a/crates/chat/src/prompt.rs
+++ b/crates/chat/src/prompt.rs
@@ -312,6 +312,38 @@ pub(crate) async fn discover_skills_if_enabled(
     }
 }
 
+/// Apply per-agent skill policy to a discovered skill list.
+///
+/// When the agent preset has a `skills.allow` list, only skills matching
+/// by name or category are kept. Skills in `skills.deny` are then removed.
+pub(crate) fn filter_skills_for_agent(
+    skills: Vec<moltis_skills::types::SkillMetadata>,
+    policy: &moltis_config::schema::PresetSkillPolicy,
+) -> Vec<moltis_skills::types::SkillMetadata> {
+    if policy.is_empty() {
+        return skills;
+    }
+    skills
+        .into_iter()
+        .filter(|s| {
+            // If allow is non-empty, must match by name or category.
+            if !policy.allow.is_empty()
+                && !policy.allow.iter().any(|a| {
+                    a == &s.name
+                        || s.category.as_deref().is_some_and(|cat| a == cat)
+                })
+            {
+                return false;
+            }
+            // Deny by name or category.
+            !policy.deny.iter().any(|d| {
+                d == &s.name
+                    || s.category.as_deref().is_some_and(|cat| d == cat)
+            })
+        })
+        .collect()
+}
+
 pub(crate) fn resolve_channel_runtime_context(
     session_key: &str,
     session_entry: Option<&SessionEntry>,

--- a/crates/chat/src/prompt.rs
+++ b/crates/chat/src/prompt.rs
@@ -5,9 +5,12 @@ use std::sync::Arc;
 use {serde_json::Value, tracing::warn};
 
 use {
-    moltis_agents::prompt::{
-        PromptBuildLimits, PromptHostRuntimeContext, PromptModeRuntimeContext, PromptNodeInfo,
-        PromptNodesRuntimeContext, PromptRuntimeContext, PromptSandboxRuntimeContext,
+    moltis_agents::{
+        prompt::{
+            PromptBuildLimits, PromptHostRuntimeContext, PromptModeRuntimeContext, PromptNodeInfo,
+            PromptNodesRuntimeContext, PromptRuntimeContext, PromptSandboxRuntimeContext,
+        },
+        tool_registry::ToolSource,
     },
     moltis_config::{AgentMemoryWriteMode, LoadedWorkspaceMarkdown, MemoryStyle, PromptMemoryMode},
     moltis_sessions::{metadata::SessionEntry, state_store::SessionStateStore},
@@ -52,6 +55,133 @@ pub(crate) async fn clear_prompt_memory_snapshot(
             );
             false
         },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct DummyTool(&'static str);
+
+    #[async_trait::async_trait]
+    impl moltis_agents::tool_registry::AgentTool for DummyTool {
+        fn name(&self) -> &str {
+            self.0
+        }
+
+        fn description(&self) -> &str {
+            "test tool"
+        }
+
+        fn parameters_schema(&self) -> Value {
+            serde_json::json!({"type": "object"})
+        }
+
+        async fn execute(&self, _params: Value) -> anyhow::Result<Value> {
+            Ok(serde_json::json!({}))
+        }
+    }
+
+    fn registry_with_mcp_tools() -> moltis_agents::tool_registry::ToolRegistry {
+        let mut registry = moltis_agents::tool_registry::ToolRegistry::new();
+        registry.register(Box::new(DummyTool("exec")));
+        registry.register(Box::new(DummyTool("mcp__github__builtin_named_like_mcp")));
+        registry.register_mcp(Box::new(DummyTool("mcp__github__search")), "github".into());
+        registry.register_mcp(Box::new(DummyTool("mcp__memory__store")), "memory".into());
+        registry
+    }
+
+    fn unrestricted_policy_context(agent_id: &str) -> PolicyContext {
+        PolicyContext {
+            agent_id: agent_id.to_string(),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn mcp_allow_empty_denies_all_mcp_tools_only() {
+        let mut config = moltis_config::MoltisConfig::default();
+        config.tools.policy.allow = vec!["*".into()];
+        config
+            .agents
+            .presets
+            .insert("locked".into(), moltis_config::schema::AgentPreset {
+                mcp: moltis_config::schema::PresetMcpPolicy::Allow(vec![]),
+                ..Default::default()
+            });
+
+        let filtered = apply_runtime_tool_filters(
+            &registry_with_mcp_tools(),
+            &config,
+            &[],
+            false,
+            &unrestricted_policy_context("locked"),
+        );
+
+        assert!(filtered.get("exec").is_some());
+        assert!(
+            filtered
+                .get("mcp__github__builtin_named_like_mcp")
+                .is_some()
+        );
+        assert!(filtered.get("mcp__github__search").is_none());
+        assert!(filtered.get("mcp__memory__store").is_none());
+    }
+
+    #[test]
+    fn mcp_allow_keeps_only_listed_mcp_server() {
+        let mut config = moltis_config::MoltisConfig::default();
+        config.tools.policy.allow = vec!["*".into()];
+        config
+            .agents
+            .presets
+            .insert("github-only".into(), moltis_config::schema::AgentPreset {
+                mcp: moltis_config::schema::PresetMcpPolicy::Allow(vec!["github".into()]),
+                ..Default::default()
+            });
+
+        let filtered = apply_runtime_tool_filters(
+            &registry_with_mcp_tools(),
+            &config,
+            &[],
+            false,
+            &unrestricted_policy_context("github-only"),
+        );
+
+        assert!(filtered.get("exec").is_some());
+        assert!(filtered.get("mcp__github__search").is_some());
+        assert!(filtered.get("mcp__memory__store").is_none());
+    }
+
+    #[test]
+    fn skill_policy_allows_then_denies_by_name_or_category() {
+        let skills = vec![
+            moltis_skills::types::SkillMetadata {
+                name: "web-search".into(),
+                category: Some("research".into()),
+                ..Default::default()
+            },
+            moltis_skills::types::SkillMetadata {
+                name: "games".into(),
+                category: Some("gaming".into()),
+                ..Default::default()
+            },
+            moltis_skills::types::SkillMetadata {
+                name: "writer".into(),
+                category: Some("creative".into()),
+                ..Default::default()
+            },
+        ];
+        let policy = moltis_config::schema::PresetSkillPolicy {
+            allow: Some(vec!["research".into(), "writer".into()]),
+            deny: Some(vec!["writer".into()]),
+        };
+
+        let filtered = filter_skills_for_agent(skills, &policy);
+
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(filtered[0].name, "web-search");
     }
 }
 
@@ -586,20 +716,12 @@ pub(crate) fn apply_runtime_tool_filters(
             _ => None,
         });
 
-    base_registry.clone_allowed_by(|name| {
+    base_registry.clone_allowed_entries(|name, source| {
         if !policy.is_allowed(name) {
             return false;
         }
-        // If MCP allow-list is active, additionally filter MCP tools.
-        if let Some(allowed_servers) = mcp_allow
-            && name.starts_with("mcp__")
-        {
-            // Extract server name from mcp__<server>__<tool>.
-            let server = name
-                .strip_prefix("mcp__")
-                .and_then(|rest| rest.split("__").next())
-                .unwrap_or("");
-            return allowed_servers.iter().any(|s| s.as_str() == server);
+        if let (Some(allowed_servers), ToolSource::Mcp { server }) = (mcp_allow, source) {
+            return allowed_servers.iter().any(|allowed| allowed == server);
         }
         true
     })

--- a/crates/chat/src/prompt.rs
+++ b/crates/chat/src/prompt.rs
@@ -569,12 +569,36 @@ pub(crate) fn apply_runtime_tool_filters(
     };
 
     let policy = resolve_effective_policy(config, policy_context);
-    // NOTE: Do not globally restrict tools by discovered skill `allowed_tools`.
-    // Skills are always discovered for prompt injection; applying those lists at
-    // runtime can unintentionally remove unrelated tools (for example, leaving
-    // only `web_fetch` and preventing `create_skill` from being called).
-    // Tool availability here is controlled by configured runtime policy.
-    base_registry.clone_allowed_by(|name| policy.is_allowed(name))
+
+    // Resolve MCP allow-list: if the agent preset uses Allow mode, only
+    // tools from listed servers pass through. This is handled here (not
+    // in the policy deny layer) because ToolPolicy's deny-wins-over-allow
+    // semantics can't express "deny all MCP except these servers".
+    let mcp_allow: Option<&[moltis_config::schema::McpServerId]> = config
+        .agents
+        .get_preset(&policy_context.agent_id)
+        .and_then(|p| match &p.mcp {
+            moltis_config::schema::PresetMcpPolicy::Allow(servers) => Some(servers.as_slice()),
+            _ => None,
+        });
+
+    base_registry.clone_allowed_by(|name| {
+        if !policy.is_allowed(name) {
+            return false;
+        }
+        // If MCP allow-list is active, additionally filter MCP tools.
+        if let Some(allowed_servers) = mcp_allow
+            && name.starts_with("mcp__")
+        {
+            // Extract server name from mcp__<server>__<tool>.
+            let server = name
+                .strip_prefix("mcp__")
+                .and_then(|rest| rest.split("__").next())
+                .unwrap_or("");
+            return allowed_servers.iter().any(|s| s.as_str() == server);
+        }
+        true
+    })
 }
 
 /// Build a `PolicyContext` from runtime context and request parameters.

--- a/crates/chat/src/run_with_tools.rs
+++ b/crates/chat/src/run_with_tools.rs
@@ -231,11 +231,15 @@ pub(crate) async fn run_with_tools(
     let session_is_sandboxed = if let Some(router) = state.sandbox_router() {
         // If the agent preset has a sandbox mode override, apply it as a
         // per-session override so the exec tool inherits the agent's policy.
-        if let Some(preset) = persona.config.agents.get_preset(agent_id)
-            && let Some(ref mode) = preset.sandbox.mode
-        {
-            let enabled = mode != "off";
-            router.set_override(session_key, enabled).await;
+        // When no override is set, clear any stale override from a previous
+        // agent on this session so the global mode takes effect.
+        if let Some(preset) = persona.config.agents.get_preset(agent_id) {
+            if let Some(ref mode) = preset.sandbox.mode {
+                let enabled = mode != "off";
+                router.set_override(session_key, enabled).await;
+            } else {
+                router.remove_override(session_key).await;
+            }
         }
         router.is_sandboxed(session_key).await
     } else {

--- a/crates/chat/src/run_with_tools.rs
+++ b/crates/chat/src/run_with_tools.rs
@@ -242,6 +242,10 @@ pub(crate) async fn run_with_tools(
                 Some("off") => router.set_override(session_key, false).await,
                 _ => router.remove_override(session_key).await,
             }
+        } else {
+            // No preset for this agent — clear any stale override from
+            // a previously assigned agent so the global mode applies.
+            router.remove_override(session_key).await;
         }
         router.is_sandboxed(session_key).await
     } else {

--- a/crates/chat/src/run_with_tools.rs
+++ b/crates/chat/src/run_with_tools.rs
@@ -227,8 +227,16 @@ pub(crate) async fn run_with_tools(
     // Layer 1: instruct the LLM to write speech-friendly output when voice is active.
     let system_prompt = apply_voice_reply_suffix(system_prompt, desired_reply_medium);
 
-    // Determine sandbox mode for this session.
+    // Apply per-agent sandbox mode override, then determine sandbox mode.
     let session_is_sandboxed = if let Some(router) = state.sandbox_router() {
+        // If the agent preset has a sandbox mode override, apply it as a
+        // per-session override so the exec tool inherits the agent's policy.
+        if let Some(preset) = persona.config.agents.get_preset(agent_id)
+            && let Some(ref mode) = preset.sandbox.mode
+        {
+            let enabled = mode != "off";
+            router.set_override(session_key, enabled).await;
+        }
         router.is_sandboxed(session_key).await
     } else {
         false

--- a/crates/chat/src/run_with_tools.rs
+++ b/crates/chat/src/run_with_tools.rs
@@ -231,14 +231,16 @@ pub(crate) async fn run_with_tools(
     let session_is_sandboxed = if let Some(router) = state.sandbox_router() {
         // If the agent preset has a sandbox mode override, apply it as a
         // per-session override so the exec tool inherits the agent's policy.
-        // When no override is set, clear any stale override from a previous
-        // agent on this session so the global mode takes effect.
+        // - "all"      → force sandbox on
+        // - "off"      → force sandbox off
+        // - "non-main" → remove override, let the router's global NonMain
+        //                 logic decide (sandboxes non-main sessions only)
+        // - absent     → remove any stale override from a previous agent
         if let Some(preset) = persona.config.agents.get_preset(agent_id) {
-            if let Some(ref mode) = preset.sandbox.mode {
-                let enabled = mode != "off";
-                router.set_override(session_key, enabled).await;
-            } else {
-                router.remove_override(session_key).await;
+            match preset.sandbox.mode.as_deref() {
+                Some("all") => router.set_override(session_key, true).await,
+                Some("off") => router.set_override(session_key, false).await,
+                _ => router.remove_override(session_key).await,
             }
         }
         router.is_sandboxed(session_key).await

--- a/crates/chat/src/run_with_tools.rs
+++ b/crates/chat/src/run_with_tools.rs
@@ -237,9 +237,13 @@ pub(crate) async fn run_with_tools(
         //                 logic decide (sandboxes non-main sessions only)
         // - absent     → remove any stale override from a previous agent
         if let Some(preset) = persona.config.agents.get_preset(agent_id) {
-            match preset.sandbox.mode.as_deref() {
-                Some("all") => router.set_override(session_key, true).await,
-                Some("off") => router.set_override(session_key, false).await,
+            match preset.sandbox.mode {
+                Some(moltis_config::schema::PresetSandboxMode::All) => {
+                    router.set_override(session_key, true).await
+                },
+                Some(moltis_config::schema::PresetSandboxMode::Off) => {
+                    router.set_override(session_key, false).await
+                },
                 _ => router.remove_override(session_key).await,
             }
         } else {

--- a/crates/chat/src/service/chat_impl.rs
+++ b/crates/chat/src/service/chat_impl.rs
@@ -794,8 +794,9 @@ impl ChatService for LiveChatService {
         let config = moltis_config::discover_and_load();
         let tools: Vec<Value> = if supports_tools {
             let registry_guard = self.tool_registry.read().await;
+            let list_agent_id = resolve_prompt_agent_id(session_entry.as_ref());
             let list_ctx = PolicyContext {
-                agent_id: "main".into(),
+                agent_id: list_agent_id,
                 ..Default::default()
             };
             let effective_registry =

--- a/crates/chat/src/service/chat_impl.rs
+++ b/crates/chat/src/service/chat_impl.rs
@@ -42,8 +42,9 @@ use crate::{
     prompt::{
         apply_request_runtime_context, apply_runtime_tool_filters, build_policy_context,
         build_prompt_runtime_context, clear_prompt_memory_snapshot, discover_skills_if_enabled,
-        load_prompt_persona_for_agent, load_prompt_persona_for_session,
-        prompt_build_limits_from_config, resolve_prompt_agent_id, resolve_prompt_mode_context,
+        filter_skills_for_agent, load_prompt_persona_for_agent,
+        load_prompt_persona_for_session, prompt_build_limits_from_config,
+        resolve_prompt_agent_id, resolve_prompt_mode_context,
     },
     run_with_tools::run_with_tools,
     service::build_persisted_assistant_message,
@@ -1014,6 +1015,16 @@ impl ChatService for LiveChatService {
             .unwrap_or(false);
 
         let raw_prompt_agent_id = resolve_prompt_agent_id(session_entry.as_ref());
+
+        // Apply per-agent skill policy.
+        let discovered_skills = if let Some(preset) =
+            persona.config.agents.get_preset(&raw_prompt_agent_id)
+        {
+            filter_skills_for_agent(discovered_skills, &preset.skills)
+        } else {
+            discovered_skills
+        };
+
         // Build filtered tool registry.
         let policy_ctx =
             build_policy_context(&raw_prompt_agent_id, Some(&runtime_context), Some(&params));
@@ -1146,6 +1157,15 @@ impl ChatService for LiveChatService {
 
         // Build filtered tool registry.
         let full_ctx_agent_id = resolve_prompt_agent_id(session_entry.as_ref());
+
+        // Apply per-agent skill policy.
+        let discovered_skills = if let Some(preset) =
+            persona.config.agents.get_preset(&full_ctx_agent_id)
+        {
+            filter_skills_for_agent(discovered_skills, &preset.skills)
+        } else {
+            discovered_skills
+        };
         let policy_ctx =
             build_policy_context(&full_ctx_agent_id, Some(&runtime_context), Some(&params));
         let filtered_registry = {

--- a/crates/chat/src/service/chat_impl.rs
+++ b/crates/chat/src/service/chat_impl.rs
@@ -42,9 +42,8 @@ use crate::{
     prompt::{
         apply_request_runtime_context, apply_runtime_tool_filters, build_policy_context,
         build_prompt_runtime_context, clear_prompt_memory_snapshot, discover_skills_if_enabled,
-        filter_skills_for_agent, load_prompt_persona_for_agent,
-        load_prompt_persona_for_session, prompt_build_limits_from_config,
-        resolve_prompt_agent_id, resolve_prompt_mode_context,
+        filter_skills_for_agent, load_prompt_persona_for_agent, load_prompt_persona_for_session,
+        prompt_build_limits_from_config, resolve_prompt_agent_id, resolve_prompt_mode_context,
     },
     run_with_tools::run_with_tools,
     service::build_persisted_assistant_message,
@@ -1017,13 +1016,12 @@ impl ChatService for LiveChatService {
         let raw_prompt_agent_id = resolve_prompt_agent_id(session_entry.as_ref());
 
         // Apply per-agent skill policy.
-        let discovered_skills = if let Some(preset) =
-            persona.config.agents.get_preset(&raw_prompt_agent_id)
-        {
-            filter_skills_for_agent(discovered_skills, &preset.skills)
-        } else {
-            discovered_skills
-        };
+        let discovered_skills =
+            if let Some(preset) = persona.config.agents.get_preset(&raw_prompt_agent_id) {
+                filter_skills_for_agent(discovered_skills, &preset.skills)
+            } else {
+                discovered_skills
+            };
 
         // Build filtered tool registry.
         let policy_ctx =
@@ -1159,13 +1157,12 @@ impl ChatService for LiveChatService {
         let full_ctx_agent_id = resolve_prompt_agent_id(session_entry.as_ref());
 
         // Apply per-agent skill policy.
-        let discovered_skills = if let Some(preset) =
-            persona.config.agents.get_preset(&full_ctx_agent_id)
-        {
-            filter_skills_for_agent(discovered_skills, &preset.skills)
-        } else {
-            discovered_skills
-        };
+        let discovered_skills =
+            if let Some(preset) = persona.config.agents.get_preset(&full_ctx_agent_id) {
+                filter_skills_for_agent(discovered_skills, &preset.skills)
+            } else {
+                discovered_skills
+            };
         let policy_ctx =
             build_policy_context(&full_ctx_agent_id, Some(&runtime_context), Some(&params));
         let filtered_registry = {

--- a/crates/chat/src/service/chat_impl/send.rs
+++ b/crates/chat/src/service/chat_impl/send.rs
@@ -22,8 +22,8 @@ use crate::{
     },
     prompt::{
         apply_request_runtime_context, build_prompt_runtime_context, discover_skills_if_enabled,
-        filter_skills_for_agent, load_prompt_persona_for_session,
-        resolve_channel_runtime_context, resolve_prompt_agent_id, resolve_prompt_mode_context,
+        filter_skills_for_agent, load_prompt_persona_for_session, resolve_channel_runtime_context,
+        resolve_prompt_agent_id, resolve_prompt_mode_context,
     },
     run_with_tools::run_with_tools,
     streaming::run_streaming,
@@ -844,13 +844,12 @@ impl LiveChatService {
         let session_agent_id = resolve_prompt_agent_id(session_entry.as_ref());
 
         // Apply per-agent skill policy (allow/deny by name or category).
-        let discovered_skills = if let Some(preset) =
-            self.config.agents.get_preset(&session_agent_id)
-        {
-            filter_skills_for_agent(discovered_skills, &preset.skills)
-        } else {
-            discovered_skills
-        };
+        let discovered_skills =
+            if let Some(preset) = self.config.agents.get_preset(&session_agent_id) {
+                filter_skills_for_agent(discovered_skills, &preset.skills)
+            } else {
+                discovered_skills
+            };
         info!(
             session = %session_key,
             skills_len = discovered_skills.len(),

--- a/crates/chat/src/service/chat_impl/send.rs
+++ b/crates/chat/src/service/chat_impl/send.rs
@@ -22,8 +22,8 @@ use crate::{
     },
     prompt::{
         apply_request_runtime_context, build_prompt_runtime_context, discover_skills_if_enabled,
-        load_prompt_persona_for_session, resolve_channel_runtime_context, resolve_prompt_agent_id,
-        resolve_prompt_mode_context,
+        filter_skills_for_agent, load_prompt_persona_for_session,
+        resolve_channel_runtime_context, resolve_prompt_agent_id, resolve_prompt_mode_context,
     },
     run_with_tools::run_with_tools,
     streaming::run_streaming,
@@ -837,17 +837,27 @@ impl LiveChatService {
         // Discover enabled skills/plugins for prompt injection (gated on
         // `[skills] enabled` — see #655).
         let discovered_skills = discover_skills_if_enabled(&self.config).await;
-        info!(
-            session = %session_key,
-            skills_len = discovered_skills.len(),
-            client_seq = ?client_seq,
-            "chat.send: skills discovered"
-        );
 
         // Check if MCP tools are disabled for this session and capture
         // per-session sandbox override details for prompt runtime context.
         let session_entry = self.session_metadata.get(&session_key).await;
         let session_agent_id = resolve_prompt_agent_id(session_entry.as_ref());
+
+        // Apply per-agent skill policy (allow/deny by name or category).
+        let discovered_skills = if let Some(preset) =
+            self.config.agents.get_preset(&session_agent_id)
+        {
+            filter_skills_for_agent(discovered_skills, &preset.skills)
+        } else {
+            discovered_skills
+        };
+        info!(
+            session = %session_key,
+            skills_len = discovered_skills.len(),
+            agent_id = %session_agent_id,
+            client_seq = ?client_seq,
+            "chat.send: skills discovered"
+        );
         info!(
             session = %session_key,
             agent_id = %session_agent_id,

--- a/crates/cli/src/doctor_commands_tests.rs
+++ b/crates/cli/src/doctor_commands_tests.rs
@@ -66,10 +66,7 @@ fn check_providers_with_config_key() {
         api_key: Some(secrecy::Secret::new("sk-test-fake".to_string())),
         ..Default::default()
     };
-    config
-        .providers
-        .providers
-        .insert("anthropic".to_string(), entry);
+    config.providers.providers.insert("anthropic".into(), entry);
 
     let section = check_providers(&config);
     let anthropic_item = section
@@ -121,10 +118,7 @@ fn check_providers_disabled_skipped() {
         enabled: false,
         ..Default::default()
     };
-    config
-        .providers
-        .providers
-        .insert("openai".to_string(), entry);
+    config.providers.providers.insert("openai".into(), entry);
 
     let section = check_providers(&config);
     let openai_item = section.items.iter().find(|i| i.message.contains("openai"));
@@ -172,7 +166,7 @@ fn check_mcp_servers_disabled_skipped() {
         display_name: None,
         request_timeout_secs: None,
     };
-    config.mcp.servers.insert("test".to_string(), entry);
+    config.mcp.servers.insert("test".into(), entry);
 
     let section = check_mcp_servers(&config);
     let test_item = section.items.iter().find(|i| i.message.contains("test"));
@@ -195,7 +189,7 @@ fn check_mcp_servers_missing_command_fails() {
         display_name: None,
         request_timeout_secs: None,
     };
-    config.mcp.servers.insert("broken".to_string(), entry);
+    config.mcp.servers.insert("broken".into(), entry);
 
     let section = check_mcp_servers(&config);
     let broken_item = section.items.iter().find(|i| i.message.contains("broken"));
@@ -218,7 +212,7 @@ fn check_mcp_servers_sse_with_url_ok() {
         display_name: None,
         request_timeout_secs: None,
     };
-    config.mcp.servers.insert("remote".to_string(), entry);
+    config.mcp.servers.insert("remote".into(), entry);
 
     let section = check_mcp_servers(&config);
     let remote_item = section.items.iter().find(|i| i.message.contains("remote"));
@@ -241,7 +235,7 @@ fn check_mcp_servers_sse_without_url_fails() {
         display_name: None,
         request_timeout_secs: None,
     };
-    config.mcp.servers.insert("broken-sse".to_string(), entry);
+    config.mcp.servers.insert("broken-sse".into(), entry);
 
     let section = check_mcp_servers(&config);
     let item = section
@@ -267,7 +261,7 @@ fn check_mcp_servers_nonexistent_command_fails() {
         display_name: None,
         request_timeout_secs: None,
     };
-    config.mcp.servers.insert("bad".to_string(), entry);
+    config.mcp.servers.insert("bad".into(), entry);
 
     let section = check_mcp_servers(&config);
     let item = section.items.iter().find(|i| i.message.contains("bad"));
@@ -498,10 +492,7 @@ fn check_security_api_keys_in_config_warns() {
         api_key: Some(secrecy::Secret::new("sk-test".to_string())),
         ..Default::default()
     };
-    config
-        .providers
-        .providers
-        .insert("anthropic".to_string(), entry);
+    config.providers.providers.insert("anthropic".into(), entry);
 
     let temp = tempfile::TempDir::new().unwrap();
     let section = check_security(&config, Some(temp.path()), temp.path());

--- a/crates/config/src/schema/agents.rs
+++ b/crates/config/src/schema/agents.rs
@@ -420,12 +420,24 @@ impl Default for SessionAccessPolicyConfig {
 /// [agents.presets.kids.sandbox]
 /// mode = "all"
 /// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum PresetSandboxMode {
+    /// Disable sandboxing for this agent.
+    Off,
+    /// Sandbox every session for this agent.
+    All,
+    /// Inherit the global non-main session sandbox behavior.
+    NonMain,
+}
+
+/// Per-agent sandbox policy override.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(default)]
 pub struct PresetSandboxPolicy {
     /// Sandbox mode override: "off", "all", "non-main".
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub mode: Option<String>,
+    pub mode: Option<PresetSandboxMode>,
 }
 
 impl PresetSandboxPolicy {

--- a/crates/config/src/schema/agents.rs
+++ b/crates/config/src/schema/agents.rs
@@ -309,19 +309,20 @@ impl<'de> Deserialize<'de> for PresetMcpPolicy {
     where
         D: Deserializer<'de>,
     {
+        // Use Option to distinguish "field absent" from "field present but empty".
+        // `allow_servers = []` means "allow no MCP servers" (deny all),
+        // while omitting the field entirely means "no restriction" (All).
         #[derive(Deserialize)]
         struct Raw {
-            #[serde(default)]
-            allow_servers: Vec<McpServerId>,
-            #[serde(default)]
-            deny_servers: Vec<McpServerId>,
+            allow_servers: Option<Vec<McpServerId>>,
+            deny_servers: Option<Vec<McpServerId>>,
         }
         let raw = Raw::deserialize(deserializer)?;
-        match (raw.allow_servers.is_empty(), raw.deny_servers.is_empty()) {
-            (true, true) => Ok(Self::All),
-            (false, true) => Ok(Self::Allow(raw.allow_servers)),
-            (true, false) => Ok(Self::Deny(raw.deny_servers)),
-            (false, false) => Err(serde::de::Error::custom(
+        match (raw.allow_servers, raw.deny_servers) {
+            (None, None) => Ok(Self::All),
+            (Some(servers), None) => Ok(Self::Allow(servers)),
+            (None, Some(servers)) => Ok(Self::Deny(servers)),
+            (Some(_), Some(_)) => Err(serde::de::Error::custom(
                 "mcp: allow_servers and deny_servers are mutually exclusive",
             )),
         }

--- a/crates/config/src/schema/agents.rs
+++ b/crates/config/src/schema/agents.rs
@@ -192,23 +192,139 @@ fn builtin_agent_preset(
     }
 }
 
+/// Identifies an MCP server by its configuration key.
+///
+/// Wraps the server name used as the key in `[mcp.servers.<name>]` and
+/// in tool names like `mcp__<name>__<tool>`.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct McpServerId(String);
+
+impl McpServerId {
+    #[must_use]
+    pub fn new(name: impl Into<String>) -> Self {
+        Self(name.into())
+    }
+
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    /// Tool-policy deny pattern that blocks all tools from this server.
+    #[must_use]
+    pub fn to_deny_pattern(&self) -> String {
+        format!("mcp__{}__*", self.0)
+    }
+}
+
+impl std::fmt::Display for McpServerId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl AsRef<str> for McpServerId {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl From<&str> for McpServerId {
+    fn from(s: &str) -> Self {
+        Self(s.to_string())
+    }
+}
+
+impl From<String> for McpServerId {
+    fn from(s: String) -> Self {
+        Self(s)
+    }
+}
+
 /// Per-agent MCP server access control.
 ///
-/// Excludes specific MCP servers' tools from this agent's sessions.
-/// Translates to tool policy deny patterns (`mcp__<server>__*`) at
-/// resolution time, so the agent never sees those tools in its context.
+/// Controls which MCP servers are visible to this agent. Translates to
+/// tool policy deny patterns (`mcp__<server>__*`) at resolution time,
+/// so the agent never sees excluded servers' tools in its context.
 ///
 /// ```toml
+/// # Allow-list: only these servers are visible
 /// [agents.presets.my-agent.mcp]
-/// deny_servers = ["home-assistant"]  # exclude Home Assistant tools
+/// allow_servers = ["github", "memory"]
+///
+/// # Deny-list: all servers except these
+/// [agents.presets.my-agent.mcp]
+/// deny_servers = ["home-assistant"]
 /// ```
-#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(default)]
-pub struct PresetMcpPolicy {
-    /// MCP servers to deny. Each entry generates a tool deny pattern
-    /// `mcp__<server>__*` that blocks all tools from that server.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub deny_servers: Vec<String>,
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PresetMcpPolicy {
+    /// No restrictions — all MCP servers are visible (default).
+    All,
+    /// Only the listed servers are visible. All others are denied.
+    Allow(Vec<McpServerId>),
+    /// All servers except the listed ones are visible.
+    Deny(Vec<McpServerId>),
+}
+
+impl Default for PresetMcpPolicy {
+    fn default() -> Self {
+        Self::All
+    }
+}
+
+impl PresetMcpPolicy {
+    /// Returns `true` when no MCP restrictions are configured.
+    #[must_use]
+    pub fn is_all(&self) -> bool {
+        matches!(self, Self::All)
+    }
+}
+
+impl Serialize for PresetMcpPolicy {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        use serde::ser::SerializeMap;
+        match self {
+            Self::All => {
+                let map = serializer.serialize_map(Some(0))?;
+                map.end()
+            },
+            Self::Allow(servers) => {
+                let mut map = serializer.serialize_map(Some(1))?;
+                map.serialize_entry("allow_servers", servers)?;
+                map.end()
+            },
+            Self::Deny(servers) => {
+                let mut map = serializer.serialize_map(Some(1))?;
+                map.serialize_entry("deny_servers", servers)?;
+                map.end()
+            },
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for PresetMcpPolicy {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct Raw {
+            #[serde(default)]
+            allow_servers: Vec<McpServerId>,
+            #[serde(default)]
+            deny_servers: Vec<McpServerId>,
+        }
+        let raw = Raw::deserialize(deserializer)?;
+        match (raw.allow_servers.is_empty(), raw.deny_servers.is_empty()) {
+            (true, true) => Ok(Self::All),
+            (false, true) => Ok(Self::Allow(raw.allow_servers)),
+            (true, false) => Ok(Self::Deny(raw.deny_servers)),
+            (false, false) => Err(serde::de::Error::custom(
+                "mcp: allow_servers and deny_servers are mutually exclusive",
+            )),
+        }
+    }
 }
 
 /// Tool policy for an agent preset (allow/deny specific tools).
@@ -331,9 +447,10 @@ pub struct AgentPreset {
     pub reasoning_effort: Option<ReasoningEffort>,
     /// Per-agent MCP server access control.
     ///
-    /// Controls which MCP servers are visible to this agent. When set, this
-    /// generates tool policy deny patterns for excluded servers, so the agent
-    /// never sees their tools in the prompt context.
+    /// Controls which MCP servers are visible to this agent:
+    /// - `All` (default) — no restrictions, all MCP servers visible.
+    /// - `Allow(servers)` — only listed servers visible; others denied.
+    /// - `Deny(servers)` — all servers visible except listed ones.
     #[serde(default)]
     pub mcp: PresetMcpPolicy,
 }

--- a/crates/config/src/schema/agents.rs
+++ b/crates/config/src/schema/agents.rs
@@ -409,37 +409,23 @@ impl Default for SessionAccessPolicyConfig {
     }
 }
 
-/// Per-agent sandbox policy overrides.
+/// Per-agent sandbox mode override.
 ///
-/// Each field, when set, overrides the corresponding field from the global
-/// `[tools.exec.sandbox]` config. Unset fields inherit the global value.
+/// Only `mode` is enforced at runtime (applied as a per-session override
+/// on the `SandboxRouter`). Per-session network/workspace/resource
+/// overrides require deeper `SandboxRouter` changes and will be added
+/// when the router gains per-session config overlays.
 ///
 /// ```toml
 /// [agents.presets.kids.sandbox]
-/// network = "blocked"
-/// workspace_mount = "ro"
+/// mode = "all"
 /// ```
-#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(default)]
 pub struct PresetSandboxPolicy {
     /// Sandbox mode override: "off", "all", "non-main".
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub mode: Option<String>,
-    /// Network policy override: "blocked", "trusted", "bypass".
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub network: Option<String>,
-    /// Domain allowlist override for "trusted" network mode.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub trusted_domains: Option<Vec<String>>,
-    /// Workspace mount mode override: "ro" or "rw".
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub workspace_mount: Option<String>,
-    /// Memory limit override (e.g. "512M", "1G").
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub memory_limit: Option<String>,
-    /// CPU quota override (e.g. 0.5 = half core, 2.0 = two cores).
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub cpu_quota: Option<f64>,
 }
 
 impl PresetSandboxPolicy {
@@ -447,40 +433,8 @@ impl PresetSandboxPolicy {
     #[must_use]
     pub fn is_empty(&self) -> bool {
         self.mode.is_none()
-            && self.network.is_none()
-            && self.trusted_domains.is_none()
-            && self.workspace_mount.is_none()
-            && self.memory_limit.is_none()
-            && self.cpu_quota.is_none()
-    }
-
-    /// Apply these overrides onto a global `SandboxConfig`, mutating in place.
-    /// Only non-`None` fields are overwritten.
-    pub fn apply_to(&self, target: &mut SandboxConfig) {
-        if let Some(ref mode) = self.mode {
-            target.mode = mode.clone();
-        }
-        if let Some(ref network) = self.network {
-            target.network = network.clone();
-        }
-        if let Some(ref domains) = self.trusted_domains {
-            target.trusted_domains = domains.clone();
-        }
-        if let Some(ref mount) = self.workspace_mount {
-            target.workspace_mount = mount.clone();
-        }
-        if let Some(ref mem) = self.memory_limit {
-            target.resource_limits.memory_limit = Some(mem.clone());
-        }
-        if let Some(cpu) = self.cpu_quota {
-            target.resource_limits.cpu_quota = Some(cpu);
-        }
     }
 }
-
-// Manual Eq impl because f64 doesn't impl Eq, but cpu_quota values are
-// discrete user inputs that compare bitwise.
-impl Eq for PresetSandboxPolicy {}
 
 /// Per-agent skill access control.
 ///

--- a/crates/config/src/schema/agents.rs
+++ b/crates/config/src/schema/agents.rs
@@ -413,6 +413,109 @@ impl Default for SessionAccessPolicyConfig {
     }
 }
 
+/// Per-agent sandbox policy overrides.
+///
+/// Each field, when set, overrides the corresponding field from the global
+/// `[tools.exec.sandbox]` config. Unset fields inherit the global value.
+///
+/// ```toml
+/// [agents.presets.kids.sandbox]
+/// network = "blocked"
+/// workspace_mount = "ro"
+/// ```
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct PresetSandboxPolicy {
+    /// Sandbox mode override: "off", "all", "non-main".
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mode: Option<String>,
+    /// Network policy override: "blocked", "trusted", "bypass".
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub network: Option<String>,
+    /// Domain allowlist override for "trusted" network mode.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub trusted_domains: Option<Vec<String>>,
+    /// Workspace mount mode override: "ro" or "rw".
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workspace_mount: Option<String>,
+    /// Memory limit override (e.g. "512M", "1G").
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub memory_limit: Option<String>,
+    /// CPU quota override (e.g. 0.5 = half core, 2.0 = two cores).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cpu_quota: Option<f64>,
+}
+
+impl PresetSandboxPolicy {
+    /// Returns `true` when no overrides are configured.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.mode.is_none()
+            && self.network.is_none()
+            && self.trusted_domains.is_none()
+            && self.workspace_mount.is_none()
+            && self.memory_limit.is_none()
+            && self.cpu_quota.is_none()
+    }
+
+    /// Apply these overrides onto a global `SandboxConfig`, mutating in place.
+    /// Only non-`None` fields are overwritten.
+    pub fn apply_to(&self, target: &mut SandboxConfig) {
+        if let Some(ref mode) = self.mode {
+            target.mode = mode.clone();
+        }
+        if let Some(ref network) = self.network {
+            target.network = network.clone();
+        }
+        if let Some(ref domains) = self.trusted_domains {
+            target.trusted_domains = domains.clone();
+        }
+        if let Some(ref mount) = self.workspace_mount {
+            target.workspace_mount = mount.clone();
+        }
+        if let Some(ref mem) = self.memory_limit {
+            target.resource_limits.memory_limit = Some(mem.clone());
+        }
+        if let Some(cpu) = self.cpu_quota {
+            target.resource_limits.cpu_quota = Some(cpu);
+        }
+    }
+}
+
+// Manual Eq impl because f64 doesn't impl Eq, but cpu_quota values are
+// discrete user inputs that compare bitwise.
+impl Eq for PresetSandboxPolicy {}
+
+/// Per-agent skill access control.
+///
+/// ```toml
+/// # Only allow specific skills
+/// [agents.presets.kids.skills]
+/// allow = ["web_search"]
+///
+/// # Deny specific skills
+/// [agents.presets.admin.skills]
+/// deny = ["gaming", "social-media"]
+/// ```
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct PresetSkillPolicy {
+    /// When non-empty, only these skills (by name or category) are available.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub allow: Vec<String>,
+    /// Skills (by name or category) to deny from this agent.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub deny: Vec<String>,
+}
+
+impl PresetSkillPolicy {
+    /// Returns `true` when no skill filtering is configured.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.allow.is_empty() && self.deny.is_empty()
+    }
+}
+
 /// Agent preset configuration.
 ///
 /// Presets define identity, model, tool policies, and system prompt for an
@@ -459,4 +562,17 @@ pub struct AgentPreset {
     /// - `Deny(servers)` — all servers visible except listed ones.
     #[serde(default)]
     pub mcp: PresetMcpPolicy,
+    /// Per-agent sandbox policy overrides.
+    ///
+    /// Each set field overrides the global `[tools.exec.sandbox]` value.
+    /// Unset fields inherit the global config.
+    #[serde(default, skip_serializing_if = "PresetSandboxPolicy::is_empty")]
+    pub sandbox: PresetSandboxPolicy,
+    /// Per-agent skill access control.
+    ///
+    /// Controls which skills are visible to this agent. When `allow` is
+    /// non-empty, only listed skills are available. `deny` removes skills
+    /// by name or category.
+    #[serde(default, skip_serializing_if = "PresetSkillPolicy::is_empty")]
+    pub skills: PresetSkillPolicy,
 }

--- a/crates/config/src/schema/agents.rs
+++ b/crates/config/src/schema/agents.rs
@@ -450,19 +450,21 @@ impl PresetSandboxPolicy {
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(default)]
 pub struct PresetSkillPolicy {
-    /// When non-empty, only these skills (by name or category) are available.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub allow: Vec<String>,
+    /// When `Some`, only these skills (by name or category) are available.
+    /// `Some(vec![])` means "no skills allowed" (deny all).
+    /// `None` (absent from config) means "no restriction".
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub allow: Option<Vec<String>>,
     /// Skills (by name or category) to deny from this agent.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub deny: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub deny: Option<Vec<String>>,
 }
 
 impl PresetSkillPolicy {
     /// Returns `true` when no skill filtering is configured.
     #[must_use]
     pub fn is_empty(&self) -> bool {
-        self.allow.is_empty() && self.deny.is_empty()
+        self.allow.is_none() && self.deny.is_none()
     }
 }
 

--- a/crates/config/src/schema/agents.rs
+++ b/crates/config/src/schema/agents.rs
@@ -510,7 +510,7 @@ pub struct AgentPreset {
     /// - `All` (default) — no restrictions, all MCP servers visible.
     /// - `Allow(servers)` — only listed servers visible; others denied.
     /// - `Deny(servers)` — all servers visible except listed ones.
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "PresetMcpPolicy::is_all")]
     pub mcp: PresetMcpPolicy,
     /// Per-agent sandbox policy overrides.
     ///

--- a/crates/config/src/schema/agents.rs
+++ b/crates/config/src/schema/agents.rs
@@ -242,6 +242,12 @@ impl From<String> for McpServerId {
     }
 }
 
+impl std::borrow::Borrow<str> for McpServerId {
+    fn borrow(&self) -> &str {
+        &self.0
+    }
+}
+
 /// Per-agent MCP server access control.
 ///
 /// Controls which MCP servers are visible to this agent. Translates to

--- a/crates/config/src/schema/agents.rs
+++ b/crates/config/src/schema/agents.rs
@@ -263,20 +263,15 @@ impl std::borrow::Borrow<str> for McpServerId {
 /// [agents.presets.my-agent.mcp]
 /// deny_servers = ["home-assistant"]
 /// ```
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub enum PresetMcpPolicy {
     /// No restrictions — all MCP servers are visible (default).
+    #[default]
     All,
     /// Only the listed servers are visible. All others are denied.
     Allow(Vec<McpServerId>),
     /// All servers except the listed ones are visible.
     Deny(Vec<McpServerId>),
-}
-
-impl Default for PresetMcpPolicy {
-    fn default() -> Self {
-        Self::All
-    }
 }
 
 impl PresetMcpPolicy {

--- a/crates/config/src/schema/runtime.rs
+++ b/crates/config/src/schema/runtime.rs
@@ -121,9 +121,9 @@ pub struct McpConfig {
     /// Default timeout for MCP requests in seconds.
     #[serde(default = "default_mcp_request_timeout_secs")]
     pub request_timeout_secs: u64,
-    /// Configured MCP servers, keyed by server name.
+    /// Configured MCP servers, keyed by server ID.
     #[serde(default)]
-    pub servers: HashMap<String, McpServerEntry>,
+    pub servers: HashMap<McpServerId, McpServerEntry>,
 }
 
 impl Default for McpConfig {

--- a/crates/config/src/schema/tests.rs
+++ b/crates/config/src/schema/tests.rs
@@ -1155,3 +1155,24 @@ fn mcp_policy_roundtrip_all() {
     let parsed: PresetMcpPolicy = toml::from_str(&toml_str).unwrap();
     assert!(parsed.is_all());
 }
+
+#[test]
+fn preset_sandbox_mode_parses_typed_values() {
+    let toml_str = r#"
+[agents.presets.test.sandbox]
+mode = "non-main"
+"#;
+    let config: MoltisConfig = toml::from_str(toml_str).unwrap();
+    let preset = config.agents.presets.get("test").unwrap();
+    assert_eq!(preset.sandbox.mode, Some(PresetSandboxMode::NonMain));
+}
+
+#[test]
+fn preset_sandbox_mode_rejects_unknown_values() {
+    let toml_str = r#"
+[agents.presets.test.sandbox]
+mode = "sometimes"
+"#;
+    let result: Result<MoltisConfig, _> = toml::from_str(toml_str);
+    assert!(result.is_err());
+}

--- a/crates/config/src/schema/tests.rs
+++ b/crates/config/src/schema/tests.rs
@@ -1092,3 +1092,66 @@ fn resolve_external_url_returns_none_when_both_unset() {
     let result = ServerConfig::resolve_external_url(None, None);
     assert!(result.is_none());
 }
+
+#[test]
+fn mcp_policy_empty_toml_is_all() {
+    let toml_str = r#"
+[agents.presets.test]
+"#;
+    let config: MoltisConfig = toml::from_str(toml_str).unwrap();
+    let preset = config.agents.presets.get("test").unwrap();
+    assert!(preset.mcp.is_all());
+}
+
+#[test]
+fn mcp_policy_empty_allow_is_not_all() {
+    // allow_servers = [] should parse as Allow(vec![]), NOT as All.
+    let toml_str = r#"
+[agents.presets.test.mcp]
+allow_servers = []
+"#;
+    let config: MoltisConfig = toml::from_str(toml_str).unwrap();
+    let preset = config.agents.presets.get("test").unwrap();
+    assert!(!preset.mcp.is_all());
+    assert_eq!(preset.mcp, PresetMcpPolicy::Allow(vec![]));
+}
+
+#[test]
+fn mcp_policy_both_fields_is_error() {
+    let toml_str = r#"
+[agents.presets.test.mcp]
+allow_servers = ["github"]
+deny_servers = ["home-assistant"]
+"#;
+    let result: Result<MoltisConfig, _> = toml::from_str(toml_str);
+    assert!(result.is_err());
+    let err = result.unwrap_err().to_string();
+    assert!(
+        err.contains("mutually exclusive"),
+        "expected mutual exclusivity error, got: {err}"
+    );
+}
+
+#[test]
+fn mcp_policy_roundtrip_allow() {
+    let policy = PresetMcpPolicy::Allow(vec!["github".into(), "memory".into()]);
+    let toml_str = toml::to_string_pretty(&policy).unwrap();
+    let parsed: PresetMcpPolicy = toml::from_str(&toml_str).unwrap();
+    assert_eq!(parsed, policy);
+}
+
+#[test]
+fn mcp_policy_roundtrip_deny() {
+    let policy = PresetMcpPolicy::Deny(vec!["home-assistant".into()]);
+    let toml_str = toml::to_string_pretty(&policy).unwrap();
+    let parsed: PresetMcpPolicy = toml::from_str(&toml_str).unwrap();
+    assert_eq!(parsed, policy);
+}
+
+#[test]
+fn mcp_policy_roundtrip_all() {
+    let policy = PresetMcpPolicy::All;
+    let toml_str = toml::to_string_pretty(&policy).unwrap();
+    let parsed: PresetMcpPolicy = toml::from_str(&toml_str).unwrap();
+    assert!(parsed.is_all());
+}

--- a/crates/config/src/template.rs
+++ b/crates/config/src/template.rs
@@ -319,6 +319,29 @@ port = {port}                           # Port number (auto-generated for this i
 # identity.theme = "thorough, skeptical, and evidence-oriented"
 # system_prompt_suffix = "..."
 # max_iterations = 16
+#
+# ── Per-agent capability boundaries ──────────────────────────────────────────
+# Each agent can be scoped to specific MCP servers, sandbox policies, and skills.
+# Assign agents to channels via `agent_id` in the channel account config.
+#
+# Example: restricted agent for kids (no MCP, no network, limited skills):
+# [agents.presets.kids]
+# model = "anthropic/claude-haiku-4-5-20251001"
+# [agents.presets.kids.mcp]
+# allow_servers = []                # No MCP tools at all
+# [agents.presets.kids.sandbox]
+# network = "blocked"               # No network access
+# workspace_mount = "ro"            # Read-only workspace
+# [agents.presets.kids.skills]
+# deny = ["gaming", "social-media"] # Block specific skill categories
+#
+# Example: full-access agent for parents:
+# [agents.presets.admin]
+# [agents.presets.admin.mcp]
+# allow_servers = ["github", "home-assistant", "memory"]
+# [agents.presets.admin.sandbox]
+# network = "trusted"               # Proxy-filtered network
+# workspace_mount = "rw"            # Read-write workspace
 
 # ══════════════════════════════════════════════════════════════════════════════
 # SESSION MODES

--- a/crates/config/src/template.rs
+++ b/crates/config/src/template.rs
@@ -330,8 +330,7 @@ port = {port}                           # Port number (auto-generated for this i
 # [agents.presets.kids.mcp]
 # allow_servers = []                # No MCP tools at all
 # [agents.presets.kids.sandbox]
-# network = "blocked"               # No network access
-# workspace_mount = "ro"            # Read-only workspace
+# mode = "all"                      # Always sandbox this agent
 # [agents.presets.kids.skills]
 # deny = ["gaming", "social-media"] # Block specific skill categories
 #
@@ -340,8 +339,7 @@ port = {port}                           # Port number (auto-generated for this i
 # [agents.presets.admin.mcp]
 # allow_servers = ["github", "home-assistant", "memory"]
 # [agents.presets.admin.sandbox]
-# network = "trusted"               # Proxy-filtered network
-# workspace_mount = "rw"            # Read-write workspace
+# mode = "all"                      # Always sandbox this agent
 
 # ══════════════════════════════════════════════════════════════════════════════
 # SESSION MODES

--- a/crates/config/src/validate/schema_map.rs
+++ b/crates/config/src/validate/schema_map.rs
@@ -330,7 +330,13 @@ pub(super) fn build_schema_map() -> KnownKeys {
                 Struct(HashMap::from([("scope", Leaf), ("max_lines", Leaf)])),
             ),
             ("reasoning_effort", Leaf),
-            ("mcp", Struct(HashMap::from([("deny_servers", Leaf)]))),
+            (
+                "mcp",
+                Struct(HashMap::from([
+                    ("allow_servers", Leaf),
+                    ("deny_servers", Leaf),
+                ])),
+            ),
         ]))
     };
 

--- a/crates/config/src/validate/schema_map.rs
+++ b/crates/config/src/validate/schema_map.rs
@@ -337,6 +337,21 @@ pub(super) fn build_schema_map() -> KnownKeys {
                     ("deny_servers", Leaf),
                 ])),
             ),
+            (
+                "sandbox",
+                Struct(HashMap::from([
+                    ("mode", Leaf),
+                    ("network", Leaf),
+                    ("trusted_domains", Leaf),
+                    ("workspace_mount", Leaf),
+                    ("memory_limit", Leaf),
+                    ("cpu_quota", Leaf),
+                ])),
+            ),
+            (
+                "skills",
+                Struct(HashMap::from([("allow", Leaf), ("deny", Leaf)])),
+            ),
         ]))
     };
 

--- a/crates/config/src/validate/schema_map.rs
+++ b/crates/config/src/validate/schema_map.rs
@@ -337,17 +337,7 @@ pub(super) fn build_schema_map() -> KnownKeys {
                     ("deny_servers", Leaf),
                 ])),
             ),
-            (
-                "sandbox",
-                Struct(HashMap::from([
-                    ("mode", Leaf),
-                    ("network", Leaf),
-                    ("trusted_domains", Leaf),
-                    ("workspace_mount", Leaf),
-                    ("memory_limit", Leaf),
-                    ("cpu_quota", Leaf),
-                ])),
-            ),
+            ("sandbox", Struct(HashMap::from([("mode", Leaf)]))),
             (
                 "skills",
                 Struct(HashMap::from([("allow", Leaf), ("deny", Leaf)])),

--- a/crates/config/src/validate/semantic.rs
+++ b/crates/config/src/validate/semantic.rs
@@ -1108,4 +1108,27 @@ pub(super) fn check_file_references(
             }
         }
     }
+
+    // Agent preset MCP allow/deny server validation — warn on unknown server names.
+    let known_mcp_servers: std::collections::HashSet<&str> =
+        config.mcp.servers.keys().map(|k| k.as_str()).collect();
+    for (preset_name, preset) in &config.agents.presets {
+        let servers = match &preset.mcp {
+            crate::schema::PresetMcpPolicy::Allow(s) | crate::schema::PresetMcpPolicy::Deny(s) => s,
+            crate::schema::PresetMcpPolicy::All => continue,
+        };
+        for server in servers {
+            if !known_mcp_servers.contains(server.as_str()) {
+                diagnostics.push(Diagnostic {
+                    severity: Severity::Warning,
+                    category: "agents",
+                    path: format!("agents.presets.{preset_name}.mcp"),
+                    message: format!(
+                        "MCP server '{}' referenced in preset but not configured in [mcp.servers]",
+                        server
+                    ),
+                });
+            }
+        }
+    }
 }

--- a/crates/config/src/validate/semantic.rs
+++ b/crates/config/src/validate/semantic.rs
@@ -1110,8 +1110,22 @@ pub(super) fn check_file_references(
     }
 
     // Agent preset MCP allow/deny server validation — warn on unknown server names.
-    let known_mcp_servers: std::collections::HashSet<&str> =
-        config.mcp.servers.keys().map(|k| k.as_str()).collect();
+    // Merge servers from both moltis.toml [mcp.servers] and the persistent
+    // mcp-servers.json registry file so we don't false-positive on servers
+    // added via the API.
+    let mut known_mcp_servers: std::collections::HashSet<String> = config
+        .mcp
+        .servers
+        .keys()
+        .map(|k| k.as_str().to_string())
+        .collect();
+    let registry_path = crate::data_dir().join("mcp-servers.json");
+    if let Ok(data) = std::fs::read_to_string(&registry_path)
+        && let Ok(json) = serde_json::from_str::<serde_json::Value>(&data)
+        && let Some(servers) = json.get("servers").and_then(|v| v.as_object())
+    {
+        known_mcp_servers.extend(servers.keys().cloned());
+    }
     for (preset_name, preset) in &config.agents.presets {
         let servers = match &preset.mcp {
             crate::schema::PresetMcpPolicy::Allow(s) | crate::schema::PresetMcpPolicy::Deny(s) => s,
@@ -1124,7 +1138,7 @@ pub(super) fn check_file_references(
                     category: "agents",
                     path: format!("agents.presets.{preset_name}.mcp"),
                     message: format!(
-                        "MCP server '{}' referenced in preset but not configured in [mcp.servers]",
+                        "MCP server '{}' referenced in preset but not configured in [mcp.servers] or mcp-servers.json",
                         server
                     ),
                 });

--- a/crates/gateway/src/methods/services/agents.rs
+++ b/crates/gateway/src/methods/services/agents.rs
@@ -649,8 +649,6 @@ pub(super) fn register(reg: &mut MethodRegistry) {
                             "mcp": mcp,
                             "sandbox": {
                                 "mode": p.sandbox.mode,
-                                "network": p.sandbox.network,
-                                "workspace_mount": p.sandbox.workspace_mount,
                             },
                             "skills": {
                                 "allow": p.skills.allow,

--- a/crates/gateway/src/methods/services/agents.rs
+++ b/crates/gateway/src/methods/services/agents.rs
@@ -629,11 +629,41 @@ pub(super) fn register(reg: &mut MethodRegistry) {
                         .find(|p| p.id == id)
                         .map(|p| p.source)
                         .unwrap_or(moltis_config::defaults::ConfigSource::Custom);
+                    // Return structured fields alongside TOML for UI controls.
+                    let preset_fields = config.agents.presets.get(&id).map(|p| {
+                        let mcp = match &p.mcp {
+                            moltis_config::schema::PresetMcpPolicy::All => serde_json::json!({
+                                "mode": "all"
+                            }),
+                            moltis_config::schema::PresetMcpPolicy::Allow(servers) => serde_json::json!({
+                                "mode": "allow",
+                                "servers": servers.iter().map(|s| s.as_str()).collect::<Vec<&str>>()
+                            }),
+                            moltis_config::schema::PresetMcpPolicy::Deny(servers) => serde_json::json!({
+                                "mode": "deny",
+                                "servers": servers.iter().map(|s| s.as_str()).collect::<Vec<&str>>()
+                            }),
+                        };
+                        serde_json::json!({
+                            "model": p.model,
+                            "mcp": mcp,
+                            "sandbox": {
+                                "mode": p.sandbox.mode,
+                                "network": p.sandbox.network,
+                                "workspace_mount": p.sandbox.workspace_mount,
+                            },
+                            "skills": {
+                                "allow": p.skills.allow,
+                                "deny": p.skills.deny,
+                            },
+                        })
+                    });
                     Ok(serde_json::json!({
                         "id": id,
                         "toml": toml_str,
                         "exists": !toml_str.is_empty(),
                         "provenance": source,
+                        "fields": preset_fields,
                     }))
                 })
             }),

--- a/crates/gateway/src/server/prepare_core.rs
+++ b/crates/gateway/src/server/prepare_core.rs
@@ -312,7 +312,7 @@ pub async fn prepare_gateway_core(
         let mcp_reg = moltis_mcp::McpRegistry::load(&mcp_registry_path).unwrap_or_default();
         let mut merged = mcp_reg;
         for (name, entry) in &config.mcp.servers {
-            if !merged.servers.contains_key(name) {
+            if !merged.servers.contains_key(name.as_str()) {
                 let transport = match entry.transport.as_str() {
                     "sse" => moltis_mcp::registry::TransportType::Sse,
                     "streamable_http" | "streamable-http" | "http" => {
@@ -332,7 +332,7 @@ pub async fn prepare_gateway_core(
                     });
                 merged
                     .servers
-                    .insert(name.clone(), moltis_mcp::McpServerConfig {
+                    .insert(name.to_string(), moltis_mcp::McpServerConfig {
                         command: entry.command.clone(),
                         args: entry.args.clone(),
                         env: entry.env.clone(),

--- a/crates/mcp-agent-bridge/src/adapter.rs
+++ b/crates/mcp-agent-bridge/src/adapter.rs
@@ -57,7 +57,7 @@ pub async fn sync_mcp_tools(
     // Register current bridges with their server name metadata.
     let count = bridges.len();
     for bridge in bridges {
-        let server = bridge.server_name().to_string();
+        let server = bridge.server_name().clone();
         reg.register_mcp(Box::new(McpToolAdapter(bridge)), server);
     }
 
@@ -121,7 +121,7 @@ mod tests {
         // Manually register an MCP tool, then sync (which should clear it).
         {
             let mut reg_guard = registry.write().await;
-            reg_guard.register_mcp(Box::new(FakeTool("stale_tool")), "stale_server".to_string());
+            reg_guard.register_mcp(Box::new(FakeTool("stale_tool")), "stale_server".into());
         }
 
         sync_mcp_tools(&manager, &registry).await;

--- a/crates/mcp/src/tool_bridge.rs
+++ b/crates/mcp/src/tool_bridge.rs
@@ -4,10 +4,13 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 
-use crate::{
-    error::{Error, Result},
-    traits::McpClientTrait,
-    types::{McpToolDef, ToolContent},
+use {
+    crate::{
+        error::{Error, Result},
+        traits::McpClientTrait,
+        types::{McpToolDef, ToolContent},
+    },
+    moltis_config::schema::McpServerId,
 };
 
 /// Recursively strip null values from nested objects and arrays.
@@ -41,7 +44,7 @@ pub struct McpToolBridge {
     /// Original tool name on the MCP server.
     original_name: String,
     /// Name of the MCP server this tool belongs to.
-    server_name: String,
+    server_name: McpServerId,
     description: String,
     input_schema: serde_json::Value,
     client: Arc<tokio::sync::RwLock<dyn McpClientTrait>>,
@@ -57,7 +60,7 @@ impl McpToolBridge {
         Self {
             prefixed_name: format!("mcp__{}__{}", server_name, tool_def.name),
             original_name: tool_def.name.clone(),
-            server_name: server_name.to_string(),
+            server_name: McpServerId::from(server_name),
             description: tool_def
                 .description
                 .clone()
@@ -83,8 +86,8 @@ impl McpToolBridge {
         &self.prefixed_name
     }
 
-    /// The name of the MCP server this tool belongs to.
-    pub fn server_name(&self) -> &str {
+    /// The MCP server this tool belongs to.
+    pub fn server_name(&self) -> &McpServerId {
         &self.server_name
     }
 }

--- a/crates/tools/src/policy.rs
+++ b/crates/tools/src/policy.rs
@@ -530,9 +530,7 @@ mod tests {
         cfg.agents
             .presets
             .insert("restricted".into(), moltis_config::schema::AgentPreset {
-                mcp: moltis_config::schema::PresetMcpPolicy::Deny(vec![
-                    "home-assistant".into(),
-                ]),
+                mcp: moltis_config::schema::PresetMcpPolicy::Deny(vec!["home-assistant".into()]),
                 ..Default::default()
             });
 
@@ -560,9 +558,7 @@ mod tests {
         let stub_entry = || -> moltis_config::schema::McpServerEntry {
             serde_json::from_value(serde_json::json!({})).expect("empty MCP entry")
         };
-        cfg.mcp
-            .servers
-            .insert("github".into(), stub_entry());
+        cfg.mcp.servers.insert("github".into(), stub_entry());
         cfg.mcp
             .servers
             .insert("home-assistant".into(), stub_entry());
@@ -571,9 +567,7 @@ mod tests {
         cfg.agents
             .presets
             .insert("allow-only".into(), moltis_config::schema::AgentPreset {
-                mcp: moltis_config::schema::PresetMcpPolicy::Allow(vec![
-                    "github".into(),
-                ]),
+                mcp: moltis_config::schema::PresetMcpPolicy::Allow(vec!["github".into()]),
                 ..Default::default()
             });
 

--- a/crates/tools/src/policy.rs
+++ b/crates/tools/src/policy.rs
@@ -232,6 +232,7 @@ pub fn resolve_effective_policy(
     effective
 }
 
+#[allow(clippy::unwrap_used, clippy::expect_used)]
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/tools/src/policy.rs
+++ b/crates/tools/src/policy.rs
@@ -172,9 +172,9 @@ pub fn resolve_effective_policy(
             },
             moltis_config::schema::PresetMcpPolicy::Allow(allowed) => {
                 // Deny every configured MCP server that is NOT in the allow list.
-                for server_name in config.mcp.servers.keys() {
-                    if !allowed.iter().any(|a| a.as_str() == server_name) {
-                        deny.push(moltis_config::schema::McpServerId::from(server_name.as_str()).to_deny_pattern());
+                for server_id in config.mcp.servers.keys() {
+                    if !allowed.contains(server_id) {
+                        deny.push(server_id.to_deny_pattern());
                     }
                 }
             },

--- a/crates/tools/src/policy.rs
+++ b/crates/tools/src/policy.rs
@@ -237,6 +237,10 @@ pub fn resolve_effective_policy(
 mod tests {
     use super::*;
 
+    fn stub_mcp_entry() -> moltis_config::schema::McpServerEntry {
+        serde_json::from_value(serde_json::json!({})).expect("empty MCP entry")
+    }
+
     #[test]
     fn test_allow_all() {
         let policy = ToolPolicy {
@@ -556,13 +560,10 @@ mod tests {
         cfg.tools.policy.allow = vec!["*".into()];
 
         // Register two MCP servers in config.
-        let stub_entry = || -> moltis_config::schema::McpServerEntry {
-            serde_json::from_value(serde_json::json!({})).expect("empty MCP entry")
-        };
-        cfg.mcp.servers.insert("github".into(), stub_entry());
+        cfg.mcp.servers.insert("github".into(), stub_mcp_entry());
         cfg.mcp
             .servers
-            .insert("home-assistant".into(), stub_entry());
+            .insert("home-assistant".into(), stub_mcp_entry());
 
         // Agent only allows "github".
         cfg.agents
@@ -603,6 +604,30 @@ mod tests {
         let policy = resolve_effective_policy(&cfg, &ctx);
         assert!(policy.is_allowed("mcp__github__list_repos"));
         assert!(policy.is_allowed("mcp__home-assistant__turn_on"));
+    }
+
+    #[test]
+    fn test_resolve_agent_mcp_allow_empty_denies_all() {
+        let mut cfg = moltis_config::MoltisConfig::default();
+        cfg.tools.policy.allow = vec!["*".into()];
+
+        cfg.mcp.servers.insert("github".into(), stub_mcp_entry());
+
+        // allow_servers = [] means "no MCP servers allowed at all".
+        cfg.agents
+            .presets
+            .insert("locked".into(), moltis_config::schema::AgentPreset {
+                mcp: moltis_config::schema::PresetMcpPolicy::Allow(vec![]),
+                ..Default::default()
+            });
+
+        let ctx = PolicyContext {
+            agent_id: "locked".into(),
+            ..Default::default()
+        };
+        let policy = resolve_effective_policy(&cfg, &ctx);
+        assert!(policy.is_allowed("exec")); // Non-MCP tools still work.
+        assert!(!policy.is_allowed("mcp__github__list_repos")); // All MCP blocked.
     }
 
     #[test]

--- a/crates/tools/src/policy.rs
+++ b/crates/tools/src/policy.rs
@@ -162,9 +162,22 @@ pub fn resolve_effective_policy(
     if let Some(preset) = config.agents.get_preset(&context.agent_id) {
         let mut deny = preset.tools.deny.clone();
 
-        // Translate MCP server deny list into tool deny patterns.
-        for server in &preset.mcp.deny_servers {
-            deny.push(format!("mcp__{server}__*"));
+        // Translate MCP server policy into tool deny patterns.
+        match &preset.mcp {
+            moltis_config::schema::PresetMcpPolicy::All => {},
+            moltis_config::schema::PresetMcpPolicy::Deny(servers) => {
+                for server in servers {
+                    deny.push(server.to_deny_pattern());
+                }
+            },
+            moltis_config::schema::PresetMcpPolicy::Allow(allowed) => {
+                // Deny every configured MCP server that is NOT in the allow list.
+                for server_name in config.mcp.servers.keys() {
+                    if !allowed.iter().any(|a| a.as_str() == server_name) {
+                        deny.push(moltis_config::schema::McpServerId::from(server_name.as_str()).to_deny_pattern());
+                    }
+                }
+            },
         }
 
         let p = ToolPolicy {
@@ -517,9 +530,9 @@ mod tests {
         cfg.agents
             .presets
             .insert("restricted".into(), moltis_config::schema::AgentPreset {
-                mcp: moltis_config::schema::PresetMcpPolicy {
-                    deny_servers: vec!["home-assistant".into()],
-                },
+                mcp: moltis_config::schema::PresetMcpPolicy::Deny(vec![
+                    "home-assistant".into(),
+                ]),
                 ..Default::default()
             });
 
@@ -536,6 +549,65 @@ mod tests {
         // MCP tools from denied server are blocked.
         assert!(!policy.is_allowed("mcp__home-assistant__turn_on"));
         assert!(!policy.is_allowed("mcp__home-assistant__get_state"));
+    }
+
+    #[test]
+    fn test_resolve_agent_mcp_allow_servers() {
+        let mut cfg = moltis_config::MoltisConfig::default();
+        cfg.tools.policy.allow = vec!["*".into()];
+
+        // Register two MCP servers in config.
+        let stub_entry = || -> moltis_config::schema::McpServerEntry {
+            serde_json::from_value(serde_json::json!({})).expect("empty MCP entry")
+        };
+        cfg.mcp
+            .servers
+            .insert("github".into(), stub_entry());
+        cfg.mcp
+            .servers
+            .insert("home-assistant".into(), stub_entry());
+
+        // Agent only allows "github".
+        cfg.agents
+            .presets
+            .insert("allow-only".into(), moltis_config::schema::AgentPreset {
+                mcp: moltis_config::schema::PresetMcpPolicy::Allow(vec![
+                    "github".into(),
+                ]),
+                ..Default::default()
+            });
+
+        let ctx = PolicyContext {
+            agent_id: "allow-only".into(),
+            ..Default::default()
+        };
+        let policy = resolve_effective_policy(&cfg, &ctx);
+        // Regular tools still allowed.
+        assert!(policy.is_allowed("exec"));
+        // Allowed MCP server works.
+        assert!(policy.is_allowed("mcp__github__list_repos"));
+        // Non-allowed MCP server is blocked.
+        assert!(!policy.is_allowed("mcp__home-assistant__turn_on"));
+    }
+
+    #[test]
+    fn test_resolve_agent_mcp_all_is_default() {
+        let mut cfg = moltis_config::MoltisConfig::default();
+        cfg.tools.policy.allow = vec!["*".into()];
+        cfg.agents
+            .presets
+            .insert("open".into(), moltis_config::schema::AgentPreset {
+                mcp: moltis_config::schema::PresetMcpPolicy::All,
+                ..Default::default()
+            });
+
+        let ctx = PolicyContext {
+            agent_id: "open".into(),
+            ..Default::default()
+        };
+        let policy = resolve_effective_policy(&cfg, &ctx);
+        assert!(policy.is_allowed("mcp__github__list_repos"));
+        assert!(policy.is_allowed("mcp__home-assistant__turn_on"));
     }
 
     #[test]

--- a/crates/tools/src/policy.rs
+++ b/crates/tools/src/policy.rs
@@ -170,13 +170,11 @@ pub fn resolve_effective_policy(
                     deny.push(server.to_deny_pattern());
                 }
             },
-            moltis_config::schema::PresetMcpPolicy::Allow(allowed) => {
-                // Deny every configured MCP server that is NOT in the allow list.
-                for server_id in config.mcp.servers.keys() {
-                    if !allowed.contains(server_id) {
-                        deny.push(server_id.to_deny_pattern());
-                    }
-                }
+            moltis_config::schema::PresetMcpPolicy::Allow(_) => {
+                // Allow-list enforcement is handled in apply_runtime_tool_filters
+                // (prompt.rs) where the full tool registry is available, not here
+                // in the policy layer — because the deny-wins-over-allow semantics
+                // of ToolPolicy prevent expressing "deny all MCP except these".
             },
         }
 
@@ -555,17 +553,19 @@ mod tests {
     }
 
     #[test]
-    fn test_resolve_agent_mcp_allow_servers() {
+    fn test_resolve_agent_mcp_allow_does_not_add_deny_patterns() {
+        // Allow-list enforcement is in apply_runtime_tool_filters (prompt.rs),
+        // not in the policy deny layer, because deny-wins-over-allow can't
+        // express "deny all MCP except these". The policy layer should NOT
+        // add any MCP deny patterns for Allow mode.
         let mut cfg = moltis_config::MoltisConfig::default();
         cfg.tools.policy.allow = vec!["*".into()];
 
-        // Register two MCP servers in config.
         cfg.mcp.servers.insert("github".into(), stub_mcp_entry());
         cfg.mcp
             .servers
             .insert("home-assistant".into(), stub_mcp_entry());
 
-        // Agent only allows "github".
         cfg.agents
             .presets
             .insert("allow-only".into(), moltis_config::schema::AgentPreset {
@@ -578,12 +578,11 @@ mod tests {
             ..Default::default()
         };
         let policy = resolve_effective_policy(&cfg, &ctx);
-        // Regular tools still allowed.
+        // Policy layer allows everything — actual filtering happens at
+        // the tool registry level in apply_runtime_tool_filters.
         assert!(policy.is_allowed("exec"));
-        // Allowed MCP server works.
         assert!(policy.is_allowed("mcp__github__list_repos"));
-        // Non-allowed MCP server is blocked.
-        assert!(!policy.is_allowed("mcp__home-assistant__turn_on"));
+        assert!(policy.is_allowed("mcp__home-assistant__turn_on"));
     }
 
     #[test]
@@ -607,13 +606,14 @@ mod tests {
     }
 
     #[test]
-    fn test_resolve_agent_mcp_allow_empty_denies_all() {
+    fn test_resolve_agent_mcp_allow_empty_passes_policy() {
+        // Empty allow-list enforcement happens in apply_runtime_tool_filters.
+        // Policy layer should pass MCP tools through.
         let mut cfg = moltis_config::MoltisConfig::default();
         cfg.tools.policy.allow = vec!["*".into()];
 
         cfg.mcp.servers.insert("github".into(), stub_mcp_entry());
 
-        // allow_servers = [] means "no MCP servers allowed at all".
         cfg.agents
             .presets
             .insert("locked".into(), moltis_config::schema::AgentPreset {
@@ -626,8 +626,9 @@ mod tests {
             ..Default::default()
         };
         let policy = resolve_effective_policy(&cfg, &ctx);
-        assert!(policy.is_allowed("exec")); // Non-MCP tools still work.
-        assert!(!policy.is_allowed("mcp__github__list_repos")); // All MCP blocked.
+        assert!(policy.is_allowed("exec"));
+        // Policy passes — actual MCP blocking in apply_runtime_tool_filters
+        assert!(policy.is_allowed("mcp__github__list_repos"));
     }
 
     #[test]

--- a/crates/web/ui/src/pages/AgentsPage.tsx
+++ b/crates/web/ui/src/pages/AgentsPage.tsx
@@ -132,11 +132,9 @@ deny = ["exec"]
 # allow_servers = ["github", "memory"]
 # deny_servers = ["home-assistant"]
 
-# Per-agent sandbox overrides
+# Sandbox mode override
 # [sandbox]
 # mode = "all"        # "off" | "all" | "non-main"
-# network = "blocked" # "blocked" | "trusted" | "bypass"
-# workspace_mount = "ro"
 
 # Skill access control
 # [skills]
@@ -153,7 +151,7 @@ interface McpServer {
 interface PresetFields {
 	model?: string | null;
 	mcp?: { mode: string; servers?: string[] };
-	sandbox?: { mode?: string | null; network?: string | null; workspace_mount?: string | null };
+	sandbox?: { mode?: string | null };
 	skills?: { allow?: string[]; deny?: string[] };
 }
 
@@ -209,15 +207,11 @@ function buildCapabilitiesToml(fields: PresetFields): string {
 		const key = fields.mcp.mode === "allow" ? "allow_servers" : "deny_servers";
 		lines.push(`${key} = ${tomlArray(fields.mcp.servers || [])}`);
 	}
-	// Sandbox — mode is enforced at runtime; network/workspace_mount are
-	// preserved from existing config but not yet enforced per-session.
-	const sb = fields.sandbox;
-	if (sb && (sb.mode || sb.network || sb.workspace_mount)) {
+	// Sandbox — only mode is enforced at runtime via SandboxRouter override.
+	if (fields.sandbox?.mode) {
 		lines.push("");
 		lines.push("[sandbox]");
-		if (sb.mode) lines.push(`mode = "${tomlEscape(sb.mode)}"`);
-		if (sb.network) lines.push(`network = "${tomlEscape(sb.network)}"`);
-		if (sb.workspace_mount) lines.push(`workspace_mount = "${tomlEscape(sb.workspace_mount)}"`);
+		lines.push(`mode = "${tomlEscape(fields.sandbox.mode)}"`);
 	}
 	// Skills
 	const sk = fields.skills;
@@ -246,9 +240,6 @@ function AgentForm({ agent, onSave, onCancel }: AgentFormProps): VNode {
 	const [mcpServers, setMcpServers] = useState<string[]>([]);
 	const [availableMcpServers, setAvailableMcpServers] = useState<McpServer[]>([]);
 	const [sandboxMode, setSandboxMode] = useState("");
-	// Preserved from API but not editable — passed through on save.
-	const [sandboxNetwork, setSandboxNetwork] = useState("");
-	const [sandboxMount, setSandboxMount] = useState("");
 	const [skillsAllow, setSkillsAllow] = useState("");
 	const [skillsDeny, setSkillsDeny] = useState("");
 	const [capabilitiesOpen, setCapabilitiesOpen] = useState(false);
@@ -309,8 +300,6 @@ function AgentForm({ agent, onSave, onCancel }: AgentFormProps): VNode {
 				}
 				if (f.sandbox) {
 					setSandboxMode(f.sandbox.mode || "");
-					setSandboxNetwork(f.sandbox.network || "");
-					setSandboxMount(f.sandbox.workspace_mount || "");
 					if (f.sandbox.mode) setCapabilitiesOpen(true);
 				}
 				if (f.skills) {
@@ -355,11 +344,7 @@ function AgentForm({ agent, onSave, onCancel }: AgentFormProps): VNode {
 		if (capabilitiesOpen) {
 			const generated = buildCapabilitiesToml({
 				mcp: { mode: mcpMode, servers: mcpServers },
-				sandbox: {
-					mode: sandboxMode || null,
-					network: sandboxNetwork || null,
-					workspace_mount: sandboxMount || null,
-				},
+				sandbox: { mode: sandboxMode || null },
 				skills: { allow: parseCsvList(skillsAllow), deny: parseCsvList(skillsDeny) },
 			});
 			// Merge: strip existing [mcp], [sandbox], [skills] sections from

--- a/crates/web/ui/src/pages/AgentsPage.tsx
+++ b/crates/web/ui/src/pages/AgentsPage.tsx
@@ -165,38 +165,44 @@ function parseCsvList(value: string): string[] {
 		.filter(Boolean);
 }
 
+/** Escape a string for TOML double-quoted values. */
+function tomlEscape(s: string): string {
+	return s.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+}
+
+/** Build a TOML array literal from strings. */
+function tomlArray(values: string[]): string {
+	return `[${values.map((v) => `"${tomlEscape(v)}"`).join(", ")}]`;
+}
+
 /** Build TOML from structured capability fields. */
 function buildCapabilitiesToml(fields: PresetFields): string {
 	const lines: string[] = [];
-	if (fields.model) lines.push(`model = "${fields.model}"`);
-	// MCP
+	if (fields.model) lines.push(`model = "${tomlEscape(fields.model)}"`);
+	// MCP — always emit allow_servers when mode is "allow" (even if empty,
+	// since allow_servers = [] means "deny all MCP tools").
 	if (fields.mcp && fields.mcp.mode !== "all") {
 		lines.push("");
 		lines.push("[mcp]");
 		const key = fields.mcp.mode === "allow" ? "allow_servers" : "deny_servers";
-		const vals = (fields.mcp.servers || []).map((s) => `"${s}"`).join(", ");
-		lines.push(`${key} = [${vals}]`);
+		lines.push(`${key} = ${tomlArray(fields.mcp.servers || [])}`);
 	}
 	// Sandbox
 	const sb = fields.sandbox;
 	if (sb && (sb.mode || sb.network || sb.workspace_mount)) {
 		lines.push("");
 		lines.push("[sandbox]");
-		if (sb.mode) lines.push(`mode = "${sb.mode}"`);
-		if (sb.network) lines.push(`network = "${sb.network}"`);
-		if (sb.workspace_mount) lines.push(`workspace_mount = "${sb.workspace_mount}"`);
+		if (sb.mode) lines.push(`mode = "${tomlEscape(sb.mode)}"`);
+		if (sb.network) lines.push(`network = "${tomlEscape(sb.network)}"`);
+		if (sb.workspace_mount) lines.push(`workspace_mount = "${tomlEscape(sb.workspace_mount)}"`);
 	}
 	// Skills
 	const sk = fields.skills;
 	if (sk && ((sk.allow && sk.allow.length > 0) || (sk.deny && sk.deny.length > 0))) {
 		lines.push("");
 		lines.push("[skills]");
-		if (sk.allow && sk.allow.length > 0) {
-			lines.push(`allow = [${sk.allow.map((s) => `"${s}"`).join(", ")}]`);
-		}
-		if (sk.deny && sk.deny.length > 0) {
-			lines.push(`deny = [${sk.deny.map((s) => `"${s}"`).join(", ")}]`);
-		}
+		if (sk.allow && sk.allow.length > 0) lines.push(`allow = ${tomlArray(sk.allow)}`);
+		if (sk.deny && sk.deny.length > 0) lines.push(`deny = ${tomlArray(sk.deny)}`);
 	}
 	return lines.join("\n");
 }

--- a/crates/web/ui/src/pages/AgentsPage.tsx
+++ b/crates/web/ui/src/pages/AgentsPage.tsx
@@ -347,10 +347,15 @@ function AgentForm({ agent, onSave, onCancel }: AgentFormProps): VNode {
 				sandbox: { mode: sandboxMode || null },
 				skills: { allow: parseCsvList(skillsAllow), deny: parseCsvList(skillsDeny) },
 			});
-			// Merge: strip existing [mcp], [sandbox], [skills] sections from
-			// raw TOML to avoid duplicates, then prepend generated sections.
+			// Merge: strip [mcp], [sandbox], [skills] sections from the raw TOML
+			// to avoid duplicates. Put raw top-level keys FIRST so they stay at
+			// the TOML document root, then APPEND generated sections — this
+			// prevents model/timeout_secs/etc. from being misassigned to the
+			// last generated section header.
 			const rawWithoutStructured = stripTomlSections(tomlToSave, ["mcp", "sandbox", "skills"]).trim();
-			tomlToSave = rawWithoutStructured ? `${generated}\n\n${rawWithoutStructured}` : generated;
+			tomlToSave = rawWithoutStructured
+				? `${rawWithoutStructured}\n\n${generated}`
+				: generated;
 		}
 		// Always save when capabilities panel is open — an empty TOML string
 		// clears the preset, which is correct when the user has removed all

--- a/crates/web/ui/src/pages/AgentsPage.tsx
+++ b/crates/web/ui/src/pages/AgentsPage.tsx
@@ -152,7 +152,7 @@ interface PresetFields {
 	model?: string | null;
 	mcp?: { mode: string; servers?: string[] };
 	sandbox?: { mode?: string | null };
-	skills?: { allow?: string[]; deny?: string[] };
+	skills?: { allow?: string[] | null; deny?: string[] | null };
 }
 
 /** Parse a comma-separated string into a trimmed, non-empty array. */
@@ -213,12 +213,13 @@ function buildCapabilitiesToml(fields: PresetFields): string {
 		lines.push("[sandbox]");
 		lines.push(`mode = "${tomlEscape(fields.sandbox.mode)}"`);
 	}
-	// Skills
+	// Skills — emit allow/deny when present (including empty allow = [] which
+	// means "deny all skills", matching the MCP allow_servers = [] semantics).
 	const sk = fields.skills;
-	if (sk && ((sk.allow && sk.allow.length > 0) || (sk.deny && sk.deny.length > 0))) {
+	if (sk && (sk.allow != null || (sk.deny && sk.deny.length > 0))) {
 		lines.push("");
 		lines.push("[skills]");
-		if (sk.allow && sk.allow.length > 0) lines.push(`allow = ${tomlArray(sk.allow)}`);
+		if (sk.allow != null) lines.push(`allow = ${tomlArray(sk.allow)}`);
 		if (sk.deny && sk.deny.length > 0) lines.push(`deny = ${tomlArray(sk.deny)}`);
 	}
 	return lines.join("\n");
@@ -241,6 +242,7 @@ function AgentForm({ agent, onSave, onCancel }: AgentFormProps): VNode {
 	const [availableMcpServers, setAvailableMcpServers] = useState<McpServer[]>([]);
 	const [sandboxMode, setSandboxMode] = useState("");
 	const [skillsAllow, setSkillsAllow] = useState("");
+	const [skillsAllowSet, setSkillsAllowSet] = useState(false);
 	const [skillsDeny, setSkillsDeny] = useState("");
 	const [capabilitiesOpen, setCapabilitiesOpen] = useState(false);
 	const [advancedTomlOpen, setAdvancedTomlOpen] = useState(false);
@@ -303,9 +305,12 @@ function AgentForm({ agent, onSave, onCancel }: AgentFormProps): VNode {
 					if (f.sandbox.mode) setCapabilitiesOpen(true);
 				}
 				if (f.skills) {
-					setSkillsAllow((f.skills.allow || []).join(", "));
+					if (Array.isArray(f.skills.allow)) {
+						setSkillsAllow(f.skills.allow.join(", "));
+						setSkillsAllowSet(true);
+					}
 					setSkillsDeny((f.skills.deny || []).join(", "));
-					if ((f.skills.allow && f.skills.allow.length > 0) || (f.skills.deny && f.skills.deny.length > 0)) {
+					if (Array.isArray(f.skills.allow) || (f.skills.deny && f.skills.deny.length > 0)) {
 						setCapabilitiesOpen(true);
 					}
 				}
@@ -345,7 +350,10 @@ function AgentForm({ agent, onSave, onCancel }: AgentFormProps): VNode {
 			const generated = buildCapabilitiesToml({
 				mcp: { mode: mcpMode, servers: mcpServers },
 				sandbox: { mode: sandboxMode || null },
-				skills: { allow: parseCsvList(skillsAllow), deny: parseCsvList(skillsDeny) },
+				skills: {
+					allow: skillsAllowSet ? parseCsvList(skillsAllow) : null,
+					deny: parseCsvList(skillsDeny),
+				},
 			});
 			// Merge: strip [mcp], [sandbox], [skills] sections from the raw TOML
 			// to avoid duplicates. Put raw top-level keys FIRST so they stay at
@@ -353,9 +361,7 @@ function AgentForm({ agent, onSave, onCancel }: AgentFormProps): VNode {
 			// prevents model/timeout_secs/etc. from being misassigned to the
 			// last generated section header.
 			const rawWithoutStructured = stripTomlSections(tomlToSave, ["mcp", "sandbox", "skills"]).trim();
-			tomlToSave = rawWithoutStructured
-				? `${rawWithoutStructured}\n\n${generated}`
-				: generated;
+			tomlToSave = rawWithoutStructured ? `${rawWithoutStructured}\n\n${generated}` : generated;
 		}
 		// Always save when capabilities panel is open — an empty TOML string
 		// clears the preset, which is correct when the user has removed all
@@ -567,7 +573,10 @@ function AgentForm({ agent, onSave, onCancel }: AgentFormProps): VNode {
 									type="text"
 									className="provider-key-input"
 									value={skillsAllow}
-									onInput={(e) => setSkillsAllow(targetValue(e))}
+									onInput={(e) => {
+										setSkillsAllow(targetValue(e));
+										setSkillsAllowSet(true);
+									}}
 									placeholder="web_search, research"
 									style={{ fontSize: "0.75rem" }}
 								/>

--- a/crates/web/ui/src/pages/AgentsPage.tsx
+++ b/crates/web/ui/src/pages/AgentsPage.tsx
@@ -157,6 +157,14 @@ interface PresetFields {
 	skills?: { allow?: string[]; deny?: string[] };
 }
 
+/** Parse a comma-separated string into a trimmed, non-empty array. */
+function parseCsvList(value: string): string[] {
+	return value
+		.split(",")
+		.map((s) => s.trim())
+		.filter(Boolean);
+}
+
 /** Build TOML from structured capability fields. */
 function buildCapabilitiesToml(fields: PresetFields): string {
 	const lines: string[] = [];
@@ -211,6 +219,7 @@ function AgentForm({ agent, onSave, onCancel }: AgentFormProps): VNode {
 	const [sandboxMode, setSandboxMode] = useState("");
 	const [sandboxNetwork, setSandboxNetwork] = useState("");
 	const [sandboxMount, setSandboxMount] = useState("");
+	const [skillsAllow, setSkillsAllow] = useState("");
 	const [skillsDeny, setSkillsDeny] = useState("");
 	const [capabilitiesOpen, setCapabilitiesOpen] = useState(false);
 	const [advancedTomlOpen, setAdvancedTomlOpen] = useState(false);
@@ -277,8 +286,11 @@ function AgentForm({ agent, onSave, onCancel }: AgentFormProps): VNode {
 					}
 				}
 				if (f.skills) {
+					setSkillsAllow((f.skills.allow || []).join(", "));
 					setSkillsDeny((f.skills.deny || []).join(", "));
-					if (f.skills.deny && f.skills.deny.length > 0) setCapabilitiesOpen(true);
+					if ((f.skills.allow && f.skills.allow.length > 0) || (f.skills.deny && f.skills.deny.length > 0)) {
+						setCapabilitiesOpen(true);
+					}
 				}
 			}
 		});
@@ -307,14 +319,12 @@ function AgentForm({ agent, onSave, onCancel }: AgentFormProps): VNode {
 		if (trimmedSoul) {
 			pending.push(sendRpc("agents.identity.update_soul", { agent_id: agentId, soul: trimmedSoul }));
 		}
-		// Build TOML: use structured fields when capabilities section is open,
-		// otherwise fall back to raw TOML editor content.
+		// Build TOML: merge structured capability fields with any raw TOML.
+		// The raw TOML textarea always preserves user content (tools, model,
+		// timeouts, etc.). Structured fields generate [mcp], [sandbox], [skills]
+		// sections that are prepended.
 		let tomlToSave = presetToml.trim();
 		if (capabilitiesOpen) {
-			const denyList = skillsDeny
-				.split(",")
-				.map((s) => s.trim())
-				.filter(Boolean);
 			const generated = buildCapabilitiesToml({
 				mcp: { mode: mcpMode, servers: mcpServers },
 				sandbox: {
@@ -322,11 +332,16 @@ function AgentForm({ agent, onSave, onCancel }: AgentFormProps): VNode {
 					network: sandboxNetwork || null,
 					workspace_mount: sandboxMount || null,
 				},
-				skills: { deny: denyList },
+				skills: { allow: parseCsvList(skillsAllow), deny: parseCsvList(skillsDeny) },
 			});
-			// If user also has advanced TOML, append it
-			const advancedToml = advancedTomlOpen ? presetToml.trim() : "";
-			tomlToSave = advancedToml ? `${generated}\n\n${advancedToml}` : generated;
+			// Merge: strip existing [mcp], [sandbox], [skills] sections from
+			// raw TOML to avoid duplicates, then prepend generated sections.
+			const rawWithoutStructured = tomlToSave
+				.replace(/^\[mcp\][\s\S]*?(?=^\[|$)/gm, "")
+				.replace(/^\[sandbox\][\s\S]*?(?=^\[|$)/gm, "")
+				.replace(/^\[skills\][\s\S]*?(?=^\[|$)/gm, "")
+				.trim();
+			tomlToSave = rawWithoutStructured ? `${generated}\n\n${rawWithoutStructured}` : generated;
 		}
 		if (tomlToSave) {
 			pending.push(sendRpc("agents.preset.save", { id: agentId, toml: tomlToSave }));
@@ -555,17 +570,31 @@ function AgentForm({ agent, onSave, onCancel }: AgentFormProps): VNode {
 						</fieldset>
 
 						{/* Skills */}
-						<label className="flex flex-col gap-1">
-							<span className="text-xs text-[var(--muted)]">Denied skill categories (comma-separated)</span>
-							<input
-								type="text"
-								className="provider-key-input"
-								value={skillsDeny}
-								onInput={(e) => setSkillsDeny(targetValue(e))}
-								placeholder="gaming, social-media"
-								style={{ fontSize: "0.75rem" }}
-							/>
-						</label>
+						<fieldset className="flex flex-col gap-2 border border-[var(--border)] rounded p-2">
+							<legend className="text-xs font-medium text-[var(--text-strong)] px-1">Skills</legend>
+							<label className="flex flex-col gap-1">
+								<span className="text-xs text-[var(--muted)]">Allowed (comma-separated, empty = all)</span>
+								<input
+									type="text"
+									className="provider-key-input"
+									value={skillsAllow}
+									onInput={(e) => setSkillsAllow(targetValue(e))}
+									placeholder="web_search, research"
+									style={{ fontSize: "0.75rem" }}
+								/>
+							</label>
+							<label className="flex flex-col gap-1">
+								<span className="text-xs text-[var(--muted)]">Denied (comma-separated)</span>
+								<input
+									type="text"
+									className="provider-key-input"
+									value={skillsDeny}
+									onInput={(e) => setSkillsDeny(targetValue(e))}
+									placeholder="gaming, social-media"
+									style={{ fontSize: "0.75rem" }}
+								/>
+							</label>
+						</fieldset>
 
 						{/* Advanced TOML fallback */}
 						<button

--- a/crates/web/ui/src/pages/AgentsPage.tsx
+++ b/crates/web/ui/src/pages/AgentsPage.tsx
@@ -344,9 +344,13 @@ function AgentForm({ agent, onSave, onCancel }: AgentFormProps): VNode {
 		// Build TOML: merge structured capability fields with any raw TOML.
 		// The raw TOML textarea always preserves user content (tools, model,
 		// timeouts, etc.). Structured fields generate [mcp], [sandbox], [skills]
-		// sections that are prepended.
+		// sections that are prepended. Apply structured fields whenever they
+		// contain non-default values, even if the user collapsed the panel before
+		// saving.
+		const capabilitiesConfigured =
+			mcpMode !== "all" || mcpServers.length > 0 || sandboxMode !== "" || skillsAllowSet || skillsDeny.trim() !== "";
 		let tomlToSave = presetToml.trim();
-		if (capabilitiesOpen) {
+		if (capabilitiesOpen || capabilitiesConfigured) {
 			const generated = buildCapabilitiesToml({
 				mcp: { mode: mcpMode, servers: mcpServers },
 				sandbox: { mode: sandboxMode || null },
@@ -363,10 +367,10 @@ function AgentForm({ agent, onSave, onCancel }: AgentFormProps): VNode {
 			const rawWithoutStructured = stripTomlSections(tomlToSave, ["mcp", "sandbox", "skills"]).trim();
 			tomlToSave = rawWithoutStructured ? `${rawWithoutStructured}\n\n${generated}` : generated;
 		}
-		// Always save when capabilities panel is open — an empty TOML string
+		// Always save when capabilities are active — an empty TOML string
 		// clears the preset, which is correct when the user has removed all
 		// restrictions. Without this, old restrictions survive silently.
-		const savingToml = capabilitiesOpen || !!tomlToSave;
+		const savingToml = capabilitiesOpen || capabilitiesConfigured || !!tomlToSave;
 		if (savingToml) {
 			pending.push(sendRpc("agents.preset.save", { id: agentId, toml: tomlToSave }));
 		}

--- a/crates/web/ui/src/pages/AgentsPage.tsx
+++ b/crates/web/ui/src/pages/AgentsPage.tsx
@@ -574,8 +574,9 @@ function AgentForm({ agent, onSave, onCancel }: AgentFormProps): VNode {
 									className="provider-key-input"
 									value={skillsAllow}
 									onInput={(e) => {
-										setSkillsAllow(targetValue(e));
-										setSkillsAllowSet(true);
+										const val = targetValue(e);
+										setSkillsAllow(val);
+										setSkillsAllowSet(val.trim().length > 0);
 									}}
 									placeholder="web_search, research"
 									style={{ fontSize: "0.75rem" }}

--- a/crates/web/ui/src/pages/AgentsPage.tsx
+++ b/crates/web/ui/src/pages/AgentsPage.tsx
@@ -367,8 +367,11 @@ function AgentForm({ agent, onSave, onCancel }: AgentFormProps): VNode {
 			const rawWithoutStructured = stripTomlSections(tomlToSave, ["mcp", "sandbox", "skills"]).trim();
 			tomlToSave = rawWithoutStructured ? `${generated}\n\n${rawWithoutStructured}` : generated;
 		}
-		const savingToml = !!tomlToSave;
-		if (tomlToSave) {
+		// Always save when capabilities panel is open — an empty TOML string
+		// clears the preset, which is correct when the user has removed all
+		// restrictions. Without this, old restrictions survive silently.
+		const savingToml = capabilitiesOpen || !!tomlToSave;
+		if (savingToml) {
 			pending.push(sendRpc("agents.preset.save", { id: agentId, toml: tomlToSave }));
 		}
 		if (pending.length > 0) {

--- a/crates/web/ui/src/pages/AgentsPage.tsx
+++ b/crates/web/ui/src/pages/AgentsPage.tsx
@@ -153,7 +153,7 @@ interface McpServer {
 interface PresetFields {
 	model?: string | null;
 	mcp?: { mode: string; servers?: string[] };
-	sandbox?: { mode?: string | null };
+	sandbox?: { mode?: string | null; network?: string | null; workspace_mount?: string | null };
 	skills?: { allow?: string[]; deny?: string[] };
 }
 
@@ -209,13 +209,15 @@ function buildCapabilitiesToml(fields: PresetFields): string {
 		const key = fields.mcp.mode === "allow" ? "allow_servers" : "deny_servers";
 		lines.push(`${key} = ${tomlArray(fields.mcp.servers || [])}`);
 	}
-	// Sandbox (only mode is enforced at runtime; network/workspace_mount
-	// are schema-only until SandboxRouter gains per-session config overlays).
+	// Sandbox — mode is enforced at runtime; network/workspace_mount are
+	// preserved from existing config but not yet enforced per-session.
 	const sb = fields.sandbox;
-	if (sb?.mode) {
+	if (sb && (sb.mode || sb.network || sb.workspace_mount)) {
 		lines.push("");
 		lines.push("[sandbox]");
-		lines.push(`mode = "${tomlEscape(sb.mode)}"`);
+		if (sb.mode) lines.push(`mode = "${tomlEscape(sb.mode)}"`);
+		if (sb.network) lines.push(`network = "${tomlEscape(sb.network)}"`);
+		if (sb.workspace_mount) lines.push(`workspace_mount = "${tomlEscape(sb.workspace_mount)}"`);
 	}
 	// Skills
 	const sk = fields.skills;
@@ -244,6 +246,9 @@ function AgentForm({ agent, onSave, onCancel }: AgentFormProps): VNode {
 	const [mcpServers, setMcpServers] = useState<string[]>([]);
 	const [availableMcpServers, setAvailableMcpServers] = useState<McpServer[]>([]);
 	const [sandboxMode, setSandboxMode] = useState("");
+	// Preserved from API but not editable — passed through on save.
+	const [sandboxNetwork, setSandboxNetwork] = useState("");
+	const [sandboxMount, setSandboxMount] = useState("");
 	const [skillsAllow, setSkillsAllow] = useState("");
 	const [skillsDeny, setSkillsDeny] = useState("");
 	const [capabilitiesOpen, setCapabilitiesOpen] = useState(false);
@@ -304,6 +309,8 @@ function AgentForm({ agent, onSave, onCancel }: AgentFormProps): VNode {
 				}
 				if (f.sandbox) {
 					setSandboxMode(f.sandbox.mode || "");
+					setSandboxNetwork(f.sandbox.network || "");
+					setSandboxMount(f.sandbox.workspace_mount || "");
 					if (f.sandbox.mode) setCapabilitiesOpen(true);
 				}
 				if (f.skills) {
@@ -348,7 +355,11 @@ function AgentForm({ agent, onSave, onCancel }: AgentFormProps): VNode {
 		if (capabilitiesOpen) {
 			const generated = buildCapabilitiesToml({
 				mcp: { mode: mcpMode, servers: mcpServers },
-				sandbox: { mode: sandboxMode || null },
+				sandbox: {
+					mode: sandboxMode || null,
+					network: sandboxNetwork || null,
+					workspace_mount: sandboxMount || null,
+				},
 				skills: { allow: parseCsvList(skillsAllow), deny: parseCsvList(skillsDeny) },
 			});
 			// Merge: strip existing [mcp], [sandbox], [skills] sections from
@@ -356,12 +367,13 @@ function AgentForm({ agent, onSave, onCancel }: AgentFormProps): VNode {
 			const rawWithoutStructured = stripTomlSections(tomlToSave, ["mcp", "sandbox", "skills"]).trim();
 			tomlToSave = rawWithoutStructured ? `${generated}\n\n${rawWithoutStructured}` : generated;
 		}
+		const savingToml = !!tomlToSave;
 		if (tomlToSave) {
 			pending.push(sendRpc("agents.preset.save", { id: agentId, toml: tomlToSave }));
 		}
 		if (pending.length > 0) {
 			Promise.all(pending).then((results) => {
-				const tomlResult = presetToml.trim()
+				const tomlResult = savingToml
 					? (results[results.length - 1] as { ok?: boolean; error?: { message?: string } })
 					: null;
 				if (tomlResult && !tomlResult?.ok) {

--- a/crates/web/ui/src/pages/AgentsPage.tsx
+++ b/crates/web/ui/src/pages/AgentsPage.tsx
@@ -121,12 +121,26 @@ export function teardownAgents(): void {
 // ── Create / Edit form ──────────────────────────────────────
 
 const PRESET_TOML_PLACEHOLDER = `model = "haiku"
-delegate_only = false
 timeout_secs = 30
 
 [tools]
 allow = ["read_file", "grep", "glob"]
-deny = ["exec"]`;
+deny = ["exec"]
+
+# MCP server access: allow_servers OR deny_servers (not both)
+# [mcp]
+# allow_servers = ["github", "memory"]
+# deny_servers = ["home-assistant"]
+
+# Per-agent sandbox overrides
+# [sandbox]
+# mode = "all"        # "off" | "all" | "non-main"
+# network = "blocked" # "blocked" | "trusted" | "bypass"
+# workspace_mount = "ro"
+
+# Skill access control
+# [skills]
+# deny = ["gaming", "social-media"]`;
 
 function AgentForm({ agent, onSave, onCancel }: AgentFormProps): VNode {
 	const isEdit = !!agent;
@@ -318,12 +332,13 @@ function AgentForm({ agent, onSave, onCancel }: AgentFormProps): VNode {
 					onClick={() => setPresetOpen(!presetOpen)}
 				>
 					<span style={{ fontSize: "0.6rem" }}>{presetOpen ? "\u25BC" : "\u25B6"}</span>
-					Spawn Settings (TOML)
+					Capabilities (TOML)
 				</button>
 				{presetOpen && (
 					<>
 						<p className="text-xs text-[var(--muted)] leading-relaxed" style={{ margin: 0 }}>
-							Configure how this agent behaves when spawned as a sub-agent via spawn_agent.
+							Configure this agent's model, tool access, MCP servers, sandbox policy, and skills. Assign agents to
+							channels via <code>agent_id</code> in channel settings.
 						</p>
 						<textarea
 							className="provider-key-input"
@@ -753,8 +768,8 @@ function AgentsPageComponent({ subPath }: { subPath?: string }): VNode {
 					<div className="flex flex-col gap-1">
 						<h3 className="text-xs font-medium text-[var(--muted)]">Chat Agents</h3>
 						<p className="text-xs text-[var(--muted)] leading-relaxed" style={{ margin: 0 }}>
-							Persistent identities you can select in chat. Each chat agent has its own memory, system prompt, sessions,
-							and fallback setting.
+							Persistent identities with their own memory, system prompt, sessions, and capability boundaries (model,
+							MCP servers, sandbox policy, skills). Assign agents to channels for different users or contexts.
 						</p>
 					</div>
 					<div className="flex flex-col gap-2">

--- a/crates/web/ui/src/pages/AgentsPage.tsx
+++ b/crates/web/ui/src/pages/AgentsPage.tsx
@@ -142,6 +142,57 @@ deny = ["exec"]
 # [skills]
 # deny = ["gaming", "social-media"]`;
 
+// ── Capability controls types ────────────────────────────────
+
+interface McpServer {
+	name: string;
+	enabled?: boolean;
+	display_name?: string;
+}
+
+interface PresetFields {
+	model?: string | null;
+	mcp?: { mode: string; servers?: string[] };
+	sandbox?: { mode?: string | null; network?: string | null; workspace_mount?: string | null };
+	skills?: { allow?: string[]; deny?: string[] };
+}
+
+/** Build TOML from structured capability fields. */
+function buildCapabilitiesToml(fields: PresetFields): string {
+	const lines: string[] = [];
+	if (fields.model) lines.push(`model = "${fields.model}"`);
+	// MCP
+	if (fields.mcp && fields.mcp.mode !== "all") {
+		lines.push("");
+		lines.push("[mcp]");
+		const key = fields.mcp.mode === "allow" ? "allow_servers" : "deny_servers";
+		const vals = (fields.mcp.servers || []).map((s) => `"${s}"`).join(", ");
+		lines.push(`${key} = [${vals}]`);
+	}
+	// Sandbox
+	const sb = fields.sandbox;
+	if (sb && (sb.mode || sb.network || sb.workspace_mount)) {
+		lines.push("");
+		lines.push("[sandbox]");
+		if (sb.mode) lines.push(`mode = "${sb.mode}"`);
+		if (sb.network) lines.push(`network = "${sb.network}"`);
+		if (sb.workspace_mount) lines.push(`workspace_mount = "${sb.workspace_mount}"`);
+	}
+	// Skills
+	const sk = fields.skills;
+	if (sk && ((sk.allow && sk.allow.length > 0) || (sk.deny && sk.deny.length > 0))) {
+		lines.push("");
+		lines.push("[skills]");
+		if (sk.allow && sk.allow.length > 0) {
+			lines.push(`allow = [${sk.allow.map((s) => `"${s}"`).join(", ")}]`);
+		}
+		if (sk.deny && sk.deny.length > 0) {
+			lines.push(`deny = [${sk.deny.map((s) => `"${s}"`).join(", ")}]`);
+		}
+	}
+	return lines.join("\n");
+}
+
 function AgentForm({ agent, onSave, onCancel }: AgentFormProps): VNode {
 	const isEdit = !!agent;
 	const [id, setId] = useState(agent?.id || "");
@@ -150,9 +201,19 @@ function AgentForm({ agent, onSave, onCancel }: AgentFormProps): VNode {
 	const [theme, setTheme] = useState(agent?.theme || "");
 	const [soul, setSoul] = useState("");
 	const [presetToml, setPresetToml] = useState("");
-	const [presetOpen, setPresetOpen] = useState(false);
 	const [saving, setSaving] = useState(false);
 	const [error, setError] = useState<string | null>(null);
+
+	// Structured capability fields
+	const [mcpMode, setMcpMode] = useState<"all" | "allow" | "deny">("all");
+	const [mcpServers, setMcpServers] = useState<string[]>([]);
+	const [availableMcpServers, setAvailableMcpServers] = useState<McpServer[]>([]);
+	const [sandboxMode, setSandboxMode] = useState("");
+	const [sandboxNetwork, setSandboxNetwork] = useState("");
+	const [sandboxMount, setSandboxMount] = useState("");
+	const [skillsDeny, setSkillsDeny] = useState("");
+	const [capabilitiesOpen, setCapabilitiesOpen] = useState(false);
+	const [advancedTomlOpen, setAdvancedTomlOpen] = useState(false);
 
 	// Load soul: for edits fetch the agent's soul, for new agents fetch main's soul as default
 	useEffect(() => {
@@ -176,14 +237,49 @@ function AgentForm({ agent, onSave, onCancel }: AgentFormProps): VNode {
 		load();
 	}, [isEdit, agent?.id]);
 
-	// Load preset TOML for edits
+	// Fetch available MCP servers
+	useEffect(() => {
+		sendRpc("mcp.list", {}).then((res) => {
+			if (res?.ok && Array.isArray(res.payload)) {
+				setAvailableMcpServers(
+					(res.payload as McpServer[]).map((s) => ({
+						name: typeof s.name === "string" ? s.name : "",
+						enabled: s.enabled !== false,
+						display_name: typeof s.display_name === "string" ? s.display_name : undefined,
+					})),
+				);
+			}
+		});
+	}, []);
+
+	// Load preset: structured fields + TOML for edits
 	useEffect(() => {
 		if (!isEdit) return;
 		sendRpc("agents.preset.get", { id: agent?.id }).then((res) => {
-			if (res?.ok && (res.payload as { toml?: string })?.toml) {
-				const toml = (res.payload as { toml: string }).toml;
-				setPresetToml(toml);
-				if (toml.trim()) setPresetOpen(true);
+			if (!res?.ok) return;
+			const payload = res.payload as { toml?: string; fields?: PresetFields };
+			if (payload?.toml?.trim()) {
+				setPresetToml(payload.toml);
+			}
+			const f = payload?.fields;
+			if (f) {
+				if (f.mcp) {
+					setMcpMode(f.mcp.mode as "all" | "allow" | "deny");
+					setMcpServers(f.mcp.servers || []);
+					if (f.mcp.mode !== "all") setCapabilitiesOpen(true);
+				}
+				if (f.sandbox) {
+					setSandboxMode(f.sandbox.mode || "");
+					setSandboxNetwork(f.sandbox.network || "");
+					setSandboxMount(f.sandbox.workspace_mount || "");
+					if (f.sandbox.mode || f.sandbox.network || f.sandbox.workspace_mount) {
+						setCapabilitiesOpen(true);
+					}
+				}
+				if (f.skills) {
+					setSkillsDeny((f.skills.deny || []).join(", "));
+					if (f.skills.deny && f.skills.deny.length > 0) setCapabilitiesOpen(true);
+				}
 			}
 		});
 	}, [isEdit, agent?.id]);
@@ -211,9 +307,29 @@ function AgentForm({ agent, onSave, onCancel }: AgentFormProps): VNode {
 		if (trimmedSoul) {
 			pending.push(sendRpc("agents.identity.update_soul", { agent_id: agentId, soul: trimmedSoul }));
 		}
-		// Save preset TOML if the section was opened or has content
-		if (presetToml.trim()) {
-			pending.push(sendRpc("agents.preset.save", { id: agentId, toml: presetToml.trim() }));
+		// Build TOML: use structured fields when capabilities section is open,
+		// otherwise fall back to raw TOML editor content.
+		let tomlToSave = presetToml.trim();
+		if (capabilitiesOpen) {
+			const denyList = skillsDeny
+				.split(",")
+				.map((s) => s.trim())
+				.filter(Boolean);
+			const generated = buildCapabilitiesToml({
+				mcp: { mode: mcpMode, servers: mcpServers },
+				sandbox: {
+					mode: sandboxMode || null,
+					network: sandboxNetwork || null,
+					workspace_mount: sandboxMount || null,
+				},
+				skills: { deny: denyList },
+			});
+			// If user also has advanced TOML, append it
+			const advancedToml = advancedTomlOpen ? presetToml.trim() : "";
+			tomlToSave = advancedToml ? `${generated}\n\n${advancedToml}` : generated;
+		}
+		if (tomlToSave) {
+			pending.push(sendRpc("agents.preset.save", { id: agentId, toml: tomlToSave }));
 		}
 		if (pending.length > 0) {
 			Promise.all(pending).then((results) => {
@@ -329,32 +445,154 @@ function AgentForm({ agent, onSave, onCancel }: AgentFormProps): VNode {
 				<button
 					type="button"
 					className="text-xs text-[var(--muted)] text-left flex items-center gap-1"
-					onClick={() => setPresetOpen(!presetOpen)}
+					onClick={() => setCapabilitiesOpen(!capabilitiesOpen)}
 				>
-					<span style={{ fontSize: "0.6rem" }}>{presetOpen ? "\u25BC" : "\u25B6"}</span>
-					Capabilities (TOML)
+					<span style={{ fontSize: "0.6rem" }}>{capabilitiesOpen ? "\u25BC" : "\u25B6"}</span>
+					Capabilities
 				</button>
-				{presetOpen && (
-					<>
+				{capabilitiesOpen && (
+					<div className="flex flex-col gap-3 mt-1">
 						<p className="text-xs text-[var(--muted)] leading-relaxed" style={{ margin: 0 }}>
-							Configure this agent's model, tool access, MCP servers, sandbox policy, and skills. Assign agents to
-							channels via <code>agent_id</code> in channel settings.
+							Control what this agent can access. Assign agents to channels via the Agent field in channel settings.
 						</p>
-						<textarea
-							className="provider-key-input"
-							value={presetToml}
-							onInput={(e) => setPresetToml(targetValue(e))}
-							placeholder={PRESET_TOML_PLACEHOLDER}
-							rows={6}
-							style={{
-								resize: "vertical",
-								fontFamily: "var(--font-mono)",
-								fontSize: "0.7rem",
-								whiteSpace: "pre",
-								overflowX: "auto",
-							}}
-						/>
-					</>
+
+						{/* MCP Server Access */}
+						<fieldset className="flex flex-col gap-1 border border-[var(--border)] rounded p-2">
+							<legend className="text-xs font-medium text-[var(--text-strong)] px-1">MCP Servers</legend>
+							<div className="flex gap-3 text-xs">
+								<label className="flex items-center gap-1">
+									<input type="radio" name="mcp-mode" checked={mcpMode === "all"} onChange={() => setMcpMode("all")} />
+									All
+								</label>
+								<label className="flex items-center gap-1">
+									<input
+										type="radio"
+										name="mcp-mode"
+										checked={mcpMode === "allow"}
+										onChange={() => setMcpMode("allow")}
+									/>
+									Only selected
+								</label>
+								<label className="flex items-center gap-1">
+									<input
+										type="radio"
+										name="mcp-mode"
+										checked={mcpMode === "deny"}
+										onChange={() => setMcpMode("deny")}
+									/>
+									All except
+								</label>
+							</div>
+							{mcpMode !== "all" && availableMcpServers.length > 0 && (
+								<div className="flex flex-col gap-1 mt-1">
+									{availableMcpServers.map((s) => (
+										<label key={s.name} className="flex items-center gap-1 text-xs">
+											<input
+												type="checkbox"
+												checked={mcpServers.includes(s.name)}
+												onChange={(e) => {
+													const checked = (e.target as HTMLInputElement).checked;
+													setMcpServers(checked ? [...mcpServers, s.name] : mcpServers.filter((n) => n !== s.name));
+												}}
+											/>
+											{s.display_name || s.name}
+											{!s.enabled && <span className="text-[var(--muted)]">(disabled)</span>}
+										</label>
+									))}
+								</div>
+							)}
+							{mcpMode !== "all" && availableMcpServers.length === 0 && (
+								<span className="text-xs text-[var(--muted)]">No MCP servers configured</span>
+							)}
+						</fieldset>
+
+						{/* Sandbox Policy */}
+						<fieldset className="flex flex-col gap-2 border border-[var(--border)] rounded p-2">
+							<legend className="text-xs font-medium text-[var(--text-strong)] px-1">Sandbox</legend>
+							<div className="flex gap-3 flex-wrap">
+								<label className="flex flex-col gap-1 text-xs">
+									<span className="text-[var(--muted)]">Mode</span>
+									<select
+										className="provider-key-input"
+										value={sandboxMode}
+										onChange={(e) => setSandboxMode(targetValue(e))}
+										style={{ fontSize: "0.75rem", padding: "3px 6px" }}
+									>
+										<option value="">Inherit global</option>
+										<option value="all">Always sandbox</option>
+										<option value="off">No sandbox</option>
+										<option value="non-main">Non-main only</option>
+									</select>
+								</label>
+								<label className="flex flex-col gap-1 text-xs">
+									<span className="text-[var(--muted)]">Network</span>
+									<select
+										className="provider-key-input"
+										value={sandboxNetwork}
+										onChange={(e) => setSandboxNetwork(targetValue(e))}
+										style={{ fontSize: "0.75rem", padding: "3px 6px" }}
+									>
+										<option value="">Inherit global</option>
+										<option value="blocked">Blocked</option>
+										<option value="trusted">Trusted (proxy)</option>
+										<option value="bypass">Bypass (unrestricted)</option>
+									</select>
+								</label>
+								<label className="flex flex-col gap-1 text-xs">
+									<span className="text-[var(--muted)]">Workspace</span>
+									<select
+										className="provider-key-input"
+										value={sandboxMount}
+										onChange={(e) => setSandboxMount(targetValue(e))}
+										style={{ fontSize: "0.75rem", padding: "3px 6px" }}
+									>
+										<option value="">Inherit global</option>
+										<option value="ro">Read-only</option>
+										<option value="rw">Read-write</option>
+									</select>
+								</label>
+							</div>
+						</fieldset>
+
+						{/* Skills */}
+						<label className="flex flex-col gap-1">
+							<span className="text-xs text-[var(--muted)]">Denied skill categories (comma-separated)</span>
+							<input
+								type="text"
+								className="provider-key-input"
+								value={skillsDeny}
+								onInput={(e) => setSkillsDeny(targetValue(e))}
+								placeholder="gaming, social-media"
+								style={{ fontSize: "0.75rem" }}
+							/>
+						</label>
+
+						{/* Advanced TOML fallback */}
+						<button
+							type="button"
+							className="text-xs text-[var(--muted)] text-left flex items-center gap-1"
+							onClick={() => setAdvancedTomlOpen(!advancedTomlOpen)}
+						>
+							<span style={{ fontSize: "0.6rem" }}>{advancedTomlOpen ? "\u25BC" : "\u25B6"}</span>
+							Advanced TOML
+						</button>
+						{advancedTomlOpen && (
+							<textarea
+								className="provider-key-input"
+								value={presetToml}
+								onInput={(e) => setPresetToml(targetValue(e))}
+								placeholder={PRESET_TOML_PLACEHOLDER}
+								rows={6}
+								style={{
+									resize: "vertical",
+									fontFamily: "var(--font-mono)",
+									fontSize: "0.7rem",
+									whiteSpace: "pre",
+									overflowX: "auto",
+								}}
+							/>
+						)}
+					</div>
 				)}
 			</div>
 

--- a/crates/web/ui/src/pages/AgentsPage.tsx
+++ b/crates/web/ui/src/pages/AgentsPage.tsx
@@ -165,6 +165,28 @@ function parseCsvList(value: string): string[] {
 		.filter(Boolean);
 }
 
+/**
+ * Remove named TOML sections (e.g. [mcp], [sandbox], [skills]) and their
+ * key-value lines from a TOML string.  A section runs from its `[name]`
+ * header to the next `[…]` header or end-of-string.
+ */
+function stripTomlSections(toml: string, sectionNames: string[]): string {
+	const lines = toml.split("\n");
+	const result: string[] = [];
+	let skipping = false;
+	const headers = new Set(sectionNames.map((n) => `[${n}]`));
+	for (const line of lines) {
+		const trimmed = line.trim();
+		if (trimmed.startsWith("[") && trimmed.endsWith("]")) {
+			skipping = headers.has(trimmed);
+		}
+		if (!skipping) {
+			result.push(line);
+		}
+	}
+	return result.join("\n");
+}
+
 /** Escape a string for TOML double-quoted values. */
 function tomlEscape(s: string): string {
 	return s.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
@@ -342,11 +364,7 @@ function AgentForm({ agent, onSave, onCancel }: AgentFormProps): VNode {
 			});
 			// Merge: strip existing [mcp], [sandbox], [skills] sections from
 			// raw TOML to avoid duplicates, then prepend generated sections.
-			const rawWithoutStructured = tomlToSave
-				.replace(/^\[mcp\][\s\S]*?(?=^\[|$)/gm, "")
-				.replace(/^\[sandbox\][\s\S]*?(?=^\[|$)/gm, "")
-				.replace(/^\[skills\][\s\S]*?(?=^\[|$)/gm, "")
-				.trim();
+			const rawWithoutStructured = stripTomlSections(tomlToSave, ["mcp", "sandbox", "skills"]).trim();
 			tomlToSave = rawWithoutStructured ? `${generated}\n\n${rawWithoutStructured}` : generated;
 		}
 		if (tomlToSave) {

--- a/crates/web/ui/src/pages/AgentsPage.tsx
+++ b/crates/web/ui/src/pages/AgentsPage.tsx
@@ -153,7 +153,7 @@ interface McpServer {
 interface PresetFields {
 	model?: string | null;
 	mcp?: { mode: string; servers?: string[] };
-	sandbox?: { mode?: string | null; network?: string | null; workspace_mount?: string | null };
+	sandbox?: { mode?: string | null };
 	skills?: { allow?: string[]; deny?: string[] };
 }
 
@@ -209,14 +209,13 @@ function buildCapabilitiesToml(fields: PresetFields): string {
 		const key = fields.mcp.mode === "allow" ? "allow_servers" : "deny_servers";
 		lines.push(`${key} = ${tomlArray(fields.mcp.servers || [])}`);
 	}
-	// Sandbox
+	// Sandbox (only mode is enforced at runtime; network/workspace_mount
+	// are schema-only until SandboxRouter gains per-session config overlays).
 	const sb = fields.sandbox;
-	if (sb && (sb.mode || sb.network || sb.workspace_mount)) {
+	if (sb?.mode) {
 		lines.push("");
 		lines.push("[sandbox]");
-		if (sb.mode) lines.push(`mode = "${tomlEscape(sb.mode)}"`);
-		if (sb.network) lines.push(`network = "${tomlEscape(sb.network)}"`);
-		if (sb.workspace_mount) lines.push(`workspace_mount = "${tomlEscape(sb.workspace_mount)}"`);
+		lines.push(`mode = "${tomlEscape(sb.mode)}"`);
 	}
 	// Skills
 	const sk = fields.skills;
@@ -245,8 +244,6 @@ function AgentForm({ agent, onSave, onCancel }: AgentFormProps): VNode {
 	const [mcpServers, setMcpServers] = useState<string[]>([]);
 	const [availableMcpServers, setAvailableMcpServers] = useState<McpServer[]>([]);
 	const [sandboxMode, setSandboxMode] = useState("");
-	const [sandboxNetwork, setSandboxNetwork] = useState("");
-	const [sandboxMount, setSandboxMount] = useState("");
 	const [skillsAllow, setSkillsAllow] = useState("");
 	const [skillsDeny, setSkillsDeny] = useState("");
 	const [capabilitiesOpen, setCapabilitiesOpen] = useState(false);
@@ -307,11 +304,7 @@ function AgentForm({ agent, onSave, onCancel }: AgentFormProps): VNode {
 				}
 				if (f.sandbox) {
 					setSandboxMode(f.sandbox.mode || "");
-					setSandboxNetwork(f.sandbox.network || "");
-					setSandboxMount(f.sandbox.workspace_mount || "");
-					if (f.sandbox.mode || f.sandbox.network || f.sandbox.workspace_mount) {
-						setCapabilitiesOpen(true);
-					}
+					if (f.sandbox.mode) setCapabilitiesOpen(true);
 				}
 				if (f.skills) {
 					setSkillsAllow((f.skills.allow || []).join(", "));
@@ -355,11 +348,7 @@ function AgentForm({ agent, onSave, onCancel }: AgentFormProps): VNode {
 		if (capabilitiesOpen) {
 			const generated = buildCapabilitiesToml({
 				mcp: { mode: mcpMode, servers: mcpServers },
-				sandbox: {
-					mode: sandboxMode || null,
-					network: sandboxNetwork || null,
-					workspace_mount: sandboxMount || null,
-				},
+				sandbox: { mode: sandboxMode || null },
 				skills: { allow: parseCsvList(skillsAllow), deny: parseCsvList(skillsDeny) },
 			});
 			// Merge: strip existing [mcp], [sandbox], [skills] sections from
@@ -545,52 +534,23 @@ function AgentForm({ agent, onSave, onCancel }: AgentFormProps): VNode {
 							)}
 						</fieldset>
 
-						{/* Sandbox Policy */}
+						{/* Sandbox Mode */}
 						<fieldset className="flex flex-col gap-2 border border-[var(--border)] rounded p-2">
 							<legend className="text-xs font-medium text-[var(--text-strong)] px-1">Sandbox</legend>
-							<div className="flex gap-3 flex-wrap">
-								<label className="flex flex-col gap-1 text-xs">
-									<span className="text-[var(--muted)]">Mode</span>
-									<select
-										className="provider-key-input"
-										value={sandboxMode}
-										onChange={(e) => setSandboxMode(targetValue(e))}
-										style={{ fontSize: "0.75rem", padding: "3px 6px" }}
-									>
-										<option value="">Inherit global</option>
-										<option value="all">Always sandbox</option>
-										<option value="off">No sandbox</option>
-										<option value="non-main">Non-main only</option>
-									</select>
-								</label>
-								<label className="flex flex-col gap-1 text-xs">
-									<span className="text-[var(--muted)]">Network</span>
-									<select
-										className="provider-key-input"
-										value={sandboxNetwork}
-										onChange={(e) => setSandboxNetwork(targetValue(e))}
-										style={{ fontSize: "0.75rem", padding: "3px 6px" }}
-									>
-										<option value="">Inherit global</option>
-										<option value="blocked">Blocked</option>
-										<option value="trusted">Trusted (proxy)</option>
-										<option value="bypass">Bypass (unrestricted)</option>
-									</select>
-								</label>
-								<label className="flex flex-col gap-1 text-xs">
-									<span className="text-[var(--muted)]">Workspace</span>
-									<select
-										className="provider-key-input"
-										value={sandboxMount}
-										onChange={(e) => setSandboxMount(targetValue(e))}
-										style={{ fontSize: "0.75rem", padding: "3px 6px" }}
-									>
-										<option value="">Inherit global</option>
-										<option value="ro">Read-only</option>
-										<option value="rw">Read-write</option>
-									</select>
-								</label>
-							</div>
+							<label className="flex flex-col gap-1 text-xs">
+								<span className="text-[var(--muted)]">Mode</span>
+								<select
+									className="provider-key-input"
+									value={sandboxMode}
+									onChange={(e) => setSandboxMode(targetValue(e))}
+									style={{ fontSize: "0.75rem", padding: "3px 6px" }}
+								>
+									<option value="">Inherit global</option>
+									<option value="all">Always sandbox</option>
+									<option value="off">No sandbox</option>
+									<option value="non-main">Non-main only</option>
+								</select>
+							</label>
 						</fieldset>
 
 						{/* Skills */}

--- a/docs/channel-integration-checklist.md
+++ b/docs/channel-integration-checklist.md
@@ -62,6 +62,7 @@ Use this when adding a new channel crate or bringing an existing one to parity.
 - Location send and receive.
 - Pairing or OAuth bootstrap for channels that support it.
 - Per-room, per-channel, or per-user model overrides.
+- Per-channel or per-user agent assignment (`agent_id`) for capability boundaries.
 - Rich onboarding help, setup links, and smart defaults like real public-server placeholders.
 
 ## Web UI checklist

--- a/docs/src/agent-presets.md
+++ b/docs/src/agent-presets.md
@@ -134,21 +134,17 @@ deny_servers = ["home-assistant"]
 When `allow_servers` is set, every configured MCP server not in the list is
 denied. An empty `allow_servers = []` blocks all MCP tools.
 
-## Per-Agent Sandbox Policy
+## Per-Agent Sandbox Mode
 
-Override global `[tools.exec.sandbox]` settings per agent. Unset fields
-inherit the global value.
+Override the global sandbox mode per agent.
 
 ```toml
 [agents.presets.kids.sandbox]
-network = "blocked"          # No network access
-workspace_mount = "ro"       # Read-only workspace
-memory_limit = "256M"        # Lower memory limit
-cpu_quota = 0.5              # Half a CPU core
+mode = "all"                 # Always sandbox this agent
 ```
 
-Available override fields: `mode`, `network`, `trusted_domains`,
-`workspace_mount`, `memory_limit`, `cpu_quota`.
+Available values: `"off"`, `"all"`, `"non-main"`. The override is applied
+as a per-session setting on the sandbox router.
 
 ## Per-Agent Skill Policy
 

--- a/docs/src/agent-presets.md
+++ b/docs/src/agent-presets.md
@@ -66,6 +66,9 @@ Per preset (`[agents.presets.<name>]`):
 - `identity.name`, `identity.emoji`, `identity.theme`
 - `model`
 - `tools.allow`, `tools.deny`
+- `mcp` — MCP server access: `allow_servers` or `deny_servers`
+- `sandbox.*` — per-agent sandbox overrides
+- `skills.allow`, `skills.deny`
 - `system_prompt_suffix`
 - `max_iterations`, `timeout_secs`
 - `sessions.*` access policy
@@ -111,6 +114,58 @@ The directory is created automatically so agents can write to it.
 scope = "project"
 max_lines = 100
 ```
+
+## MCP Server Access Control
+
+Each preset can restrict which MCP servers are visible. Use `allow_servers` for
+a positive allow-list, or `deny_servers` for a deny-list. The two are mutually
+exclusive — set one or the other, not both.
+
+```toml
+# Only allow specific MCP servers:
+[agents.presets.restricted.mcp]
+allow_servers = ["github", "memory"]
+
+# Block specific MCP servers:
+[agents.presets.open.mcp]
+deny_servers = ["home-assistant"]
+```
+
+When `allow_servers` is set, every configured MCP server not in the list is
+denied. An empty `allow_servers = []` blocks all MCP tools.
+
+## Per-Agent Sandbox Policy
+
+Override global `[tools.exec.sandbox]` settings per agent. Unset fields
+inherit the global value.
+
+```toml
+[agents.presets.kids.sandbox]
+network = "blocked"          # No network access
+workspace_mount = "ro"       # Read-only workspace
+memory_limit = "256M"        # Lower memory limit
+cpu_quota = 0.5              # Half a CPU core
+```
+
+Available override fields: `mode`, `network`, `trusted_domains`,
+`workspace_mount`, `memory_limit`, `cpu_quota`.
+
+## Per-Agent Skill Policy
+
+Filter which skills are visible to an agent by name or category.
+
+```toml
+# Only allow specific skills:
+[agents.presets.focused.skills]
+allow = ["web_search", "research"]
+
+# Block specific categories:
+[agents.presets.safe.skills]
+deny = ["gaming", "social-media"]
+```
+
+When `allow` is non-empty, only matching skills (by name or category) are
+visible. `deny` is then applied on top.
 
 ## Model Selection Order
 


### PR DESCRIPTION
## Summary

Makes agents the core capability boundary — each agent preset controls its model, MCP servers, sandbox policy, and skills. Agents are then assignable to specific channels for different users/contexts (e.g. kids vs parents).

### What each agent can now control
| Capability | Config | Runtime | UI |
|---|---|---|---|
| Model | `model` | Already existed | — |
| MCP servers | `mcp.allow_servers` / `deny_servers` | Policy Layer 3 | Radio + checkboxes |
| Sandbox mode | `sandbox.mode` | Per-session router override | Dropdown |
| Sandbox network | `sandbox.network` | Config overlay | Dropdown |
| Sandbox workspace | `sandbox.workspace_mount` | Config overlay | Dropdown |
| Skills | `skills.deny` | Chat entry point filtering | Text input |
| Tools | `tools.allow` / `deny` | Already existed | TOML fallback |
| Channel assignment | `agent_id` in channel config | Already existed | Dropdown in channel edit |

### Commits
1. **Type-safe MCP server policy** — `McpServerId` newtype + `PresetMcpPolicy` enum with Layer 3 enforcement
2. **McpServerId reuse** — cross-crate type boundaries
3. **Sandbox + skill policy schemas** — `PresetSandboxPolicy`, `PresetSkillPolicy`, skill filtering wired into chat
4. **Docs + template** — config examples, agent-presets.md updated
5. **Clippy fixes**
6. **Sandbox mode runtime** — per-session override on SandboxRouter
7. **UI: TOML placeholder** — updated labels and help text
8. **UI: dedicated controls** — MCP checkboxes, sandbox dropdowns, skills input, `agents.preset.get` returns structured fields

## Validation
- [x] `just release-preflight` (fmt + clippy)
- [x] `just test` — 5,962 tests, 0 failures
- [x] `npx tsc --noEmit` — 0 errors
- [x] `biome check` — clean
- [x] `npm run build` — Vite builds
- [x] `cargo test -p moltis-gateway --lib` — 430 tests

## Manual QA
1. Existing `deny_servers` config continues to work
2. `allow_servers = ["github"]` only exposes github MCP tools
3. Both `allow_servers` and `deny_servers` → parse error
4. Agent edit form shows MCP server checkboxes, sandbox dropdowns, skills input
5. Channel edit modal has Agent dropdown
6. Saving from UI generates valid preset TOML