### PR TITLE
fix(sessions): surface auto-title generation failures

### DIFF
--- a/crates/chat/src/service/chat_impl/send.rs
+++ b/crates/chat/src/service/chat_impl/send.rs
@@ -933,6 +933,18 @@ impl LiveChatService {
 
         let provider_name = provider.name().to_string();
         let model_id = provider.id().to_string();
+        if self
+            .session_metadata
+            .get(&session_key)
+            .await
+            .and_then(|entry| entry.model)
+            .as_deref()
+            != Some(model_id.as_str())
+        {
+            self.session_metadata
+                .set_model(&session_key, Some(model_id.clone()))
+                .await;
+        }
         let model_store = Arc::clone(&self.model_store);
         let session_store = Arc::clone(&self.session_store);
         let session_metadata = Arc::clone(&self.session_metadata);

--- a/crates/gateway/src/channel_events/commands/session_handlers.rs
+++ b/crates/gateway/src/channel_events/commands/session_handlers.rs
@@ -182,15 +182,10 @@ pub(in crate::channel_events) async fn handle_title(
     state: &Arc<GatewayState>,
     session_key: &str,
 ) -> ChannelResult<String> {
-    crate::session::title::generate_title_for_session(state, session_key).await;
-    let label = if let Some(ref meta) = state.services.session_metadata {
-        meta.get(session_key)
-            .await
-            .and_then(|e| e.label)
-            .unwrap_or_else(|| "untitled".to_string())
-    } else {
-        "untitled".to_string()
-    };
+    let label = crate::session::title::generate_title_for_session(state, session_key)
+        .await
+        .map_err(ChannelError::unavailable)?
+        .unwrap_or_else(|| "untitled".to_string());
     Ok(format!("Title: {label}"))
 }
 

--- a/crates/gateway/src/channel_events/commands/session_handlers.rs
+++ b/crates/gateway/src/channel_events/commands/session_handlers.rs
@@ -182,10 +182,19 @@ pub(in crate::channel_events) async fn handle_title(
     state: &Arc<GatewayState>,
     session_key: &str,
 ) -> ChannelResult<String> {
-    let label = crate::session::title::generate_title_for_session(state, session_key)
+    let generated = crate::session::title::generate_title_for_session(state, session_key)
         .await
-        .map_err(ChannelError::unavailable)?
-        .unwrap_or_else(|| "untitled".to_string());
+        .map_err(ChannelError::unavailable)?;
+    let label = if let Some(label) = generated {
+        label
+    } else if let Some(ref meta) = state.services.session_metadata {
+        meta.get(session_key)
+            .await
+            .and_then(|e| e.label)
+            .unwrap_or_else(|| "untitled".to_string())
+    } else {
+        "untitled".to_string()
+    };
     Ok(format!("Title: {label}"))
 }
 

--- a/crates/gateway/src/methods/services/sessions.rs
+++ b/crates/gateway/src/methods/services/sessions.rs
@@ -325,9 +325,16 @@ pub(super) fn register(reg: &mut MethodRegistry) {
                         ErrorShape::new(error_codes::INVALID_REQUEST, "missing 'key' parameter")
                     })?
                     .to_string();
-                let label = crate::session::title::generate_title_for_session(&ctx.state, &key)
+                let generated = crate::session::title::generate_title_for_session(&ctx.state, &key)
                     .await
                     .map_err(|e| ErrorShape::new(error_codes::UNAVAILABLE, e.to_string()))?;
+                let label = if generated.is_some() {
+                    generated
+                } else if let Some(ref meta) = ctx.state.services.session_metadata {
+                    meta.get(&key).await.and_then(|e| e.label)
+                } else {
+                    None
+                };
                 Ok(serde_json::json!({ "ok": true, "label": label }))
             })
         }),

--- a/crates/gateway/src/methods/services/sessions.rs
+++ b/crates/gateway/src/methods/services/sessions.rs
@@ -325,12 +325,9 @@ pub(super) fn register(reg: &mut MethodRegistry) {
                         ErrorShape::new(error_codes::INVALID_REQUEST, "missing 'key' parameter")
                     })?
                     .to_string();
-                crate::session::title::generate_title_for_session(&ctx.state, &key).await;
-                let label = if let Some(ref meta) = ctx.state.services.session_metadata {
-                    meta.get(&key).await.and_then(|e| e.label)
-                } else {
-                    None
-                };
+                let label = crate::session::title::generate_title_for_session(&ctx.state, &key)
+                    .await
+                    .map_err(|e| ErrorShape::new(error_codes::UNAVAILABLE, e.to_string()))?;
                 Ok(serde_json::json!({ "ok": true, "label": label }))
             })
         }),

--- a/crates/gateway/src/session/title.rs
+++ b/crates/gateway/src/session/title.rs
@@ -6,7 +6,10 @@
 
 use std::sync::Arc;
 
-use tracing::{debug, info, warn};
+use {
+    anyhow::{Context, Result},
+    tracing::{debug, info, warn},
+};
 
 use crate::{
     broadcast::{BroadcastOpts, broadcast},
@@ -24,107 +27,264 @@ const MIN_MESSAGES_FOR_TITLE: usize = 2;
 /// - there are too few messages
 /// - no provider is available
 pub(crate) async fn generate_title_if_needed(state: &Arc<GatewayState>, session_key: &str) {
-    let Some(session_metadata) = state.services.session_metadata.as_ref() else {
+    let Err(e) = try_generate_title_if_needed(state, session_key).await else {
         return;
+    };
+    warn!(error = %e, session = %session_key, "auto-title: generation failed");
+}
+
+async fn try_generate_title_if_needed(
+    state: &Arc<GatewayState>,
+    session_key: &str,
+) -> Result<Option<String>> {
+    let Some(session_metadata) = state.services.session_metadata.as_ref() else {
+        return Ok(None);
     };
     let entry = match session_metadata.get(session_key).await {
         Some(e) => e,
-        None => return,
+        None => return Ok(None),
     };
 
     // Skip if the session already has a user-set label.
     if entry.label.is_some() {
         debug!(session = %session_key, "auto-title: session already has label, skipping");
-        return;
+        return Ok(entry.label);
     }
 
-    generate_title_for_session(state, session_key).await;
+    generate_title_for_session(state, session_key).await
 }
 
 /// Unconditionally generate and persist a title for the session.
 ///
 /// Used by both the auto-trigger (via [`generate_title_if_needed`]) and the
 /// manual `/title` command / RPC endpoint.
-pub(crate) async fn generate_title_for_session(state: &Arc<GatewayState>, session_key: &str) {
+pub(crate) async fn generate_title_for_session(
+    state: &Arc<GatewayState>,
+    session_key: &str,
+) -> Result<Option<String>> {
     let Some(session_store) = state.services.session_store.as_ref() else {
-        return;
+        return Ok(None);
     };
     let Some(session_metadata) = state.services.session_metadata.as_ref() else {
-        return;
+        return Ok(None);
     };
 
     let history = match session_store.read(session_key).await {
         Ok(h) if h.len() >= MIN_MESSAGES_FOR_TITLE => h,
         Ok(_) => {
             debug!("auto-title: too few messages, skipping");
-            return;
+            return Ok(None);
         },
         Err(e) => {
             warn!(error = %e, "auto-title: failed to read session history");
-            return;
+            return Err(e).context("failed to read session history");
         },
     };
 
     // Resolve a provider — prefer auxiliary.title_generation, fall back to session model.
+    let session_model = session_metadata
+        .get(session_key)
+        .await
+        .and_then(|e| e.model);
     let provider: Arc<dyn moltis_agents::model::LlmProvider> = {
         let inner = state.inner.read().await;
         let Some(ref registry) = inner.llm_providers else {
             debug!("auto-title: no provider registry available");
-            return;
+            return Ok(None);
         };
         let reg = registry.read().await;
 
         // Try auxiliary title_generation model first.
         let auxiliary_model = state.config.auxiliary.title_generation.as_deref();
         let from_auxiliary = auxiliary_model.and_then(|id| reg.get(id));
+        if auxiliary_model.is_some() && from_auxiliary.is_none() {
+            let available: Vec<_> = reg.list_models().iter().map(|m| m.id.as_str()).collect();
+            warn!(
+                requested = auxiliary_model.unwrap_or_default(),
+                available = ?available,
+                "auto-title: configured auxiliary title_generation model is unavailable"
+            );
+        }
 
         // Fall back to the session's own model.
-        let entry = session_metadata.get(session_key).await;
-        let session_model = entry.and_then(|e| e.model);
-        let from_session = session_model.and_then(|id| reg.get(&id));
+        let from_session = session_model.as_deref().and_then(|id| reg.get(id));
 
         match from_auxiliary.or(from_session).or_else(|| reg.first()) {
             Some(p) => p,
             None => {
                 debug!("auto-title: no provider available, skipping");
-                return;
+                return Ok(None);
             },
         }
     };
 
     let chat_msgs = moltis_agents::model::values_to_chat_messages(&history);
-    match moltis_agents::title::generate_title(provider, &chat_msgs).await {
-        Ok(title) => {
-            // Persist the title as the session label and read back the
-            // entry atomically so the broadcast version is consistent.
-            let entry = match session_metadata
-                .upsert(session_key, Some(title.clone()))
-                .await
-            {
-                Ok(e) => e,
-                Err(e) => {
-                    warn!(error = %e, session = %session_key, "auto-title: failed to persist title");
-                    return;
-                },
+    let title = moltis_agents::title::generate_title(provider, &chat_msgs).await?;
+    // Persist the title as the session label and read back the
+    // entry atomically so the broadcast version is consistent.
+    let entry = session_metadata
+        .upsert(session_key, Some(title.clone()))
+        .await
+        .with_context(|| format!("failed to persist title for session {session_key}"))?;
+
+    info!(session = %session_key, title = %title, "auto-title: set session title");
+
+    broadcast(
+        state,
+        "session",
+        serde_json::json!({
+            "kind": "patched",
+            "sessionKey": session_key,
+            "version": entry.version,
+            "label": title,
+        }),
+        BroadcastOpts::default(),
+    )
+    .await;
+
+    Ok(Some(title))
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use std::{pin::Pin, sync::Arc};
+
+    use {
+        async_trait::async_trait,
+        moltis_agents::model::{ChatMessage, CompletionResponse, LlmProvider, StreamEvent, Usage},
+        moltis_auth::{AuthMode, ResolvedAuth},
+        moltis_providers::{ModelCapabilities, ModelInfo, ProviderRegistry},
+        moltis_sessions::{metadata::SqliteSessionMetadata, store::SessionStore},
+        tokio::sync::RwLock,
+        tokio_stream::Stream,
+    };
+
+    use {super::*, crate::services::GatewayServices};
+
+    struct MockTitleProvider {
+        result: Result<&'static str>,
+    }
+
+    #[async_trait]
+    impl LlmProvider for MockTitleProvider {
+        fn name(&self) -> &str {
+            "mock"
+        }
+
+        fn id(&self) -> &str {
+            "mock-title"
+        }
+
+        async fn complete(
+            &self,
+            _messages: &[ChatMessage],
+            _tools: &[serde_json::Value],
+        ) -> Result<CompletionResponse> {
+            let text = match &self.result {
+                Ok(title) => Some((*title).to_string()),
+                Err(e) => anyhow::bail!(e.to_string()),
             };
+            Ok(CompletionResponse {
+                text,
+                tool_calls: Vec::new(),
+                usage: Usage::default(),
+            })
+        }
 
-            info!(session = %session_key, title = %title, "auto-title: set session title");
+        fn stream(
+            &self,
+            _messages: Vec<ChatMessage>,
+        ) -> Pin<Box<dyn Stream<Item = StreamEvent> + Send + '_>> {
+            Box::pin(tokio_stream::empty())
+        }
+    }
 
-            broadcast(
-                state,
-                "session",
-                serde_json::json!({
-                    "kind": "patched",
-                    "sessionKey": session_key,
-                    "version": entry.version,
-                    "label": title,
-                }),
-                BroadcastOpts::default(),
+    async fn test_state(provider: Arc<dyn LlmProvider>) -> (Arc<GatewayState>, tempfile::TempDir) {
+        let dir = tempfile::tempdir().unwrap();
+        let session_store = Arc::new(SessionStore::new(dir.path().to_path_buf()));
+        let pool = sqlx::SqlitePool::connect("sqlite::memory:").await.unwrap();
+        moltis_projects::run_migrations(&pool).await.unwrap();
+        SqliteSessionMetadata::init(&pool).await.unwrap();
+        let session_metadata = Arc::new(SqliteSessionMetadata::new(pool));
+        let services = GatewayServices::noop()
+            .with_session_store(Arc::clone(&session_store))
+            .with_session_metadata(Arc::clone(&session_metadata));
+        let state = GatewayState::new(
+            ResolvedAuth {
+                mode: AuthMode::Token,
+                token: None,
+                password: None,
+            },
+            services,
+        );
+
+        let mut registry = ProviderRegistry::empty();
+        registry.register(
+            ModelInfo {
+                id: "mock-title".to_string(),
+                provider: "mock".to_string(),
+                display_name: "Mock Title".to_string(),
+                created_at: None,
+                recommended: false,
+                capabilities: ModelCapabilities::infer("mock-title"),
+            },
+            provider,
+        );
+        state.inner.write().await.llm_providers = Some(Arc::new(RwLock::new(registry)));
+
+        session_metadata.upsert("session:test", None).await.unwrap();
+        session_store
+            .append(
+                "session:test",
+                &serde_json::json!({"role": "user", "content": "How do I deploy Moltis?"}),
             )
-            .await;
-        },
-        Err(e) => {
-            warn!(error = %e, session = %session_key, "auto-title: generation failed");
-        },
+            .await
+            .unwrap();
+        session_store
+            .append(
+                "session:test",
+                &serde_json::json!({"role": "assistant", "content": "Use the Docker image."}),
+            )
+            .await
+            .unwrap();
+        (state, dir)
+    }
+
+    #[tokio::test]
+    async fn generate_title_for_session_persists_label() {
+        let (state, _dir) = test_state(Arc::new(MockTitleProvider {
+            result: Ok("Docker Deployment"),
+        }))
+        .await;
+
+        let title = generate_title_for_session(&state, "session:test")
+            .await
+            .unwrap();
+
+        assert_eq!(title.as_deref(), Some("Docker Deployment"));
+        let label = state
+            .services
+            .session_metadata
+            .as_ref()
+            .unwrap()
+            .get("session:test")
+            .await
+            .and_then(|entry| entry.label);
+        assert_eq!(label.as_deref(), Some("Docker Deployment"));
+    }
+
+    #[tokio::test]
+    async fn generate_title_for_session_returns_provider_errors() {
+        let (state, _dir) = test_state(Arc::new(MockTitleProvider {
+            result: Err(anyhow::anyhow!("provider unavailable")),
+        }))
+        .await;
+
+        let err = generate_title_for_session(&state, "session:test")
+            .await
+            .unwrap_err();
+
+        assert!(err.to_string().contains("provider unavailable"));
     }
 }

--- a/crates/gateway/src/session/title.rs
+++ b/crates/gateway/src/session/title.rs
@@ -287,4 +287,28 @@ mod tests {
 
         assert!(err.to_string().contains("provider unavailable"));
     }
+
+    #[tokio::test]
+    async fn generate_title_for_session_skip_keeps_existing_label() {
+        let (state, _dir) = test_state(Arc::new(MockTitleProvider {
+            result: Ok("Should Not Be Used"),
+        }))
+        .await;
+        let metadata = state.services.session_metadata.as_ref().unwrap();
+        metadata
+            .upsert("session:short", Some("Existing Label".to_string()))
+            .await
+            .unwrap();
+
+        let title = generate_title_for_session(&state, "session:short")
+            .await
+            .unwrap();
+
+        assert_eq!(title, None);
+        let label = metadata
+            .get("session:short")
+            .await
+            .and_then(|entry| entry.label);
+        assert_eq!(label.as_deref(), Some("Existing Label"));
+    }
 }

--- a/crates/web/ui/e2e/specs/sessions.spec.js
+++ b/crates/web/ui/e2e/specs/sessions.spec.js
@@ -107,6 +107,16 @@ test.describe("Session management", () => {
 		expect(pageErrors).toEqual([]);
 	});
 
+	test("session header exposes auto-title action", async ({ page }) => {
+		const pageErrors = await navigateAndWait(page, "/");
+		await waitForWsConnected(page);
+		await createSession(page);
+
+		await expect(page.getByRole("button", { name: "Auto-title" })).toBeVisible();
+
+		expect(pageErrors).toEqual([]);
+	});
+
 	test("opening full context button opens and closes the full context view", async ({ page }) => {
 		const pageErrors = await navigateAndWait(page, "/");
 		await waitForWsConnected(page);

--- a/crates/web/ui/src/components/SessionHeader.tsx
+++ b/crates/web/ui/src/components/SessionHeader.tsx
@@ -270,7 +270,11 @@ export function SessionHeader({
 		setGeneratingTitle(true);
 		sendRpc<{ label?: string }>("sessions.generate_title", { key: currentKey })
 			.then((res) => {
-				if (res?.ok) fetchSessions();
+				if (!res?.ok) {
+					showToast(res?.error?.message || "Failed to auto-generate title", "error");
+					return;
+				}
+				fetchSessions();
 			})
 			.finally(() => setGeneratingTitle(false));
 	}, [currentKey]);
@@ -583,10 +587,11 @@ export function SessionHeader({
 
 	const renameCta = showName && showRenameButton && canRename && !renaming && (
 		<div className="flex items-center gap-1">
-			<button className={actionButtonClass} onClick={startRename} title="Rename session">
+			<button type="button" className={actionButtonClass} onClick={startRename} title="Rename session">
 				Rename
 			</button>
 			<button
+				type="button"
 				className={actionButtonClass}
 				onClick={onGenerateTitle}
 				disabled={generatingTitle}

--- a/crates/web/ui/src/pages/ChatPage.tsx
+++ b/crates/web/ui/src/pages/ChatPage.tsx
@@ -636,6 +636,7 @@ function mountSessionHeaderControls(): void {
 			<SessionHeader
 				showSelectors={false}
 				showName={true}
+				showRenameButton={true}
 				showShare={false}
 				showFork={false}
 				showStop={false}


### PR DESCRIPTION
## Summary
- Propagate session auto-title generation failures through RPC and channel commands instead of returning `label: null` on failure.
- Persist the selected chat model in session metadata so auto-title fallback uses the working session model.
- Expose the existing Auto-title action for non-main chat sessions and add focused backend/E2E coverage.

## Validation
### Completed
- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p moltis-gateway generate_title_for_session`
- [x] `cargo check -p moltis-chat`
- [x] `cargo check -p moltis`
- [x] `cd crates/web/ui && npm run build`
- [x] `cd crates/web/ui && npx tsc --noEmit`
- [x] `cd crates/web/ui && npx playwright test e2e/specs/sessions.spec.js -g "session header exposes auto-title action"`
- [x] `./scripts/local-validate.sh 1064` attempted; build/test portions completed, then the command timed out after 20 minutes during later validation.

### Remaining
- [ ] Full `./scripts/local-validate.sh 1064` completion.
- [ ] Full Playwright suite was not run.

## Manual QA
- Opened the chat UI in the targeted Playwright test, created a new session, and verified the `Auto-title` button is visible for that non-main session.