### PR TITLE
fix(web): prevent chat toolbar horizontal overflow

### DIFF
--- a/crates/web/src/assets/css/layout.css
+++ b/crates/web/src/assets/css/layout.css
@@ -118,7 +118,33 @@
 /* ── Model Dropdown ── */
 
 /* Toolbar needs a stacking context so dropdowns render above the messages grid row. */
-.chat-toolbar { position: relative; z-index: 30; }
+.chat-toolbar {
+  position: relative;
+  z-index: 30;
+  min-width: 0;
+  max-width: 100%;
+  overflow-x: auto;
+  overflow-y: visible;
+}
+
+.chat-toolbar > * {
+  min-width: 0;
+}
+
+.chat-toolbar #sessionNameMount {
+  flex: 1 1 auto;
+}
+
+.chat-toolbar #sessionHeaderToolbarMount,
+.chat-toolbar #sessionActionsMount {
+  flex: 0 0 auto;
+}
+
+@media (max-width: 1100px) {
+  .chat-toolbar .chat-badge-desktop-only {
+    display: none !important;
+  }
+}
 
 .model-combo { position: relative; }
 .model-combo.hidden { display: none; }

--- a/crates/web/src/assets/css/layout.css
+++ b/crates/web/src/assets/css/layout.css
@@ -123,8 +123,6 @@
   z-index: 30;
   min-width: 0;
   max-width: 100%;
-  overflow-x: auto;
-  overflow-y: visible;
 }
 
 .chat-toolbar > * {

--- a/crates/web/ui/e2e/helpers.js
+++ b/crates/web/ui/e2e/helpers.js
@@ -310,7 +310,7 @@ async function expectRpcOk(page, method, params) {
 	return response;
 }
 
-async function expectNoPageHorizontalOverflow(page, label = "page") {
+async function expectNoPageHorizontalOverflow(page, label = "page", testInfo = null) {
 	const overflow = await page.evaluate(() => {
 		const doc = document.documentElement;
 		const viewportWidth = window.innerWidth;
@@ -339,16 +339,11 @@ async function expectNoPageHorizontalOverflow(page, label = "page") {
 		};
 	});
 
-	if (overflow.documentScrollWidth > overflow.documentClientWidth + 1) {
-		try {
-			const testInfo = require("@playwright/test").test.info();
-			await testInfo.attach(`horizontal-overflow-${label}`, {
-				body: Buffer.from(JSON.stringify(overflow, null, 2), "utf-8"),
-				contentType: "application/json",
-			});
-		} catch {
-			// Attachment is best-effort; assertion message still includes the details.
-		}
+	if (overflow.documentScrollWidth > overflow.documentClientWidth + 1 && testInfo) {
+		await testInfo.attach(`horizontal-overflow-${label}`, {
+			body: Buffer.from(JSON.stringify(overflow, null, 2), "utf-8"),
+			contentType: "application/json",
+		});
 	}
 
 	expect(

--- a/crates/web/ui/e2e/helpers.js
+++ b/crates/web/ui/e2e/helpers.js
@@ -310,6 +310,54 @@ async function expectRpcOk(page, method, params) {
 	return response;
 }
 
+async function expectNoPageHorizontalOverflow(page, label = "page") {
+	const overflow = await page.evaluate(() => {
+		const doc = document.documentElement;
+		const viewportWidth = window.innerWidth;
+		const tolerance = 1;
+		const overflowingElements = Array.from(document.body.querySelectorAll("*"))
+			.map((el) => {
+				const rect = el.getBoundingClientRect();
+				return {
+					tag: el.tagName.toLowerCase(),
+					id: el.id || "",
+					className: typeof el.className === "string" ? el.className : "",
+					scrollWidth: Math.round(el.scrollWidth * 100) / 100,
+					clientWidth: Math.round(el.clientWidth * 100) / 100,
+					left: Math.round(rect.left * 100) / 100,
+					right: Math.round(rect.right * 100) / 100,
+				};
+			})
+			.filter((item) => item.scrollWidth > item.clientWidth + tolerance || item.right > viewportWidth + tolerance)
+			.slice(0, 20);
+
+		return {
+			documentScrollWidth: doc.scrollWidth,
+			documentClientWidth: doc.clientWidth,
+			viewportWidth,
+			overflowingElements,
+		};
+	});
+
+	if (overflow.documentScrollWidth > overflow.documentClientWidth + 1) {
+		try {
+			const testInfo = require("@playwright/test").test.info();
+			await testInfo.attach(`horizontal-overflow-${label}`, {
+				body: Buffer.from(JSON.stringify(overflow, null, 2), "utf-8"),
+				contentType: "application/json",
+			});
+		} catch {
+			// Attachment is best-effort; assertion message still includes the details.
+		}
+	}
+
+	expect(
+		overflow.documentScrollWidth,
+		`${label} has horizontal overflow: ${JSON.stringify(overflow.overflowingElements)}`,
+	).toBeLessThanOrEqual(overflow.documentClientWidth + 1);
+	return overflow;
+}
+
 module.exports = {
 	expectPageContentMounted,
 	watchPageErrors,
@@ -319,4 +367,5 @@ module.exports = {
 	createSession,
 	sendRpcFromPage,
 	expectRpcOk,
+	expectNoPageHorizontalOverflow,
 };

--- a/crates/web/ui/e2e/specs/chat-layout.spec.js
+++ b/crates/web/ui/e2e/specs/chat-layout.spec.js
@@ -1,5 +1,5 @@
 const { expect, test } = require("../base-test");
-const { navigateAndWait, waitForWsConnected, watchPageErrors } = require("../helpers");
+const { expectNoPageHorizontalOverflow, navigateAndWait, waitForWsConnected, watchPageErrors } = require("../helpers");
 
 /**
  * Wait for the chat session to finish loading so injected DOM elements
@@ -61,6 +61,26 @@ async function getHorizontalOverflow(page) {
 			inputClientWidth: input.clientWidth,
 			viewportWidth: window.innerWidth,
 		};
+	});
+}
+
+async function getChatPaneBounds(page) {
+	return await page.evaluate(() => {
+		var pageContent = document.getElementById("pageContent");
+		if (!pageContent) throw new Error("#pageContent element not found");
+		var pageRect = pageContent.getBoundingClientRect();
+		return [".chat-toolbar", "#messages", ".chat-input-row", "#chatComposer"].map((selector) => {
+			var el = document.querySelector(selector);
+			if (!el) throw new Error(`${selector} element not found`);
+			var rect = el.getBoundingClientRect();
+			return {
+				selector,
+				left: rect.left,
+				right: rect.right,
+				pageLeft: pageRect.left,
+				pageRight: pageRect.right,
+			};
+		});
 	});
 }
 
@@ -136,6 +156,44 @@ test.describe("Chat layout — no horizontal overflow (#945)", () => {
 			expect(overflow.inputScrollWidth, `input scrollWidth at ${width}px`).toBeLessThanOrEqual(
 				overflow.inputClientWidth,
 			);
+		}
+
+		expect(pageErrors).toEqual([]);
+	});
+
+	test("toolbar does not widen chat pane with desktop session sidebar visible (#1055)", async ({ page }) => {
+		const pageErrors = watchPageErrors(page);
+
+		await page.evaluate(() => {
+			var modelLabel = document.getElementById("modelComboLabel");
+			if (modelLabel) modelLabel.textContent = "anthropic/claude-sonnet-with-a-very-long-display-name";
+			var sandboxImageLabel = document.getElementById("sandboxImageLabel");
+			if (sandboxImageLabel) sandboxImageLabel.textContent = "ubuntu:25.10-with-extra-packages";
+		});
+
+		for (const width of [1055, 1000, 900, 768]) {
+			await page.setViewportSize({ width, height: 880 });
+			await page.waitForFunction((w) => window.innerWidth === w, width, { timeout: 5_000 });
+			await expect
+				.poll(
+					() =>
+						page.evaluate(() => {
+							var panel = document.getElementById("sessionsPanel");
+							if (!panel) return false;
+							var rect = panel.getBoundingClientRect();
+							return rect.width > 200 && getComputedStyle(panel).display !== "none";
+						}),
+					{ timeout: 5_000 },
+				)
+				.toBe(true);
+
+			await expectNoPageHorizontalOverflow(page, `chat-sidebar-${width}`);
+
+			const bounds = await getChatPaneBounds(page);
+			for (const box of bounds) {
+				expect(box.left, `${box.selector} left edge at ${width}px`).toBeGreaterThanOrEqual(box.pageLeft - 1);
+				expect(box.right, `${box.selector} right edge at ${width}px`).toBeLessThanOrEqual(box.pageRight + 1);
+			}
 		}
 
 		expect(pageErrors).toEqual([]);

--- a/crates/web/ui/e2e/specs/chat-layout.spec.js
+++ b/crates/web/ui/e2e/specs/chat-layout.spec.js
@@ -161,7 +161,7 @@ test.describe("Chat layout — no horizontal overflow (#945)", () => {
 		expect(pageErrors).toEqual([]);
 	});
 
-	test("toolbar does not widen chat pane with desktop session sidebar visible (#1055)", async ({ page }) => {
+	test("toolbar does not widen chat pane with desktop session sidebar visible (#1055)", async ({ page }, testInfo) => {
 		const pageErrors = watchPageErrors(page);
 
 		await page.evaluate(() => {
@@ -171,7 +171,7 @@ test.describe("Chat layout — no horizontal overflow (#945)", () => {
 			if (sandboxImageLabel) sandboxImageLabel.textContent = "ubuntu:25.10-with-extra-packages";
 		});
 
-		for (const width of [1055, 1000, 900, 768]) {
+		for (const width of [1055, 1000, 900, 800]) {
 			await page.setViewportSize({ width, height: 880 });
 			await page.waitForFunction((w) => window.innerWidth === w, width, { timeout: 5_000 });
 			await expect
@@ -187,7 +187,7 @@ test.describe("Chat layout — no horizontal overflow (#945)", () => {
 				)
 				.toBe(true);
 
-			await expectNoPageHorizontalOverflow(page, `chat-sidebar-${width}`);
+			await expectNoPageHorizontalOverflow(page, `chat-sidebar-${width}`, testInfo);
 
 			const bounds = await getChatPaneBounds(page);
 			for (const box of bounds) {


### PR DESCRIPTION
## Summary
- Constrain the chat toolbar so it cannot widen the chat pane when the desktop session sidebar is visible.
- Add a reusable Playwright horizontal-overflow detector that reports offending elements on failure.
- Add regression coverage for issue #1055 at sidebar-visible desktop widths.

## Validation
### Completed
- [x] `npx biome check --write e2e/helpers.js e2e/specs/chat-layout.spec.js`
- [x] `npm run build`
- [x] `cd crates/web/ui && npx tsc --noEmit`
- [x] `npm run build:css`
- [x] `npm run build:sw`
- [x] `npx playwright test e2e/specs/chat-layout.spec.js`

### Remaining
- [ ] Full web UI E2E suite not run locally.

## Manual QA
- Verified targeted Playwright regression covers chat widths `1055`, `1000`, `900`, and `800` with the session sidebar visible.
- First Playwright attempt timed out while the gateway performed a fresh Rust compile and generated assets were missing; after generating assets and completing compile, the targeted spec passed.
- Addressed Greptile feedback and confirmed updated Greptile confidence score is `5/5`.

Fixes #1055