### PR TITLE
fix(onboarding): show configured LLMs in recommendations

### DIFF
--- a/crates/web/ui/e2e/specs/onboarding.spec.js
+++ b/crates/web/ui/e2e/specs/onboarding.spec.js
@@ -1113,6 +1113,74 @@ test.describe("Onboarding wizard", () => {
 		expect(pageErrors).toEqual([]);
 	});
 
+	test("configured non-default LLM providers appear in recommended onboarding list", async ({ page }) => {
+		const pageErrors = watchPageErrors(page);
+
+		await page.route("**/api/auth/status", async (route) => {
+			await route.fulfill({
+				status: 200,
+				contentType: "application/json",
+				body: JSON.stringify({ authenticated: true, setup_required: false, localhost_only: true }),
+			});
+		});
+
+		await page.addInitScript(() => {
+			class FakeWebSocket {
+				static CONNECTING = 0;
+				static OPEN = 1;
+				static CLOSING = 2;
+				static CLOSED = 3;
+
+				readyState = FakeWebSocket.CONNECTING;
+				onopen = null;
+				onmessage = null;
+				onclose = null;
+
+				constructor() {
+					queueMicrotask(() => {
+						this.readyState = FakeWebSocket.OPEN;
+						this.onopen?.({});
+					});
+				}
+
+				send(raw) {
+					const request = JSON.parse(raw || "{}");
+					let payload = {};
+					if (request.method === "connect") {
+						payload = { type: "hello-ok" };
+					} else if (request.method === "providers.available") {
+						payload = [
+							{ name: "openai", displayName: "OpenAI", authType: "api-key", configured: false },
+							{ name: "perplexity", displayName: "Perplexity", authType: "api-key", configured: true },
+							{ name: "together", displayName: "Together AI", authType: "api-key", configured: false },
+						];
+					}
+					const response = { type: "res", id: request.id, ok: true, payload };
+					queueMicrotask(() => this.onmessage?.({ data: JSON.stringify(response) }));
+				}
+
+				close() {
+					this.readyState = FakeWebSocket.CLOSED;
+					this.onclose?.({});
+				}
+			}
+
+			window.WebSocket = FakeWebSocket;
+		});
+
+		await page.goto("/onboarding");
+		await moveToLlmStep(page);
+
+		const recommendedSection = page
+			.locator(".onboarding-card .flex.flex-col.gap-2")
+			.filter({ has: page.getByText("Recommended", { exact: true }) })
+			.first();
+		await expect(recommendedSection.getByText("Perplexity", { exact: true })).toBeVisible();
+		await expect(page.getByRole("button", { name: /All providers \(1 more\)/ })).toBeVisible();
+
+		expect(pageErrors).toEqual([]);
+	});
+
 	test("voice needs-key badge uses dedicated pill styling class", async ({ page }) => {
 		const pageErrors = watchPageErrors(page);
 		await page.goto("/onboarding");

--- a/crates/web/ui/src/onboarding/steps/ProviderStep.tsx
+++ b/crates/web/ui/src/onboarding/steps/ProviderStep.tsx
@@ -1045,8 +1045,8 @@ export function ProviderStep({ onNext, onBack }: { onNext: () => void; onBack?: 
 	if (loading) return <div className="text-sm text-[var(--muted)]">{t("onboarding:provider.loadingLlms")}</div>;
 
 	const configuredProviders = providers.filter((p) => p.configured);
-	const recommendedProviders = providers.filter((p) => RECOMMENDED_PROVIDERS.has(p.name));
-	const otherProviders = providers.filter((p) => !RECOMMENDED_PROVIDERS.has(p.name));
+	const recommendedProviders = providers.filter((p) => p.configured || RECOMMENDED_PROVIDERS.has(p.name));
+	const otherProviders = providers.filter((p) => !(p.configured || RECOMMENDED_PROVIDERS.has(p.name)));
 	const otherIsActive = otherProviders.some(
 		(p) => configuring === p.name || oauthProvider === p.name || localProvider === p.name,
 	);


### PR DESCRIPTION
## Summary
- Include any configured LLM provider in onboarding's Recommended list, even when it is not part of the default recommended provider set.
- Keep configured providers out of the collapsed All providers section so users can choose models without expanding every provider.
- Add an onboarding E2E regression test for a configured non-default provider.

## Validation
### Completed
- [x] `npm ci`
- [x] `npm run build:all`
- [x] `npx tsc --noEmit`
- [x] `cargo build -p moltis`
- [x] `MOLTIS_E2E_ONLY_PROJECT=onboarding npx playwright test e2e/specs/onboarding.spec.js --grep "configured non-default LLM providers" --project=onboarding`

### Remaining
- [ ] `biome check --write crates/web/ui/src/ crates/web/ui/e2e/specs/onboarding.spec.js` is blocked by existing unrelated warnings in broader UI files.
- [ ] `biome check --write crates/web/ui/src/onboarding/steps/ProviderStep.tsx crates/web/ui/e2e/specs/onboarding.spec.js` is blocked by existing unrelated warnings in `ProviderStep.tsx`.

## Manual QA
- Verified via E2E that a configured non-default provider appears in the Recommended onboarding section.
- Verified via E2E that the configured provider is excluded from the collapsed All providers count.