### PR TITLE
fix(mcp): hide stdio env values from status

### DIFF
--- a/crates/config/src/schema.rs
+++ b/crates/config/src/schema.rs
@@ -391,6 +391,30 @@ where
     Ok(opt.map(Secret::new))
 }
 
+fn serialize_secret_string_map<S: serde::Serializer>(
+    values: &HashMap<String, Secret<String>>,
+    serializer: S,
+) -> Result<S::Ok, S::Error> {
+    let plain: HashMap<&str, &str> = values
+        .iter()
+        .map(|(key, value)| (key.as_str(), value.expose_secret().as_str()))
+        .collect();
+    plain.serialize(serializer)
+}
+
+fn deserialize_secret_string_map<'de, D>(
+    deserializer: D,
+) -> Result<HashMap<String, Secret<String>>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let plain: HashMap<String, String> = HashMap::deserialize(deserializer)?;
+    Ok(plain
+        .into_iter()
+        .map(|(key, value)| (key, Secret::new(value)))
+        .collect())
+}
+
 fn default_true() -> bool {
     true
 }

--- a/crates/config/src/schema/runtime.rs
+++ b/crates/config/src/schema/runtime.rs
@@ -149,8 +149,12 @@ pub struct McpServerEntry {
     #[serde(default)]
     pub args: Vec<String>,
     /// Environment variables to set for the process.
-    #[serde(default)]
-    pub env: HashMap<String, String>,
+    #[serde(
+        default,
+        serialize_with = "super::serialize_secret_string_map",
+        deserialize_with = "super::deserialize_secret_string_map"
+    )]
+    pub env: HashMap<String, Secret<String>>,
     /// Whether this server is enabled. Defaults to true.
     #[serde(default = "default_true")]
     pub enabled: bool,

--- a/crates/config/src/schema/tests.rs
+++ b/crates/config/src/schema/tests.rs
@@ -249,6 +249,31 @@ request_timeout_secs = 75
 }
 
 #[test]
+fn mcp_server_entry_parses_env_values_as_secrets() {
+    let config: MoltisConfig = toml::from_str(
+        r#"
+[mcp.servers.github]
+command = "npx"
+
+[mcp.servers.github.env]
+GITHUB_PERSONAL_ACCESS_TOKEN = "ghp-secret"
+"#,
+    )
+    .unwrap();
+
+    let secret = config
+        .mcp
+        .servers
+        .get("github")
+        .and_then(|entry| entry.env.get("GITHUB_PERSONAL_ACCESS_TOKEN"))
+        .map(ExposeSecret::expose_secret);
+    assert_eq!(secret.map(String::as_str), Some("ghp-secret"));
+
+    let debug = format!("{:?}", config.mcp.servers.get("github").unwrap().env);
+    assert!(!debug.contains("ghp-secret"));
+}
+
+#[test]
 fn mcp_oauth_override_parses_client_secret_as_secret() {
     let config: MoltisConfig = toml::from_str(
         r#"

--- a/crates/gateway/src/server/prepare_core.rs
+++ b/crates/gateway/src/server/prepare_core.rs
@@ -335,11 +335,7 @@ pub async fn prepare_gateway_core(
                     .insert(name.clone(), moltis_mcp::McpServerConfig {
                         command: entry.command.clone(),
                         args: entry.args.clone(),
-                        env: entry
-                            .env
-                            .iter()
-                            .map(|(key, value)| (key.clone(), Secret::new(value.clone())))
-                            .collect(),
+                        env: entry.env.clone(),
                         enabled: entry.enabled,
                         request_timeout_secs: entry.request_timeout_secs,
                         transport,

--- a/crates/gateway/src/server/prepare_core.rs
+++ b/crates/gateway/src/server/prepare_core.rs
@@ -335,7 +335,11 @@ pub async fn prepare_gateway_core(
                     .insert(name.clone(), moltis_mcp::McpServerConfig {
                         command: entry.command.clone(),
                         args: entry.args.clone(),
-                        env: entry.env.clone(),
+                        env: entry
+                            .env
+                            .iter()
+                            .map(|(key, value)| (key.clone(), Secret::new(value.clone())))
+                            .collect(),
                         enabled: entry.enabled,
                         request_timeout_secs: entry.request_timeout_secs,
                         transport,

--- a/crates/mcp/src/client.rs
+++ b/crates/mcp/src/client.rs
@@ -2,7 +2,10 @@
 
 use std::{collections::HashMap, sync::Arc, time::Duration};
 
-use tracing::{debug, info, warn};
+use {
+    secrecy::Secret,
+    tracing::{debug, info, warn},
+};
 
 #[cfg(feature = "metrics")]
 use std::time::Instant;
@@ -52,7 +55,7 @@ impl McpClient {
         server_name: &str,
         command: &str,
         args: &[String],
-        env: &HashMap<String, String>,
+        env: &HashMap<String, Secret<String>>,
         request_timeout: Duration,
     ) -> Result<Self> {
         info!(server = %server_name, command = %command, args = ?args, "connecting to MCP server");

--- a/crates/mcp/src/config_parsing.rs
+++ b/crates/mcp/src/config_parsing.rs
@@ -108,7 +108,7 @@ pub fn parse_server_config(
     ) {
         HashMap::new()
     } else if params.get("env").is_some() {
-        parse_string_map(params.get("env").unwrap_or(&Value::Null))
+        parse_secret_string_map(params.get("env").unwrap_or(&Value::Null))
     } else {
         existing.map(|cfg| cfg.env.clone()).unwrap_or_default()
     };

--- a/crates/mcp/src/config_parsing.rs
+++ b/crates/mcp/src/config_parsing.rs
@@ -108,7 +108,10 @@ pub fn parse_server_config(
     ) {
         HashMap::new()
     } else if params.get("env").is_some() {
-        parse_secret_string_map(params.get("env").unwrap_or(&Value::Null))
+        parse_env_update(
+            params.get("env").unwrap_or(&Value::Null),
+            existing.map(|cfg| &cfg.env),
+        )
     } else {
         existing.map(|cfg| cfg.env.clone()).unwrap_or_default()
     };
@@ -202,6 +205,24 @@ fn parse_secret_string_map(value: &Value) -> HashMap<String, Secret<String>> {
         .into_iter()
         .map(|(key, value)| (key, Secret::new(value)))
         .collect()
+}
+
+fn parse_env_update(
+    value: &Value,
+    existing: Option<&HashMap<String, Secret<String>>>,
+) -> HashMap<String, Secret<String>> {
+    let updates = parse_secret_string_map(value);
+    let Some(existing) = existing else {
+        return updates;
+    };
+
+    if updates.is_empty() {
+        return HashMap::new();
+    }
+
+    let mut merged = existing.clone();
+    merged.extend(updates);
+    merged
 }
 
 /// Merge environment overrides, keeping base config values authoritative.
@@ -554,5 +575,78 @@ mod tests {
         )
         .unwrap();
         assert_eq!(cfg.request_timeout_secs, Some(120));
+    }
+
+    #[test]
+    fn parse_server_config_merges_partial_stdio_env_updates() {
+        let existing = McpServerConfig {
+            command: "uvx".to_string(),
+            args: vec!["mcp-server".to_string()],
+            env: HashMap::from([
+                ("KEEP".to_string(), Secret::new("old-keep".to_string())),
+                (
+                    "REPLACE".to_string(),
+                    Secret::new("old-replace".to_string()),
+                ),
+            ]),
+            enabled: true,
+            request_timeout_secs: None,
+            transport: TransportType::Stdio,
+            url: None,
+            headers: HashMap::new(),
+            oauth: None,
+            display_name: None,
+        };
+
+        let cfg = parse_server_config(
+            &serde_json::json!({
+                "env": {
+                    "REPLACE": "new-replace"
+                }
+            }),
+            Some(&existing),
+        )
+        .unwrap();
+
+        assert_eq!(
+            cfg.env
+                .get("KEEP")
+                .map(ExposeSecret::expose_secret)
+                .map(String::as_str),
+            Some("old-keep")
+        );
+        assert_eq!(
+            cfg.env
+                .get("REPLACE")
+                .map(ExposeSecret::expose_secret)
+                .map(String::as_str),
+            Some("new-replace")
+        );
+    }
+
+    #[test]
+    fn parse_server_config_allows_clearing_stdio_env() {
+        let existing = McpServerConfig {
+            command: "uvx".to_string(),
+            args: vec!["mcp-server".to_string()],
+            env: HashMap::from([("TOKEN".to_string(), Secret::new("secret".to_string()))]),
+            enabled: true,
+            request_timeout_secs: None,
+            transport: TransportType::Stdio,
+            url: None,
+            headers: HashMap::new(),
+            oauth: None,
+            display_name: None,
+        };
+
+        let cfg = parse_server_config(
+            &serde_json::json!({
+                "env": {}
+            }),
+            Some(&existing),
+        )
+        .unwrap();
+
+        assert!(cfg.env.is_empty());
     }
 }

--- a/crates/mcp/src/manager.rs
+++ b/crates/mcp/src/manager.rs
@@ -36,7 +36,8 @@ pub struct ServerStatus {
     pub server_info: Option<String>,
     pub command: String,
     pub args: Vec<String>,
-    pub env: HashMap<String, String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub env_names: Vec<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub request_timeout_secs: Option<u64>,
     pub configured_request_timeout_secs: u64,
@@ -70,6 +71,19 @@ pub struct McpManagerInner {
 pub struct McpManager {
     pub inner: RwLock<McpManagerInner>,
     request_timeout_secs: AtomicU64,
+}
+
+fn env_names(config: &McpServerConfig) -> Vec<String> {
+    if matches!(
+        config.transport,
+        TransportType::Sse | TransportType::StreamableHttp
+    ) {
+        return Vec::new();
+    }
+
+    let mut names: Vec<String> = config.env.keys().cloned().collect();
+    names.sort();
+    names
 }
 
 impl McpManager {
@@ -617,14 +631,7 @@ impl McpManager {
                 server_info: None,
                 command: config.command.clone(),
                 args: config.args.clone(),
-                env: if matches!(
-                    config.transport,
-                    TransportType::Sse | TransportType::StreamableHttp
-                ) {
-                    HashMap::new()
-                } else {
-                    config.env.clone()
-                },
+                env_names: env_names(config),
                 request_timeout_secs: config.request_timeout_secs,
                 configured_request_timeout_secs: self.effective_timeout_secs_for(config),
                 transport: config.transport,
@@ -837,7 +844,10 @@ mod tests {
                 "X-Workspace".to_string(),
                 secrecy::Secret::new("top-secret".to_string()),
             )]),
-            env: HashMap::from([("SHOULD_NOT_LEAK".to_string(), "value".to_string())]),
+            env: HashMap::from([(
+                "SHOULD_NOT_LEAK".to_string(),
+                secrecy::Secret::new("value".to_string()),
+            )]),
             ..Default::default()
         });
         let mgr = McpManager::new(reg);
@@ -849,7 +859,29 @@ mod tests {
             Some("https://mcp.example.com/mcp?token=[REDACTED]")
         );
         assert_eq!(statuses[0].header_names, vec!["X-Workspace".to_string()]);
-        assert!(statuses[0].env.is_empty());
+        assert!(statuses[0].env_names.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_status_exposes_stdio_env_names_without_values() {
+        let mut reg = McpRegistry::new();
+        reg.servers.insert("stdio".into(), McpServerConfig {
+            command: "echo".into(),
+            env: HashMap::from([(
+                "API_TOKEN".to_string(),
+                secrecy::Secret::new("super-secret-token".to_string()),
+            )]),
+            ..Default::default()
+        });
+        let mgr = McpManager::new(reg);
+
+        let statuses = mgr.status_all().await;
+        assert_eq!(statuses.len(), 1);
+        assert_eq!(statuses[0].env_names, vec!["API_TOKEN".to_string()]);
+
+        let serialized = serde_json::to_string(&statuses).unwrap();
+        assert!(serialized.contains("API_TOKEN"));
+        assert!(!serialized.contains("super-secret-token"));
     }
 
     #[tokio::test]

--- a/crates/mcp/src/registry.rs
+++ b/crates/mcp/src/registry.rs
@@ -58,8 +58,13 @@ pub struct McpServerConfig {
     pub command: String,
     #[serde(default)]
     pub args: Vec<String>,
-    #[serde(default)]
-    pub env: HashMap<String, String>,
+    #[serde(
+        default,
+        skip_serializing_if = "HashMap::is_empty",
+        serialize_with = "serialize_secret_string_map",
+        deserialize_with = "deserialize_secret_string_map"
+    )]
+    pub env: HashMap<String, Secret<String>>,
     #[serde(default = "default_true")]
     pub enabled: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -318,14 +323,14 @@ mod tests {
         reg.servers.insert("test".into(), McpServerConfig {
             command: "echo".into(),
             args: vec!["hello".into()],
-            env: HashMap::from([("FOO".into(), "bar".into())]),
+            env: HashMap::from([("FOO".into(), Secret::new("bar".into()))]),
             ..Default::default()
         });
         reg.save().unwrap();
 
         let loaded = McpRegistry::load(&path).unwrap();
         assert_eq!(loaded.servers.len(), 1);
-        assert_eq!(loaded.servers["test"].env["FOO"], "bar");
+        assert_eq!(loaded.servers["test"].env["FOO"].expose_secret(), "bar");
     }
 
     #[test]

--- a/crates/mcp/src/transport.rs
+++ b/crates/mcp/src/transport.rs
@@ -11,6 +11,7 @@ use std::{
 };
 
 use {
+    secrecy::{ExposeSecret, Secret},
     tokio::{
         io::{AsyncBufReadExt, AsyncWriteExt, BufReader},
         process::{Child, Command},
@@ -41,7 +42,7 @@ impl StdioTransport {
     pub async fn spawn(
         command: &str,
         args: &[String],
-        env: &HashMap<String, String>,
+        env: &HashMap<String, Secret<String>>,
     ) -> Result<Arc<Self>> {
         Self::spawn_with_timeout(command, args, env, Duration::from_secs(30)).await
     }
@@ -50,7 +51,7 @@ impl StdioTransport {
     pub async fn spawn_with_timeout(
         command: &str,
         args: &[String],
-        env: &HashMap<String, String>,
+        env: &HashMap<String, Secret<String>>,
         request_timeout: Duration,
     ) -> Result<Arc<Self>> {
         info!(
@@ -61,11 +62,13 @@ impl StdioTransport {
 
         let mut cmd = Command::new(command);
         cmd.args(args)
-            .envs(env)
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
             .kill_on_drop(true);
+        for (name, value) in env {
+            cmd.env(name, value.expose_secret());
+        }
 
         let mut child = cmd
             .spawn()

--- a/crates/web/ui/src/pages/McpPage.tsx
+++ b/crates/web/ui/src/pages/McpPage.tsx
@@ -19,7 +19,6 @@ interface McpServer {
 	transport?: string;
 	command?: string;
 	args?: string[];
-	env?: Record<string, string>;
 	env_names?: string[];
 	envNames?: string[];
 	url?: string;
@@ -222,7 +221,7 @@ function remoteHeaderSummary(server: McpServer): string {
 }
 
 function stdioEnvNames(server: McpServer): string[] {
-	return (server.env_names || server.envNames || (server.env ? Object.keys(server.env) : []))
+	return (server.env_names || server.envNames || [])
 		.filter((n) => typeof n === "string" && n.trim())
 		.map((n) => n.trim());
 }

--- a/crates/web/ui/src/pages/McpPage.tsx
+++ b/crates/web/ui/src/pages/McpPage.tsx
@@ -677,6 +677,7 @@ function ServerCard({ server }: { server: McpServer }): VNode {
 	const editHeaders = useSignal("");
 	const editDisplayName = useSignal("");
 	const clearHeaders = useSignal(false);
+	const clearEnv = useSignal(false);
 	const editTimeout = useSignal("");
 	const saving = useSignal(false);
 	const isSse = (server.transport || "stdio") === "sse" || (server.transport || "stdio") === "streamable-http";
@@ -731,6 +732,7 @@ function ServerCard({ server }: { server: McpServer }): VNode {
 		editUrl.value = "";
 		editHeaders.value = "";
 		clearHeaders.value = false;
+		clearEnv.value = false;
 		editTimeout.value = server.request_timeout_secs == null ? "" : String(server.request_timeout_secs);
 		editDisplayName.value = server.display_name || "";
 		editing.value = true;
@@ -773,8 +775,11 @@ function ServerCard({ server }: { server: McpServer }): VNode {
 					url: null,
 					display_name: editDisplayName.value.trim() || null,
 				};
-				const envUpdates = parseNonEmptyEnvLines(editEnv.value);
-				if (Object.keys(envUpdates).length) payload.env = envUpdates;
+				if (clearEnv.value) payload.env = {};
+				else {
+					const envUpdates = parseNonEmptyEnvLines(editEnv.value);
+					if (Object.keys(envUpdates).length) payload.env = envUpdates;
+				}
 			}
 			const res = await sendRpc("mcp.update", payload);
 			if (res?.ok) {
@@ -998,18 +1003,30 @@ function ServerCard({ server }: { server: McpServer }): VNode {
 								<div className="rounded-[var(--radius-sm)] border border-[var(--border)] bg-[var(--surface2)] px-3 py-2 text-xs font-mono text-[var(--text)] mb-2">
 									{currentEnvSummary}
 								</div>
+								<div className="mb-2">
+									<button
+										onClick={() => {
+											clearEnv.value = !clearEnv.value;
+										}}
+										className="provider-btn provider-btn-secondary provider-btn-sm"
+									>
+										{clearEnv.value ? "Keep stored env vars" : "Clear stored env vars"}
+									</button>
+								</div>
 								<div className="text-xs text-[var(--muted)] mb-1">Replace env values (KEY=VALUE per line)</div>
 								<textarea
 									className="provider-key-input w-full min-h-[40px] resize-y font-mono text-sm"
 									rows={2}
 									value={editEnv.value}
+									disabled={clearEnv.value}
 									onInput={(e) => {
 										editEnv.value = (e.target as HTMLTextAreaElement).value;
 									}}
 								/>
 								<div className="text-xs text-[var(--muted)] mt-1">
-									Stored values are hidden. Leave values blank to preserve existing env vars; enter values only for keys
-									you want to replace.
+									{clearEnv.value
+										? "Saving now removes every stored env var for this stdio server."
+										: "Stored values are hidden. Leave values blank to preserve existing env vars; enter values only for keys you want to replace."}
 								</div>
 							</div>
 						</>

--- a/crates/web/ui/src/pages/McpPage.tsx
+++ b/crates/web/ui/src/pages/McpPage.tsx
@@ -20,6 +20,8 @@ interface McpServer {
 	command?: string;
 	args?: string[];
 	env?: Record<string, string>;
+	env_names?: string[];
+	envNames?: string[];
 	url?: string;
 	headers?: Record<string, string>;
 	header_names?: string[];
@@ -170,6 +172,10 @@ function parseEnvLines(text: string): Record<string, string> {
 	return env;
 }
 
+function parseNonEmptyEnvLines(text: string): Record<string, string> {
+	return Object.fromEntries(Object.entries(parseEnvLines(text)).filter(([, value]) => value.length > 0));
+}
+
 function transportLabel(transport: string | undefined): string {
 	if (transport === "streamable-http") return "streamable-http remote";
 	return transport === "sse" ? "sse remote" : "stdio local";
@@ -213,6 +219,17 @@ function remoteHeaderSummary(server: McpServer): string {
 	if (!(count || names.length)) return "none configured";
 	if (!names.length) return `${count} configured`;
 	return `${names.join(", ")} (${count} total)`;
+}
+
+function stdioEnvNames(server: McpServer): string[] {
+	return (server.env_names || server.envNames || (server.env ? Object.keys(server.env) : []))
+		.filter((n) => typeof n === "string" && n.trim())
+		.map((n) => n.trim());
+}
+
+function stdioEnvSummary(server: McpServer): string {
+	const names = stdioEnvNames(server);
+	return names.length ? names.join(", ") : "none configured";
 }
 
 // ── Featured MCP servers ────────────────────────────────────
@@ -709,8 +726,8 @@ function ServerCard({ server }: { server: McpServer }): VNode {
 		editTransport.value = server.transport || "stdio";
 		editCmd.value = server.command || "";
 		editArgs.value = (server.args || []).join(" ");
-		editEnv.value = Object.entries(server.env || {})
-			.map(([k, v]) => `${k}=${v}`)
+		editEnv.value = stdioEnvNames(server)
+			.map((k) => `${k}=`)
 			.join("\n");
 		editUrl.value = "";
 		editHeaders.value = "";
@@ -753,11 +770,12 @@ function ServerCard({ server }: { server: McpServer }): VNode {
 					request_timeout_secs: tr.value,
 					command: cmd,
 					args: editArgs.value.split(/\s+/).filter(Boolean),
-					env: parseEnvLines(editEnv.value),
 					headers: {},
 					url: null,
 					display_name: editDisplayName.value.trim() || null,
 				};
+				const envUpdates = parseNonEmptyEnvLines(editEnv.value);
+				if (Object.keys(envUpdates).length) payload.env = envUpdates;
 			}
 			const res = await sendRpc("mcp.update", payload);
 			if (res?.ok) {
@@ -785,6 +803,7 @@ function ServerCard({ server }: { server: McpServer }): VNode {
 	const showTechnical = server.display_name && server.display_name !== server.name;
 	const currentSafeUrl = typeof server.url === "string" ? server.url.trim() : "";
 	const currentHeaderSummary = remoteHeaderSummary(server);
+	const currentEnvSummary = stdioEnvSummary(server);
 
 	return (
 		<div className="skills-repo-card">
@@ -976,7 +995,11 @@ function ServerCard({ server }: { server: McpServer }): VNode {
 								/>
 							</div>
 							<div className="project-edit-group mb-2">
-								<div className="text-xs text-[var(--muted)] mb-1">Env vars (KEY=VALUE per line)</div>
+								<div className="text-xs text-[var(--muted)] mb-1">Current env vars</div>
+								<div className="rounded-[var(--radius-sm)] border border-[var(--border)] bg-[var(--surface2)] px-3 py-2 text-xs font-mono text-[var(--text)] mb-2">
+									{currentEnvSummary}
+								</div>
+								<div className="text-xs text-[var(--muted)] mb-1">Replace env values (KEY=VALUE per line)</div>
 								<textarea
 									className="provider-key-input w-full min-h-[40px] resize-y font-mono text-sm"
 									rows={2}
@@ -985,6 +1008,10 @@ function ServerCard({ server }: { server: McpServer }): VNode {
 										editEnv.value = (e.target as HTMLTextAreaElement).value;
 									}}
 								/>
+								<div className="text-xs text-[var(--muted)] mt-1">
+									Stored values are hidden. Leave values blank to preserve existing env vars; enter values only for keys
+									you want to replace.
+								</div>
 							</div>
 						</>
 					)}
@@ -1031,11 +1058,17 @@ function ServerCard({ server }: { server: McpServer }): VNode {
 							</div>
 						</div>
 					) : (
-						<div className="flex items-center gap-1.5 py-1.5 text-xs text-[var(--muted)]">
-							<span className="opacity-60">$</span>
-							<code className="font-mono text-[var(--text)]">
-								{server.command} {(server.args || []).join(" ")}
-							</code>
+						<div>
+							<div className="flex items-center gap-1.5 py-1.5 text-xs text-[var(--muted)]">
+								<span className="opacity-60">$</span>
+								<code className="font-mono text-[var(--text)]">
+									{server.command} {(server.args || []).join(" ")}
+								</code>
+							</div>
+							<div className="flex items-center gap-1.5 py-1.5 text-xs text-[var(--muted)]">
+								<span className="opacity-60">ENV</span>
+								<code className="font-mono text-[var(--text)]">{currentEnvSummary}</code>
+							</div>
 						</div>
 					)}
 					{!tools.value && <div className="text-[var(--muted)] text-sm py-2">Loading tools&hellip;</div>}


### PR DESCRIPTION
## Summary
- Store stdio MCP environment values as `Secret<String>` from config parsing through registry/runtime use, exposing values only when spawning the child process.
- Change MCP status/list responses to return env variable names instead of values, preventing `mcp_list` from leaking secrets to agents.
- Update MCP UI to display env names only and preserve stored env values during partial edits.

## Validation
### Completed
- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p moltis-mcp`
- [x] `cargo test -p moltis-config mcp_server_entry_parses_env_values_as_secrets`
- [x] `cargo check -p moltis-gateway`
- [x] `npm run build`
- [x] `npx tsc --noEmit`

### Remaining
- [ ] Full `just test` / release preflight not run locally.

## Manual QA
- Reviewed `mcp_list`/status serialization path to confirm stdio env values are no longer present in the response DTO.
- Confirmed regression tests serialize a status response containing the env name but not the secret value, and config TOML env values deserialize as secrets.

Fixes #1054