### PR TITLE
fix(vault): initialize existing password vaults

### DIFF
--- a/crates/auth/src/credential_store.rs
+++ b/crates/auth/src/credential_store.rs
@@ -27,7 +27,7 @@ pub use {
 };
 
 #[cfg(feature = "vault")]
-pub use sessions::{PasswordVaultChangeError, VaultInitializeError};
+pub use sessions::{PasswordVaultChangeError, VaultInitializeError, VaultInitializeOutcome};
 
 /// Single-user credential store backed by SQLite.
 pub struct CredentialStore {

--- a/crates/auth/src/credential_store.rs
+++ b/crates/auth/src/credential_store.rs
@@ -27,7 +27,7 @@ pub use {
 };
 
 #[cfg(feature = "vault")]
-pub use sessions::PasswordVaultChangeError;
+pub use sessions::{PasswordVaultChangeError, VaultInitializeError};
 
 /// Single-user credential store backed by SQLite.
 pub struct CredentialStore {

--- a/crates/auth/src/credential_store/sessions.rs
+++ b/crates/auth/src/credential_store/sessions.rs
@@ -36,6 +36,21 @@ pub enum PasswordVaultChangeError {
 }
 
 #[cfg(feature = "vault")]
+#[derive(Debug, thiserror::Error)]
+pub enum VaultInitializeError {
+    #[error("current password is incorrect")]
+    IncorrectCurrentPassword,
+    #[error("vault is already initialized")]
+    AlreadyInitialized,
+    #[error(transparent)]
+    Database(#[from] sqlx::Error),
+    #[error(transparent)]
+    Auth(#[from] Error),
+    #[error(transparent)]
+    Vault(#[from] moltis_vault::VaultError),
+}
+
+#[cfg(feature = "vault")]
 fn map_vault_password_change_error(error: moltis_vault::VaultError) -> PasswordVaultChangeError {
     match error {
         moltis_vault::VaultError::BadCredential => PasswordVaultChangeError::VaultBadCredential,
@@ -548,6 +563,41 @@ impl CredentialStore {
 
         tx.commit().await?;
         Ok(())
+    }
+
+    #[cfg(feature = "vault")]
+    pub async fn initialize_vault_for_current_password(
+        &self,
+        current: &str,
+    ) -> std::result::Result<moltis_vault::RecoveryKey, VaultInitializeError> {
+        let Some(ref vault) = self.vault else {
+            return Err(moltis_vault::VaultError::NotInitialized.into());
+        };
+
+        let mut tx = self.pool.begin().await?;
+        let row: Option<(String,)> =
+            sqlx::query_as("SELECT password_hash FROM auth_password WHERE id = 1")
+                .fetch_optional(&mut *tx)
+                .await?;
+        let Some((current_hash,)) = row else {
+            return Err(VaultInitializeError::IncorrectCurrentPassword);
+        };
+        if !verify_password(current, &current_hash) {
+            return Err(VaultInitializeError::IncorrectCurrentPassword);
+        }
+
+        let recovery_key = match vault.status().await? {
+            moltis_vault::VaultStatus::Uninitialized => {
+                vault.initialize_in_transaction(current, &mut tx).await?
+            },
+            moltis_vault::VaultStatus::Sealed | moltis_vault::VaultStatus::Unsealed => {
+                return Err(VaultInitializeError::AlreadyInitialized);
+            },
+        };
+
+        tx.commit().await?;
+        vault.unseal(current).await?;
+        Ok(recovery_key)
     }
 
     /// Create a new session token (30-day expiry).

--- a/crates/auth/src/credential_store/sessions.rs
+++ b/crates/auth/src/credential_store/sessions.rs
@@ -51,6 +51,12 @@ pub enum VaultInitializeError {
 }
 
 #[cfg(feature = "vault")]
+pub struct VaultInitializeOutcome {
+    pub recovery_key: moltis_vault::RecoveryKey,
+    pub unsealed: bool,
+}
+
+#[cfg(feature = "vault")]
 fn map_vault_password_change_error(error: moltis_vault::VaultError) -> PasswordVaultChangeError {
     match error {
         moltis_vault::VaultError::BadCredential => PasswordVaultChangeError::VaultBadCredential,
@@ -569,7 +575,7 @@ impl CredentialStore {
     pub async fn initialize_vault_for_current_password(
         &self,
         current: &str,
-    ) -> std::result::Result<moltis_vault::RecoveryKey, VaultInitializeError> {
+    ) -> std::result::Result<VaultInitializeOutcome, VaultInitializeError> {
         let Some(ref vault) = self.vault else {
             return Err(moltis_vault::VaultError::NotInitialized.into());
         };
@@ -596,8 +602,17 @@ impl CredentialStore {
         };
 
         tx.commit().await?;
-        vault.unseal(current).await?;
-        Ok(recovery_key)
+        let unsealed = match vault.unseal(current).await {
+            Ok(()) => true,
+            Err(error) => {
+                tracing::warn!(%error, "vault initialized but post-commit unseal failed");
+                false
+            },
+        };
+        Ok(VaultInitializeOutcome {
+            recovery_key,
+            unsealed,
+        })
     }
 
     /// Create a new session token (30-day expiry).

--- a/crates/httpd/src/auth_routes.rs
+++ b/crates/httpd/src/auth_routes.rs
@@ -95,6 +95,7 @@ pub fn auth_router() -> axum::Router<AuthState> {
 fn vault_routes() -> axum::Router<AuthState> {
     axum::Router::new()
         .route("/vault/status", get(vault::vault_status_handler))
+        .route("/vault/initialize", post(vault::vault_initialize_handler))
         .route("/vault/unlock", post(vault::vault_unlock_handler))
         .route("/vault/recovery", post(vault::vault_recovery_handler))
         .route("/vault/disable", post(vault::vault_disable_handler))

--- a/crates/httpd/src/auth_routes/vault.rs
+++ b/crates/httpd/src/auth_routes/vault.rs
@@ -57,12 +57,20 @@ pub(super) async fn vault_initialize_handler(
         .initialize_vault_for_current_password(&body.password)
         .await
     {
-        Ok(recovery_key) => {
-            run_vault_env_migration(&state).await;
-            start_stored_channels_on_vault_unseal(&state).await;
+        Ok(outcome) => {
+            let status = if outcome.unsealed {
+                "unsealed"
+            } else {
+                "sealed"
+            };
+            if outcome.unsealed {
+                run_vault_env_migration(&state).await;
+                start_stored_channels_on_vault_unseal(&state).await;
+            }
             Json(serde_json::json!({
                 "ok": true,
-                "recovery_key": recovery_key.phrase(),
+                "recovery_key": outcome.recovery_key.phrase(),
+                "status": status,
             }))
             .into_response()
         },

--- a/crates/httpd/src/auth_routes/vault.rs
+++ b/crates/httpd/src/auth_routes/vault.rs
@@ -35,6 +35,49 @@ pub(super) async fn vault_status_handler(State(state): State<AuthState>) -> impl
 
 #[cfg(feature = "vault")]
 #[derive(serde::Deserialize)]
+pub(super) struct VaultInitializeRequest {
+    password: String,
+}
+
+#[cfg(feature = "vault")]
+pub(super) async fn vault_initialize_handler(
+    _session: crate::auth_middleware::AuthSession,
+    State(state): State<AuthState>,
+    Json(body): Json<VaultInitializeRequest>,
+) -> impl IntoResponse {
+    if !moltis_gateway::vault_lifecycle::is_vault_encryption_runtime_enabled() {
+        return (StatusCode::NOT_FOUND, "vault not available").into_response();
+    }
+    if state.gateway_state.vault.is_none() {
+        return (StatusCode::NOT_FOUND, "vault not available").into_response();
+    }
+
+    match state
+        .credential_store
+        .initialize_vault_for_current_password(&body.password)
+        .await
+    {
+        Ok(recovery_key) => {
+            run_vault_env_migration(&state).await;
+            start_stored_channels_on_vault_unseal(&state).await;
+            Json(serde_json::json!({
+                "ok": true,
+                "recovery_key": recovery_key.phrase(),
+            }))
+            .into_response()
+        },
+        Err(moltis_gateway::auth::VaultInitializeError::IncorrectCurrentPassword) => {
+            (StatusCode::FORBIDDEN, "current password is incorrect").into_response()
+        },
+        Err(moltis_gateway::auth::VaultInitializeError::AlreadyInitialized) => {
+            (StatusCode::CONFLICT, "vault is already initialized").into_response()
+        },
+        Err(error) => (StatusCode::INTERNAL_SERVER_ERROR, error.to_string()).into_response(),
+    }
+}
+
+#[cfg(feature = "vault")]
+#[derive(serde::Deserialize)]
 pub(super) struct VaultUnlockRequest {
     password: String,
 }

--- a/crates/httpd/tests/auth_middleware/more.rs
+++ b/crates/httpd/tests/auth_middleware/more.rs
@@ -397,6 +397,7 @@ pub(super) async fn vault_initialize_uses_existing_password() {
 
     let body: serde_json::Value = resp.json().await.unwrap();
     assert_eq!(body["ok"], true);
+    assert_eq!(body["status"], "unsealed");
     assert!(
         body["recovery_key"]
             .as_str()

--- a/crates/httpd/tests/auth_middleware/more.rs
+++ b/crates/httpd/tests/auth_middleware/more.rs
@@ -369,6 +369,91 @@ pub(super) async fn password_change_initializes_vault() {
     assert!(store.verify_password(&new_password).await.unwrap());
 }
 
+/// Passwords migrated from the environment can initialize an existing but
+/// uninitialized vault without removing authentication.
+#[cfg(all(feature = "web-ui", feature = "vault"))]
+#[tokio::test]
+pub(super) async fn vault_initialize_uses_existing_password() {
+    let (addr, store, _state, vault) = start_localhost_server_with_vault().await;
+    let password = generated_password();
+    store.set_initial_password(&password).await.unwrap();
+    let token = store.create_session().await.unwrap();
+
+    assert_eq!(
+        vault.status().await.unwrap(),
+        moltis_vault::VaultStatus::Uninitialized
+    );
+
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(format!("http://{addr}/api/auth/vault/initialize"))
+        .header("Content-Type", "application/json")
+        .header("Cookie", format!("moltis_session={token}"))
+        .body(json_password(&password))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(body["ok"], true);
+    assert!(
+        body["recovery_key"]
+            .as_str()
+            .is_some_and(|key| !key.is_empty())
+    );
+    assert_eq!(
+        vault.status().await.unwrap(),
+        moltis_vault::VaultStatus::Unsealed
+    );
+}
+
+#[cfg(all(feature = "web-ui", feature = "vault"))]
+#[tokio::test]
+pub(super) async fn vault_initialize_rejects_wrong_password() {
+    let (addr, store, _state, vault) = start_localhost_server_with_vault().await;
+    let password = generated_password();
+    let wrong_password = different_password(&password);
+    store.set_initial_password(&password).await.unwrap();
+    let token = store.create_session().await.unwrap();
+
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(format!("http://{addr}/api/auth/vault/initialize"))
+        .header("Content-Type", "application/json")
+        .header("Cookie", format!("moltis_session={token}"))
+        .body(json_password(&wrong_password))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 403);
+    assert_eq!(
+        vault.status().await.unwrap(),
+        moltis_vault::VaultStatus::Uninitialized
+    );
+}
+
+#[cfg(all(feature = "web-ui", feature = "vault"))]
+#[tokio::test]
+pub(super) async fn vault_initialize_rejects_already_initialized_vault() {
+    let (addr, store, _state, vault) = start_localhost_server_with_vault().await;
+    let password = generated_password();
+    store.set_initial_password(&password).await.unwrap();
+    let token = store.create_session().await.unwrap();
+    let _rk = vault.initialize(&password).await.unwrap();
+
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(format!("http://{addr}/api/auth/vault/initialize"))
+        .header("Content-Type", "application/json")
+        .header("Cookie", format!("moltis_session={token}"))
+        .body(json_password(&password))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 409);
+}
+
 /// Setting a password via /api/auth/password/change when the vault is already
 /// initialized should not return a recovery key (no double-init).
 #[cfg(all(feature = "web-ui", feature = "vault"))]

--- a/crates/web/src/templates.rs
+++ b/crates/web/src/templates.rs
@@ -95,6 +95,7 @@ pub(crate) struct GonData {
     agents: Vec<serde_json::Value>,
     webhooks: Vec<serde_json::Value>,
     webhook_profiles: Vec<serde_json::Value>,
+    auth_has_password: bool,
     #[cfg(feature = "vault")]
     vault_status: String,
 }
@@ -571,6 +572,10 @@ pub(crate) async fn build_gon_data(gw: &GatewayState) -> GonData {
         agents,
         webhooks,
         webhook_profiles,
+        auth_has_password: match gw.credential_store.as_ref() {
+            Some(store) => store.has_password().await.unwrap_or(false),
+            None => false,
+        },
         #[cfg(feature = "vault")]
         vault_status: {
             if let Some(ref vault) = gw.vault {

--- a/crates/web/ui/src/app.tsx
+++ b/crates/web/ui/src/app.tsx
@@ -40,6 +40,7 @@ import * as _sessionHistoryCache from "./stores/session-history-cache";
 import * as _sessionStoreModule from "./stores/session-store";
 import { insertSessionInOrder, sessionStore } from "./stores/session-store";
 import { initTheme, injectMarkdownStyles } from "./theme";
+import type { VaultStatus } from "./types/gon";
 import { GlobalDialogs, Toasts } from "./ui";
 import { connect } from "./websocket";
 import * as _wsConnect from "./ws-connect";
@@ -196,7 +197,7 @@ gon.onChange("update", showUpdateBanner as (v: unknown) => void);
 onEvent("update.available", showUpdateBanner as (payload: unknown) => void);
 initUpdateBannerDismiss();
 initUpdateNowButton();
-showVaultBanner(gon.get("vault_status") as string | null);
+showVaultBanner(gon.get("vault_status") ?? null);
 gon.onChange("vault_status", showVaultBanner as (v: unknown) => void);
 
 function upsertSessionFromEvent(entry: SessionEntry | null): boolean {
@@ -540,7 +541,7 @@ function initUpdateNowButton(): void {
 	});
 }
 
-function showVaultBanner(status: string | null): void {
+function showVaultBanner(status: VaultStatus | null): void {
 	const el = document.getElementById("vaultBanner");
 	if (!el) return;
 	el.style.display = status === "sealed" ? "" : "none";

--- a/crates/web/ui/src/login-app.tsx
+++ b/crates/web/ui/src/login-app.tsx
@@ -5,6 +5,7 @@ import { applyIdentityFavicon, formatLoginTitle } from "./branding";
 import { init as initI18n, t } from "./i18n";
 import * as S from "./state";
 import { initTheme } from "./theme";
+import type { VaultStatus } from "./types/gon";
 import * as _wsConnect from "./ws-connect";
 
 // Expose state module for E2E test WS mocking via shims.
@@ -59,9 +60,9 @@ const identity = (gonData.identity as IdentityInfo) || null;
 // Set page branding from identity.
 document.title = formatLoginTitle(identity);
 applyIdentityFavicon(identity);
-showVaultBanner((gonData.vault_status as string) || null);
+showVaultBanner((gonData.vault_status as VaultStatus) || null);
 
-function showVaultBanner(status: string | null): void {
+function showVaultBanner(status: VaultStatus | null): void {
 	const el = document.getElementById("vaultBanner");
 	if (!el) return;
 	el.style.display = status === "sealed" ? "" : "none";
@@ -189,8 +190,11 @@ function renderLoginCard({
 			{showPassword ? (
 				<form onSubmit={onPasswordLogin} className="flex flex-col gap-3">
 					<div>
-						<label className="text-xs text-[var(--muted)] mb-1 block">{t("login:password")}</label>
+						<label htmlFor="login-password" className="text-xs text-[var(--muted)] mb-1 block">
+							{t("login:password")}
+						</label>
 						<input
+							id="login-password"
 							type="password"
 							className="provider-key-input w-full"
 							value={password}

--- a/crates/web/ui/src/pages/sections/EnvironmentSection.tsx
+++ b/crates/web/ui/src/pages/sections/EnvironmentSection.tsx
@@ -15,6 +15,7 @@ import {
 import * as gon from "../../gon";
 import { localizedApiErrorMessage } from "../../helpers";
 import { targetValue } from "../../typed-events";
+import type { VaultStatus } from "../../types/gon";
 import { rerender } from "./_shared";
 
 interface EnvVar {
@@ -22,6 +23,61 @@ interface EnvVar {
 	key: string;
 	encrypted?: boolean;
 	updated_at?: string;
+}
+
+interface EnvVaultNoticeProps {
+	vaultStatus: VaultStatus | null;
+	authHasPassword: boolean;
+}
+
+function EnvVaultNotice({ vaultStatus, authHasPassword }: EnvVaultNoticeProps): VNode | null {
+	if (!vaultStatus || vaultStatus === "disabled") return null;
+
+	return (
+		<div
+			className="text-xs"
+			style={{
+				maxWidth: "600px",
+				padding: "8px 12px",
+				borderRadius: "6px",
+				border: "1px solid var(--border)",
+				background: "var(--bg)",
+			}}
+		>
+			{vaultStatus === "unsealed" ? (
+				<>
+					<span style={{ color: "var(--accent)" }}>Vault unlocked.</span> Your keys are stored encrypted.
+				</>
+			) : vaultStatus === "sealed" ? (
+				<>
+					<span style={{ color: "var(--warning,var(--error))" }}>Vault locked.</span> Encrypted keys can{"\u2019"}t be
+					read {"\u2014"} sandbox commands won{"\u2019"}t work.{" "}
+					<a href="/settings/vault" style={{ color: "inherit", textDecoration: "underline" }}>
+						Unlock in Encryption settings.
+					</a>
+				</>
+			) : (
+				<>
+					<span className="text-[var(--muted)]">Vault not set up.</span>{" "}
+					{authHasPassword ? (
+						<>
+							<a href="/settings/vault" style={{ color: "inherit", textDecoration: "underline" }}>
+								Initialize the vault
+							</a>{" "}
+							to encrypt your stored keys.
+						</>
+					) : (
+						<>
+							<a href="/settings/security" style={{ color: "inherit", textDecoration: "underline" }}>
+								Set a password
+							</a>{" "}
+							to encrypt your stored keys.
+						</>
+					)}
+				</>
+			)}
+		</div>
+	);
 }
 
 export function EnvironmentSection(): VNode {
@@ -127,7 +183,8 @@ export function EnvironmentSection(): VNode {
 		});
 	}
 
-	const envVaultStatus = gon.get("vault_status");
+	const envVaultStatus = gon.get("vault_status") ?? null;
+	const authHasPassword = gon.get("auth_has_password") === true;
 
 	return (
 		<div className="flex-1 flex flex-col min-w-0 p-4 gap-4 overflow-y-auto">
@@ -135,40 +192,7 @@ export function EnvironmentSection(): VNode {
 			<p className="text-xs text-[var(--muted)] leading-relaxed" style={{ maxWidth: "600px", margin: 0 }}>
 				Environment variables are injected into sandbox command execution. Values are write-only and never displayed.
 			</p>
-			{envVaultStatus && envVaultStatus !== "disabled" ? (
-				<div
-					className="text-xs"
-					style={{
-						maxWidth: "600px",
-						padding: "8px 12px",
-						borderRadius: "6px",
-						border: "1px solid var(--border)",
-						background: "var(--bg)",
-					}}
-				>
-					{envVaultStatus === "unsealed" ? (
-						<>
-							<span style={{ color: "var(--accent)" }}>Vault unlocked.</span> Your keys are stored encrypted.
-						</>
-					) : envVaultStatus === "sealed" ? (
-						<>
-							<span style={{ color: "var(--warning,var(--error))" }}>Vault locked.</span> Encrypted keys can{"\u2019"}t
-							be read {"\u2014"} sandbox commands won{"\u2019"}t work.{" "}
-							<a href="/settings/vault" style={{ color: "inherit", textDecoration: "underline" }}>
-								Unlock in Encryption settings.
-							</a>
-						</>
-					) : (
-						<>
-							<span className="text-[var(--muted)]">Vault not set up.</span>{" "}
-							<a href="/settings/security" style={{ color: "inherit", textDecoration: "underline" }}>
-								Set a password
-							</a>{" "}
-							to encrypt your stored keys.
-						</>
-					)}
-				</div>
-			) : null}
+			<EnvVaultNotice vaultStatus={envVaultStatus} authHasPassword={authHasPassword} />
 
 			{envLoading ? (
 				<Loading />
@@ -226,6 +250,7 @@ export function EnvironmentSection(): VNode {
 											}
 											actions={[
 												<button
+													type="button"
 													key="update"
 													className="provider-btn provider-btn-sm"
 													onClick={() => onStartUpdate(v.id)}
@@ -233,6 +258,7 @@ export function EnvironmentSection(): VNode {
 													Update
 												</button>,
 												<button
+													type="button"
 													key="delete"
 													className="provider-btn provider-btn-sm provider-btn-danger"
 													onClick={() => onDelete(v.id)}

--- a/crates/web/ui/src/pages/sections/VaultSection.tsx
+++ b/crates/web/ui/src/pages/sections/VaultSection.tsx
@@ -384,7 +384,7 @@ export function VaultSection(): VNode {
 					/>
 				) : null}
 
-				{vaultStatus === "uninitialized" && hasPassword ? (
+				{initializeRecoveryKey || (vaultStatus === "uninitialized" && hasPassword) ? (
 					<InitializeVaultForm
 						password={initializePw}
 						initializing={initializing}

--- a/crates/web/ui/src/pages/sections/VaultSection.tsx
+++ b/crates/web/ui/src/pages/sections/VaultSection.tsx
@@ -264,14 +264,20 @@ export function VaultSection(): VNode {
 	const [initializing, setInitializing] = useState(false);
 
 	useEffect(() => {
-		gon.onChange("vault_status", (val) => {
+		const onVaultStatusChange = (val: VaultStatus | undefined): void => {
 			setVaultStatus(val ?? null);
 			rerender();
-		});
-		gon.onChange("auth_has_password", (val) => {
+		};
+		const onAuthHasPasswordChange = (val: boolean): void => {
 			setHasPassword(val === true);
 			rerender();
-		});
+		};
+		gon.onChange("vault_status", onVaultStatusChange);
+		gon.onChange("auth_has_password", onAuthHasPasswordChange);
+		return () => {
+			gon.offChange("vault_status", onVaultStatusChange);
+			gon.offChange("auth_has_password", onAuthHasPasswordChange);
+		};
 	}, []);
 
 	function onInitializeVault(e: Event): void {

--- a/crates/web/ui/src/pages/sections/VaultSection.tsx
+++ b/crates/web/ui/src/pages/sections/VaultSection.tsx
@@ -288,10 +288,10 @@ export function VaultSection(): VNode {
 		})
 			.then((r) => {
 				if (!r.ok) return r.text().then((t) => setErr(t || "Vault initialization failed"));
-				return r.json().then((data: { recovery_key?: string }) => {
+				return r.json().then((data: { recovery_key?: string; status?: VaultStatus }) => {
 					setInitializePw("");
 					setInitializeRecoveryKey(data.recovery_key || null);
-					setVaultStatus("unsealed");
+					setVaultStatus(data.status || "sealed");
 					setMsg("Vault initialized.");
 					refreshGon();
 				});

--- a/crates/web/ui/src/pages/sections/VaultSection.tsx
+++ b/crates/web/ui/src/pages/sections/VaultSection.tsx
@@ -6,6 +6,7 @@ import { SectionHeading, StatusMessage } from "../../components/forms";
 import * as gon from "../../gon";
 import { refresh as refreshGon } from "../../gon";
 import { targetValue } from "../../typed-events";
+import type { VaultStatus } from "../../types/gon";
 import { rerender } from "./_shared";
 
 interface DisabledVaultStateProps {
@@ -172,17 +173,20 @@ function VaultIntro(): VNode {
 }
 
 interface VaultStatusRowProps {
-	vaultStatus: string;
+	vaultStatus: VaultStatus;
+	hasPassword: boolean;
 }
 
-function VaultStatusRow({ vaultStatus }: VaultStatusRowProps): VNode {
+function VaultStatusRow({ vaultStatus, hasPassword }: VaultStatusRowProps): VNode {
 	const label = vaultStatus === "unsealed" ? "Unlocked" : vaultStatus === "sealed" ? "Locked" : "Off";
 	const detail =
 		vaultStatus === "unsealed"
 			? "Your API keys and secrets are encrypted in the database. Everything is working."
 			: vaultStatus === "sealed"
 				? "Log in or unlock below to access your encrypted keys."
-				: "Set a password in Authentication settings to start encrypting your stored keys.";
+				: hasPassword
+					? "Password authentication is configured, but the vault has not been initialized yet."
+					: "Set a password in Authentication settings to start encrypting your stored keys.";
 	return (
 		<div style={{ display: "flex", alignItems: "center", gap: "8px", marginBottom: "12px" }}>
 			<span
@@ -195,21 +199,109 @@ function VaultStatusRow({ vaultStatus }: VaultStatusRowProps): VNode {
 	);
 }
 
+interface InitializeVaultFormProps {
+	password: string;
+	initializing: boolean;
+	recoveryKey: string | null;
+	onPasswordInput: (value: string) => void;
+	onInitialize: (event: Event) => void;
+}
+
+function InitializeVaultForm({
+	password,
+	initializing,
+	recoveryKey,
+	onPasswordInput,
+	onInitialize,
+}: InitializeVaultFormProps): VNode {
+	return (
+		<div className="mt-3 rounded border border-[var(--border)] bg-[var(--surface2)] p-3">
+			{recoveryKey ? (
+				<>
+					<div className="text-sm font-semibold text-[var(--text)]">Vault initialized. Save this recovery key.</div>
+					<p className="my-2 text-xs leading-relaxed text-[var(--muted)]">
+						This key is shown once. Store it somewhere safe so you can unlock the vault if you forget your password.
+					</p>
+					<code className="block select-all rounded border border-[var(--border)] bg-[var(--bg)] p-2 font-mono text-xs">
+						{recoveryKey}
+					</code>
+				</>
+			) : (
+				<form onSubmit={onInitialize}>
+					<div className="text-sm font-semibold text-[var(--text)]">Initialize encryption vault</div>
+					<p className="my-2 text-xs leading-relaxed text-[var(--muted)]">
+						Use your current password to create the encrypted vault and receive a one-time recovery key.
+					</p>
+					<div className="flex items-center gap-2">
+						<input
+							type="password"
+							className="provider-key-input flex-1"
+							value={password}
+							onInput={(event: Event) => onPasswordInput(targetValue(event))}
+							placeholder="Current password"
+						/>
+						<button type="submit" className="provider-btn" disabled={initializing || !password.trim()}>
+							{initializing ? "Initializing..." : "Initialize vault"}
+						</button>
+					</div>
+				</form>
+			)}
+		</div>
+	);
+}
+
 export function VaultSection(): VNode {
-	const [vaultStatus, setVaultStatus] = useState(gon.get("vault_status") || null);
+	const [vaultStatus, setVaultStatus] = useState<VaultStatus | null>(gon.get("vault_status") ?? null);
+	const [hasPassword, setHasPassword] = useState(gon.get("auth_has_password") === true);
 	const [unlockPw, setUnlockPw] = useState("");
 	const [recoveryKey, setRecoveryKey] = useState("");
+	const [initializePw, setInitializePw] = useState("");
+	const [initializeRecoveryKey, setInitializeRecoveryKey] = useState<string | null>(null);
 	const [msg, setMsg] = useState<string | null>(null);
 	const [err, setErr] = useState<string | null>(null);
 	const [unlockingPw, setUnlockingPw] = useState(false);
 	const [unlockingRk, setUnlockingRk] = useState(false);
+	const [initializing, setInitializing] = useState(false);
 
 	useEffect(() => {
-		return gon.onChange("vault_status", (val: unknown) => {
-			setVaultStatus(val as string);
+		gon.onChange("vault_status", (val) => {
+			setVaultStatus(val ?? null);
+			rerender();
+		});
+		gon.onChange("auth_has_password", (val) => {
+			setHasPassword(val === true);
 			rerender();
 		});
 	}, []);
+
+	function onInitializeVault(e: Event): void {
+		e.preventDefault();
+		if (!initializePw.trim()) return;
+		setErr(null);
+		setMsg(null);
+		setInitializing(true);
+		rerender();
+		fetch("/api/auth/vault/initialize", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ password: initializePw }),
+		})
+			.then((r) => {
+				if (!r.ok) return r.text().then((t) => setErr(t || "Vault initialization failed"));
+				return r.json().then((data: { recovery_key?: string }) => {
+					setInitializePw("");
+					setInitializeRecoveryKey(data.recovery_key || null);
+					setVaultStatus("unsealed");
+					setMsg("Vault initialized.");
+					refreshGon();
+				});
+			})
+			.catch((error: Error) => setErr(error.message))
+			.finally(() => {
+				setInitializing(false);
+				rerender();
+			});
+	}
 
 	function onUnlockPw(e: Event): void {
 		e.preventDefault();
@@ -277,7 +369,7 @@ export function VaultSection(): VNode {
 
 			<div style={{ maxWidth: "600px" }}>
 				<VaultIntro />
-				<VaultStatusRow vaultStatus={vaultStatus} />
+				<VaultStatusRow vaultStatus={vaultStatus} hasPassword={hasPassword} />
 
 				{vaultStatus === "sealed" ? (
 					<UnlockForms
@@ -292,7 +384,17 @@ export function VaultSection(): VNode {
 					/>
 				) : null}
 
-				{vaultStatus === "uninitialized" ? (
+				{vaultStatus === "uninitialized" && hasPassword ? (
+					<InitializeVaultForm
+						password={initializePw}
+						initializing={initializing}
+						recoveryKey={initializeRecoveryKey}
+						onPasswordInput={setInitializePw}
+						onInitialize={onInitializeVault}
+					/>
+				) : null}
+
+				{vaultStatus === "uninitialized" && !hasPassword ? (
 					<div style={{ marginTop: "4px" }}>
 						<a
 							href="/settings/security"

--- a/crates/web/ui/src/types/gon.ts
+++ b/crates/web/ui/src/types/gon.ts
@@ -67,6 +67,8 @@ export interface SandboxGonInfo {
 	available_backends: SandboxBackendId[];
 }
 
+export type VaultStatus = "disabled" | "error" | "sealed" | "uninitialized" | "unsealed";
+
 // ── Identity ────────────────────────────────────────────────
 
 /**
@@ -249,7 +251,8 @@ export interface GonData {
 	agents: unknown[];
 	webhooks: unknown[];
 	webhook_profiles: unknown[];
-	vault_status?: string;
+	auth_has_password: boolean;
+	vault_status?: VaultStatus;
 }
 
 /** Key of GonData for use with get/set/onChange. */

--- a/docs/src/docker.md
+++ b/docs/src/docker.md
@@ -201,6 +201,10 @@ secrets:
 
 This lets encrypted environment variables and channel credentials load during
 startup. Treat the secret file as sensitive as the vault recovery key itself.
+If you create the secret file before the vault is initialized, Docker will
+accept the mount but Moltis cannot auto-unseal from an empty file. After you
+initialize the vault in **Settings > Encryption**, copy the one-time recovery
+key into this file before relying on unattended auto-unseal.
 
 ### Coolify (Hetzner/VPS)
 

--- a/docs/src/vault.md
+++ b/docs/src/vault.md
@@ -308,6 +308,12 @@ also returns a `recovery_key`. The page keeps the user on Settings long
 enough to copy it, then shows a **Continue to sign in** action when the
 new password makes authentication mandatory.
 
+If password authentication already exists but the vault is still
+uninitialized, **Settings > Encryption** shows an **Initialize vault** form
+instead of sending the user back to Authentication. Submitting the current
+password initializes the vault, migrates plaintext secrets into encrypted
+storage, and returns the one-time recovery key.
+
 Passkey-only setup does not trigger vault initialization (no password to
 derive a KEK from), so the recovery key screen is never shown in that flow.
 
@@ -322,7 +328,7 @@ on restart and unlocks on login.
 |-------------|-------|---------------|
 | **Unsealed** | Green ("Unlocked") | Your API keys and secrets are encrypted in the database. Everything is working. |
 | **Sealed** | Amber ("Locked") | Log in or unlock below to access your encrypted keys. |
-| **Uninitialized** | Gray ("Off") | Set a password in Authentication settings to start encrypting your stored keys. |
+| **Uninitialized** | Gray ("Off") | Set a password, or initialize the vault if password authentication already exists. |
 
 When the vault is **sealed**, both unlock forms are shown in the same
 panel (password and recovery key, separated by an "or" divider). Submitting


### PR DESCRIPTION
## Summary
- Add an authenticated vault initialization endpoint for installs that already have password auth but still have an uninitialized vault.
- Update Settings > Encryption and Environment messaging to distinguish setting a password from initializing an existing-password vault.
- Type `vault_status` as a UI union and document Docker auto-unseal behavior for empty secret files.

Fixes #1046

## Validation
### Completed
- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p moltis-httpd --test auth_middleware vault_initialize --features web-ui,vault`
- [x] `npx biome check --write crates/web/ui/src/pages/sections/VaultSection.tsx crates/web/ui/src/pages/sections/EnvironmentSection.tsx crates/web/ui/src/types/gon.ts crates/web/ui/src/app.tsx crates/web/ui/src/login-app.tsx`
- [x] `cd crates/web/ui && npm run build`
- [x] `cd crates/web/ui && npx tsc --noEmit`

### Remaining
- [ ] Full `just test`
- [ ] Full `just lint`

## Manual QA
- Not run manually. The focused HTTP integration tests cover successful initialization, wrong-password rejection, and already-initialized rejection.