### PR TITLE
Hide disabled external agents from chat picker

### DIFF
--- a/crates/gateway/src/external_agents.rs
+++ b/crates/gateway/src/external_agents.rs
@@ -340,6 +340,9 @@ impl SessionService for ExternalAgentSessionService {
 #[async_trait]
 impl ExternalAgentService for GatewayExternalAgentService {
     async fn list(&self) -> ServiceResult {
+        if !self.config.enabled {
+            return Ok(serde_json::json!([]));
+        }
         Ok(serde_json::to_value(self.registry.list_agents().await)
             .unwrap_or_else(|_| serde_json::json!([])))
     }
@@ -426,6 +429,9 @@ impl ExternalAgentChatService {
     }
 
     async fn maybe_send_external(&self, params: &Value) -> Option<ServiceResult> {
+        if !self.external_agents.config.enabled {
+            return None;
+        }
         let session_key = resolve_session_key(params, &self.state).await;
         let entry = self.session_metadata.get(&session_key).await?;
         let kind = entry.external_agent_kind?;
@@ -917,15 +923,25 @@ mod tests {
         metadata: Arc<SqliteSessionMetadata>,
         state: Arc<FakeAgentState>,
     ) -> Arc<GatewayExternalAgentService> {
-        let mut registry = ExternalAgentRegistry::new();
-        registry.register(Box::new(FakeTransport { state }));
-        Arc::new(GatewayExternalAgentService::with_registry(
+        fake_external_agents_with_config(
             ExternalAgentsConfig {
                 enabled: true,
                 ..ExternalAgentsConfig::default()
             },
             metadata,
-            registry,
+            state,
+        )
+    }
+
+    fn fake_external_agents_with_config(
+        config: ExternalAgentsConfig,
+        metadata: Arc<SqliteSessionMetadata>,
+        state: Arc<FakeAgentState>,
+    ) -> Arc<GatewayExternalAgentService> {
+        let mut registry = ExternalAgentRegistry::new();
+        registry.register(Box::new(FakeTransport { state }));
+        Arc::new(GatewayExternalAgentService::with_registry(
+            config, metadata, registry,
         ))
     }
 
@@ -983,6 +999,60 @@ mod tests {
             .expect("status after unbind");
         assert_eq!(status["bound"], false);
         assert!(status["kind"].is_null());
+    }
+
+    #[tokio::test]
+    async fn list_returns_empty_when_external_agents_disabled() {
+        let metadata = Arc::new(SqliteSessionMetadata::new(sqlite_pool().await));
+        let agent_state = Arc::new(FakeAgentState::default());
+        let service = fake_external_agents_with_config(
+            ExternalAgentsConfig::default(),
+            Arc::clone(&metadata),
+            Arc::clone(&agent_state),
+        );
+
+        let agents = service.list().await.expect("list external agents");
+
+        assert_eq!(agents, serde_json::json!([]));
+        assert_eq!(agent_state.starts.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn disabled_external_agents_do_not_route_stale_bindings() {
+        let dir = tempfile::tempdir().unwrap();
+        let session_store = Arc::new(SessionStore::new(dir.path().to_path_buf()));
+        let metadata = Arc::new(SqliteSessionMetadata::new(sqlite_pool().await));
+        metadata.upsert("main", None).await.unwrap();
+        metadata
+            .set_external_agent("main", Some(AgentTransportKind::Codex), None)
+            .await;
+        let agent_state = Arc::new(FakeAgentState::default());
+        let external_agents = fake_external_agents_with_config(
+            ExternalAgentsConfig::default(),
+            Arc::clone(&metadata),
+            Arc::clone(&agent_state),
+        );
+        let chat = test_chat_service(
+            Arc::clone(&external_agents),
+            Arc::clone(&metadata),
+            Arc::clone(&session_store),
+        )
+        .await;
+
+        let error = chat
+            .send(serde_json::json!({ "sessionKey": "main", "text": "hello" }))
+            .await
+            .expect_err("disabled external agents should fall back to inner chat");
+
+        assert_eq!(error.to_string(), "chat not configured");
+        assert_eq!(agent_state.starts.load(Ordering::SeqCst), 0);
+        assert!(
+            agent_state
+                .prompts
+                .lock()
+                .unwrap_or_else(|error| error.into_inner())
+                .is_empty()
+        );
     }
 
     #[test]

--- a/crates/web/ui/e2e/specs/agents.spec.js
+++ b/crates/web/ui/e2e/specs/agents.spec.js
@@ -46,11 +46,15 @@ async function deleteAgentByName(page, agentName) {
 	await expect(testCard).toHaveCount(0, { timeout: 10_000 });
 }
 
-async function mockExternalAgentsRpc(page) {
-	await page.addInitScript(() => {
+async function mockExternalAgentsRpc(page, listPayload) {
+	await page.addInitScript((externalAgentsListPayload) => {
 		if (window.__externalAgentE2EPatched) return;
 		window.__externalAgentE2EPatched = true;
 		window.__externalAgentE2ERequests = [];
+		window.__externalAgentE2EListPayload = externalAgentsListPayload || [
+			{ kind: "codex", name: "Codex", installed: true, version: null },
+			{ kind: "claude-code", name: "Claude Code", installed: false, version: null },
+		];
 		const originalSend = WebSocket.prototype.send;
 
 		function respond(socket, id, payload) {
@@ -67,10 +71,7 @@ async function mockExternalAgentsRpc(page) {
 				var parsed = JSON.parse(payload);
 				if (parsed?.method === "external_agents.list") {
 					window.__externalAgentE2ERequests.push({ method: parsed.method, params: parsed.params || {} });
-					respond(this, parsed.id, [
-						{ kind: "codex", name: "Codex", installed: true, version: null },
-						{ kind: "claude-code", name: "Claude Code", installed: false, version: null },
-					]);
+					respond(this, parsed.id, window.__externalAgentE2EListPayload);
 					return;
 				}
 				if (parsed?.method === "external_agents.bind") {
@@ -88,7 +89,7 @@ async function mockExternalAgentsRpc(page) {
 			}
 			return originalSend.call(this, payload);
 		};
-	});
+	}, listPayload);
 }
 
 async function expectActiveSessionExternalAgent(page, kind) {
@@ -367,6 +368,30 @@ test.describe("Agents settings page", () => {
 			)
 			.toBe(true);
 		await expectActiveSessionExternalAgent(page, null);
+
+		expect(pageErrors).toEqual([]);
+	});
+
+	test("external-agent picker is hidden when external agents are disabled", async ({ page }) => {
+		const pageErrors = watchPageErrors(page);
+		await mockExternalAgentsRpc(page, []);
+		await page.goto("/chats");
+		await expectPageContentMounted(page);
+		await waitForWsConnected(page);
+		await createSession(page);
+
+		await expect
+			.poll(
+				async () =>
+					page.evaluate(() =>
+						(window.__externalAgentE2ERequests || []).some((req) => req.method === "external_agents.list"),
+					),
+				{ timeout: 10_000 },
+			)
+			.toBe(true);
+		await expect(page.getByTestId("external-agent-picker")).toHaveCount(0);
+		await expect(page.getByText("Claude Code (unavailable)", { exact: true })).toHaveCount(0);
+		await expect(page.getByText("Codex", { exact: true })).toHaveCount(0);
 
 		expect(pageErrors).toEqual([]);
 	});


### PR DESCRIPTION
## Summary
- Return an empty external agent list when `[external_agents] enabled = false`, so the chat header picker has no disabled options to render.
- Ignore stale persisted external-agent bindings while the feature is disabled so chat falls back to the Moltis agent path.
- Add Rust and Playwright regressions for the disabled external-agent state.

Closes #1057

## Validation
### Completed
- [x] `cargo test -p moltis-gateway external_agents::tests::`
- [x] `biome check --write crates/web/ui/e2e/specs/agents.spec.js`
- [x] `cd crates/web/ui && npm run build`
- [x] `cd crates/web/ui && npx tsc --noEmit`
- [x] `cd crates/web/ui && npm run build:all`
- [x] `cd crates/web/ui && npx playwright test e2e/specs/agents.spec.js`
- [x] `cargo fmt --all -- --check`

### Remaining
- [ ] Full release preflight was not run locally.

## Manual QA
- Verified through the new E2E regression that an empty `external_agents.list` response hides `data-testid=\"external-agent-picker\"` and does not render unavailable external agents.