### PR TITLE
fix(web): show long model names in picker

### DIFF
--- a/crates/web/src/assets/css/chat.css
+++ b/crates/web/src/assets/css/chat.css
@@ -785,7 +785,6 @@
   width: clamp(360px, 56vw, 640px);
   min-width: 320px;
   max-width: calc(100vw - 32px);
-  resize: horizontal;
   overflow: hidden;
 }
 

--- a/crates/web/src/assets/css/chat.css
+++ b/crates/web/src/assets/css/chat.css
@@ -781,6 +781,14 @@
   bottom: calc(100% + 6px);
 }
 
+.chat-composer-footer #modelDropdown {
+  width: clamp(360px, 56vw, 640px);
+  min-width: 320px;
+  max-width: calc(100vw - 32px);
+  resize: horizontal;
+  overflow: hidden;
+}
+
 .chat-composer-footer .model-combo-btn {
   min-height: 36px;
   border-radius: 14px;
@@ -788,6 +796,16 @@
   background: var(--surface);
   color: var(--text);
   font-size: 0.85rem;
+}
+
+.chat-composer-footer #modelComboBtn {
+  max-width: min(56vw, 360px);
+}
+
+#modelComboLabel {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .chat-composer-icon-btn,

--- a/crates/web/ui/e2e/specs/chat-input.spec.js
+++ b/crates/web/ui/e2e/specs/chat-input.spec.js
@@ -19,6 +19,22 @@ async function waitForWsConnectedIfPossible(page) {
 	await waitForWsConnected(page, 5_000).catch(() => "ignored");
 }
 
+async function setMockModels(page, models, selectedId) {
+	await page.evaluate(
+		async ([models, selectedId]) => {
+			var appScript = document.querySelector('script[type="module"][src*="js/app.js"]');
+			if (!appScript) throw new Error("app module script not found");
+			var appUrl = new URL(appScript.src, window.location.origin);
+			var prefix = appUrl.href.slice(0, appUrl.href.length - "js/app.js".length);
+			var store = await import(`${prefix}js/stores/model-store.js`);
+
+			store.select(selectedId);
+			store.setAll(models);
+		},
+		[models, selectedId],
+	);
+}
+
 async function mockFullContextRpc(page) {
 	await page.evaluate(async () => {
 		var appScript = document.querySelector('script[type="module"][src*="js/app.js"]');
@@ -426,6 +442,34 @@ test.describe("Chat input and slash commands", () => {
 		await expect(dropdown).toBeVisible();
 		const box = await dropdown.boundingBox();
 		expect(box?.height || 0).toBeGreaterThan(40);
+		expect(box?.width || 0).toBeLessThanOrEqual(390);
+	});
+
+	test("model selector exposes long gateway model names", async ({ page }) => {
+		const pageErrors = watchPageErrors(page);
+		const modelId = "requesty/anthropic/claude-sonnet-4-20250514-thinking-extended-beta";
+		const displayName = "Claude Sonnet 4 20250514 Thinking Extended Beta";
+		const fullTitle = `${displayName} (${modelId})`;
+
+		await setMockModels(
+			page,
+			[{ id: modelId, displayName, provider: "requesty", supportsReasoning: false }],
+			modelId,
+		);
+
+		await page.locator("#modelComboBtn").click();
+		const dropdown = page.locator("#modelDropdown");
+		await expect(dropdown).toBeVisible();
+
+		const box = await dropdown.boundingBox();
+		expect(box?.width || 0).toBeGreaterThan(360);
+
+		const item = page.locator("#modelDropdownList .model-dropdown-item").first();
+		await expect(item).toHaveAttribute("title", fullTitle);
+		await expect(item.locator(".model-item-label")).toHaveAttribute("title", fullTitle);
+		await item.click();
+		await expect(page.locator("#modelComboLabel")).toHaveAttribute("title", fullTitle);
+		expect(pageErrors).toEqual([]);
 	});
 
 	test("send button is present", async ({ page }) => {

--- a/crates/web/ui/src/models.ts
+++ b/crates/web/ui/src/models.ts
@@ -14,7 +14,11 @@ function setSessionModel(sessionKey: string, modelId: string): void {
 export { setSessionModel };
 
 function updateModelComboLabel(model: ModelInfo): void {
-	if (S.modelComboLabel) S.modelComboLabel.textContent = model.displayName || model.id;
+	if (!S.modelComboLabel) return;
+	const label = model.displayName || model.id;
+	S.modelComboLabel.textContent = label;
+	S.modelComboLabel.title =
+		model.displayName && model.displayName !== model.id ? `${model.displayName} (${model.id})` : label;
 }
 
 export function fetchModels(): Promise<void> {
@@ -73,6 +77,8 @@ function buildModelItem(m: ModelInfo, currentId: string): HTMLDivElement {
 	const label = document.createElement("span");
 	label.className = "model-item-label";
 	label.textContent = m.displayName || m.id;
+	label.title = m.displayName && m.displayName !== m.id ? `${m.displayName} (${m.id})` : label.textContent;
+	el.title = label.title;
 	el.appendChild(label);
 
 	const meta = document.createElement("span");

--- a/crates/web/ui/src/models.ts
+++ b/crates/web/ui/src/models.ts
@@ -13,12 +13,25 @@ function setSessionModel(sessionKey: string, modelId: string): void {
 
 export { setSessionModel };
 
+export interface ModelLabelInfo {
+	id: string;
+	displayName?: string;
+}
+
+export function modelDisplayLabel(model: ModelLabelInfo): string {
+	return model.displayName || model.id;
+}
+
+export function modelTitle(model: ModelLabelInfo): string {
+	const label = modelDisplayLabel(model);
+	return model.displayName && model.displayName !== model.id ? `${model.displayName} (${model.id})` : label;
+}
+
 function updateModelComboLabel(model: ModelInfo): void {
 	if (!S.modelComboLabel) return;
-	const label = model.displayName || model.id;
+	const label = modelDisplayLabel(model);
 	S.modelComboLabel.textContent = label;
-	S.modelComboLabel.title =
-		model.displayName && model.displayName !== model.id ? `${model.displayName} (${model.id})` : label;
+	S.modelComboLabel.title = modelTitle(model);
 }
 
 export function fetchModels(): Promise<void> {
@@ -76,8 +89,8 @@ function buildModelItem(m: ModelInfo, currentId: string): HTMLDivElement {
 
 	const label = document.createElement("span");
 	label.className = "model-item-label";
-	label.textContent = m.displayName || m.id;
-	label.title = m.displayName && m.displayName !== m.id ? `${m.displayName} (${m.id})` : label.textContent;
+	label.textContent = modelDisplayLabel(m);
+	label.title = modelTitle(m);
 	el.title = label.title;
 	el.appendChild(label);
 

--- a/crates/web/ui/src/pages/ChatPage.tsx
+++ b/crates/web/ui/src/pages/ChatPage.tsx
@@ -19,7 +19,7 @@ import {
 import { SessionHeader } from "../components/SessionHeader";
 import { formatTokens, sendRpc } from "../helpers";
 import { initMediaDrop, teardownMediaDrop } from "../media-drop";
-import { bindModelComboEvents } from "../models";
+import { bindModelComboEvents, modelDisplayLabel, modelTitle } from "../models";
 import { bindNodeComboEvents, fetchNodes, unbindNodeEvents } from "../nodes-selector";
 import { bindProjectComboEvents } from "../project-combo";
 import { fetchProjects } from "../projects";
@@ -801,19 +801,15 @@ function syncModelComboLabel(): void {
 	const models = S.models as Array<{ id: string; displayName?: string }>;
 	const found = models.find((m) => m.id === S.selectedModelId);
 	if (found) {
-		const label = found.displayName || found.id;
+		const label = modelDisplayLabel(found);
 		S.modelComboLabel.textContent = label;
-		S.modelComboLabel.title =
-			found.displayName && found.displayName !== found.id ? `${found.displayName} (${found.id})` : label;
+		S.modelComboLabel.title = modelTitle(found);
 		return;
 	}
 	if (models[0]) {
-		const label = models[0].displayName || models[0].id;
+		const label = modelDisplayLabel(models[0]);
 		S.modelComboLabel.textContent = label;
-		S.modelComboLabel.title =
-			models[0].displayName && models[0].displayName !== models[0].id
-				? `${models[0].displayName} (${models[0].id})`
-				: label;
+		S.modelComboLabel.title = modelTitle(models[0]);
 	}
 }
 

--- a/crates/web/ui/src/pages/ChatPage.tsx
+++ b/crates/web/ui/src/pages/ChatPage.tsx
@@ -801,10 +801,20 @@ function syncModelComboLabel(): void {
 	const models = S.models as Array<{ id: string; displayName?: string }>;
 	const found = models.find((m) => m.id === S.selectedModelId);
 	if (found) {
-		S.modelComboLabel.textContent = found.displayName || found.id;
+		const label = found.displayName || found.id;
+		S.modelComboLabel.textContent = label;
+		S.modelComboLabel.title =
+			found.displayName && found.displayName !== found.id ? `${found.displayName} (${found.id})` : label;
 		return;
 	}
-	if (models[0]) S.modelComboLabel.textContent = models[0].displayName || models[0].id;
+	if (models[0]) {
+		const label = models[0].displayName || models[0].id;
+		S.modelComboLabel.textContent = label;
+		S.modelComboLabel.title =
+			models[0].displayName && models[0].displayName !== models[0].id
+				? `${models[0].displayName} (${models[0].id})`
+				: label;
+	}
 }
 
 function resolveInitialSessionKey(sessionKeyFromUrl: string | null): string {

--- a/crates/web/ui/src/sessions/session-switch.ts
+++ b/crates/web/ui/src/sessions/session-switch.ts
@@ -110,7 +110,12 @@ export function restoreSessionState(entry: SessionMeta, projectId?: string): voi
 		S.setSelectedModelId(baseModelId);
 		localStorage.setItem("moltis-model", baseModelId);
 		const found = modelStore.getById(baseModelId);
-		if (S.modelComboLabel) S.modelComboLabel.textContent = found ? found.displayName || found.id : baseModelId;
+		if (S.modelComboLabel) {
+			const label = found ? found.displayName || found.id : baseModelId;
+			S.modelComboLabel.textContent = label;
+			S.modelComboLabel.title =
+				found?.displayName && found.displayName !== found.id ? `${found.displayName} (${found.id})` : label;
+		}
 	}
 	updateSandboxUI(entry.sandbox_enabled !== false);
 	updateSandboxImageUI(entry.sandbox_image || null);

--- a/crates/web/ui/src/sessions/session-switch.ts
+++ b/crates/web/ui/src/sessions/session-switch.ts
@@ -2,6 +2,7 @@
 
 import { chatAddMsg, removeThinking, setComposerStopButton, updateCommandInputUI, updateTokenBar } from "../chat-ui";
 import { sendRpc } from "../helpers";
+import { modelDisplayLabel, modelTitle } from "../models";
 import { restoreNodeSelection } from "../nodes-selector";
 import { updateSessionProjectSelect } from "../project-combo";
 import { restoreReasoningFromModelId } from "../reasoning-toggle";
@@ -111,10 +112,9 @@ export function restoreSessionState(entry: SessionMeta, projectId?: string): voi
 		localStorage.setItem("moltis-model", baseModelId);
 		const found = modelStore.getById(baseModelId);
 		if (S.modelComboLabel) {
-			const label = found ? found.displayName || found.id : baseModelId;
+			const label = found ? modelDisplayLabel(found) : baseModelId;
 			S.modelComboLabel.textContent = label;
-			S.modelComboLabel.title =
-				found?.displayName && found.displayName !== found.id ? `${found.displayName} (${found.id})` : label;
+			S.modelComboLabel.title = found ? modelTitle(found) : label;
 		}
 	}
 	updateSandboxUI(entry.sandbox_enabled !== false);


### PR DESCRIPTION
## Summary
- Widen the chat model picker responsively so gateway model IDs with versions are easier to read.
- Add full model-name tooltips to picker rows and the selected model chip.
- Cover long gateway model IDs and mobile dropdown bounds in chat input E2E tests.

Fixes #1052

## Validation
### Completed
- [x] `biome check --write crates/web/ui/src/` (completed with pre-existing warnings outside this change)
- [x] `cd crates/web/ui && npm run build`
- [x] `cd crates/web/ui && npx tsc --noEmit`
- [x] `just build-web-assets`
- [x] `cargo build --bin moltis`
- [x] `cd crates/web/ui && npx playwright test e2e/specs/chat-input.spec.js`
- [x] `git diff --check`

### Remaining
- [ ] CI full validation

## Manual QA
- Opened the chat model picker in Playwright with a long Requesty-style model ID.
- Verified the dropdown is wider than the old compact width, remains bounded on mobile, and exposes full names via `title` attributes.