### PR TITLE
Fix Docker build failures

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,11 @@ COPY crates ./crates
 COPY apps/courier ./apps/courier
 COPY scripts ./scripts
 COPY wit ./wit
+# docs/src is embedded into moltis-agents via include_dir! (crates/agents/src/docs.rs).
+# CHANGELOG.md is the target of the docs/src/changelog.md symlink, so it must be
+# present at the repo root for that symlink to resolve during the embed.
+COPY CHANGELOG.md ./CHANGELOG.md
+COPY docs/src ./docs/src
 
 ENV DEBIAN_FRONTEND=noninteractive
 # Install build dependencies for llama-cpp-sys-2


### PR DESCRIPTION
Without this Docker builds fail similar to:
```
   Compiling moltis-agents v0.1.0 (/build/crates/agents)
error: proc macro panicked
  --> crates/agents/src/docs.rs:18:32
   |
18 | static BUNDLED_DOCS: Dir<'_> = include_dir!("$CARGO_MANIFEST_DIR/../../docs/src");
   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = help: message: "/build/crates/agents/../../docs/src/changelog.md" is neither a file nor a directory

error: could not compile `moltis-agents` (lib) due to 1 previous error
warning: build failed, waiting for other jobs to finish...
Error: building at STEP "RUN ./scripts/cargo-build-moltis.sh --release": while running runtime: exit status 101
```