### PR TITLE
feat(tools): support nonblocking spawn agents

### DIFF
--- a/crates/gateway/src/server/prepare_core/post_state.rs
+++ b/crates/gateway/src/server/prepare_core/post_state.rs
@@ -1262,9 +1262,19 @@ pub(super) async fn complete_startup(
         )));
 
         if let Some(default_provider) = registry.read().await.first_with_tools() {
-            let base_tools = Arc::new(tool_registry.clone_without(&[]));
             let spawn_task_store =
                 Arc::new(moltis_tools::spawn_agent_tasks::SpawnTaskStore::default());
+            tool_registry.register(Box::new(
+                moltis_tools::spawn_agent_tasks::SpawnStatusTool::new(Arc::clone(
+                    &spawn_task_store,
+                )),
+            ));
+            tool_registry.register(Box::new(
+                moltis_tools::spawn_agent_tasks::SpawnResultTool::new(Arc::clone(
+                    &spawn_task_store,
+                )),
+            ));
+            let base_tools = Arc::new(tool_registry.clone_without(&[]));
             let state_for_spawn = Arc::clone(&state);
             let on_spawn_event: moltis_tools::spawn_agent::OnSpawnEvent = Arc::new(move |event| {
                 use moltis_agents::runner::RunnerEvent;
@@ -1307,14 +1317,6 @@ pub(super) async fn complete_startup(
             .with_agents_config(agents_config)
             .with_task_store(Arc::clone(&spawn_task_store));
             tool_registry.register(Box::new(spawn_tool));
-            tool_registry.register(Box::new(
-                moltis_tools::spawn_agent_tasks::SpawnStatusTool::new(Arc::clone(
-                    &spawn_task_store,
-                )),
-            ));
-            tool_registry.register(Box::new(
-                moltis_tools::spawn_agent_tasks::SpawnResultTool::new(spawn_task_store),
-            ));
         }
 
         let shared_tool_registry = Arc::new(tokio::sync::RwLock::new(tool_registry));

--- a/crates/gateway/src/server/prepare_core/post_state.rs
+++ b/crates/gateway/src/server/prepare_core/post_state.rs
@@ -1277,6 +1277,11 @@ pub(super) async fn complete_startup(
             tool_registry.register(Box::new(
                 moltis_tools::spawn_agent_tasks::SpawnListTool::new(Arc::clone(&spawn_task_store)),
             ));
+            tool_registry.register(Box::new(
+                moltis_tools::spawn_agent_tasks::SpawnCancelTool::new(Arc::clone(
+                    &spawn_task_store,
+                )),
+            ));
             let base_tools = Arc::new(tool_registry.clone_without(&[]));
             let state_for_spawn = Arc::clone(&state);
             let on_spawn_event: moltis_tools::spawn_agent::OnSpawnEvent = Arc::new(move |event| {

--- a/crates/gateway/src/server/prepare_core/post_state.rs
+++ b/crates/gateway/src/server/prepare_core/post_state.rs
@@ -1274,6 +1274,9 @@ pub(super) async fn complete_startup(
                     &spawn_task_store,
                 )),
             ));
+            tool_registry.register(Box::new(
+                moltis_tools::spawn_agent_tasks::SpawnListTool::new(Arc::clone(&spawn_task_store)),
+            ));
             let base_tools = Arc::new(tool_registry.clone_without(&[]));
             let state_for_spawn = Arc::clone(&state);
             let on_spawn_event: moltis_tools::spawn_agent::OnSpawnEvent = Arc::new(move |event| {

--- a/crates/gateway/src/server/prepare_core/post_state.rs
+++ b/crates/gateway/src/server/prepare_core/post_state.rs
@@ -1263,6 +1263,8 @@ pub(super) async fn complete_startup(
 
         if let Some(default_provider) = registry.read().await.first_with_tools() {
             let base_tools = Arc::new(tool_registry.clone_without(&[]));
+            let spawn_task_store =
+                Arc::new(moltis_tools::spawn_agent_tasks::SpawnTaskStore::default());
             let state_for_spawn = Arc::clone(&state);
             let on_spawn_event: moltis_tools::spawn_agent::OnSpawnEvent = Arc::new(move |event| {
                 use moltis_agents::runner::RunnerEvent;
@@ -1302,8 +1304,17 @@ pub(super) async fn complete_startup(
                 base_tools,
             )
             .with_on_event(on_spawn_event)
-            .with_agents_config(agents_config);
+            .with_agents_config(agents_config)
+            .with_task_store(Arc::clone(&spawn_task_store));
             tool_registry.register(Box::new(spawn_tool));
+            tool_registry.register(Box::new(
+                moltis_tools::spawn_agent_tasks::SpawnStatusTool::new(Arc::clone(
+                    &spawn_task_store,
+                )),
+            ));
+            tool_registry.register(Box::new(
+                moltis_tools::spawn_agent_tasks::SpawnResultTool::new(spawn_task_store),
+            ));
         }
 
         let shared_tool_registry = Arc::new(tokio::sync::RwLock::new(tool_registry));

--- a/crates/metrics/src/definitions.rs
+++ b/crates/metrics/src/definitions.rs
@@ -554,6 +554,18 @@ pub mod config {
     pub const VALIDATION_ERRORS_TOTAL: &str = "moltis_config_validation_errors_total";
 }
 
+/// Spawn agent (sub-agent) metrics
+pub mod spawn {
+    /// Total sub-agents spawned (label: mode=blocking|nonblocking)
+    pub const SPAWNED_TOTAL: &str = "moltis_spawn_agents_spawned_total";
+    /// Sub-agent completions (label: status=completed|failed)
+    pub const COMPLETED_TOTAL: &str = "moltis_spawn_agents_completed_total";
+    /// Number of currently running background (nonblocking) spawn tasks
+    pub const TASKS_IN_FLIGHT: &str = "moltis_spawn_agents_tasks_in_flight";
+    /// Expired tasks cleaned up from the store
+    pub const TASKS_EXPIRED_TOTAL: &str = "moltis_spawn_agents_tasks_expired_total";
+}
+
 /// Common/shared metrics
 pub mod common {
     /// Application errors by type

--- a/crates/metrics/src/definitions.rs
+++ b/crates/metrics/src/definitions.rs
@@ -558,7 +558,7 @@ pub mod config {
 pub mod spawn {
     /// Total sub-agents spawned (label: mode=blocking|nonblocking)
     pub const SPAWNED_TOTAL: &str = "moltis_spawn_agents_spawned_total";
-    /// Sub-agent completions (label: status=completed|failed)
+    /// Sub-agent completions (label: status=completed|failed|cancelled)
     pub const COMPLETED_TOTAL: &str = "moltis_spawn_agents_completed_total";
     /// Number of currently running background (nonblocking) spawn tasks
     pub const TASKS_IN_FLIGHT: &str = "moltis_spawn_agents_tasks_in_flight";

--- a/crates/tools/src/lib.rs
+++ b/crates/tools/src/lib.rs
@@ -43,6 +43,7 @@ pub mod sessions_communicate;
 pub mod sessions_manage;
 pub mod skill_tools;
 pub mod spawn_agent;
+pub mod spawn_agent_tasks;
 pub mod ssrf;
 pub mod task_list;
 #[cfg(feature = "wasm")]

--- a/crates/tools/src/spawn_agent.rs
+++ b/crates/tools/src/spawn_agent.rs
@@ -7,6 +7,7 @@ use {async_trait::async_trait, tracing::info};
 use crate::{
     error::Error,
     params::{bool_param, str_param, string_array_param, u64_param},
+    spawn_agent_tasks::{SpawnTaskStore, SpawnTaskUpdate},
 };
 
 use {
@@ -69,6 +70,7 @@ pub struct SpawnAgentTool {
     agents_config: Option<Arc<tokio::sync::RwLock<AgentsConfig>>>,
     on_event: Option<OnSpawnEvent>,
     session_deps: Option<SessionDeps>,
+    task_store: Arc<SpawnTaskStore>,
 }
 
 impl SpawnAgentTool {
@@ -84,6 +86,7 @@ impl SpawnAgentTool {
             agents_config: None,
             on_event: None,
             session_deps: None,
+            task_store: Arc::new(SpawnTaskStore::default()),
         }
     }
 
@@ -105,6 +108,12 @@ impl SpawnAgentTool {
     /// Provide session dependencies so sub-agents can get policy-aware session tools.
     pub fn with_session_deps(mut self, deps: SessionDeps) -> Self {
         self.session_deps = Some(deps);
+        self
+    }
+
+    /// Share background task state with `spawn_status` and `spawn_result`.
+    pub fn with_task_store(mut self, task_store: Arc<SpawnTaskStore>) -> Self {
+        self.task_store = task_store;
         self
     }
 
@@ -359,6 +368,10 @@ impl AgentTool for SpawnAgentTool {
                 "delegate_only": {
                     "type": "boolean",
                     "description": "If true, sub-agent is restricted to delegation/session/task tools."
+                },
+                "nonblocking": {
+                    "type": "boolean",
+                    "description": "If true, return immediately with a task_id and let the sub-agent continue in the background. Use spawn_status and spawn_result to inspect it."
                 }
             },
             "required": ["task"]
@@ -403,6 +416,7 @@ impl AgentTool for SpawnAgentTool {
             "delegate_only",
             preset.as_ref().map(|p| p.delegate_only).unwrap_or(false),
         );
+        let nonblocking = bool_param(&params, "nonblocking", false);
 
         // Check nesting depth.
         let depth = u64_param(&params, SPAWN_DEPTH_KEY, 0);
@@ -494,35 +508,92 @@ impl AgentTool for SpawnAgentTool {
             tool_context["_session_key"] = session_key.clone();
         }
 
-        // Run the sub-agent loop, optionally with a timeout.
-        let user_content = moltis_agents::UserContent::text(task);
-        let agent_future = run_agent_loop_with_context_and_limits(
-            provider,
-            &sub_tools,
-            &system_prompt,
-            &user_content,
-            None,
-            None, // no history
-            Some(tool_context),
-            None, // no hooks for sub-agents
-            None, // no sender name for spawned agents
-            AgentLoopLimits {
-                max_iterations: Some(runtime_limits.max_iterations),
-            },
-        );
+        let session_key = params
+            .get("_session_key")
+            .and_then(serde_json::Value::as_str)
+            .map(String::from);
 
-        let result = if runtime_limits.timeout_secs > 0 {
-            let timeout_secs = runtime_limits.timeout_secs;
-            let duration = std::time::Duration::from_secs(timeout_secs);
-            match tokio::time::timeout(duration, agent_future).await {
-                Ok(r) => r,
-                Err(_) => Err(AgentRunError::Other(anyhow::anyhow!(
-                    "sub-agent timed out after {timeout_secs}s"
-                ))),
-            }
-        } else {
-            agent_future.await
-        };
+        if nonblocking {
+            let task_entry = self
+                .task_store
+                .insert_running(
+                    task.to_string(),
+                    session_key,
+                    model_id.clone(),
+                    preset_name.clone(),
+                )
+                .await;
+            let task_id = task_entry.id.clone();
+            let store = Arc::clone(&self.task_store);
+            let on_event = self.on_event.clone();
+            let task_for_run = task.to_string();
+            let model_for_run = model_id.clone();
+            tokio::spawn(async move {
+                let result = run_spawned_agent(
+                    provider,
+                    sub_tools,
+                    system_prompt,
+                    task_for_run.clone(),
+                    tool_context,
+                    runtime_limits,
+                )
+                .await;
+                let (update, iterations, tool_calls_made) = match result {
+                    Ok(result) => {
+                        let iterations = result.iterations;
+                        let tool_calls_made = result.tool_calls_made;
+                        (
+                            SpawnTaskUpdate {
+                                text: Some(result.text),
+                                iterations,
+                                tool_calls_made,
+                                error: None,
+                            },
+                            iterations,
+                            tool_calls_made,
+                        )
+                    },
+                    Err(err) => (
+                        SpawnTaskUpdate {
+                            text: None,
+                            iterations: 0,
+                            tool_calls_made: 0,
+                            error: Some(err.to_string()),
+                        },
+                        0,
+                        0,
+                    ),
+                };
+                store.complete(&task_id, update).await;
+                if let Some(cb) = on_event {
+                    cb(RunnerEvent::SubAgentEnd {
+                        task: task_for_run,
+                        model: model_for_run,
+                        depth,
+                        iterations,
+                        tool_calls_made,
+                    });
+                }
+            });
+
+            return Ok(serde_json::json!({
+                "task_id": task_entry.id,
+                "status": "running",
+                "started_at": task_entry.started_at,
+                "model": model_id,
+                "preset": preset_name,
+            }));
+        }
+
+        let result = run_spawned_agent(
+            provider,
+            sub_tools,
+            system_prompt,
+            task.to_string(),
+            tool_context,
+            runtime_limits,
+        )
+        .await;
 
         // Emit SubAgentEnd regardless of success/failure.
         let (iterations, tool_calls_made) = match &result {
@@ -558,6 +629,44 @@ impl AgentTool for SpawnAgentTool {
     }
 }
 
+async fn run_spawned_agent(
+    provider: Arc<dyn LlmProvider>,
+    sub_tools: ToolRegistry,
+    system_prompt: String,
+    task: String,
+    tool_context: serde_json::Value,
+    runtime_limits: AgentRuntimeLimits,
+) -> Result<moltis_agents::runner::AgentRunResult, AgentRunError> {
+    let user_content = moltis_agents::UserContent::text(&task);
+    let agent_future = run_agent_loop_with_context_and_limits(
+        provider,
+        &sub_tools,
+        &system_prompt,
+        &user_content,
+        None,
+        None,
+        Some(tool_context),
+        None,
+        None,
+        AgentLoopLimits {
+            max_iterations: Some(runtime_limits.max_iterations),
+        },
+    );
+
+    if runtime_limits.timeout_secs > 0 {
+        let timeout_secs = runtime_limits.timeout_secs;
+        let duration = std::time::Duration::from_secs(timeout_secs);
+        match tokio::time::timeout(duration, agent_future).await {
+            Ok(r) => r,
+            Err(_) => Err(AgentRunError::Other(anyhow::anyhow!(
+                "sub-agent timed out after {timeout_secs}s"
+            ))),
+        }
+    } else {
+        agent_future.await
+    }
+}
+
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 #[cfg(test)]
 mod tests {
@@ -566,14 +675,81 @@ mod tests {
         moltis_agents::model::{ChatMessage, CompletionResponse, StreamEvent, Usage},
         moltis_config::schema::{AgentIdentity, PresetToolPolicy},
         std::{pin::Pin, sync::Mutex},
+        tokio::sync::Notify,
         tokio_stream::Stream,
     };
+
+    use crate::spawn_agent_tasks::{SpawnResultTool, SpawnStatusTool};
 
     /// Mock provider that returns a fixed response.
     struct MockProvider {
         response: String,
         model_id: String,
         seen_tool_names: Arc<Mutex<Vec<String>>>,
+    }
+
+    struct NotifyProvider {
+        response: String,
+        notify: Arc<Notify>,
+    }
+
+    #[async_trait]
+    impl LlmProvider for NotifyProvider {
+        fn name(&self) -> &str {
+            "notify"
+        }
+
+        fn id(&self) -> &str {
+            "notify-model"
+        }
+
+        async fn complete(
+            &self,
+            _messages: &[ChatMessage],
+            _tools: &[serde_json::Value],
+        ) -> anyhow::Result<CompletionResponse> {
+            self.notify.notified().await;
+            Ok(CompletionResponse {
+                text: Some(self.response.clone()),
+                tool_calls: vec![],
+                usage: Usage::default(),
+            })
+        }
+
+        fn stream(
+            &self,
+            _messages: Vec<ChatMessage>,
+        ) -> Pin<Box<dyn Stream<Item = StreamEvent> + Send + '_>> {
+            Box::pin(tokio_stream::empty())
+        }
+    }
+
+    struct FailingProvider;
+
+    #[async_trait]
+    impl LlmProvider for FailingProvider {
+        fn name(&self) -> &str {
+            "failing"
+        }
+
+        fn id(&self) -> &str {
+            "failing-model"
+        }
+
+        async fn complete(
+            &self,
+            _messages: &[ChatMessage],
+            _tools: &[serde_json::Value],
+        ) -> anyhow::Result<CompletionResponse> {
+            Err(anyhow::anyhow!("provider failed"))
+        }
+
+        fn stream(
+            &self,
+            _messages: Vec<ChatMessage>,
+        ) -> Pin<Box<dyn Stream<Item = StreamEvent> + Send + '_>> {
+            Box::pin(tokio_stream::empty())
+        }
     }
 
     impl MockProvider {
@@ -729,6 +905,167 @@ mod tests {
         let result = spawn_tool.execute(params).await;
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("nesting depth"));
+    }
+
+    #[tokio::test]
+    async fn test_nonblocking_returns_task_handle_before_completion() {
+        let notify = Arc::new(Notify::new());
+        let provider: Arc<dyn LlmProvider> = Arc::new(NotifyProvider {
+            response: "background result".to_string(),
+            notify: Arc::clone(&notify),
+        });
+        let store = Arc::new(SpawnTaskStore::default());
+        let spawn_tool = SpawnAgentTool::new(
+            make_empty_provider_registry(),
+            provider,
+            Arc::new(ToolRegistry::new()),
+        )
+        .with_task_store(Arc::clone(&store));
+
+        let result = tokio::time::timeout(
+            std::time::Duration::from_millis(100),
+            spawn_tool.execute(serde_json::json!({
+                "task": "do something later",
+                "nonblocking": true,
+                "_session_key": "session-a",
+            })),
+        )
+        .await
+        .expect("nonblocking spawn should return before provider completes")
+        .unwrap();
+
+        let task_id = result["task_id"].as_str().unwrap();
+        assert_eq!(result["status"], "running");
+
+        let status_tool = SpawnStatusTool::new(Arc::clone(&store));
+        let status = status_tool
+            .execute(serde_json::json!({
+                "task_id": task_id,
+                "_session_key": "session-a",
+            }))
+            .await
+            .unwrap();
+        assert_eq!(status["status"], "running");
+
+        notify.notify_one();
+        let result_tool = SpawnResultTool::new(store);
+        let mut final_result = serde_json::Value::Null;
+        for _ in 0..20 {
+            final_result = result_tool
+                .execute(serde_json::json!({
+                    "task_id": task_id,
+                    "_session_key": "session-a",
+                }))
+                .await
+                .unwrap();
+            if final_result["status"] == "completed" {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+        assert_eq!(final_result["status"], "completed");
+        assert_eq!(final_result["text"], "background result");
+        assert_eq!(final_result["iterations"], 1);
+    }
+
+    #[tokio::test]
+    async fn test_nonblocking_result_enforces_session_key() {
+        let (provider, _) = MockProvider::with_capture("done", "mock");
+        let store = Arc::new(SpawnTaskStore::default());
+        let spawn_tool = SpawnAgentTool::new(
+            make_empty_provider_registry(),
+            provider,
+            Arc::new(ToolRegistry::new()),
+        )
+        .with_task_store(Arc::clone(&store));
+
+        let result = spawn_tool
+            .execute(serde_json::json!({
+                "task": "private task",
+                "nonblocking": true,
+                "_session_key": "session-a",
+            }))
+            .await
+            .unwrap();
+        let task_id = result["task_id"].as_str().unwrap();
+        let status_tool = SpawnStatusTool::new(store);
+        let denied = status_tool
+            .execute(serde_json::json!({
+                "task_id": task_id,
+                "_session_key": "session-b",
+            }))
+            .await;
+
+        assert!(denied.is_err());
+        assert!(denied.unwrap_err().to_string().contains("access denied"));
+    }
+
+    #[tokio::test]
+    async fn test_nonblocking_failure_is_persisted() {
+        let provider: Arc<dyn LlmProvider> = Arc::new(FailingProvider);
+        let store = Arc::new(SpawnTaskStore::default());
+        let spawn_tool = SpawnAgentTool::new(
+            make_empty_provider_registry(),
+            provider,
+            Arc::new(ToolRegistry::new()),
+        )
+        .with_task_store(Arc::clone(&store));
+
+        let result = spawn_tool
+            .execute(serde_json::json!({
+                "task": "fail in background",
+                "nonblocking": true,
+            }))
+            .await
+            .unwrap();
+        let task_id = result["task_id"].as_str().unwrap();
+        let result_tool = SpawnResultTool::new(store);
+
+        let mut final_result = serde_json::Value::Null;
+        for _ in 0..20 {
+            final_result = result_tool
+                .execute(serde_json::json!({ "task_id": task_id }))
+                .await
+                .unwrap();
+            if final_result["status"] == "failed" {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+
+        assert_eq!(final_result["status"], "failed");
+        assert!(
+            final_result["error"]
+                .as_str()
+                .unwrap()
+                .contains("provider failed")
+        );
+    }
+
+    #[test]
+    fn test_nonblocking_and_companion_tool_schemas() {
+        let (provider, _) = MockProvider::with_capture("ok", "mock");
+        let store = Arc::new(SpawnTaskStore::default());
+        let spawn_tool = SpawnAgentTool::new(
+            make_empty_provider_registry(),
+            provider,
+            Arc::new(ToolRegistry::new()),
+        )
+        .with_task_store(Arc::clone(&store));
+
+        assert!(
+            spawn_tool.parameters_schema()["properties"]
+                .get("nonblocking")
+                .is_some()
+        );
+        assert_eq!(
+            SpawnStatusTool::new(Arc::clone(&store)).parameters_schema()["required"][0],
+            "task_id"
+        );
+        assert_eq!(
+            SpawnResultTool::new(store).parameters_schema()["required"][0],
+            "task_id"
+        );
     }
 
     #[tokio::test]

--- a/crates/tools/src/spawn_agent.rs
+++ b/crates/tools/src/spawn_agent.rs
@@ -2,7 +2,7 @@
 
 use std::{collections::HashSet, sync::Arc};
 
-use {async_trait::async_trait, tracing::info};
+use {async_trait::async_trait, futures::FutureExt, tracing::info};
 
 use crate::{
     error::Error,
@@ -41,6 +41,7 @@ const DELEGATE_TOOLS: &[&str] = &[
     "spawn_agent",
     "spawn_status",
     "spawn_result",
+    "spawn_list",
     "sessions_list",
     "sessions_history",
     "sessions_search",
@@ -48,12 +49,6 @@ const DELEGATE_TOOLS: &[&str] = &[
     "task_list",
 ];
 
-/// A tool that spawns a sub-agent running its own agent loop.
-///
-/// The sub-agent executes synchronously (blocks until done) and its result
-/// is returned as the tool output. Sub-agents get a filtered copy of the
-/// parent's tool registry (without the `spawn_agent` tool itself) and a
-/// focused system prompt.
 /// Callback for emitting events from the sub-agent back to the parent UI.
 pub type OnSpawnEvent = Arc<dyn Fn(RunnerEvent) + Send + Sync>;
 
@@ -65,6 +60,15 @@ pub struct SessionDeps {
     pub send_to_session: SendToSessionFn,
 }
 
+/// A tool that spawns a sub-agent running its own agent loop.
+///
+/// By default the sub-agent executes synchronously (blocks until done) and
+/// its result is returned as the tool output. With `nonblocking: true`, the
+/// sub-agent runs in the background and the caller gets a `task_id` to poll
+/// via `spawn_status` / `spawn_result`.
+///
+/// Sub-agents get a filtered copy of the parent's tool registry and a
+/// focused system prompt.
 pub struct SpawnAgentTool {
     provider_registry: Arc<tokio::sync::RwLock<ProviderRegistry>>,
     default_provider: Arc<dyn LlmProvider>,
@@ -503,19 +507,25 @@ impl AgentTool for SpawnAgentTool {
             build_sub_agent_prompt(task, context, preset.as_ref(), preset_name.as_deref());
 
         // Build tool context with incremented depth and propagated session key.
-        let mut tool_context = serde_json::json!({
-            SPAWN_DEPTH_KEY: depth + 1,
-        });
-        if let Some(session_key) = params.get("_session_key") {
-            tool_context["_session_key"] = session_key.clone();
-        }
-
         let session_key = params
             .get("_session_key")
             .and_then(serde_json::Value::as_str)
             .map(String::from);
+        let mut tool_context = serde_json::json!({
+            SPAWN_DEPTH_KEY: depth + 1,
+        });
+        if let Some(ref key) = session_key {
+            tool_context["_session_key"] = serde_json::Value::String(key.clone());
+        }
 
         if nonblocking {
+            #[cfg(feature = "metrics")]
+            {
+                use moltis_metrics::{counter, gauge, labels, spawn as spawn_metrics};
+                counter!(spawn_metrics::SPAWNED_TOTAL, labels::MODE => "nonblocking").increment(1);
+                gauge!(spawn_metrics::TASKS_IN_FLIGHT).increment(1.0);
+            }
+
             let task_entry = self
                 .task_store
                 .insert_running(
@@ -530,18 +540,21 @@ impl AgentTool for SpawnAgentTool {
             let on_event = self.on_event.clone();
             let task_for_run = task.to_string();
             let model_for_run = model_id.clone();
+            let preset_for_log = preset_name.clone();
             tokio::spawn(async move {
-                let result = run_spawned_agent(
+                let result = std::panic::AssertUnwindSafe(run_spawned_agent(
                     provider,
                     sub_tools,
                     system_prompt,
                     task_for_run.clone(),
                     tool_context,
                     runtime_limits,
-                )
+                ))
+                .catch_unwind()
                 .await;
+
                 let (update, iterations, tool_calls_made) = match result {
-                    Ok(result) => {
+                    Ok(Ok(result)) => {
                         let iterations = result.iterations;
                         let tool_calls_made = result.tool_calls_made;
                         (
@@ -555,7 +568,7 @@ impl AgentTool for SpawnAgentTool {
                             tool_calls_made,
                         )
                     },
-                    Err(err) => (
+                    Ok(Err(err)) => (
                         SpawnTaskUpdate {
                             text: None,
                             iterations: 0,
@@ -565,8 +578,56 @@ impl AgentTool for SpawnAgentTool {
                         0,
                         0,
                     ),
+                    Err(_panic) => {
+                        tracing::error!(
+                            task_id = %task_id,
+                            task = %task_for_run,
+                            "nonblocking sub-agent panicked"
+                        );
+                        (
+                            SpawnTaskUpdate {
+                                text: None,
+                                iterations: 0,
+                                tool_calls_made: 0,
+                                error: Some("sub-agent panicked".to_string()),
+                            },
+                            0,
+                            0,
+                        )
+                    },
                 };
+
+                let status_label = if update.error.is_some() {
+                    "failed"
+                } else {
+                    "completed"
+                };
+
                 store.complete(&task_id, update).await;
+
+                info!(
+                    task_id = %task_id,
+                    task = %task_for_run,
+                    model = %model_for_run,
+                    depth = depth,
+                    iterations = iterations,
+                    tool_calls = tool_calls_made,
+                    preset = ?preset_for_log,
+                    status = status_label,
+                    "nonblocking sub-agent finished"
+                );
+
+                #[cfg(feature = "metrics")]
+                {
+                    use moltis_metrics::{counter, gauge, labels, spawn as spawn_metrics};
+                    counter!(
+                        spawn_metrics::COMPLETED_TOTAL,
+                        labels::STATUS => status_label.to_string()
+                    )
+                    .increment(1);
+                    gauge!(spawn_metrics::TASKS_IN_FLIGHT).decrement(1.0);
+                }
+
                 if let Some(cb) = on_event {
                     cb(RunnerEvent::SubAgentEnd {
                         task: task_for_run,
@@ -585,6 +646,12 @@ impl AgentTool for SpawnAgentTool {
                 "model": model_id,
                 "preset": preset_name,
             }));
+        }
+
+        #[cfg(feature = "metrics")]
+        {
+            use moltis_metrics::{counter, labels, spawn as spawn_metrics};
+            counter!(spawn_metrics::SPAWNED_TOTAL, labels::MODE => "blocking").increment(1);
         }
 
         let result = run_spawned_agent(
@@ -610,6 +677,21 @@ impl AgentTool for SpawnAgentTool {
             tool_calls_made,
         });
 
+        #[cfg(feature = "metrics")]
+        {
+            use moltis_metrics::{counter, labels, spawn as spawn_metrics};
+            let status = if result.is_ok() {
+                "completed"
+            } else {
+                "failed"
+            };
+            counter!(
+                spawn_metrics::COMPLETED_TOTAL,
+                labels::STATUS => status.to_string()
+            )
+            .increment(1);
+        }
+
         let result = result?;
 
         info!(
@@ -631,6 +713,7 @@ impl AgentTool for SpawnAgentTool {
     }
 }
 
+#[tracing::instrument(skip(provider, sub_tools, system_prompt, tool_context, runtime_limits), fields(task_len = task.len()))]
 async fn run_spawned_agent(
     provider: Arc<dyn LlmProvider>,
     sub_tools: ToolRegistry,
@@ -1236,6 +1319,7 @@ mod tests {
                 "spawn_agent",
                 "spawn_status",
                 "spawn_result",
+                "spawn_list",
                 "sessions_list",
                 "sessions_history",
                 "sessions_send",
@@ -1248,6 +1332,7 @@ mod tests {
         assert!(filtered.get("spawn_agent").is_some());
         assert!(filtered.get("spawn_status").is_some());
         assert!(filtered.get("spawn_result").is_some());
+        assert!(filtered.get("spawn_list").is_some());
         assert!(filtered.get("sessions_list").is_some());
         assert!(filtered.get("sessions_history").is_some());
         assert!(filtered.get("sessions_send").is_some());

--- a/crates/tools/src/spawn_agent.rs
+++ b/crates/tools/src/spawn_agent.rs
@@ -623,7 +623,6 @@ impl AgentTool for SpawnAgentTool {
                     },
                 };
 
-                let result = result;
                 let (update, iterations, tool_calls_made) = match result {
                     Ok(Ok(result)) => {
                         let iterations = result.iterations;

--- a/crates/tools/src/spawn_agent.rs
+++ b/crates/tools/src/spawn_agent.rs
@@ -39,6 +39,8 @@ const SPAWN_DEPTH_KEY: &str = "_spawn_depth";
 /// Minimal delegate-only toolset for coordinator-style sub-agents.
 const DELEGATE_TOOLS: &[&str] = &[
     "spawn_agent",
+    "spawn_status",
+    "spawn_result",
     "sessions_list",
     "sessions_history",
     "sessions_search",
@@ -1232,6 +1234,8 @@ mod tests {
             provider,
             registry_with_tools(&[
                 "spawn_agent",
+                "spawn_status",
+                "spawn_result",
                 "sessions_list",
                 "sessions_history",
                 "sessions_send",
@@ -1242,6 +1246,8 @@ mod tests {
 
         let filtered = spawn_tool.build_sub_tools(&[], &[], true);
         assert!(filtered.get("spawn_agent").is_some());
+        assert!(filtered.get("spawn_status").is_some());
+        assert!(filtered.get("spawn_result").is_some());
         assert!(filtered.get("sessions_list").is_some());
         assert!(filtered.get("sessions_history").is_some());
         assert!(filtered.get("sessions_send").is_some());

--- a/crates/tools/src/spawn_agent.rs
+++ b/crates/tools/src/spawn_agent.rs
@@ -1,6 +1,9 @@
 //! Sub-agent tool: lets the LLM delegate tasks to a child agent loop.
 
-use std::{collections::HashSet, sync::Arc};
+use std::{
+    collections::HashSet,
+    sync::{Arc, OnceLock},
+};
 
 use {
     async_trait::async_trait,
@@ -97,7 +100,7 @@ impl SpawnAgentTool {
             agents_config: None,
             on_event: None,
             session_deps: None,
-            task_store: Arc::new(SpawnTaskStore::default()),
+            task_store: default_spawn_task_store(),
         }
     }
 
@@ -240,6 +243,11 @@ impl SpawnAgentTool {
         })?;
         Ok((Some(preset_name), Some(preset)))
     }
+}
+
+fn default_spawn_task_store() -> Arc<SpawnTaskStore> {
+    static STORE: OnceLock<Arc<SpawnTaskStore>> = OnceLock::new();
+    Arc::clone(STORE.get_or_init(|| Arc::new(SpawnTaskStore::default())))
 }
 
 /// Resolve the memory directory for a preset based on its scope.

--- a/crates/tools/src/spawn_agent.rs
+++ b/crates/tools/src/spawn_agent.rs
@@ -2,7 +2,11 @@
 
 use std::{collections::HashSet, sync::Arc};
 
-use {async_trait::async_trait, futures::FutureExt, tracing::info};
+use {
+    async_trait::async_trait,
+    futures::{FutureExt, future::Abortable},
+    tracing::info,
+};
 
 use crate::{
     error::Error,
@@ -42,6 +46,7 @@ const DELEGATE_TOOLS: &[&str] = &[
     "spawn_status",
     "spawn_result",
     "spawn_list",
+    "cancel_spawn",
     "sessions_list",
     "sessions_history",
     "sessions_search",
@@ -153,7 +158,23 @@ impl SpawnAgentTool {
             sub_tools = sub_tools.clone_allowed_by(|name| !deny.contains(name));
         }
 
+        if delegate_only && sub_tools.get("spawn_agent").is_none() {
+            sub_tools.replace(Box::new(self.child_spawn_tool()));
+        }
+
         sub_tools
+    }
+
+    fn child_spawn_tool(&self) -> Self {
+        Self {
+            provider_registry: Arc::clone(&self.provider_registry),
+            default_provider: Arc::clone(&self.default_provider),
+            tool_registry: Arc::clone(&self.tool_registry),
+            agents_config: self.agents_config.clone(),
+            on_event: self.on_event.clone(),
+            session_deps: self.session_deps.clone(),
+            task_store: Arc::clone(&self.task_store),
+        }
     }
 
     /// Apply reasoning_effort from the agent preset to the provider, if set.
@@ -526,6 +547,7 @@ impl AgentTool for SpawnAgentTool {
                 gauge!(spawn_metrics::TASKS_IN_FLIGHT).increment(1.0);
             }
 
+            let (abort_handle, abort_registration) = futures::future::AbortHandle::new_pair();
             let task_entry = self
                 .task_store
                 .insert_running(
@@ -533,6 +555,7 @@ impl AgentTool for SpawnAgentTool {
                     session_key,
                     model_id.clone(),
                     preset_name.clone(),
+                    abort_handle,
                 )
                 .await;
             let task_id = task_entry.id.clone();
@@ -542,17 +565,57 @@ impl AgentTool for SpawnAgentTool {
             let model_for_run = model_id.clone();
             let preset_for_log = preset_name.clone();
             tokio::spawn(async move {
-                let result = std::panic::AssertUnwindSafe(run_spawned_agent(
-                    provider,
-                    sub_tools,
-                    system_prompt,
-                    task_for_run.clone(),
-                    tool_context,
-                    runtime_limits,
-                ))
-                .catch_unwind()
+                let result = Abortable::new(
+                    std::panic::AssertUnwindSafe(run_spawned_agent(
+                        provider,
+                        sub_tools,
+                        system_prompt,
+                        task_for_run.clone(),
+                        tool_context,
+                        runtime_limits,
+                    ))
+                    .catch_unwind(),
+                    abort_registration,
+                )
                 .await;
 
+                let result = match result {
+                    Ok(result) => result,
+                    Err(_aborted) => {
+                        store
+                            .complete(&task_id, SpawnTaskUpdate {
+                                text: None,
+                                iterations: 0,
+                                tool_calls_made: 0,
+                                error: Some("cancelled by caller".to_string()),
+                            })
+                            .await;
+
+                        #[cfg(feature = "metrics")]
+                        {
+                            use moltis_metrics::{counter, gauge, labels, spawn as spawn_metrics};
+                            counter!(
+                                spawn_metrics::COMPLETED_TOTAL,
+                                labels::STATUS => "cancelled"
+                            )
+                            .increment(1);
+                            gauge!(spawn_metrics::TASKS_IN_FLIGHT).decrement(1.0);
+                        }
+
+                        if let Some(cb) = on_event {
+                            cb(RunnerEvent::SubAgentEnd {
+                                task: task_for_run,
+                                model: model_for_run,
+                                depth,
+                                iterations: 0,
+                                tool_calls_made: 0,
+                            });
+                        }
+                        return;
+                    },
+                };
+
+                let result = result;
                 let (update, iterations, tool_calls_made) = match result {
                     Ok(Ok(result)) => {
                         let iterations = result.iterations;
@@ -752,805 +815,7 @@ async fn run_spawned_agent(
     }
 }
 
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 #[cfg(test)]
-mod tests {
-    use {
-        super::*,
-        moltis_agents::model::{ChatMessage, CompletionResponse, StreamEvent, Usage},
-        moltis_config::schema::{AgentIdentity, PresetToolPolicy},
-        std::{pin::Pin, sync::Mutex},
-        tokio::sync::Notify,
-        tokio_stream::Stream,
-    };
-
-    use crate::spawn_agent_tasks::{SpawnResultTool, SpawnStatusTool};
-
-    /// Mock provider that returns a fixed response.
-    struct MockProvider {
-        response: String,
-        model_id: String,
-        seen_tool_names: Arc<Mutex<Vec<String>>>,
-    }
-
-    struct NotifyProvider {
-        response: String,
-        notify: Arc<Notify>,
-    }
-
-    #[async_trait]
-    impl LlmProvider for NotifyProvider {
-        fn name(&self) -> &str {
-            "notify"
-        }
-
-        fn id(&self) -> &str {
-            "notify-model"
-        }
-
-        async fn complete(
-            &self,
-            _messages: &[ChatMessage],
-            _tools: &[serde_json::Value],
-        ) -> anyhow::Result<CompletionResponse> {
-            self.notify.notified().await;
-            Ok(CompletionResponse {
-                text: Some(self.response.clone()),
-                tool_calls: vec![],
-                usage: Usage::default(),
-            })
-        }
-
-        fn stream(
-            &self,
-            _messages: Vec<ChatMessage>,
-        ) -> Pin<Box<dyn Stream<Item = StreamEvent> + Send + '_>> {
-            Box::pin(tokio_stream::empty())
-        }
-    }
-
-    struct FailingProvider;
-
-    #[async_trait]
-    impl LlmProvider for FailingProvider {
-        fn name(&self) -> &str {
-            "failing"
-        }
-
-        fn id(&self) -> &str {
-            "failing-model"
-        }
-
-        async fn complete(
-            &self,
-            _messages: &[ChatMessage],
-            _tools: &[serde_json::Value],
-        ) -> anyhow::Result<CompletionResponse> {
-            Err(anyhow::anyhow!("provider failed"))
-        }
-
-        fn stream(
-            &self,
-            _messages: Vec<ChatMessage>,
-        ) -> Pin<Box<dyn Stream<Item = StreamEvent> + Send + '_>> {
-            Box::pin(tokio_stream::empty())
-        }
-    }
-
-    impl MockProvider {
-        fn with_capture(
-            response: impl Into<String>,
-            model_id: impl Into<String>,
-        ) -> (Arc<dyn LlmProvider>, Arc<Mutex<Vec<String>>>) {
-            let seen_tool_names = Arc::new(Mutex::new(Vec::new()));
-            let provider: Arc<dyn LlmProvider> = Arc::new(Self {
-                response: response.into(),
-                model_id: model_id.into(),
-                seen_tool_names: Arc::clone(&seen_tool_names),
-            });
-            (provider, seen_tool_names)
-        }
-    }
-
-    #[async_trait]
-    impl LlmProvider for MockProvider {
-        fn name(&self) -> &str {
-            "mock"
-        }
-
-        fn id(&self) -> &str {
-            &self.model_id
-        }
-
-        async fn complete(
-            &self,
-            _messages: &[ChatMessage],
-            tools: &[serde_json::Value],
-        ) -> anyhow::Result<CompletionResponse> {
-            let tool_names = tools
-                .iter()
-                .filter_map(|tool| {
-                    tool.get("name")
-                        .and_then(serde_json::Value::as_str)
-                        .map(str::to_string)
-                })
-                .collect();
-            *self.seen_tool_names.lock().unwrap() = tool_names;
-            Ok(CompletionResponse {
-                text: Some(self.response.clone()),
-                tool_calls: vec![],
-                usage: Usage {
-                    input_tokens: 10,
-                    output_tokens: 5,
-                    ..Default::default()
-                },
-            })
-        }
-
-        fn stream(
-            &self,
-            _messages: Vec<ChatMessage>,
-        ) -> Pin<Box<dyn Stream<Item = StreamEvent> + Send + '_>> {
-            Box::pin(tokio_stream::empty())
-        }
-
-        fn supports_tools(&self) -> bool {
-            true
-        }
-    }
-
-    fn make_empty_provider_registry() -> Arc<tokio::sync::RwLock<ProviderRegistry>> {
-        let env_overrides = std::collections::HashMap::new();
-        Arc::new(tokio::sync::RwLock::new(
-            ProviderRegistry::from_config_with_static_catalogs(
-                &Default::default(),
-                &env_overrides,
-                std::collections::HashMap::new(),
-            ),
-        ))
-    }
-
-    struct DummyNamedTool {
-        name: String,
-    }
-
-    #[async_trait]
-    impl AgentTool for DummyNamedTool {
-        fn name(&self) -> &str {
-            &self.name
-        }
-
-        fn description(&self) -> &str {
-            "dummy"
-        }
-
-        fn parameters_schema(&self) -> serde_json::Value {
-            serde_json::json!({})
-        }
-
-        async fn execute(&self, params: serde_json::Value) -> anyhow::Result<serde_json::Value> {
-            Ok(params)
-        }
-    }
-
-    fn registry_with_tools(names: &[&str]) -> Arc<ToolRegistry> {
-        let mut registry = ToolRegistry::new();
-        for name in names {
-            registry.register(Box::new(DummyNamedTool {
-                name: (*name).to_string(),
-            }));
-        }
-        Arc::new(registry)
-    }
-
-    fn agents_config_with_presets(
-        default_preset: Option<&str>,
-        presets: &[(&str, AgentPreset)],
-    ) -> Arc<tokio::sync::RwLock<AgentsConfig>> {
-        let mut cfg = AgentsConfig {
-            default_preset: default_preset.map(String::from),
-            ..Default::default()
-        };
-        for (name, preset) in presets {
-            cfg.presets.insert((*name).to_string(), preset.clone());
-        }
-        Arc::new(tokio::sync::RwLock::new(cfg))
-    }
-
-    #[tokio::test]
-    async fn test_sub_agent_runs_and_returns_result() {
-        let (provider, _) = MockProvider::with_capture("Sub-agent result", "mock-model");
-        let tool_registry = Arc::new(ToolRegistry::new());
-        let spawn_tool = SpawnAgentTool::new(
-            make_empty_provider_registry(),
-            Arc::clone(&provider),
-            tool_registry,
-        );
-
-        let params = serde_json::json!({ "task": "do something" });
-        let result = spawn_tool.execute(params).await.unwrap();
-
-        assert_eq!(result["text"], "Sub-agent result");
-        assert_eq!(result["iterations"], 1);
-        assert_eq!(result["tool_calls_made"], 0);
-        assert_eq!(result["model"], "mock-model");
-    }
-
-    #[tokio::test]
-    async fn test_depth_limit_rejects() {
-        let (provider, _) = MockProvider::with_capture("nope", "mock");
-        let tool_registry = Arc::new(ToolRegistry::new());
-        let spawn_tool =
-            SpawnAgentTool::new(make_empty_provider_registry(), provider, tool_registry);
-
-        let params = serde_json::json!({
-            "task": "do something",
-            "_spawn_depth": MAX_SPAWN_DEPTH,
-        });
-        let result = spawn_tool.execute(params).await;
-        assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("nesting depth"));
-    }
-
-    #[tokio::test]
-    async fn test_nonblocking_returns_task_handle_before_completion() {
-        let notify = Arc::new(Notify::new());
-        let provider: Arc<dyn LlmProvider> = Arc::new(NotifyProvider {
-            response: "background result".to_string(),
-            notify: Arc::clone(&notify),
-        });
-        let store = Arc::new(SpawnTaskStore::default());
-        let spawn_tool = SpawnAgentTool::new(
-            make_empty_provider_registry(),
-            provider,
-            Arc::new(ToolRegistry::new()),
-        )
-        .with_task_store(Arc::clone(&store));
-
-        let result = tokio::time::timeout(
-            std::time::Duration::from_millis(100),
-            spawn_tool.execute(serde_json::json!({
-                "task": "do something later",
-                "nonblocking": true,
-                "_session_key": "session-a",
-            })),
-        )
-        .await
-        .expect("nonblocking spawn should return before provider completes")
-        .unwrap();
-
-        let task_id = result["task_id"].as_str().unwrap();
-        assert_eq!(result["status"], "running");
-
-        let status_tool = SpawnStatusTool::new(Arc::clone(&store));
-        let status = status_tool
-            .execute(serde_json::json!({
-                "task_id": task_id,
-                "_session_key": "session-a",
-            }))
-            .await
-            .unwrap();
-        assert_eq!(status["status"], "running");
-
-        notify.notify_one();
-        let result_tool = SpawnResultTool::new(store);
-        let mut final_result = serde_json::Value::Null;
-        for _ in 0..20 {
-            final_result = result_tool
-                .execute(serde_json::json!({
-                    "task_id": task_id,
-                    "_session_key": "session-a",
-                }))
-                .await
-                .unwrap();
-            if final_result["status"] == "completed" {
-                break;
-            }
-            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
-        }
-        assert_eq!(final_result["status"], "completed");
-        assert_eq!(final_result["text"], "background result");
-        assert_eq!(final_result["iterations"], 1);
-    }
-
-    #[tokio::test]
-    async fn test_nonblocking_result_enforces_session_key() {
-        let (provider, _) = MockProvider::with_capture("done", "mock");
-        let store = Arc::new(SpawnTaskStore::default());
-        let spawn_tool = SpawnAgentTool::new(
-            make_empty_provider_registry(),
-            provider,
-            Arc::new(ToolRegistry::new()),
-        )
-        .with_task_store(Arc::clone(&store));
-
-        let result = spawn_tool
-            .execute(serde_json::json!({
-                "task": "private task",
-                "nonblocking": true,
-                "_session_key": "session-a",
-            }))
-            .await
-            .unwrap();
-        let task_id = result["task_id"].as_str().unwrap();
-        let status_tool = SpawnStatusTool::new(store);
-        let denied = status_tool
-            .execute(serde_json::json!({
-                "task_id": task_id,
-                "_session_key": "session-b",
-            }))
-            .await;
-
-        assert!(denied.is_err());
-        assert!(denied.unwrap_err().to_string().contains("access denied"));
-    }
-
-    #[tokio::test]
-    async fn test_nonblocking_failure_is_persisted() {
-        let provider: Arc<dyn LlmProvider> = Arc::new(FailingProvider);
-        let store = Arc::new(SpawnTaskStore::default());
-        let spawn_tool = SpawnAgentTool::new(
-            make_empty_provider_registry(),
-            provider,
-            Arc::new(ToolRegistry::new()),
-        )
-        .with_task_store(Arc::clone(&store));
-
-        let result = spawn_tool
-            .execute(serde_json::json!({
-                "task": "fail in background",
-                "nonblocking": true,
-            }))
-            .await
-            .unwrap();
-        let task_id = result["task_id"].as_str().unwrap();
-        let result_tool = SpawnResultTool::new(store);
-
-        let mut final_result = serde_json::Value::Null;
-        for _ in 0..20 {
-            final_result = result_tool
-                .execute(serde_json::json!({ "task_id": task_id }))
-                .await
-                .unwrap();
-            if final_result["status"] == "failed" {
-                break;
-            }
-            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
-        }
-
-        assert_eq!(final_result["status"], "failed");
-        assert!(
-            final_result["error"]
-                .as_str()
-                .unwrap()
-                .contains("provider failed")
-        );
-    }
-
-    #[test]
-    fn test_nonblocking_and_companion_tool_schemas() {
-        let (provider, _) = MockProvider::with_capture("ok", "mock");
-        let store = Arc::new(SpawnTaskStore::default());
-        let spawn_tool = SpawnAgentTool::new(
-            make_empty_provider_registry(),
-            provider,
-            Arc::new(ToolRegistry::new()),
-        )
-        .with_task_store(Arc::clone(&store));
-
-        assert!(
-            spawn_tool.parameters_schema()["properties"]
-                .get("nonblocking")
-                .is_some()
-        );
-        assert_eq!(
-            SpawnStatusTool::new(Arc::clone(&store)).parameters_schema()["required"][0],
-            "task_id"
-        );
-        assert_eq!(
-            SpawnResultTool::new(store).parameters_schema()["required"][0],
-            "task_id"
-        );
-    }
-
-    #[tokio::test]
-    async fn test_spawn_agent_excluded_from_sub_registry() {
-        let (provider, _) = MockProvider::with_capture("ok", "mock");
-
-        // Create a registry with spawn_agent in it.
-        let mut registry = ToolRegistry::new();
-
-        struct DummyTool;
-        #[async_trait]
-        impl AgentTool for DummyTool {
-            fn name(&self) -> &str {
-                "spawn_agent"
-            }
-
-            fn description(&self) -> &str {
-                "dummy"
-            }
-
-            fn parameters_schema(&self) -> serde_json::Value {
-                serde_json::json!({})
-            }
-
-            async fn execute(&self, _: serde_json::Value) -> anyhow::Result<serde_json::Value> {
-                Ok(serde_json::json!("dummy"))
-            }
-        }
-
-        struct EchoTool;
-        #[async_trait]
-        impl AgentTool for EchoTool {
-            fn name(&self) -> &str {
-                "echo"
-            }
-
-            fn description(&self) -> &str {
-                "echo"
-            }
-
-            fn parameters_schema(&self) -> serde_json::Value {
-                serde_json::json!({})
-            }
-
-            async fn execute(&self, p: serde_json::Value) -> anyhow::Result<serde_json::Value> {
-                Ok(p)
-            }
-        }
-
-        registry.register(Box::new(DummyTool));
-        registry.register(Box::new(EchoTool));
-
-        let filtered = registry.clone_without(&["spawn_agent"]);
-        assert!(filtered.get("spawn_agent").is_none());
-        assert!(filtered.get("echo").is_some());
-
-        // Also verify schemas don't include spawn_agent.
-        let schemas = filtered.list_schemas();
-        assert_eq!(schemas.len(), 1);
-        assert_eq!(schemas[0]["name"], "echo");
-
-        // Ensure original is unaffected.
-        assert!(registry.get("spawn_agent").is_some());
-
-        // The SpawnAgentTool itself should work with the filtered registry.
-        let spawn_tool =
-            SpawnAgentTool::new(make_empty_provider_registry(), provider, Arc::new(registry));
-        let result = spawn_tool
-            .execute(serde_json::json!({ "task": "test" }))
-            .await
-            .unwrap();
-        assert_eq!(result["text"], "ok");
-    }
-
-    #[tokio::test]
-    async fn test_context_passed_to_sub_agent() {
-        let (provider, _) = MockProvider::with_capture("done with context", "mock");
-        let spawn_tool = SpawnAgentTool::new(
-            make_empty_provider_registry(),
-            provider,
-            Arc::new(ToolRegistry::new()),
-        );
-
-        let params = serde_json::json!({
-            "task": "analyze code",
-            "context": "The code is in src/main.rs",
-        });
-        let result = spawn_tool.execute(params).await.unwrap();
-        assert_eq!(result["text"], "done with context");
-    }
-
-    #[tokio::test]
-    async fn test_null_optional_array_params_are_treated_as_absent() {
-        let (provider, seen_tool_names) = MockProvider::with_capture("done", "mock");
-        let spawn_tool = SpawnAgentTool::new(
-            make_empty_provider_registry(),
-            provider,
-            registry_with_tools(&["spawn_agent", "exec", "web_fetch", "task_list"]),
-        );
-
-        let params = serde_json::json!({
-            "task": "analyze code",
-            "allow_tools": null,
-            "deny_tools": null,
-            "context": null,
-            "model": null,
-            "preset": null,
-            "delegate_only": null,
-        });
-        let result = spawn_tool.execute(params).await.unwrap();
-        assert_eq!(result["text"], "done");
-        let mut seen = seen_tool_names.lock().unwrap().clone();
-        seen.sort();
-        assert_eq!(seen, vec![
-            "exec".to_string(),
-            "task_list".to_string(),
-            "web_fetch".to_string(),
-        ]);
-    }
-
-    #[tokio::test]
-    async fn test_missing_task_parameter() {
-        let (provider, _) = MockProvider::with_capture("nope", "mock");
-        let spawn_tool = SpawnAgentTool::new(
-            make_empty_provider_registry(),
-            provider,
-            Arc::new(ToolRegistry::new()),
-        );
-
-        let result = spawn_tool.execute(serde_json::json!({})).await;
-        assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("task"));
-    }
-
-    #[tokio::test]
-    async fn test_build_sub_tools_applies_allow_and_deny() {
-        let (provider, _) = MockProvider::with_capture("ok", "mock");
-        let spawn_tool = SpawnAgentTool::new(
-            make_empty_provider_registry(),
-            provider,
-            registry_with_tools(&["spawn_agent", "exec", "web_fetch", "task_list"]),
-        );
-
-        let filtered = spawn_tool.build_sub_tools(
-            &[
-                "exec".to_string(),
-                "task_list".to_string(),
-                "spawn_agent".to_string(),
-            ],
-            &["task_list".to_string()],
-            false,
-        );
-        assert!(filtered.get("exec").is_some());
-        assert!(filtered.get("task_list").is_none());
-        assert!(filtered.get("spawn_agent").is_none());
-        assert!(filtered.get("web_fetch").is_none());
-    }
-
-    #[tokio::test]
-    async fn test_build_sub_tools_delegate_only_uses_delegate_set() {
-        let (provider, _) = MockProvider::with_capture("ok", "mock");
-        let spawn_tool = SpawnAgentTool::new(
-            make_empty_provider_registry(),
-            provider,
-            registry_with_tools(&[
-                "spawn_agent",
-                "spawn_status",
-                "spawn_result",
-                "spawn_list",
-                "sessions_list",
-                "sessions_history",
-                "sessions_send",
-                "task_list",
-                "exec",
-            ]),
-        );
-
-        let filtered = spawn_tool.build_sub_tools(&[], &[], true);
-        assert!(filtered.get("spawn_agent").is_some());
-        assert!(filtered.get("spawn_status").is_some());
-        assert!(filtered.get("spawn_result").is_some());
-        assert!(filtered.get("spawn_list").is_some());
-        assert!(filtered.get("sessions_list").is_some());
-        assert!(filtered.get("sessions_history").is_some());
-        assert!(filtered.get("sessions_send").is_some());
-        assert!(filtered.get("task_list").is_some());
-        assert!(filtered.get("exec").is_none());
-    }
-
-    #[tokio::test]
-    async fn test_resolve_preset_uses_explicit_name() {
-        let (provider, _) = MockProvider::with_capture("ok", "mock");
-        let spawn_tool = SpawnAgentTool::new(
-            make_empty_provider_registry(),
-            provider,
-            Arc::new(ToolRegistry::new()),
-        )
-        .with_agents_config(agents_config_with_presets(Some("default"), &[(
-            "research",
-            AgentPreset {
-                delegate_only: true,
-                ..Default::default()
-            },
-        )]));
-
-        let (name, preset) = spawn_tool
-            .resolve_preset(&serde_json::json!({ "preset": "research" }))
-            .await
-            .expect("resolve preset");
-        assert_eq!(name.as_deref(), Some("research"));
-        assert_eq!(preset.as_ref().map(|p| p.delegate_only), Some(true));
-    }
-
-    #[tokio::test]
-    async fn test_resolve_preset_uses_default_when_missing() {
-        let (provider, _) = MockProvider::with_capture("ok", "mock");
-        let spawn_tool = SpawnAgentTool::new(
-            make_empty_provider_registry(),
-            provider,
-            Arc::new(ToolRegistry::new()),
-        )
-        .with_agents_config(agents_config_with_presets(Some("default"), &[(
-            "default",
-            AgentPreset {
-                tools: PresetToolPolicy {
-                    allow: vec!["task_list".to_string()],
-                    ..Default::default()
-                },
-                ..Default::default()
-            },
-        )]));
-
-        let (name, preset) = spawn_tool
-            .resolve_preset(&serde_json::json!({}))
-            .await
-            .expect("resolve default preset");
-        assert_eq!(name.as_deref(), Some("default"));
-        assert_eq!(
-            preset
-                .as_ref()
-                .map(|p| p.tools.allow.clone())
-                .unwrap_or_default(),
-            vec!["task_list".to_string()]
-        );
-    }
-
-    #[tokio::test]
-    async fn test_resolve_preset_errors_when_name_missing() {
-        let (provider, _) = MockProvider::with_capture("ok", "mock");
-        let spawn_tool = SpawnAgentTool::new(
-            make_empty_provider_registry(),
-            provider,
-            Arc::new(ToolRegistry::new()),
-        )
-        .with_agents_config(agents_config_with_presets(None, &[]));
-
-        let result = spawn_tool
-            .resolve_preset(&serde_json::json!({ "preset": "missing" }))
-            .await;
-        assert!(result.is_err());
-        assert!(
-            result
-                .err()
-                .map(|e| e.to_string().contains("not found"))
-                .unwrap_or(false)
-        );
-    }
-
-    #[test]
-    fn test_identity_injected_into_system_prompt() {
-        let preset = AgentPreset {
-            identity: AgentIdentity {
-                name: Some("scout".into()),
-                emoji: Some("🔍".into()),
-                theme: Some("thorough".into()),
-            },
-            system_prompt_suffix: Some("Focus on accuracy.".into()),
-            ..Default::default()
-        };
-
-        let prompt =
-            build_sub_agent_prompt("find bugs", "in main.rs", Some(&preset), Some("scout"));
-
-        assert!(prompt.contains("You are scout (🔍)"));
-        assert!(prompt.contains("Your style is thorough"));
-        assert!(prompt.contains("Task: find bugs"));
-        assert!(prompt.contains("Context: in main.rs"));
-        assert!(prompt.contains("Focus on accuracy."));
-    }
-
-    #[test]
-    fn test_no_identity_uses_default_prompt() {
-        let prompt = build_sub_agent_prompt("do work", "", None, None);
-
-        assert!(prompt.contains("You are a sub-agent"));
-        assert!(prompt.contains("Task: do work"));
-        assert!(!prompt.contains("Context:"));
-    }
-
-    #[test]
-    fn test_memory_injected_into_system_prompt() {
-        let dir = tempfile::tempdir().unwrap();
-        let memory_dir = dir.path().join("agent-memory").join("researcher");
-        std::fs::create_dir_all(&memory_dir).unwrap();
-        std::fs::write(
-            memory_dir.join("MEMORY.md"),
-            "- Always check edge cases\n- Prefer iterators",
-        )
-        .unwrap();
-
-        // Load memory directly to verify the function works.
-        let content = load_memory_from_dir(&memory_dir, 200);
-        assert!(content.is_some());
-        let content = content.unwrap();
-        assert!(content.contains("Always check edge cases"));
-        assert!(content.contains("Prefer iterators"));
-    }
-
-    #[test]
-    fn test_load_memory_truncates() {
-        let dir = tempfile::tempdir().unwrap();
-        let memory_dir = dir.path();
-        let lines: Vec<String> = (0..10).map(|i| format!("Line {i}")).collect();
-        std::fs::write(memory_dir.join("MEMORY.md"), lines.join("\n")).unwrap();
-
-        let content = load_memory_from_dir(memory_dir, 3).unwrap();
-        assert!(content.contains("Line 0"));
-        assert!(content.contains("Line 2"));
-        assert!(!content.contains("Line 3"));
-    }
-
-    #[test]
-    fn test_load_memory_empty_returns_none() {
-        let dir = tempfile::tempdir().unwrap();
-        std::fs::write(dir.path().join("MEMORY.md"), "   \n  \n").unwrap();
-
-        let content = load_memory_from_dir(dir.path(), 200);
-        assert!(content.is_none());
-    }
-
-    #[test]
-    fn test_load_memory_missing_file_returns_none() {
-        let dir = tempfile::tempdir().unwrap();
-        let content = load_memory_from_dir(dir.path(), 200);
-        assert!(content.is_none());
-    }
-
-    #[tokio::test]
-    async fn test_timeout_cancels_long_running_agent() {
-        // Mock provider with a slow response.
-        struct SlowProvider;
-
-        #[async_trait]
-        impl LlmProvider for SlowProvider {
-            fn name(&self) -> &str {
-                "slow"
-            }
-
-            fn id(&self) -> &str {
-                "slow-model"
-            }
-
-            async fn complete(
-                &self,
-                _messages: &[ChatMessage],
-                _tools: &[serde_json::Value],
-            ) -> anyhow::Result<CompletionResponse> {
-                tokio::time::sleep(std::time::Duration::from_secs(10)).await;
-                Ok(CompletionResponse {
-                    text: Some("too late".into()),
-                    tool_calls: vec![],
-                    usage: Usage::default(),
-                })
-            }
-
-            fn stream(
-                &self,
-                _messages: Vec<ChatMessage>,
-            ) -> Pin<Box<dyn Stream<Item = StreamEvent> + Send + '_>> {
-                Box::pin(tokio_stream::empty())
-            }
-        }
-
-        let provider: Arc<dyn LlmProvider> = Arc::new(SlowProvider);
-        let spawn_tool = SpawnAgentTool::new(
-            make_empty_provider_registry(),
-            provider,
-            Arc::new(ToolRegistry::new()),
-        )
-        .with_agents_config(agents_config_with_presets(None, &[("slow", AgentPreset {
-            timeout_secs: Some(1),
-            ..Default::default()
-        })]));
-
-        let params = serde_json::json!({
-            "task": "do something slowly",
-            "preset": "slow",
-        });
-        let result = spawn_tool.execute(params).await;
-        assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("timed out"));
-    }
-}
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+#[path = "spawn_agent_tests.rs"]
+mod spawn_agent_tests;

--- a/crates/tools/src/spawn_agent_tasks.rs
+++ b/crates/tools/src/spawn_agent_tasks.rs
@@ -58,7 +58,10 @@ pub struct SpawnTask {
 impl SpawnTask {
     fn is_expired(&self, now: OffsetDateTime, ttl: Duration) -> bool {
         match self.finished_at {
+            // Completed/failed tasks expire after one TTL from completion.
             Some(finished_at) => finished_at + ttl <= now,
+            // Running tasks that never completed get a grace period of 2× TTL
+            // from their start time before being reaped as stale.
             None => self.started_at + ttl + ttl <= now,
         }
     }
@@ -131,6 +134,7 @@ impl SpawnTaskStore {
         }
     }
 
+    #[tracing::instrument(skip(self, task), fields(model = %model))]
     pub async fn insert_running(
         &self,
         task: String,
@@ -159,6 +163,7 @@ impl SpawnTaskStore {
         entry
     }
 
+    #[tracing::instrument(skip(self, update))]
     pub async fn complete(&self, id: &str, update: SpawnTaskUpdate) {
         if let Some(task) = self.tasks.write().await.get_mut(id) {
             task.status = if update.error.is_some() {
@@ -174,6 +179,7 @@ impl SpawnTaskStore {
         }
     }
 
+    #[tracing::instrument(skip(self))]
     pub async fn status(&self, id: &str, session_key: Option<&str>) -> crate::Result<Value> {
         let now = OffsetDateTime::now_utc();
         self.cleanup_expired(now).await;
@@ -185,6 +191,7 @@ impl SpawnTaskStore {
         Ok(task.status_json(now))
     }
 
+    #[tracing::instrument(skip(self))]
     pub async fn result(&self, id: &str, session_key: Option<&str>) -> crate::Result<Value> {
         let now = OffsetDateTime::now_utc();
         self.cleanup_expired(now).await;
@@ -196,12 +203,33 @@ impl SpawnTaskStore {
         Ok(task.result_json(now))
     }
 
+    pub async fn list(&self, session_key: Option<&str>) -> Vec<Value> {
+        let now = OffsetDateTime::now_utc();
+        self.cleanup_expired(now).await;
+        let tasks = self.tasks.read().await;
+        tasks
+            .values()
+            .filter(|task| task.session_key.as_deref() == session_key)
+            .map(|task| task.status_json(now))
+            .collect()
+    }
+
     async fn cleanup_expired(&self, now: OffsetDateTime) {
         if !self.should_cleanup(now) {
             return;
         }
         let mut tasks = self.tasks.write().await;
+        let before = tasks.len();
         tasks.retain(|_, task| !task.is_expired(now, self.ttl));
+        let expired = before - tasks.len();
+
+        #[cfg(feature = "metrics")]
+        if expired > 0 {
+            use moltis_metrics::{counter, spawn as spawn_metrics};
+            counter!(spawn_metrics::TASKS_EXPIRED_TOTAL).increment(expired as u64);
+        }
+
+        let _ = expired; // silence unused warning when metrics feature is off
     }
 
     fn should_cleanup(&self, now: OffsetDateTime) -> bool {
@@ -251,6 +279,7 @@ impl AgentTool for SpawnStatusTool {
         })
     }
 
+    #[tracing::instrument(skip(self, params))]
     async fn execute(&self, params: Value) -> anyhow::Result<Value> {
         let id = str_param(&params, "task_id")
             .ok_or_else(|| Error::message("missing required parameter: task_id"))?;
@@ -293,11 +322,48 @@ impl AgentTool for SpawnResultTool {
         })
     }
 
+    #[tracing::instrument(skip(self, params))]
     async fn execute(&self, params: Value) -> anyhow::Result<Value> {
         let id = str_param(&params, "task_id")
             .ok_or_else(|| Error::message("missing required parameter: task_id"))?;
         let session_key = str_param(&params, "_session_key");
         Ok(self.store.result(id, session_key).await?)
+    }
+}
+
+#[derive(Clone)]
+pub struct SpawnListTool {
+    store: Arc<SpawnTaskStore>,
+}
+
+impl SpawnListTool {
+    pub fn new(store: Arc<SpawnTaskStore>) -> Self {
+        Self { store }
+    }
+}
+
+#[async_trait]
+impl AgentTool for SpawnListTool {
+    fn name(&self) -> &str {
+        "spawn_list"
+    }
+
+    fn description(&self) -> &str {
+        "List all non-blocking spawn_agent tasks visible to the current session. Useful for recovering task IDs after context loss."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {},
+        })
+    }
+
+    #[tracing::instrument(skip(self, params))]
+    async fn execute(&self, params: Value) -> anyhow::Result<Value> {
+        let session_key = str_param(&params, "_session_key");
+        let tasks = self.store.list(session_key).await;
+        Ok(serde_json::json!({ "tasks": tasks }))
     }
 }
 
@@ -360,5 +426,50 @@ mod tests {
 
         assert!(description.contains("check status"));
         assert!(description.contains("running tasks have no final text"));
+    }
+
+    #[tokio::test]
+    async fn list_returns_tasks_for_matching_session() {
+        let store = SpawnTaskStore::default();
+        store
+            .insert_running(
+                "task a".to_string(),
+                Some("session-1".to_string()),
+                "model".to_string(),
+                None,
+            )
+            .await;
+        store
+            .insert_running(
+                "task b".to_string(),
+                Some("session-2".to_string()),
+                "model".to_string(),
+                None,
+            )
+            .await;
+        store
+            .insert_running(
+                "task c".to_string(),
+                Some("session-1".to_string()),
+                "model".to_string(),
+                None,
+            )
+            .await;
+
+        let session_1_tasks = store.list(Some("session-1")).await;
+        assert_eq!(session_1_tasks.len(), 2);
+
+        let session_2_tasks = store.list(Some("session-2")).await;
+        assert_eq!(session_2_tasks.len(), 1);
+
+        let no_session_tasks = store.list(None).await;
+        assert_eq!(no_session_tasks.len(), 0);
+    }
+
+    #[test]
+    fn spawn_list_tool_has_no_required_params() {
+        let tool = SpawnListTool::new(Arc::new(SpawnTaskStore::default()));
+        let schema = tool.parameters_schema();
+        assert!(schema.get("required").is_none());
     }
 }

--- a/crates/tools/src/spawn_agent_tasks.rs
+++ b/crates/tools/src/spawn_agent_tasks.rs
@@ -210,22 +210,26 @@ impl SpawnTaskStore {
 
     #[tracing::instrument(skip(self, update))]
     pub async fn complete(&self, id: &str, update: SpawnTaskUpdate) {
-        self.abort_handles.write().await.remove(id);
-        if let Some(task) = self.tasks.write().await.get_mut(id) {
-            if task.status == SpawnTaskStatus::Cancelled {
-                return;
-            }
-            task.status = if update.error.is_some() {
-                SpawnTaskStatus::Failed
-            } else {
-                SpawnTaskStatus::Completed
-            };
-            task.finished_at = Some(OffsetDateTime::now_utc());
-            task.text = update.text;
-            task.iterations = update.iterations;
-            task.tool_calls_made = update.tool_calls_made;
-            task.error = update.error;
+        let mut tasks = self.tasks.write().await;
+        let Some(task) = tasks.get_mut(id) else {
+            return;
+        };
+        if task.status == SpawnTaskStatus::Cancelled {
+            return;
         }
+        task.status = if update.error.is_some() {
+            SpawnTaskStatus::Failed
+        } else {
+            SpawnTaskStatus::Completed
+        };
+        task.finished_at = Some(OffsetDateTime::now_utc());
+        task.text = update.text;
+        task.iterations = update.iterations;
+        task.tool_calls_made = update.tool_calls_made;
+        task.error = update.error;
+        drop(tasks);
+
+        self.abort_handles.write().await.remove(id);
     }
 
     pub async fn cancel(&self, id: &str, session_key: Option<&str>) -> crate::Result<Value> {

--- a/crates/tools/src/spawn_agent_tasks.rs
+++ b/crates/tools/src/spawn_agent_tasks.rs
@@ -1,0 +1,272 @@
+use std::{collections::HashMap, sync::Arc};
+
+use {
+    async_trait::async_trait,
+    moltis_agents::tool_registry::AgentTool,
+    serde_json::Value,
+    time::{Duration, OffsetDateTime},
+    tokio::sync::RwLock,
+    uuid::Uuid,
+};
+
+use crate::{error::Error, params::str_param};
+
+const DEFAULT_TASK_TTL_HOURS: i64 = 24;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SpawnTaskStatus {
+    Running,
+    Completed,
+    Failed,
+}
+
+impl SpawnTaskStatus {
+    fn as_str(&self) -> &'static str {
+        match self {
+            Self::Running => "running",
+            Self::Completed => "completed",
+            Self::Failed => "failed",
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct SpawnTaskUpdate {
+    pub text: Option<String>,
+    pub iterations: usize,
+    pub tool_calls_made: usize,
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct SpawnTask {
+    pub id: String,
+    pub task: String,
+    pub session_key: Option<String>,
+    pub status: SpawnTaskStatus,
+    pub model: String,
+    pub preset: Option<String>,
+    pub started_at: OffsetDateTime,
+    pub finished_at: Option<OffsetDateTime>,
+    pub text: Option<String>,
+    pub iterations: usize,
+    pub tool_calls_made: usize,
+    pub error: Option<String>,
+}
+
+impl SpawnTask {
+    fn is_expired(&self, now: OffsetDateTime, ttl: Duration) -> bool {
+        let Some(finished_at) = self.finished_at else {
+            return false;
+        };
+        finished_at + ttl <= now
+    }
+
+    fn assert_access(&self, session_key: Option<&str>) -> crate::Result<()> {
+        if self.session_key.as_deref() == session_key {
+            return Ok(());
+        }
+        Err(Error::message("spawn task access denied"))
+    }
+
+    fn elapsed_secs(&self, now: OffsetDateTime) -> i64 {
+        (self.finished_at.unwrap_or(now) - self.started_at).whole_seconds()
+    }
+
+    fn status_json(&self, now: OffsetDateTime) -> Value {
+        serde_json::json!({
+            "task_id": self.id,
+            "status": self.status.as_str(),
+            "task": self.task,
+            "model": self.model,
+            "preset": self.preset,
+            "started_at": self.started_at,
+            "finished_at": self.finished_at,
+            "elapsed_secs": self.elapsed_secs(now),
+            "iterations": self.iterations,
+            "tool_calls_made": self.tool_calls_made,
+            "error": self.error,
+        })
+    }
+
+    fn result_json(&self, now: OffsetDateTime) -> Value {
+        let mut value = self.status_json(now);
+        value["text"] = self.text.clone().into();
+        value
+    }
+}
+
+#[derive(Debug)]
+pub struct SpawnTaskStore {
+    tasks: RwLock<HashMap<String, SpawnTask>>,
+    ttl: Duration,
+}
+
+impl Default for SpawnTaskStore {
+    fn default() -> Self {
+        Self::new(Duration::hours(DEFAULT_TASK_TTL_HOURS))
+    }
+}
+
+impl SpawnTaskStore {
+    pub fn new(ttl: Duration) -> Self {
+        Self {
+            tasks: RwLock::new(HashMap::new()),
+            ttl,
+        }
+    }
+
+    pub async fn insert_running(
+        &self,
+        task: String,
+        session_key: Option<String>,
+        model: String,
+        preset: Option<String>,
+    ) -> SpawnTask {
+        let entry = SpawnTask {
+            id: Uuid::new_v4().to_string(),
+            task,
+            session_key,
+            status: SpawnTaskStatus::Running,
+            model,
+            preset,
+            started_at: OffsetDateTime::now_utc(),
+            finished_at: None,
+            text: None,
+            iterations: 0,
+            tool_calls_made: 0,
+            error: None,
+        };
+        self.tasks
+            .write()
+            .await
+            .insert(entry.id.clone(), entry.clone());
+        entry
+    }
+
+    pub async fn complete(&self, id: &str, update: SpawnTaskUpdate) {
+        if let Some(task) = self.tasks.write().await.get_mut(id) {
+            task.status = if update.error.is_some() {
+                SpawnTaskStatus::Failed
+            } else {
+                SpawnTaskStatus::Completed
+            };
+            task.finished_at = Some(OffsetDateTime::now_utc());
+            task.text = update.text;
+            task.iterations = update.iterations;
+            task.tool_calls_made = update.tool_calls_made;
+            task.error = update.error;
+        }
+    }
+
+    pub async fn status(&self, id: &str, session_key: Option<&str>) -> crate::Result<Value> {
+        let now = OffsetDateTime::now_utc();
+        self.cleanup_expired(now).await;
+        let tasks = self.tasks.read().await;
+        let task = tasks
+            .get(id)
+            .ok_or_else(|| Error::message(format!("spawn task not found: {id}")))?;
+        task.assert_access(session_key)?;
+        Ok(task.status_json(now))
+    }
+
+    pub async fn result(&self, id: &str, session_key: Option<&str>) -> crate::Result<Value> {
+        let now = OffsetDateTime::now_utc();
+        self.cleanup_expired(now).await;
+        let tasks = self.tasks.read().await;
+        let task = tasks
+            .get(id)
+            .ok_or_else(|| Error::message(format!("spawn task not found: {id}")))?;
+        task.assert_access(session_key)?;
+        Ok(task.result_json(now))
+    }
+
+    async fn cleanup_expired(&self, now: OffsetDateTime) {
+        let mut tasks = self.tasks.write().await;
+        tasks.retain(|_, task| !task.is_expired(now, self.ttl));
+    }
+}
+
+#[derive(Clone)]
+pub struct SpawnStatusTool {
+    store: Arc<SpawnTaskStore>,
+}
+
+impl SpawnStatusTool {
+    pub fn new(store: Arc<SpawnTaskStore>) -> Self {
+        Self { store }
+    }
+}
+
+#[async_trait]
+impl AgentTool for SpawnStatusTool {
+    fn name(&self) -> &str {
+        "spawn_status"
+    }
+
+    fn description(&self) -> &str {
+        "Check the status of a non-blocking spawn_agent task."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "task_id": {
+                    "type": "string",
+                    "description": "Task ID returned by spawn_agent with nonblocking=true."
+                }
+            },
+            "required": ["task_id"]
+        })
+    }
+
+    async fn execute(&self, params: Value) -> anyhow::Result<Value> {
+        let id = str_param(&params, "task_id")
+            .ok_or_else(|| Error::message("missing required parameter: task_id"))?;
+        let session_key = str_param(&params, "_session_key");
+        Ok(self.store.status(id, session_key).await?)
+    }
+}
+
+#[derive(Clone)]
+pub struct SpawnResultTool {
+    store: Arc<SpawnTaskStore>,
+}
+
+impl SpawnResultTool {
+    pub fn new(store: Arc<SpawnTaskStore>) -> Self {
+        Self { store }
+    }
+}
+
+#[async_trait]
+impl AgentTool for SpawnResultTool {
+    fn name(&self) -> &str {
+        "spawn_result"
+    }
+
+    fn description(&self) -> &str {
+        "Fetch the result of a non-blocking spawn_agent task."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "task_id": {
+                    "type": "string",
+                    "description": "Task ID returned by spawn_agent with nonblocking=true."
+                }
+            },
+            "required": ["task_id"]
+        })
+    }
+
+    async fn execute(&self, params: Value) -> anyhow::Result<Value> {
+        let id = str_param(&params, "task_id")
+            .ok_or_else(|| Error::message("missing required parameter: task_id"))?;
+        let session_key = str_param(&params, "_session_key");
+        Ok(self.store.result(id, session_key).await?)
+    }
+}

--- a/crates/tools/src/spawn_agent_tasks.rs
+++ b/crates/tools/src/spawn_agent_tasks.rs
@@ -12,6 +12,7 @@ use {
 use crate::{error::Error, params::str_param};
 
 const DEFAULT_TASK_TTL_HOURS: i64 = 24;
+const DEFAULT_STALE_RUNNING_TTL_HOURS: i64 = 48;
 const CLEANUP_INTERVAL_SECS: i64 = 60;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -19,6 +20,7 @@ pub enum SpawnTaskStatus {
     Running,
     Completed,
     Failed,
+    Cancelled,
 }
 
 impl SpawnTaskStatus {
@@ -27,6 +29,43 @@ impl SpawnTaskStatus {
             Self::Running => "running",
             Self::Completed => "completed",
             Self::Failed => "failed",
+            Self::Cancelled => "cancelled",
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct SpawnTaskRetention {
+    completed_ttl: Duration,
+    failed_ttl: Duration,
+    running_ttl: Duration,
+    cleanup_interval: Duration,
+}
+
+impl Default for SpawnTaskRetention {
+    fn default() -> Self {
+        Self {
+            completed_ttl: Duration::hours(DEFAULT_TASK_TTL_HOURS),
+            failed_ttl: Duration::hours(DEFAULT_TASK_TTL_HOURS),
+            running_ttl: Duration::hours(DEFAULT_STALE_RUNNING_TTL_HOURS),
+            cleanup_interval: Duration::seconds(CLEANUP_INTERVAL_SECS),
+        }
+    }
+}
+
+impl SpawnTaskRetention {
+    #[must_use]
+    pub fn new(
+        completed_ttl: Duration,
+        failed_ttl: Duration,
+        running_ttl: Duration,
+        cleanup_interval: Duration,
+    ) -> Self {
+        Self {
+            completed_ttl,
+            failed_ttl,
+            running_ttl,
+            cleanup_interval,
         }
     }
 }
@@ -56,13 +95,19 @@ pub struct SpawnTask {
 }
 
 impl SpawnTask {
-    fn is_expired(&self, now: OffsetDateTime, ttl: Duration) -> bool {
-        match self.finished_at {
+    fn is_expired(&self, now: OffsetDateTime, retention: &SpawnTaskRetention) -> bool {
+        match (self.status.clone(), self.finished_at) {
             // Completed/failed tasks expire after one TTL from completion.
-            Some(finished_at) => finished_at + ttl <= now,
-            // Running tasks that never completed get a grace period of 2× TTL
-            // from their start time before being reaped as stale.
-            None => self.started_at + ttl + ttl <= now,
+            (SpawnTaskStatus::Completed, Some(finished_at)) => {
+                finished_at + retention.completed_ttl <= now
+            },
+            (SpawnTaskStatus::Failed | SpawnTaskStatus::Cancelled, Some(finished_at)) => {
+                finished_at + retention.failed_ttl <= now
+            },
+            // Running tasks that never completed get a separate stale-running TTL.
+            (SpawnTaskStatus::Running, _) => self.started_at + retention.running_ttl <= now,
+            // Malformed terminal records without finished_at should not be retained forever.
+            (_, None) => self.started_at + retention.failed_ttl <= now,
         }
     }
 
@@ -103,35 +148,30 @@ impl SpawnTask {
 #[derive(Debug)]
 pub struct SpawnTaskStore {
     tasks: RwLock<HashMap<String, SpawnTask>>,
-    ttl: Duration,
-    cleanup_interval: Duration,
+    abort_handles: RwLock<HashMap<String, futures::future::AbortHandle>>,
+    retention: SpawnTaskRetention,
     last_cleanup: std::sync::Mutex<Option<OffsetDateTime>>,
 }
 
 impl Default for SpawnTaskStore {
     fn default() -> Self {
-        Self::new(Duration::hours(DEFAULT_TASK_TTL_HOURS))
+        Self::new(SpawnTaskRetention::default())
     }
 }
 
 impl SpawnTaskStore {
-    pub fn new(ttl: Duration) -> Self {
+    pub fn new(retention: SpawnTaskRetention) -> Self {
         Self {
             tasks: RwLock::new(HashMap::new()),
-            ttl,
-            cleanup_interval: Duration::seconds(CLEANUP_INTERVAL_SECS),
+            abort_handles: RwLock::new(HashMap::new()),
+            retention,
             last_cleanup: std::sync::Mutex::new(None),
         }
     }
 
     #[cfg(test)]
-    fn with_cleanup_interval(ttl: Duration, cleanup_interval: Duration) -> Self {
-        Self {
-            tasks: RwLock::new(HashMap::new()),
-            ttl,
-            cleanup_interval,
-            last_cleanup: std::sync::Mutex::new(None),
-        }
+    fn with_retention(retention: SpawnTaskRetention) -> Self {
+        Self::new(retention)
     }
 
     #[tracing::instrument(skip(self, task), fields(model = %model))]
@@ -141,6 +181,7 @@ impl SpawnTaskStore {
         session_key: Option<String>,
         model: String,
         preset: Option<String>,
+        abort_handle: futures::future::AbortHandle,
     ) -> SpawnTask {
         let entry = SpawnTask {
             id: Uuid::new_v4().to_string(),
@@ -160,12 +201,20 @@ impl SpawnTaskStore {
             .write()
             .await
             .insert(entry.id.clone(), entry.clone());
+        self.abort_handles
+            .write()
+            .await
+            .insert(entry.id.clone(), abort_handle);
         entry
     }
 
     #[tracing::instrument(skip(self, update))]
     pub async fn complete(&self, id: &str, update: SpawnTaskUpdate) {
+        self.abort_handles.write().await.remove(id);
         if let Some(task) = self.tasks.write().await.get_mut(id) {
+            if task.status == SpawnTaskStatus::Cancelled {
+                return;
+            }
             task.status = if update.error.is_some() {
                 SpawnTaskStatus::Failed
             } else {
@@ -177,6 +226,33 @@ impl SpawnTaskStore {
             task.tool_calls_made = update.tool_calls_made;
             task.error = update.error;
         }
+    }
+
+    pub async fn cancel(&self, id: &str, session_key: Option<&str>) -> crate::Result<Value> {
+        let now = OffsetDateTime::now_utc();
+        self.cleanup_expired(now).await;
+        let mut tasks = self.tasks.write().await;
+        let task = tasks
+            .get_mut(id)
+            .ok_or_else(|| Error::message(format!("spawn task not found: {id}")))?;
+        task.assert_access(session_key)?;
+        if task.status != SpawnTaskStatus::Running {
+            let mut value = task.status_json(now);
+            value["cancelled"] = false.into();
+            return Ok(value);
+        }
+
+        task.status = SpawnTaskStatus::Cancelled;
+        task.finished_at = Some(now);
+        task.error = Some("cancelled by caller".to_string());
+        let mut value = task.status_json(now);
+        value["cancelled"] = true.into();
+        drop(tasks);
+
+        if let Some(handle) = self.abort_handles.write().await.remove(id) {
+            handle.abort();
+        }
+        Ok(value)
     }
 
     #[tracing::instrument(skip(self))]
@@ -220,8 +296,24 @@ impl SpawnTaskStore {
         }
         let mut tasks = self.tasks.write().await;
         let before = tasks.len();
-        tasks.retain(|_, task| !task.is_expired(now, self.ttl));
+        let mut expired_ids = Vec::new();
+        tasks.retain(|id, task| {
+            let keep = !task.is_expired(now, &self.retention);
+            if !keep {
+                expired_ids.push(id.clone());
+            }
+            keep
+        });
         let expired = before - tasks.len();
+        drop(tasks);
+        if !expired_ids.is_empty() {
+            let mut abort_handles = self.abort_handles.write().await;
+            for id in expired_ids {
+                if let Some(handle) = abort_handles.remove(&id) {
+                    handle.abort();
+                }
+            }
+        }
 
         #[cfg(feature = "metrics")]
         if expired > 0 {
@@ -237,7 +329,7 @@ impl SpawnTaskStore {
             .last_cleanup
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
-        if last_cleanup.is_some_and(|last| last + self.cleanup_interval > now) {
+        if last_cleanup.is_some_and(|last| last + self.retention.cleanup_interval > now) {
             return false;
         }
         *last_cleanup = Some(now);
@@ -367,22 +459,73 @@ impl AgentTool for SpawnListTool {
     }
 }
 
+#[derive(Clone)]
+pub struct SpawnCancelTool {
+    store: Arc<SpawnTaskStore>,
+}
+
+impl SpawnCancelTool {
+    pub fn new(store: Arc<SpawnTaskStore>) -> Self {
+        Self { store }
+    }
+}
+
+#[async_trait]
+impl AgentTool for SpawnCancelTool {
+    fn name(&self) -> &str {
+        "cancel_spawn"
+    }
+
+    fn description(&self) -> &str {
+        "Cancel a running non-blocking spawn_agent task by task_id."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "task_id": {
+                    "type": "string",
+                    "description": "Task ID returned by spawn_agent with nonblocking=true."
+                }
+            },
+            "required": ["task_id"]
+        })
+    }
+
+    #[tracing::instrument(skip(self, params))]
+    async fn execute(&self, params: Value) -> anyhow::Result<Value> {
+        let id = str_param(&params, "task_id")
+            .ok_or_else(|| Error::message("missing required parameter: task_id"))?;
+        let session_key = str_param(&params, "_session_key");
+        Ok(self.store.cancel(id, session_key).await?)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
+    fn abort_handle() -> futures::future::AbortHandle {
+        let (handle, _registration) = futures::future::AbortHandle::new_pair();
+        handle
+    }
+
     #[tokio::test]
     async fn stale_running_tasks_are_cleaned_up() {
-        let store = SpawnTaskStore::with_cleanup_interval(
+        let store = SpawnTaskStore::with_retention(SpawnTaskRetention::new(
+            Duration::hours(1),
+            Duration::hours(1),
             Duration::milliseconds(1),
             Duration::milliseconds(0),
-        );
+        ));
         let task = store
             .insert_running(
                 "zombie task".to_string(),
                 None,
                 "mock-model".to_string(),
                 None,
+                abort_handle(),
             )
             .await;
         tokio::time::sleep(std::time::Duration::from_millis(3)).await;
@@ -395,13 +538,19 @@ mod tests {
 
     #[tokio::test]
     async fn cleanup_is_amortized_between_polls() {
-        let store = SpawnTaskStore::with_cleanup_interval(Duration::hours(1), Duration::minutes(1));
+        let store = SpawnTaskStore::with_retention(SpawnTaskRetention::new(
+            Duration::hours(1),
+            Duration::hours(1),
+            Duration::hours(1),
+            Duration::minutes(1),
+        ));
         let task = store
             .insert_running(
                 "active task".to_string(),
                 None,
                 "mock-model".to_string(),
                 None,
+                abort_handle(),
             )
             .await;
 
@@ -437,6 +586,7 @@ mod tests {
                 Some("session-1".to_string()),
                 "model".to_string(),
                 None,
+                abort_handle(),
             )
             .await;
         store
@@ -445,6 +595,7 @@ mod tests {
                 Some("session-2".to_string()),
                 "model".to_string(),
                 None,
+                abort_handle(),
             )
             .await;
         store
@@ -453,6 +604,7 @@ mod tests {
                 Some("session-1".to_string()),
                 "model".to_string(),
                 None,
+                abort_handle(),
             )
             .await;
 
@@ -471,5 +623,50 @@ mod tests {
         let tool = SpawnListTool::new(Arc::new(SpawnTaskStore::default()));
         let schema = tool.parameters_schema();
         assert!(schema.get("required").is_none());
+    }
+
+    #[tokio::test]
+    async fn cancel_marks_running_task_cancelled() {
+        let store = SpawnTaskStore::default();
+        let task = store
+            .insert_running(
+                "cancel me".to_string(),
+                Some("session-1".to_string()),
+                "model".to_string(),
+                None,
+                abort_handle(),
+            )
+            .await;
+
+        let cancelled = store.cancel(&task.id, Some("session-1")).await.unwrap();
+
+        assert_eq!(cancelled["status"], "cancelled");
+        assert_eq!(cancelled["cancelled"], true);
+        assert_eq!(cancelled["error"], "cancelled by caller");
+    }
+
+    #[tokio::test]
+    async fn cancel_enforces_session_key() {
+        let store = SpawnTaskStore::default();
+        let task = store
+            .insert_running(
+                "private task".to_string(),
+                Some("session-1".to_string()),
+                "model".to_string(),
+                None,
+                abort_handle(),
+            )
+            .await;
+
+        let denied = store.cancel(&task.id, Some("session-2")).await;
+
+        assert!(denied.is_err());
+        assert!(denied.unwrap_err().to_string().contains("access denied"));
+    }
+
+    #[test]
+    fn cancel_spawn_tool_requires_task_id() {
+        let tool = SpawnCancelTool::new(Arc::new(SpawnTaskStore::default()));
+        assert_eq!(tool.parameters_schema()["required"][0], "task_id");
     }
 }

--- a/crates/tools/src/spawn_agent_tasks.rs
+++ b/crates/tools/src/spawn_agent_tasks.rs
@@ -197,10 +197,14 @@ impl SpawnTaskStore {
             tool_calls_made: 0,
             error: None,
         };
-        let mut tasks = self.tasks.write().await;
-        let mut abort_handles = self.abort_handles.write().await;
-        abort_handles.insert(entry.id.clone(), abort_handle);
-        tasks.insert(entry.id.clone(), entry.clone());
+        self.tasks
+            .write()
+            .await
+            .insert(entry.id.clone(), entry.clone());
+        self.abort_handles
+            .write()
+            .await
+            .insert(entry.id.clone(), abort_handle);
         entry
     }
 

--- a/crates/tools/src/spawn_agent_tasks.rs
+++ b/crates/tools/src/spawn_agent_tasks.rs
@@ -536,8 +536,10 @@ mod tests {
 
         let status = store.status(&task.id, None).await;
 
-        assert!(status.is_err());
-        assert!(status.unwrap_err().to_string().contains("not found"));
+        match status {
+            Ok(value) => panic!("expected stale task to be cleaned up, got {value:?}"),
+            Err(err) => assert!(err.to_string().contains("not found")),
+        }
     }
 
     #[tokio::test]
@@ -558,12 +560,16 @@ mod tests {
             )
             .await;
 
-        store.status(&task.id, None).await.unwrap();
+        if let Err(err) = store.status(&task.id, None).await {
+            panic!("expected status lookup to succeed: {err}");
+        }
         let first_cleanup = *store
             .last_cleanup
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
-        store.status(&task.id, None).await.unwrap();
+        if let Err(err) = store.status(&task.id, None).await {
+            panic!("expected second status lookup to succeed: {err}");
+        }
         let second_cleanup = *store
             .last_cleanup
             .lock()
@@ -642,7 +648,10 @@ mod tests {
             )
             .await;
 
-        let cancelled = store.cancel(&task.id, Some("session-1")).await.unwrap();
+        let cancelled = match store.cancel(&task.id, Some("session-1")).await {
+            Ok(value) => value,
+            Err(err) => panic!("expected cancellation to succeed: {err}"),
+        };
 
         assert_eq!(cancelled["status"], "cancelled");
         assert_eq!(cancelled["cancelled"], true);
@@ -664,8 +673,10 @@ mod tests {
 
         let denied = store.cancel(&task.id, Some("session-2")).await;
 
-        assert!(denied.is_err());
-        assert!(denied.unwrap_err().to_string().contains("access denied"));
+        match denied {
+            Ok(value) => panic!("expected cancellation to be denied, got {value:?}"),
+            Err(err) => assert!(err.to_string().contains("access denied")),
+        }
     }
 
     #[test]

--- a/crates/tools/src/spawn_agent_tasks.rs
+++ b/crates/tools/src/spawn_agent_tasks.rs
@@ -197,14 +197,10 @@ impl SpawnTaskStore {
             tool_calls_made: 0,
             error: None,
         };
-        self.tasks
-            .write()
-            .await
-            .insert(entry.id.clone(), entry.clone());
-        self.abort_handles
-            .write()
-            .await
-            .insert(entry.id.clone(), abort_handle);
+        let mut tasks = self.tasks.write().await;
+        let mut abort_handles = self.abort_handles.write().await;
+        abort_handles.insert(entry.id.clone(), abort_handle);
+        tasks.insert(entry.id.clone(), entry.clone());
         entry
     }
 

--- a/crates/tools/src/spawn_agent_tasks.rs
+++ b/crates/tools/src/spawn_agent_tasks.rs
@@ -12,6 +12,7 @@ use {
 use crate::{error::Error, params::str_param};
 
 const DEFAULT_TASK_TTL_HOURS: i64 = 24;
+const CLEANUP_INTERVAL_SECS: i64 = 60;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SpawnTaskStatus {
@@ -56,10 +57,10 @@ pub struct SpawnTask {
 
 impl SpawnTask {
     fn is_expired(&self, now: OffsetDateTime, ttl: Duration) -> bool {
-        let Some(finished_at) = self.finished_at else {
-            return false;
-        };
-        finished_at + ttl <= now
+        match self.finished_at {
+            Some(finished_at) => finished_at + ttl <= now,
+            None => self.started_at + ttl + ttl <= now,
+        }
     }
 
     fn assert_access(&self, session_key: Option<&str>) -> crate::Result<()> {
@@ -100,6 +101,8 @@ impl SpawnTask {
 pub struct SpawnTaskStore {
     tasks: RwLock<HashMap<String, SpawnTask>>,
     ttl: Duration,
+    cleanup_interval: Duration,
+    last_cleanup: std::sync::Mutex<Option<OffsetDateTime>>,
 }
 
 impl Default for SpawnTaskStore {
@@ -113,6 +116,18 @@ impl SpawnTaskStore {
         Self {
             tasks: RwLock::new(HashMap::new()),
             ttl,
+            cleanup_interval: Duration::seconds(CLEANUP_INTERVAL_SECS),
+            last_cleanup: std::sync::Mutex::new(None),
+        }
+    }
+
+    #[cfg(test)]
+    fn with_cleanup_interval(ttl: Duration, cleanup_interval: Duration) -> Self {
+        Self {
+            tasks: RwLock::new(HashMap::new()),
+            ttl,
+            cleanup_interval,
+            last_cleanup: std::sync::Mutex::new(None),
         }
     }
 
@@ -182,8 +197,23 @@ impl SpawnTaskStore {
     }
 
     async fn cleanup_expired(&self, now: OffsetDateTime) {
+        if !self.should_cleanup(now) {
+            return;
+        }
         let mut tasks = self.tasks.write().await;
         tasks.retain(|_, task| !task.is_expired(now, self.ttl));
+    }
+
+    fn should_cleanup(&self, now: OffsetDateTime) -> bool {
+        let mut last_cleanup = self
+            .last_cleanup
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if last_cleanup.is_some_and(|last| last + self.cleanup_interval > now) {
+            return false;
+        }
+        *last_cleanup = Some(now);
+        true
     }
 }
 
@@ -247,7 +277,7 @@ impl AgentTool for SpawnResultTool {
     }
 
     fn description(&self) -> &str {
-        "Fetch the result of a non-blocking spawn_agent task."
+        "Fetch the result of a non-blocking spawn_agent task. Returns the current state; check status before using text because running tasks have no final text yet."
     }
 
     fn parameters_schema(&self) -> Value {
@@ -268,5 +298,67 @@ impl AgentTool for SpawnResultTool {
             .ok_or_else(|| Error::message("missing required parameter: task_id"))?;
         let session_key = str_param(&params, "_session_key");
         Ok(self.store.result(id, session_key).await?)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn stale_running_tasks_are_cleaned_up() {
+        let store = SpawnTaskStore::with_cleanup_interval(
+            Duration::milliseconds(1),
+            Duration::milliseconds(0),
+        );
+        let task = store
+            .insert_running(
+                "zombie task".to_string(),
+                None,
+                "mock-model".to_string(),
+                None,
+            )
+            .await;
+        tokio::time::sleep(std::time::Duration::from_millis(3)).await;
+
+        let status = store.status(&task.id, None).await;
+
+        assert!(status.is_err());
+        assert!(status.unwrap_err().to_string().contains("not found"));
+    }
+
+    #[tokio::test]
+    async fn cleanup_is_amortized_between_polls() {
+        let store = SpawnTaskStore::with_cleanup_interval(Duration::hours(1), Duration::minutes(1));
+        let task = store
+            .insert_running(
+                "active task".to_string(),
+                None,
+                "mock-model".to_string(),
+                None,
+            )
+            .await;
+
+        store.status(&task.id, None).await.unwrap();
+        let first_cleanup = *store
+            .last_cleanup
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        store.status(&task.id, None).await.unwrap();
+        let second_cleanup = *store
+            .last_cleanup
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+
+        assert_eq!(first_cleanup, second_cleanup);
+    }
+
+    #[test]
+    fn spawn_result_description_warns_running_results_have_no_text() {
+        let tool = SpawnResultTool::new(Arc::new(SpawnTaskStore::default()));
+        let description = tool.description();
+
+        assert!(description.contains("check status"));
+        assert!(description.contains("running tasks have no final text"));
     }
 }

--- a/crates/tools/src/spawn_agent_tests.rs
+++ b/crates/tools/src/spawn_agent_tests.rs
@@ -1,0 +1,843 @@
+use {
+    super::*,
+    moltis_agents::model::{ChatMessage, CompletionResponse, StreamEvent, Usage},
+    moltis_config::schema::{AgentIdentity, PresetToolPolicy},
+    std::{pin::Pin, sync::Mutex},
+    tokio::sync::Notify,
+    tokio_stream::Stream,
+};
+
+use crate::spawn_agent_tasks::{SpawnCancelTool, SpawnResultTool, SpawnStatusTool};
+
+/// Mock provider that returns a fixed response.
+struct MockProvider {
+    response: String,
+    model_id: String,
+    seen_tool_names: Arc<Mutex<Vec<String>>>,
+}
+
+struct NotifyProvider {
+    response: String,
+    notify: Arc<Notify>,
+}
+
+#[async_trait]
+impl LlmProvider for NotifyProvider {
+    fn name(&self) -> &str {
+        "notify"
+    }
+
+    fn id(&self) -> &str {
+        "notify-model"
+    }
+
+    async fn complete(
+        &self,
+        _messages: &[ChatMessage],
+        _tools: &[serde_json::Value],
+    ) -> anyhow::Result<CompletionResponse> {
+        self.notify.notified().await;
+        Ok(CompletionResponse {
+            text: Some(self.response.clone()),
+            tool_calls: vec![],
+            usage: Usage::default(),
+        })
+    }
+
+    fn stream(
+        &self,
+        _messages: Vec<ChatMessage>,
+    ) -> Pin<Box<dyn Stream<Item = StreamEvent> + Send + '_>> {
+        Box::pin(tokio_stream::empty())
+    }
+}
+
+struct FailingProvider;
+
+#[async_trait]
+impl LlmProvider for FailingProvider {
+    fn name(&self) -> &str {
+        "failing"
+    }
+
+    fn id(&self) -> &str {
+        "failing-model"
+    }
+
+    async fn complete(
+        &self,
+        _messages: &[ChatMessage],
+        _tools: &[serde_json::Value],
+    ) -> anyhow::Result<CompletionResponse> {
+        Err(anyhow::anyhow!("provider failed"))
+    }
+
+    fn stream(
+        &self,
+        _messages: Vec<ChatMessage>,
+    ) -> Pin<Box<dyn Stream<Item = StreamEvent> + Send + '_>> {
+        Box::pin(tokio_stream::empty())
+    }
+}
+
+impl MockProvider {
+    fn with_capture(
+        response: impl Into<String>,
+        model_id: impl Into<String>,
+    ) -> (Arc<dyn LlmProvider>, Arc<Mutex<Vec<String>>>) {
+        let seen_tool_names = Arc::new(Mutex::new(Vec::new()));
+        let provider: Arc<dyn LlmProvider> = Arc::new(Self {
+            response: response.into(),
+            model_id: model_id.into(),
+            seen_tool_names: Arc::clone(&seen_tool_names),
+        });
+        (provider, seen_tool_names)
+    }
+}
+
+#[async_trait]
+impl LlmProvider for MockProvider {
+    fn name(&self) -> &str {
+        "mock"
+    }
+
+    fn id(&self) -> &str {
+        &self.model_id
+    }
+
+    async fn complete(
+        &self,
+        _messages: &[ChatMessage],
+        tools: &[serde_json::Value],
+    ) -> anyhow::Result<CompletionResponse> {
+        let tool_names = tools
+            .iter()
+            .filter_map(|tool| {
+                tool.get("name")
+                    .and_then(serde_json::Value::as_str)
+                    .map(str::to_string)
+            })
+            .collect();
+        *self.seen_tool_names.lock().unwrap() = tool_names;
+        Ok(CompletionResponse {
+            text: Some(self.response.clone()),
+            tool_calls: vec![],
+            usage: Usage {
+                input_tokens: 10,
+                output_tokens: 5,
+                ..Default::default()
+            },
+        })
+    }
+
+    fn stream(
+        &self,
+        _messages: Vec<ChatMessage>,
+    ) -> Pin<Box<dyn Stream<Item = StreamEvent> + Send + '_>> {
+        Box::pin(tokio_stream::empty())
+    }
+
+    fn supports_tools(&self) -> bool {
+        true
+    }
+}
+
+fn make_empty_provider_registry() -> Arc<tokio::sync::RwLock<ProviderRegistry>> {
+    let env_overrides = std::collections::HashMap::new();
+    Arc::new(tokio::sync::RwLock::new(
+        ProviderRegistry::from_config_with_static_catalogs(
+            &Default::default(),
+            &env_overrides,
+            std::collections::HashMap::new(),
+        ),
+    ))
+}
+
+struct DummyNamedTool {
+    name: String,
+}
+
+#[async_trait]
+impl AgentTool for DummyNamedTool {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn description(&self) -> &str {
+        "dummy"
+    }
+
+    fn parameters_schema(&self) -> serde_json::Value {
+        serde_json::json!({})
+    }
+
+    async fn execute(&self, params: serde_json::Value) -> anyhow::Result<serde_json::Value> {
+        Ok(params)
+    }
+}
+
+fn registry_with_tools(names: &[&str]) -> Arc<ToolRegistry> {
+    let mut registry = ToolRegistry::new();
+    for name in names {
+        registry.register(Box::new(DummyNamedTool {
+            name: (*name).to_string(),
+        }));
+    }
+    Arc::new(registry)
+}
+
+fn agents_config_with_presets(
+    default_preset: Option<&str>,
+    presets: &[(&str, AgentPreset)],
+) -> Arc<tokio::sync::RwLock<AgentsConfig>> {
+    let mut cfg = AgentsConfig {
+        default_preset: default_preset.map(String::from),
+        ..Default::default()
+    };
+    for (name, preset) in presets {
+        cfg.presets.insert((*name).to_string(), preset.clone());
+    }
+    Arc::new(tokio::sync::RwLock::new(cfg))
+}
+
+#[tokio::test]
+async fn test_sub_agent_runs_and_returns_result() {
+    let (provider, _) = MockProvider::with_capture("Sub-agent result", "mock-model");
+    let tool_registry = Arc::new(ToolRegistry::new());
+    let spawn_tool = SpawnAgentTool::new(
+        make_empty_provider_registry(),
+        Arc::clone(&provider),
+        tool_registry,
+    );
+
+    let params = serde_json::json!({ "task": "do something" });
+    let result = spawn_tool.execute(params).await.unwrap();
+
+    assert_eq!(result["text"], "Sub-agent result");
+    assert_eq!(result["iterations"], 1);
+    assert_eq!(result["tool_calls_made"], 0);
+    assert_eq!(result["model"], "mock-model");
+}
+
+#[tokio::test]
+async fn test_depth_limit_rejects() {
+    let (provider, _) = MockProvider::with_capture("nope", "mock");
+    let tool_registry = Arc::new(ToolRegistry::new());
+    let spawn_tool = SpawnAgentTool::new(make_empty_provider_registry(), provider, tool_registry);
+
+    let params = serde_json::json!({
+        "task": "do something",
+        "_spawn_depth": MAX_SPAWN_DEPTH,
+    });
+    let result = spawn_tool.execute(params).await;
+    assert!(result.is_err());
+    assert!(result.unwrap_err().to_string().contains("nesting depth"));
+}
+
+#[tokio::test]
+async fn test_nonblocking_returns_task_handle_before_completion() {
+    let notify = Arc::new(Notify::new());
+    let provider: Arc<dyn LlmProvider> = Arc::new(NotifyProvider {
+        response: "background result".to_string(),
+        notify: Arc::clone(&notify),
+    });
+    let store = Arc::new(SpawnTaskStore::default());
+    let spawn_tool = SpawnAgentTool::new(
+        make_empty_provider_registry(),
+        provider,
+        Arc::new(ToolRegistry::new()),
+    )
+    .with_task_store(Arc::clone(&store));
+
+    let result = tokio::time::timeout(
+        std::time::Duration::from_millis(100),
+        spawn_tool.execute(serde_json::json!({
+            "task": "do something later",
+            "nonblocking": true,
+            "_session_key": "session-a",
+        })),
+    )
+    .await
+    .expect("nonblocking spawn should return before provider completes")
+    .unwrap();
+
+    let task_id = result["task_id"].as_str().unwrap();
+    assert_eq!(result["status"], "running");
+
+    let status_tool = SpawnStatusTool::new(Arc::clone(&store));
+    let status = status_tool
+        .execute(serde_json::json!({
+            "task_id": task_id,
+            "_session_key": "session-a",
+        }))
+        .await
+        .unwrap();
+    assert_eq!(status["status"], "running");
+
+    notify.notify_one();
+    let result_tool = SpawnResultTool::new(store);
+    let mut final_result = serde_json::Value::Null;
+    for _ in 0..20 {
+        final_result = result_tool
+            .execute(serde_json::json!({
+                "task_id": task_id,
+                "_session_key": "session-a",
+            }))
+            .await
+            .unwrap();
+        if final_result["status"] == "completed" {
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+    }
+    assert_eq!(final_result["status"], "completed");
+    assert_eq!(final_result["text"], "background result");
+    assert_eq!(final_result["iterations"], 1);
+}
+
+#[tokio::test]
+async fn test_nonblocking_result_enforces_session_key() {
+    let (provider, _) = MockProvider::with_capture("done", "mock");
+    let store = Arc::new(SpawnTaskStore::default());
+    let spawn_tool = SpawnAgentTool::new(
+        make_empty_provider_registry(),
+        provider,
+        Arc::new(ToolRegistry::new()),
+    )
+    .with_task_store(Arc::clone(&store));
+
+    let result = spawn_tool
+        .execute(serde_json::json!({
+            "task": "private task",
+            "nonblocking": true,
+            "_session_key": "session-a",
+        }))
+        .await
+        .unwrap();
+    let task_id = result["task_id"].as_str().unwrap();
+    let status_tool = SpawnStatusTool::new(store);
+    let denied = status_tool
+        .execute(serde_json::json!({
+            "task_id": task_id,
+            "_session_key": "session-b",
+        }))
+        .await;
+
+    assert!(denied.is_err());
+    assert!(denied.unwrap_err().to_string().contains("access denied"));
+}
+
+#[tokio::test]
+async fn test_nonblocking_failure_is_persisted() {
+    let provider: Arc<dyn LlmProvider> = Arc::new(FailingProvider);
+    let store = Arc::new(SpawnTaskStore::default());
+    let spawn_tool = SpawnAgentTool::new(
+        make_empty_provider_registry(),
+        provider,
+        Arc::new(ToolRegistry::new()),
+    )
+    .with_task_store(Arc::clone(&store));
+
+    let result = spawn_tool
+        .execute(serde_json::json!({
+            "task": "fail in background",
+            "nonblocking": true,
+        }))
+        .await
+        .unwrap();
+    let task_id = result["task_id"].as_str().unwrap();
+    let result_tool = SpawnResultTool::new(store);
+
+    let mut final_result = serde_json::Value::Null;
+    for _ in 0..20 {
+        final_result = result_tool
+            .execute(serde_json::json!({ "task_id": task_id }))
+            .await
+            .unwrap();
+        if final_result["status"] == "failed" {
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+    }
+
+    assert_eq!(final_result["status"], "failed");
+    assert!(
+        final_result["error"]
+            .as_str()
+            .unwrap()
+            .contains("provider failed")
+    );
+}
+
+#[test]
+fn test_nonblocking_and_companion_tool_schemas() {
+    let (provider, _) = MockProvider::with_capture("ok", "mock");
+    let store = Arc::new(SpawnTaskStore::default());
+    let spawn_tool = SpawnAgentTool::new(
+        make_empty_provider_registry(),
+        provider,
+        Arc::new(ToolRegistry::new()),
+    )
+    .with_task_store(Arc::clone(&store));
+
+    assert!(
+        spawn_tool.parameters_schema()["properties"]
+            .get("nonblocking")
+            .is_some()
+    );
+    assert_eq!(
+        SpawnStatusTool::new(Arc::clone(&store)).parameters_schema()["required"][0],
+        "task_id"
+    );
+    assert_eq!(
+        SpawnResultTool::new(store).parameters_schema()["required"][0],
+        "task_id"
+    );
+    assert_eq!(
+        SpawnCancelTool::new(Arc::new(SpawnTaskStore::default())).parameters_schema()["required"]
+            [0],
+        "task_id"
+    );
+}
+
+#[tokio::test]
+async fn test_spawn_agent_excluded_from_sub_registry() {
+    let (provider, _) = MockProvider::with_capture("ok", "mock");
+
+    // Create a registry with spawn_agent in it.
+    let mut registry = ToolRegistry::new();
+
+    struct DummyTool;
+    #[async_trait]
+    impl AgentTool for DummyTool {
+        fn name(&self) -> &str {
+            "spawn_agent"
+        }
+
+        fn description(&self) -> &str {
+            "dummy"
+        }
+
+        fn parameters_schema(&self) -> serde_json::Value {
+            serde_json::json!({})
+        }
+
+        async fn execute(&self, _: serde_json::Value) -> anyhow::Result<serde_json::Value> {
+            Ok(serde_json::json!("dummy"))
+        }
+    }
+
+    struct EchoTool;
+    #[async_trait]
+    impl AgentTool for EchoTool {
+        fn name(&self) -> &str {
+            "echo"
+        }
+
+        fn description(&self) -> &str {
+            "echo"
+        }
+
+        fn parameters_schema(&self) -> serde_json::Value {
+            serde_json::json!({})
+        }
+
+        async fn execute(&self, p: serde_json::Value) -> anyhow::Result<serde_json::Value> {
+            Ok(p)
+        }
+    }
+
+    registry.register(Box::new(DummyTool));
+    registry.register(Box::new(EchoTool));
+
+    let filtered = registry.clone_without(&["spawn_agent"]);
+    assert!(filtered.get("spawn_agent").is_none());
+    assert!(filtered.get("echo").is_some());
+
+    // Also verify schemas don't include spawn_agent.
+    let schemas = filtered.list_schemas();
+    assert_eq!(schemas.len(), 1);
+    assert_eq!(schemas[0]["name"], "echo");
+
+    // Ensure original is unaffected.
+    assert!(registry.get("spawn_agent").is_some());
+
+    // The SpawnAgentTool itself should work with the filtered registry.
+    let spawn_tool =
+        SpawnAgentTool::new(make_empty_provider_registry(), provider, Arc::new(registry));
+    let result = spawn_tool
+        .execute(serde_json::json!({ "task": "test" }))
+        .await
+        .unwrap();
+    assert_eq!(result["text"], "ok");
+}
+
+#[tokio::test]
+async fn test_context_passed_to_sub_agent() {
+    let (provider, _) = MockProvider::with_capture("done with context", "mock");
+    let spawn_tool = SpawnAgentTool::new(
+        make_empty_provider_registry(),
+        provider,
+        Arc::new(ToolRegistry::new()),
+    );
+
+    let params = serde_json::json!({
+        "task": "analyze code",
+        "context": "The code is in src/main.rs",
+    });
+    let result = spawn_tool.execute(params).await.unwrap();
+    assert_eq!(result["text"], "done with context");
+}
+
+#[tokio::test]
+async fn test_null_optional_array_params_are_treated_as_absent() {
+    let (provider, seen_tool_names) = MockProvider::with_capture("done", "mock");
+    let spawn_tool = SpawnAgentTool::new(
+        make_empty_provider_registry(),
+        provider,
+        registry_with_tools(&["spawn_agent", "exec", "web_fetch", "task_list"]),
+    );
+
+    let params = serde_json::json!({
+        "task": "analyze code",
+        "allow_tools": null,
+        "deny_tools": null,
+        "context": null,
+        "model": null,
+        "preset": null,
+        "delegate_only": null,
+    });
+    let result = spawn_tool.execute(params).await.unwrap();
+    assert_eq!(result["text"], "done");
+    let mut seen = seen_tool_names.lock().unwrap().clone();
+    seen.sort();
+    assert_eq!(seen, vec![
+        "exec".to_string(),
+        "task_list".to_string(),
+        "web_fetch".to_string(),
+    ]);
+}
+
+#[tokio::test]
+async fn test_missing_task_parameter() {
+    let (provider, _) = MockProvider::with_capture("nope", "mock");
+    let spawn_tool = SpawnAgentTool::new(
+        make_empty_provider_registry(),
+        provider,
+        Arc::new(ToolRegistry::new()),
+    );
+
+    let result = spawn_tool.execute(serde_json::json!({})).await;
+    assert!(result.is_err());
+    assert!(result.unwrap_err().to_string().contains("task"));
+}
+
+#[tokio::test]
+async fn test_build_sub_tools_applies_allow_and_deny() {
+    let (provider, _) = MockProvider::with_capture("ok", "mock");
+    let spawn_tool = SpawnAgentTool::new(
+        make_empty_provider_registry(),
+        provider,
+        registry_with_tools(&["spawn_agent", "exec", "web_fetch", "task_list"]),
+    );
+
+    let filtered = spawn_tool.build_sub_tools(
+        &[
+            "exec".to_string(),
+            "task_list".to_string(),
+            "spawn_agent".to_string(),
+        ],
+        &["task_list".to_string()],
+        false,
+    );
+    assert!(filtered.get("exec").is_some());
+    assert!(filtered.get("task_list").is_none());
+    assert!(filtered.get("spawn_agent").is_none());
+    assert!(filtered.get("web_fetch").is_none());
+}
+
+#[tokio::test]
+async fn test_build_sub_tools_delegate_only_uses_delegate_set() {
+    let (provider, _) = MockProvider::with_capture("ok", "mock");
+    let spawn_tool = SpawnAgentTool::new(
+        make_empty_provider_registry(),
+        provider,
+        registry_with_tools(&[
+            "spawn_agent",
+            "spawn_status",
+            "spawn_result",
+            "spawn_list",
+            "cancel_spawn",
+            "sessions_list",
+            "sessions_history",
+            "sessions_send",
+            "task_list",
+            "exec",
+        ]),
+    );
+
+    let filtered = spawn_tool.build_sub_tools(&[], &[], true);
+    assert!(filtered.get("spawn_agent").is_some());
+    assert!(filtered.get("spawn_status").is_some());
+    assert!(filtered.get("spawn_result").is_some());
+    assert!(filtered.get("spawn_list").is_some());
+    assert!(filtered.get("cancel_spawn").is_some());
+    assert!(filtered.get("sessions_list").is_some());
+    assert!(filtered.get("sessions_history").is_some());
+    assert!(filtered.get("sessions_send").is_some());
+    assert!(filtered.get("task_list").is_some());
+    assert!(filtered.get("exec").is_none());
+}
+
+#[tokio::test]
+async fn test_delegate_only_injects_spawn_agent_with_shared_task_store() {
+    let (provider, _) = MockProvider::with_capture("nested result", "mock");
+    let store = Arc::new(SpawnTaskStore::default());
+    let registry = registry_with_tools(&["spawn_status", "spawn_result", "spawn_list"]);
+    let spawn_tool = SpawnAgentTool::new(make_empty_provider_registry(), provider, registry)
+        .with_task_store(Arc::clone(&store));
+
+    let filtered = spawn_tool.build_sub_tools(&[], &[], true);
+    let nested_spawn = filtered.get("spawn_agent").expect("injected spawn_agent");
+    let result = nested_spawn
+        .execute(serde_json::json!({
+            "task": "nested background task",
+            "nonblocking": true,
+            "_session_key": "session-a",
+        }))
+        .await
+        .unwrap();
+    let task_id = result["task_id"].as_str().unwrap();
+
+    let result_tool = SpawnResultTool::new(store);
+    let mut final_result = serde_json::Value::Null;
+    for _ in 0..20 {
+        final_result = result_tool
+            .execute(serde_json::json!({
+                "task_id": task_id,
+                "_session_key": "session-a",
+            }))
+            .await
+            .unwrap();
+        if final_result["status"] == "completed" {
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+    }
+
+    assert_eq!(final_result["status"], "completed");
+    assert_eq!(final_result["text"], "nested result");
+}
+
+#[tokio::test]
+async fn test_resolve_preset_uses_explicit_name() {
+    let (provider, _) = MockProvider::with_capture("ok", "mock");
+    let spawn_tool = SpawnAgentTool::new(
+        make_empty_provider_registry(),
+        provider,
+        Arc::new(ToolRegistry::new()),
+    )
+    .with_agents_config(agents_config_with_presets(Some("default"), &[(
+        "research",
+        AgentPreset {
+            delegate_only: true,
+            ..Default::default()
+        },
+    )]));
+
+    let (name, preset) = spawn_tool
+        .resolve_preset(&serde_json::json!({ "preset": "research" }))
+        .await
+        .expect("resolve preset");
+    assert_eq!(name.as_deref(), Some("research"));
+    assert_eq!(preset.as_ref().map(|p| p.delegate_only), Some(true));
+}
+
+#[tokio::test]
+async fn test_resolve_preset_uses_default_when_missing() {
+    let (provider, _) = MockProvider::with_capture("ok", "mock");
+    let spawn_tool = SpawnAgentTool::new(
+        make_empty_provider_registry(),
+        provider,
+        Arc::new(ToolRegistry::new()),
+    )
+    .with_agents_config(agents_config_with_presets(Some("default"), &[(
+        "default",
+        AgentPreset {
+            tools: PresetToolPolicy {
+                allow: vec!["task_list".to_string()],
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+    )]));
+
+    let (name, preset) = spawn_tool
+        .resolve_preset(&serde_json::json!({}))
+        .await
+        .expect("resolve default preset");
+    assert_eq!(name.as_deref(), Some("default"));
+    assert_eq!(
+        preset
+            .as_ref()
+            .map(|p| p.tools.allow.clone())
+            .unwrap_or_default(),
+        vec!["task_list".to_string()]
+    );
+}
+
+#[tokio::test]
+async fn test_resolve_preset_errors_when_name_missing() {
+    let (provider, _) = MockProvider::with_capture("ok", "mock");
+    let spawn_tool = SpawnAgentTool::new(
+        make_empty_provider_registry(),
+        provider,
+        Arc::new(ToolRegistry::new()),
+    )
+    .with_agents_config(agents_config_with_presets(None, &[]));
+
+    let result = spawn_tool
+        .resolve_preset(&serde_json::json!({ "preset": "missing" }))
+        .await;
+    assert!(result.is_err());
+    assert!(
+        result
+            .err()
+            .map(|e| e.to_string().contains("not found"))
+            .unwrap_or(false)
+    );
+}
+
+#[test]
+fn test_identity_injected_into_system_prompt() {
+    let preset = AgentPreset {
+        identity: AgentIdentity {
+            name: Some("scout".into()),
+            emoji: Some("🔍".into()),
+            theme: Some("thorough".into()),
+        },
+        system_prompt_suffix: Some("Focus on accuracy.".into()),
+        ..Default::default()
+    };
+
+    let prompt = build_sub_agent_prompt("find bugs", "in main.rs", Some(&preset), Some("scout"));
+
+    assert!(prompt.contains("You are scout (🔍)"));
+    assert!(prompt.contains("Your style is thorough"));
+    assert!(prompt.contains("Task: find bugs"));
+    assert!(prompt.contains("Context: in main.rs"));
+    assert!(prompt.contains("Focus on accuracy."));
+}
+
+#[test]
+fn test_no_identity_uses_default_prompt() {
+    let prompt = build_sub_agent_prompt("do work", "", None, None);
+
+    assert!(prompt.contains("You are a sub-agent"));
+    assert!(prompt.contains("Task: do work"));
+    assert!(!prompt.contains("Context:"));
+}
+
+#[test]
+fn test_memory_injected_into_system_prompt() {
+    let dir = tempfile::tempdir().unwrap();
+    let memory_dir = dir.path().join("agent-memory").join("researcher");
+    std::fs::create_dir_all(&memory_dir).unwrap();
+    std::fs::write(
+        memory_dir.join("MEMORY.md"),
+        "- Always check edge cases\n- Prefer iterators",
+    )
+    .unwrap();
+
+    // Load memory directly to verify the function works.
+    let content = load_memory_from_dir(&memory_dir, 200);
+    assert!(content.is_some());
+    let content = content.unwrap();
+    assert!(content.contains("Always check edge cases"));
+    assert!(content.contains("Prefer iterators"));
+}
+
+#[test]
+fn test_load_memory_truncates() {
+    let dir = tempfile::tempdir().unwrap();
+    let memory_dir = dir.path();
+    let lines: Vec<String> = (0..10).map(|i| format!("Line {i}")).collect();
+    std::fs::write(memory_dir.join("MEMORY.md"), lines.join("\n")).unwrap();
+
+    let content = load_memory_from_dir(memory_dir, 3).unwrap();
+    assert!(content.contains("Line 0"));
+    assert!(content.contains("Line 2"));
+    assert!(!content.contains("Line 3"));
+}
+
+#[test]
+fn test_load_memory_empty_returns_none() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("MEMORY.md"), "   \n  \n").unwrap();
+
+    let content = load_memory_from_dir(dir.path(), 200);
+    assert!(content.is_none());
+}
+
+#[test]
+fn test_load_memory_missing_file_returns_none() {
+    let dir = tempfile::tempdir().unwrap();
+    let content = load_memory_from_dir(dir.path(), 200);
+    assert!(content.is_none());
+}
+
+#[tokio::test]
+async fn test_timeout_cancels_long_running_agent() {
+    // Mock provider with a slow response.
+    struct SlowProvider;
+
+    #[async_trait]
+    impl LlmProvider for SlowProvider {
+        fn name(&self) -> &str {
+            "slow"
+        }
+
+        fn id(&self) -> &str {
+            "slow-model"
+        }
+
+        async fn complete(
+            &self,
+            _messages: &[ChatMessage],
+            _tools: &[serde_json::Value],
+        ) -> anyhow::Result<CompletionResponse> {
+            tokio::time::sleep(std::time::Duration::from_secs(10)).await;
+            Ok(CompletionResponse {
+                text: Some("too late".into()),
+                tool_calls: vec![],
+                usage: Usage::default(),
+            })
+        }
+
+        fn stream(
+            &self,
+            _messages: Vec<ChatMessage>,
+        ) -> Pin<Box<dyn Stream<Item = StreamEvent> + Send + '_>> {
+            Box::pin(tokio_stream::empty())
+        }
+    }
+
+    let provider: Arc<dyn LlmProvider> = Arc::new(SlowProvider);
+    let spawn_tool = SpawnAgentTool::new(
+        make_empty_provider_registry(),
+        provider,
+        Arc::new(ToolRegistry::new()),
+    )
+    .with_agents_config(agents_config_with_presets(None, &[("slow", AgentPreset {
+        timeout_secs: Some(1),
+        ..Default::default()
+    })]));
+
+    let params = serde_json::json!({
+        "task": "do something slowly",
+        "preset": "slow",
+    });
+    let result = spawn_tool.execute(params).await;
+    assert!(result.is_err());
+    assert!(result.unwrap_err().to_string().contains("timed out"));
+}

--- a/docs/src/session-tools.md
+++ b/docs/src/session-tools.md
@@ -85,8 +85,9 @@ When no policy is configured, all sessions are visible and sendable.
 
 Use `spawn_agent` when work is short-lived and synchronous. For longer delegated
 work, call `spawn_agent` with `nonblocking: true`; it returns a `task_id` while
-the sub-agent continues in the background. Use `spawn_status` to check progress
-and `spawn_result` to fetch the final output.
+the sub-agent continues in the background. Use `spawn_status` to check progress,
+`spawn_result` to fetch the final output, and `spawn_list` to recover task IDs
+after context loss.
 
 Use session tools when you need:
 

--- a/docs/src/session-tools.md
+++ b/docs/src/session-tools.md
@@ -86,8 +86,8 @@ When no policy is configured, all sessions are visible and sendable.
 Use `spawn_agent` when work is short-lived and synchronous. For longer delegated
 work, call `spawn_agent` with `nonblocking: true`; it returns a `task_id` while
 the sub-agent continues in the background. Use `spawn_status` to check progress,
-`spawn_result` to fetch the final output, and `spawn_list` to recover task IDs
-after context loss.
+`spawn_result` to fetch the final output, `spawn_list` to recover task IDs after
+context loss, and `cancel_spawn` to stop work that is no longer needed.
 
 Use session tools when you need:
 

--- a/docs/src/session-tools.md
+++ b/docs/src/session-tools.md
@@ -83,7 +83,10 @@ When no policy is configured, all sessions are visible and sendable.
 
 ## Coordination Patterns
 
-Use `spawn_agent` when work is short-lived and synchronous.
+Use `spawn_agent` when work is short-lived and synchronous. For longer delegated
+work, call `spawn_agent` with `nonblocking: true`; it returns a `task_id` while
+the sub-agent continues in the background. Use `spawn_status` to check progress
+and `spawn_result` to fetch the final output.
 
 Use session tools when you need:
 


### PR DESCRIPTION
## Summary
- Add `spawn_agent` `nonblocking: true` mode that returns a task handle while the sub-agent continues in the background.
- Add `spawn_status`, `spawn_result`, `spawn_list`, and `cancel_spawn` tools backed by a shared task store with session-key access checks.
- Harden background task lifecycle with panic handling, cancellation, metrics, configurable retention windows, stale-running cleanup, and delegate/nested coordinator coverage.
- Document the non-blocking coordination pattern for longer delegated work.

## Validation
### Completed
- [x] `cargo test -p moltis-tools spawn_agent`
- [x] `cargo fmt --all -- --check`
- [x] `cargo check -p moltis-gateway`
- [x] `cargo check -p moltis-tools --features metrics`
- [x] `./scripts/check-file-size.sh`

### Remaining
- [ ] Full `just lint`
- [ ] Full `just test`

## Manual QA
- Not run; covered by targeted Rust regression tests for immediate return, status/result retrieval, persisted failure, cancellation/access denial, delegate-only nested polling, schema coverage, stale cleanup, and session-key denial.