### PR TITLE
fix(sandbox): quiet image prebuild logs

### DIFF
--- a/crates/gateway/src/server/prepare_core/sandbox.rs
+++ b/crates/gateway/src/server/prepare_core/sandbox.rs
@@ -329,13 +329,20 @@ pub(super) fn spawn_sandbox_background_tasks(
 }
 
 fn concise_error_summary(error: &moltis_tools::error::Error) -> String {
-    error
+    const MAX_SUMMARY_CHARS: usize = 160;
+
+    let mut summary = error
         .to_string()
         .lines()
         .next()
         .unwrap_or("unknown error")
         .trim()
-        .to_string()
+        .to_string();
+    if summary.chars().count() > MAX_SUMMARY_CHARS {
+        summary = summary.chars().take(MAX_SUMMARY_CHARS).collect::<String>();
+        summary.push_str("...");
+    }
+    summary
 }
 
 #[cfg(test)]
@@ -347,5 +354,15 @@ mod tests {
         let error = moltis_tools::error::Error::message("exit code 1\n#1 DONE 0.0s");
 
         assert_eq!(concise_error_summary(&error), "exit code 1");
+    }
+
+    #[test]
+    fn concise_error_summary_truncates_long_single_line_errors() {
+        let error = moltis_tools::error::Error::message("x".repeat(200));
+
+        assert_eq!(
+            concise_error_summary(&error),
+            format!("{}...", "x".repeat(160))
+        );
     }
 }

--- a/crates/gateway/src/server/prepare_core/sandbox.rs
+++ b/crates/gateway/src/server/prepare_core/sandbox.rs
@@ -118,12 +118,19 @@ pub(super) fn spawn_sandbox_background_tasks(
                     let backend_name = backend.backend_name();
                     match backend.build_image(&base_image, &packages).await {
                         Ok(Some(result)) => {
-                            info!(
-                                backend = backend_name,
-                                tag = %result.tag,
-                                built = result.built,
-                                "sandbox image pre-build complete"
-                            );
+                            if result.built {
+                                info!(
+                                    backend = backend_name,
+                                    tag = %result.tag,
+                                    "sandbox image pre-build complete"
+                                );
+                            } else {
+                                debug!(
+                                    backend = backend_name,
+                                    tag = %result.tag,
+                                    "sandbox image pre-build skipped: image already exists"
+                                );
+                            }
                             built_any |= result.built;
                             if let Err(error) = router
                                 .set_backend_image(backend_name, result.tag.clone())
@@ -157,9 +164,15 @@ pub(super) fn spawn_sandbox_background_tasks(
                             );
                         },
                         Err(error) => {
+                            debug!(
+                                backend = backend_name,
+                                error = %error,
+                                "sandbox image pre-build failed"
+                            );
                             warn!(
                                 backend = backend_name,
-                                "sandbox image pre-build failed: {error}"
+                                summary = %concise_error_summary(&error),
+                                "sandbox image pre-build failed"
                             );
                             errors.push(serde_json::json!({
                                 "backend": backend_name,
@@ -312,5 +325,27 @@ pub(super) fn spawn_sandbox_background_tasks(
                 }
             }
         });
+    }
+}
+
+fn concise_error_summary(error: &moltis_tools::error::Error) -> String {
+    error
+        .to_string()
+        .lines()
+        .next()
+        .unwrap_or("unknown error")
+        .trim()
+        .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::concise_error_summary;
+
+    #[test]
+    fn concise_error_summary_uses_first_line() {
+        let error = moltis_tools::error::Error::message("exit code 1\n#1 DONE 0.0s");
+
+        assert_eq!(concise_error_summary(&error), "exit code 1");
     }
 }

--- a/crates/tools/src/sandbox/apple.rs
+++ b/crates/tools/src/sandbox/apple.rs
@@ -1134,7 +1134,7 @@ impl Sandbox for AppleContainerSandbox {
         let tag = sandbox_image_tag(self.image_repo(), base, packages);
 
         if sandbox_image_exists("container", &tag).await {
-            info!(
+            debug!(
                 tag,
                 "pre-built sandbox image already exists, skipping build"
             );
@@ -1165,6 +1165,7 @@ impl Sandbox for AppleContainerSandbox {
 
         let output = output?;
         if !output.status.success() {
+            let stdout = String::from_utf8_lossy(&output.stdout);
             let stderr = String::from_utf8_lossy(&output.stderr);
             if stderr.contains("XPC connection error") || stderr.contains("Connection invalid") {
                 return Err(Error::message(
@@ -1172,9 +1173,19 @@ impl Sandbox for AppleContainerSandbox {
                      Start it with `container system start` and restart moltis",
                 ));
             }
+            debug!(
+                tag,
+                stdout = %stdout.trim(),
+                stderr = %stderr.trim(),
+                "container build failed"
+            );
+            let status = output.status.code().map_or_else(
+                || output.status.to_string(),
+                |code| format!("exit code {code}"),
+            );
             return Err(Error::message(format!(
                 "container build failed for {tag}: {}",
-                stderr.trim()
+                status
             )));
         }
 

--- a/crates/tools/src/sandbox/apple.rs
+++ b/crates/tools/src/sandbox/apple.rs
@@ -27,7 +27,7 @@ use super::paths::{
 #[cfg(target_os = "macos")]
 use super::types::{
     BuildImageResult, DEFAULT_SANDBOX_IMAGE, NetworkPolicy, SANDBOX_HOME_DIR, Sandbox,
-    SandboxConfig, SandboxId, canonical_sandbox_packages, truncate_output_for_display,
+    SandboxConfig, SandboxId, canonical_sandbox_packages, tail_lines, truncate_output_for_display,
 };
 #[cfg(target_os = "macos")]
 use crate::error::{Error, Result};
@@ -1175,8 +1175,8 @@ impl Sandbox for AppleContainerSandbox {
             }
             debug!(
                 tag,
-                stdout = %stdout.trim(),
-                stderr = %stderr.trim(),
+                stdout = %tail_lines(&stdout, 20),
+                stderr = %tail_lines(&stderr, 20),
                 "container build failed"
             );
             let status = output.status.code().map_or_else(

--- a/crates/tools/src/sandbox/docker.rs
+++ b/crates/tools/src/sandbox/docker.rs
@@ -644,7 +644,7 @@ impl Sandbox for DockerSandbox {
             debug!(
                 tag,
                 stdout = %tail_lines(&stdout, 20),
-                stderr = %stderr.trim(),
+                stderr = %tail_lines(&stderr, 20),
                 "{} build failed",
                 self.cli,
             );

--- a/crates/tools/src/sandbox/docker.rs
+++ b/crates/tools/src/sandbox/docker.rs
@@ -643,7 +643,7 @@ impl Sandbox for DockerSandbox {
             let stderr = String::from_utf8_lossy(&output.stderr);
             debug!(
                 tag,
-                stdout = %stdout.trim(),
+                stdout = %tail_lines(&stdout, 20),
                 stderr = %stderr.trim(),
                 "{} build failed",
                 self.cli,

--- a/crates/tools/src/sandbox/docker.rs
+++ b/crates/tools/src/sandbox/docker.rs
@@ -608,7 +608,7 @@ impl Sandbox for DockerSandbox {
 
         // Check if image already exists.
         if sandbox_image_exists(self.cli, &tag).await {
-            info!(
+            debug!(
                 tag,
                 "pre-built sandbox image already exists, skipping build"
             );
@@ -641,17 +641,20 @@ impl Sandbox for DockerSandbox {
             let _ = std::fs::remove_dir_all(&tmp_dir);
             let stdout = String::from_utf8_lossy(&output.stdout);
             let stderr = String::from_utf8_lossy(&output.stderr);
-            warn!(
+            debug!(
                 tag,
-                stdout = %tail_lines(&stdout, 20),
+                stdout = %stdout.trim(),
                 stderr = %stderr.trim(),
                 "{} build failed",
                 self.cli,
             );
+            let status = output.status.code().map_or_else(
+                || output.status.to_string(),
+                |code| format!("exit code {code}"),
+            );
             return Err(Error::message(format!(
                 "{} build failed for {tag}: {}",
-                self.cli,
-                stderr.trim()
+                self.cli, status
             )));
         }
 


### PR DESCRIPTION
## Summary
- Log cached sandbox image prebuild skips at debug level so startup stays quiet.
- Keep full Docker/container build output at debug level while warning with concise failure summaries.
- Return status-based build errors from Docker and Apple container image builds instead of embedding verbose build output.

Fixes #1056

## Validation
### Completed
- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p moltis-gateway concise_error_summary_uses_first_line`
- [x] `cargo check -p moltis-tools -p moltis-gateway`

### Remaining
- [ ] Full `just test` suite not run for this focused logging-only fix.

## Manual QA
- Not run. Changes are covered by the targeted unit test and Rust compile checks.