### PR TITLE
fix(providers): strip MiniMax user names

### DIFF
--- a/crates/providers/src/model_catalogs.rs
+++ b/crates/providers/src/model_catalogs.rs
@@ -1,5 +1,7 @@
 //! Static model catalogs and OpenAI-compatible provider definitions.
 
+use crate::openai::SystemMessageRewriteStrategy;
+
 /// Known Anthropic Claude models (model_id, display_name).
 /// Current models listed first, then legacy models.
 pub(crate) const ANTHROPIC_MODELS: &[(&str, &str)] = &[
@@ -180,6 +182,18 @@ pub(crate) struct OpenAiCompatDef {
     pub(crate) local_only: bool,
     /// Whether this provider accepts the OpenAI-compatible `name` field on user messages.
     pub(crate) supports_user_name: bool,
+    /// Default strict tool schema mode before config overrides.
+    pub(crate) default_strict_tools: bool,
+    /// Whether assistant tool-call messages need `reasoning_content` on replay.
+    pub(crate) default_reasoning_content_on_tool_messages: bool,
+    /// Whether this provider rejects `null` entries inside JSON Schema enum arrays.
+    pub(crate) rejects_null_in_enums: bool,
+    /// Whether provider metadata should be nested as Gemini `extra_content`.
+    pub(crate) requires_gemini_tool_call_extra_content: bool,
+    /// Provider-specific system-message rewrite behavior.
+    pub(crate) system_message_rewrite: SystemMessageRewriteStrategy,
+    /// Whether Qwen-family models on this provider need one leading system message.
+    pub(crate) qwen_models_require_single_leading_system: bool,
 }
 
 impl OpenAiCompatDef {
@@ -193,6 +207,12 @@ impl OpenAiCompatDef {
         requires_api_key: true,
         local_only: false,
         supports_user_name: true,
+        default_strict_tools: true,
+        default_reasoning_content_on_tool_messages: false,
+        rejects_null_in_enums: false,
+        requires_gemini_tool_call_extra_content: false,
+        system_message_rewrite: SystemMessageRewriteStrategy::None,
+        qwen_models_require_single_leading_system: false,
     };
 }
 
@@ -211,6 +231,7 @@ pub(crate) const OPENAI_COMPAT_PROVIDERS: &[OpenAiCompatDef] = &[
         env_key: "OPENROUTER_API_KEY",
         env_base_url_key: "OPENROUTER_BASE_URL",
         default_base_url: "https://openrouter.ai/api/v1",
+        default_strict_tools: false,
         ..OpenAiCompatDef::DEFAULT
     },
     OpenAiCompatDef {
@@ -230,6 +251,7 @@ pub(crate) const OPENAI_COMPAT_PROVIDERS: &[OpenAiCompatDef] = &[
         // MiniMax API does not expose a /models endpoint (returns 404).
         supports_model_discovery: false,
         supports_user_name: false,
+        system_message_rewrite: SystemMessageRewriteStrategy::InlineIntoFirstUser,
         ..OpenAiCompatDef::DEFAULT
     },
     OpenAiCompatDef {
@@ -238,6 +260,7 @@ pub(crate) const OPENAI_COMPAT_PROVIDERS: &[OpenAiCompatDef] = &[
         env_base_url_key: "MOONSHOT_BASE_URL",
         default_base_url: "https://api.moonshot.ai/v1",
         models: MOONSHOT_MODELS,
+        default_reasoning_content_on_tool_messages: true,
         ..OpenAiCompatDef::DEFAULT
     },
     OpenAiCompatDef {
@@ -285,6 +308,7 @@ pub(crate) const OPENAI_COMPAT_PROVIDERS: &[OpenAiCompatDef] = &[
         env_base_url_key: "FIREWORKS_BASE_URL",
         default_base_url: "https://api.fireworks.ai/inference/v1",
         models: FIREWORKS_MODELS,
+        rejects_null_in_enums: true,
         ..OpenAiCompatDef::DEFAULT
     },
     OpenAiCompatDef {
@@ -294,6 +318,7 @@ pub(crate) const OPENAI_COMPAT_PROVIDERS: &[OpenAiCompatDef] = &[
         default_base_url: "http://localhost:11434/v1",
         requires_api_key: false,
         local_only: true,
+        qwen_models_require_single_leading_system: true,
         ..OpenAiCompatDef::DEFAULT
     },
     OpenAiCompatDef {
@@ -311,6 +336,7 @@ pub(crate) const OPENAI_COMPAT_PROVIDERS: &[OpenAiCompatDef] = &[
         env_base_url_key: "ALIBABA_CODING_BASE_URL",
         default_base_url: "https://coding-intl.dashscope.aliyuncs.com/v1",
         models: ALIBABA_CODING_MODELS,
+        qwen_models_require_single_leading_system: true,
         ..OpenAiCompatDef::DEFAULT
     },
     OpenAiCompatDef {
@@ -319,6 +345,8 @@ pub(crate) const OPENAI_COMPAT_PROVIDERS: &[OpenAiCompatDef] = &[
         env_base_url_key: "GEMINI_BASE_URL",
         default_base_url: "https://generativelanguage.googleapis.com/v1beta/openai",
         models: GEMINI_MODELS,
+        default_strict_tools: false,
+        requires_gemini_tool_call_extra_content: true,
         ..OpenAiCompatDef::DEFAULT
     },
 ];

--- a/crates/providers/src/model_catalogs.rs
+++ b/crates/providers/src/model_catalogs.rs
@@ -300,6 +300,7 @@ pub(crate) const OPENAI_COMPAT_PROVIDERS: &[OpenAiCompatDef] = &[
         env_base_url_key: "DEEPSEEK_BASE_URL",
         default_base_url: "https://api.deepseek.com",
         models: DEEPSEEK_MODELS,
+        default_reasoning_content_on_tool_messages: true,
         ..OpenAiCompatDef::DEFAULT
     },
     OpenAiCompatDef {
@@ -462,6 +463,16 @@ mod tests {
 
         assert!(!mistral.supports_user_name);
         assert!(!minimax.supports_user_name);
+    }
+
+    #[test]
+    fn deepseek_preserves_reasoning_content_for_v4_tool_replay() {
+        let deepseek = OPENAI_COMPAT_PROVIDERS
+            .iter()
+            .find(|d| d.config_name == "deepseek")
+            .expect("deepseek entry must exist");
+
+        assert!(deepseek.default_reasoning_content_on_tool_messages);
     }
 
     #[test]

--- a/crates/providers/src/model_catalogs.rs
+++ b/crates/providers/src/model_catalogs.rs
@@ -186,6 +186,8 @@ pub(crate) struct OpenAiCompatDef {
     pub(crate) default_strict_tools: bool,
     /// Whether assistant tool-call messages need `reasoning_content` on replay.
     pub(crate) default_reasoning_content_on_tool_messages: bool,
+    /// Raw model-id prefixes that need `reasoning_content` on tool-call replay.
+    pub(crate) reasoning_content_model_prefixes: &'static [&'static str],
     /// Whether this provider rejects `null` entries inside JSON Schema enum arrays.
     pub(crate) rejects_null_in_enums: bool,
     /// Whether provider metadata should be nested as Gemini `extra_content`.
@@ -209,6 +211,7 @@ impl OpenAiCompatDef {
         supports_user_name: true,
         default_strict_tools: true,
         default_reasoning_content_on_tool_messages: false,
+        reasoning_content_model_prefixes: &[],
         rejects_null_in_enums: false,
         requires_gemini_tool_call_extra_content: false,
         system_message_rewrite: SystemMessageRewriteStrategy::None,
@@ -300,7 +303,7 @@ pub(crate) const OPENAI_COMPAT_PROVIDERS: &[OpenAiCompatDef] = &[
         env_base_url_key: "DEEPSEEK_BASE_URL",
         default_base_url: "https://api.deepseek.com",
         models: DEEPSEEK_MODELS,
-        default_reasoning_content_on_tool_messages: true,
+        reasoning_content_model_prefixes: &["deepseek-v4"],
         ..OpenAiCompatDef::DEFAULT
     },
     OpenAiCompatDef {
@@ -466,13 +469,14 @@ mod tests {
     }
 
     #[test]
-    fn deepseek_preserves_reasoning_content_for_v4_tool_replay() {
+    fn deepseek_preserves_reasoning_content_only_for_v4_tool_replay() {
         let deepseek = OPENAI_COMPAT_PROVIDERS
             .iter()
             .find(|d| d.config_name == "deepseek")
             .expect("deepseek entry must exist");
 
-        assert!(deepseek.default_reasoning_content_on_tool_messages);
+        assert!(!deepseek.default_reasoning_content_on_tool_messages);
+        assert_eq!(deepseek.reasoning_content_model_prefixes, &["deepseek-v4"]);
     }
 
     #[test]

--- a/crates/providers/src/model_catalogs.rs
+++ b/crates/providers/src/model_catalogs.rs
@@ -178,6 +178,22 @@ pub(crate) struct OpenAiCompatDef {
     /// Also ensures model discovery is always attempted (never short-circuited
     /// by the empty-catalog heuristic).
     pub(crate) local_only: bool,
+    /// Whether this provider accepts the OpenAI-compatible `name` field on user messages.
+    pub(crate) supports_user_name: bool,
+}
+
+impl OpenAiCompatDef {
+    const DEFAULT: Self = Self {
+        config_name: "",
+        env_key: "",
+        env_base_url_key: "",
+        default_base_url: "",
+        models: &[],
+        supports_model_discovery: true,
+        requires_api_key: true,
+        local_only: false,
+        supports_user_name: true,
+    };
 }
 
 pub(crate) const OPENAI_COMPAT_PROVIDERS: &[OpenAiCompatDef] = &[
@@ -187,19 +203,15 @@ pub(crate) const OPENAI_COMPAT_PROVIDERS: &[OpenAiCompatDef] = &[
         env_base_url_key: "MISTRAL_BASE_URL",
         default_base_url: "https://api.mistral.ai/v1",
         models: MISTRAL_MODELS,
-        supports_model_discovery: true,
-        requires_api_key: true,
-        local_only: false,
+        supports_user_name: false,
+        ..OpenAiCompatDef::DEFAULT
     },
     OpenAiCompatDef {
         config_name: "openrouter",
         env_key: "OPENROUTER_API_KEY",
         env_base_url_key: "OPENROUTER_BASE_URL",
         default_base_url: "https://openrouter.ai/api/v1",
-        models: &[],
-        supports_model_discovery: true,
-        requires_api_key: true,
-        local_only: false,
+        ..OpenAiCompatDef::DEFAULT
     },
     OpenAiCompatDef {
         config_name: "cerebras",
@@ -207,9 +219,7 @@ pub(crate) const OPENAI_COMPAT_PROVIDERS: &[OpenAiCompatDef] = &[
         env_base_url_key: "CEREBRAS_BASE_URL",
         default_base_url: "https://api.cerebras.ai/v1",
         models: CEREBRAS_MODELS,
-        supports_model_discovery: true,
-        requires_api_key: true,
-        local_only: false,
+        ..OpenAiCompatDef::DEFAULT
     },
     OpenAiCompatDef {
         config_name: "minimax",
@@ -219,8 +229,8 @@ pub(crate) const OPENAI_COMPAT_PROVIDERS: &[OpenAiCompatDef] = &[
         models: MINIMAX_MODELS,
         // MiniMax API does not expose a /models endpoint (returns 404).
         supports_model_discovery: false,
-        requires_api_key: true,
-        local_only: false,
+        supports_user_name: false,
+        ..OpenAiCompatDef::DEFAULT
     },
     OpenAiCompatDef {
         config_name: "moonshot",
@@ -228,9 +238,7 @@ pub(crate) const OPENAI_COMPAT_PROVIDERS: &[OpenAiCompatDef] = &[
         env_base_url_key: "MOONSHOT_BASE_URL",
         default_base_url: "https://api.moonshot.ai/v1",
         models: MOONSHOT_MODELS,
-        supports_model_discovery: true,
-        requires_api_key: true,
-        local_only: false,
+        ..OpenAiCompatDef::DEFAULT
     },
     OpenAiCompatDef {
         config_name: "zai",
@@ -238,9 +246,7 @@ pub(crate) const OPENAI_COMPAT_PROVIDERS: &[OpenAiCompatDef] = &[
         env_base_url_key: "Z_BASE_URL",
         default_base_url: "https://api.z.ai/api/paas/v4",
         models: ZAI_MODELS,
-        supports_model_discovery: true,
-        requires_api_key: true,
-        local_only: false,
+        ..OpenAiCompatDef::DEFAULT
     },
     OpenAiCompatDef {
         config_name: "zai-code",
@@ -248,19 +254,14 @@ pub(crate) const OPENAI_COMPAT_PROVIDERS: &[OpenAiCompatDef] = &[
         env_base_url_key: "Z_CODE_BASE_URL",
         default_base_url: "https://api.z.ai/api/coding/paas/v4",
         models: ZAI_MODELS,
-        supports_model_discovery: true,
-        requires_api_key: true,
-        local_only: false,
+        ..OpenAiCompatDef::DEFAULT
     },
     OpenAiCompatDef {
         config_name: "venice",
         env_key: "VENICE_API_KEY",
         env_base_url_key: "VENICE_BASE_URL",
         default_base_url: "https://api.venice.ai/api/v1",
-        models: &[],
-        supports_model_discovery: true,
-        requires_api_key: true,
-        local_only: false,
+        ..OpenAiCompatDef::DEFAULT
     },
     OpenAiCompatDef {
         config_name: "deepinfra",
@@ -268,9 +269,7 @@ pub(crate) const OPENAI_COMPAT_PROVIDERS: &[OpenAiCompatDef] = &[
         env_base_url_key: "DEEPINFRA_BASE_URL",
         default_base_url: "https://api.deepinfra.com/v1/openai",
         models: DEEPINFRA_MODELS,
-        supports_model_discovery: true,
-        requires_api_key: true,
-        local_only: false,
+        ..OpenAiCompatDef::DEFAULT
     },
     OpenAiCompatDef {
         config_name: "deepseek",
@@ -278,9 +277,7 @@ pub(crate) const OPENAI_COMPAT_PROVIDERS: &[OpenAiCompatDef] = &[
         env_base_url_key: "DEEPSEEK_BASE_URL",
         default_base_url: "https://api.deepseek.com",
         models: DEEPSEEK_MODELS,
-        supports_model_discovery: true,
-        requires_api_key: true,
-        local_only: false,
+        ..OpenAiCompatDef::DEFAULT
     },
     OpenAiCompatDef {
         config_name: "fireworks",
@@ -288,29 +285,25 @@ pub(crate) const OPENAI_COMPAT_PROVIDERS: &[OpenAiCompatDef] = &[
         env_base_url_key: "FIREWORKS_BASE_URL",
         default_base_url: "https://api.fireworks.ai/inference/v1",
         models: FIREWORKS_MODELS,
-        supports_model_discovery: true,
-        requires_api_key: true,
-        local_only: false,
+        ..OpenAiCompatDef::DEFAULT
     },
     OpenAiCompatDef {
         config_name: "ollama",
         env_key: "OLLAMA_API_KEY",
         env_base_url_key: "OLLAMA_BASE_URL",
         default_base_url: "http://localhost:11434/v1",
-        models: &[],
-        supports_model_discovery: true,
         requires_api_key: false,
         local_only: true,
+        ..OpenAiCompatDef::DEFAULT
     },
     OpenAiCompatDef {
         config_name: "lmstudio",
         env_key: "LMSTUDIO_API_KEY",
         env_base_url_key: "LMSTUDIO_BASE_URL",
         default_base_url: "http://127.0.0.1:1234/v1",
-        models: &[],
-        supports_model_discovery: true,
         requires_api_key: false,
         local_only: true,
+        ..OpenAiCompatDef::DEFAULT
     },
     OpenAiCompatDef {
         config_name: "alibaba-coding",
@@ -318,9 +311,7 @@ pub(crate) const OPENAI_COMPAT_PROVIDERS: &[OpenAiCompatDef] = &[
         env_base_url_key: "ALIBABA_CODING_BASE_URL",
         default_base_url: "https://coding-intl.dashscope.aliyuncs.com/v1",
         models: ALIBABA_CODING_MODELS,
-        supports_model_discovery: true,
-        requires_api_key: true,
-        local_only: false,
+        ..OpenAiCompatDef::DEFAULT
     },
     OpenAiCompatDef {
         config_name: "gemini",
@@ -328,9 +319,7 @@ pub(crate) const OPENAI_COMPAT_PROVIDERS: &[OpenAiCompatDef] = &[
         env_base_url_key: "GEMINI_BASE_URL",
         default_base_url: "https://generativelanguage.googleapis.com/v1beta/openai",
         models: GEMINI_MODELS,
-        supports_model_discovery: true,
-        requires_api_key: true,
-        local_only: false,
+        ..OpenAiCompatDef::DEFAULT
     },
 ];
 
@@ -430,6 +419,21 @@ mod tests {
                 def.config_name
             );
         }
+    }
+
+    #[test]
+    fn strict_name_providers_disable_user_names() {
+        let mistral = OPENAI_COMPAT_PROVIDERS
+            .iter()
+            .find(|d| d.config_name == "mistral")
+            .expect("mistral entry must exist");
+        let minimax = OPENAI_COMPAT_PROVIDERS
+            .iter()
+            .find(|d| d.config_name == "minimax")
+            .expect("minimax entry must exist");
+
+        assert!(!mistral.supports_user_name);
+        assert!(!minimax.supports_user_name);
     }
 
     #[test]

--- a/crates/providers/src/openai/mod.rs
+++ b/crates/providers/src/openai/mod.rs
@@ -40,6 +40,8 @@ pub struct OpenAiProvider {
     default_strict_tools: bool,
     /// Whether assistant tool-call messages need `reasoning_content` on replay.
     default_reasoning_content_on_tool_messages: bool,
+    /// Raw model-id prefixes that need `reasoning_content` on tool-call replay.
+    reasoning_content_model_prefixes: &'static [&'static str],
     /// Whether this provider rejects `null` entries in JSON Schema enum arrays.
     rejects_null_in_enums: bool,
     /// Whether tool-call metadata should be nested as Gemini extra_content.

--- a/crates/providers/src/openai/mod.rs
+++ b/crates/providers/src/openai/mod.rs
@@ -11,6 +11,13 @@ pub use {
 
 use moltis_agents::model::ModelMetadata;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SystemMessageRewriteStrategy {
+    None,
+    MergeLeadingSystem,
+    InlineIntoFirstUser,
+}
+
 pub struct OpenAiProvider {
     api_key: secrecy::Secret<String>,
     model: String,
@@ -29,6 +36,18 @@ pub struct OpenAiProvider {
     strict_tools_override: Option<bool>,
     /// Explicit override for reasoning_content requirement. `None` = auto-detect.
     reasoning_content_override: Option<bool>,
+    /// Default strict tool schema mode for this provider.
+    default_strict_tools: bool,
+    /// Whether assistant tool-call messages need `reasoning_content` on replay.
+    default_reasoning_content_on_tool_messages: bool,
+    /// Whether this provider rejects `null` entries in JSON Schema enum arrays.
+    rejects_null_in_enums: bool,
+    /// Whether tool-call metadata should be nested as Gemini extra_content.
+    requires_gemini_tool_call_extra_content: bool,
+    /// Provider-specific system-message rewrite behavior.
+    system_message_rewrite_strategy: SystemMessageRewriteStrategy,
+    /// Whether Qwen-family models on this provider need one leading system message.
+    qwen_models_require_single_leading_system: bool,
     /// Global per-model context window overrides from `[models.<id>]` config.
     context_window_global: std::collections::HashMap<String, u32>,
     /// Provider-scoped per-model context window overrides from

--- a/crates/providers/src/openai/provider/core.rs
+++ b/crates/providers/src/openai/provider/core.rs
@@ -19,7 +19,7 @@ use moltis_agents::model::{
     ToolChoice,
 };
 
-use super::super::OpenAiProvider;
+use super::super::{OpenAiProvider, SystemMessageRewriteStrategy};
 
 impl OpenAiProvider {
     pub fn new(api_key: secrecy::Secret<String>, model: String, base_url: String) -> Self {
@@ -37,6 +37,12 @@ impl OpenAiProvider {
             cache_retention: moltis_config::CacheRetention::Short,
             strict_tools_override: None,
             reasoning_content_override: None,
+            default_strict_tools: true,
+            default_reasoning_content_on_tool_messages: false,
+            rejects_null_in_enums: false,
+            requires_gemini_tool_call_extra_content: false,
+            system_message_rewrite_strategy: SystemMessageRewriteStrategy::None,
+            qwen_models_require_single_leading_system: false,
             context_window_global: std::collections::HashMap::new(),
             context_window_provider: std::collections::HashMap::new(),
             supports_user_name: true,
@@ -64,6 +70,12 @@ impl OpenAiProvider {
             cache_retention: moltis_config::CacheRetention::Short,
             strict_tools_override: None,
             reasoning_content_override: None,
+            default_strict_tools: true,
+            default_reasoning_content_on_tool_messages: false,
+            rejects_null_in_enums: false,
+            requires_gemini_tool_call_extra_content: false,
+            system_message_rewrite_strategy: SystemMessageRewriteStrategy::None,
+            qwen_models_require_single_leading_system: false,
             context_window_global: std::collections::HashMap::new(),
             context_window_provider: std::collections::HashMap::new(),
             supports_user_name: true,
@@ -113,6 +125,45 @@ impl OpenAiProvider {
     #[must_use]
     pub fn with_supports_user_name(mut self, supported: bool) -> Self {
         self.supports_user_name = supported;
+        self
+    }
+
+    #[must_use]
+    pub(crate) fn with_default_strict_tools(mut self, strict: bool) -> Self {
+        self.default_strict_tools = strict;
+        self
+    }
+
+    #[must_use]
+    pub(crate) fn with_default_reasoning_content(mut self, required: bool) -> Self {
+        self.default_reasoning_content_on_tool_messages = required;
+        self
+    }
+
+    #[must_use]
+    pub(crate) fn with_rejects_null_in_enums(mut self, rejects: bool) -> Self {
+        self.rejects_null_in_enums = rejects;
+        self
+    }
+
+    #[must_use]
+    pub(crate) fn with_gemini_tool_call_extra_content(mut self, required: bool) -> Self {
+        self.requires_gemini_tool_call_extra_content = required;
+        self
+    }
+
+    #[must_use]
+    pub(crate) fn with_system_message_rewrite(
+        mut self,
+        strategy: SystemMessageRewriteStrategy,
+    ) -> Self {
+        self.system_message_rewrite_strategy = strategy;
+        self
+    }
+
+    #[must_use]
+    pub(crate) fn with_qwen_models_require_single_leading_system(mut self, required: bool) -> Self {
+        self.qwen_models_require_single_leading_system = required;
         self
     }
 
@@ -347,6 +398,14 @@ impl LlmProvider for OpenAiProvider {
             context_window_provider: self.context_window_provider.clone(),
             strict_tools_override: self.strict_tools_override,
             reasoning_content_override: self.reasoning_content_override,
+            default_strict_tools: self.default_strict_tools,
+            default_reasoning_content_on_tool_messages: self
+                .default_reasoning_content_on_tool_messages,
+            rejects_null_in_enums: self.rejects_null_in_enums,
+            requires_gemini_tool_call_extra_content: self.requires_gemini_tool_call_extra_content,
+            system_message_rewrite_strategy: self.system_message_rewrite_strategy,
+            qwen_models_require_single_leading_system: self
+                .qwen_models_require_single_leading_system,
             supports_user_name: self.supports_user_name,
             probe_timeout_secs: self.probe_timeout_secs,
         }))

--- a/crates/providers/src/openai/provider/core.rs
+++ b/crates/providers/src/openai/provider/core.rs
@@ -39,6 +39,7 @@ impl OpenAiProvider {
             reasoning_content_override: None,
             default_strict_tools: true,
             default_reasoning_content_on_tool_messages: false,
+            reasoning_content_model_prefixes: &[],
             rejects_null_in_enums: false,
             requires_gemini_tool_call_extra_content: false,
             system_message_rewrite_strategy: SystemMessageRewriteStrategy::None,
@@ -72,6 +73,7 @@ impl OpenAiProvider {
             reasoning_content_override: None,
             default_strict_tools: true,
             default_reasoning_content_on_tool_messages: false,
+            reasoning_content_model_prefixes: &[],
             rejects_null_in_enums: false,
             requires_gemini_tool_call_extra_content: false,
             system_message_rewrite_strategy: SystemMessageRewriteStrategy::None,
@@ -137,6 +139,15 @@ impl OpenAiProvider {
     #[must_use]
     pub(crate) fn with_default_reasoning_content(mut self, required: bool) -> Self {
         self.default_reasoning_content_on_tool_messages = required;
+        self
+    }
+
+    #[must_use]
+    pub(crate) fn with_reasoning_content_model_prefixes(
+        mut self,
+        prefixes: &'static [&'static str],
+    ) -> Self {
+        self.reasoning_content_model_prefixes = prefixes;
         self
     }
 
@@ -401,6 +412,7 @@ impl LlmProvider for OpenAiProvider {
             default_strict_tools: self.default_strict_tools,
             default_reasoning_content_on_tool_messages: self
                 .default_reasoning_content_on_tool_messages,
+            reasoning_content_model_prefixes: self.reasoning_content_model_prefixes,
             rejects_null_in_enums: self.rejects_null_in_enums,
             requires_gemini_tool_call_extra_content: self.requires_gemini_tool_call_extra_content,
             system_message_rewrite_strategy: self.system_message_rewrite_strategy,

--- a/crates/providers/src/openai/provider/core.rs
+++ b/crates/providers/src/openai/provider/core.rs
@@ -50,11 +50,6 @@ impl OpenAiProvider {
         base_url: String,
         provider_name: String,
     ) -> Self {
-        let base_url_lower = base_url.to_ascii_lowercase();
-        let supports_user_name = !provider_name.eq_ignore_ascii_case("mistral")
-            && !base_url_lower.contains("mistral.ai")
-            && !provider_name.eq_ignore_ascii_case("minimax")
-            && !base_url_lower.contains("minimax");
         Self {
             api_key,
             model,
@@ -71,7 +66,7 @@ impl OpenAiProvider {
             reasoning_content_override: None,
             context_window_global: std::collections::HashMap::new(),
             context_window_provider: std::collections::HashMap::new(),
-            supports_user_name,
+            supports_user_name: true,
             probe_timeout_secs: None,
         }
     }

--- a/crates/providers/src/openai/provider/core.rs
+++ b/crates/providers/src/openai/provider/core.rs
@@ -50,8 +50,11 @@ impl OpenAiProvider {
         base_url: String,
         provider_name: String,
     ) -> Self {
+        let base_url_lower = base_url.to_ascii_lowercase();
         let supports_user_name = !provider_name.eq_ignore_ascii_case("mistral")
-            && !base_url.to_ascii_lowercase().contains("mistral.ai");
+            && !base_url_lower.contains("mistral.ai")
+            && !provider_name.eq_ignore_ascii_case("minimax")
+            && !base_url_lower.contains("minimax");
         Self {
             api_key,
             model,

--- a/crates/providers/src/openai/provider/request.rs
+++ b/crates/providers/src/openai/provider/request.rs
@@ -957,6 +957,42 @@ mod tests {
         );
     }
 
+    /// MiniMax rejects chat histories containing inconsistent user `name` values.
+    #[test]
+    fn minimax_provider_strips_user_names_from_group_chat_history() {
+        let p = provider("MiniMax-M2.7", "minimax", "https://api.minimax.io/v1");
+        assert!(!p.supports_user_name);
+
+        let messages = vec![
+            ChatMessage::user_named("hello", "Alice"),
+            ChatMessage::assistant("hi"),
+            ChatMessage::user_named("jumping in", "Bob"),
+        ];
+        let serialized = p.serialize_messages_for_request(&messages);
+
+        assert_eq!(serialized.len(), 3);
+        assert!(serialized[0].get("name").is_none());
+        assert!(serialized[2].get("name").is_none());
+    }
+
+    /// Custom-named provider pointing at a MiniMax URL also strips names.
+    #[test]
+    fn minimax_url_detection_strips_user_names() {
+        let p = provider(
+            "MiniMax-M2.7",
+            "custom-minimax",
+            "https://api.minimax.io/v1",
+        );
+        assert!(!p.supports_user_name);
+
+        let messages = vec![ChatMessage::user_named("hello", "Alice")];
+        let serialized = p.serialize_messages_for_request(&messages);
+        assert!(
+            serialized[0].get("name").is_none(),
+            "MiniMax URL-based detection must strip name field"
+        );
+    }
+
     /// OpenAI provider must preserve the (sanitized) `name` field.
     #[test]
     fn openai_provider_preserves_user_name() {

--- a/crates/providers/src/openai/provider/request.rs
+++ b/crates/providers/src/openai/provider/request.rs
@@ -926,7 +926,8 @@ mod tests {
             "mistral-small-latest",
             "mistral",
             "https://api.mistral.ai/v1",
-        );
+        )
+        .with_supports_user_name(false);
         assert!(!p.supports_user_name);
 
         let messages = vec![ChatMessage::user_named("hello", "rokku")];
@@ -939,28 +940,11 @@ mod tests {
         );
     }
 
-    /// Custom-named provider pointing at Mistral URL also strips name.
-    #[test]
-    fn mistral_url_detection_strips_user_name() {
-        let p = provider(
-            "mistral-small-latest",
-            "my-mistral-eu",
-            "https://api.mistral.ai/v1",
-        );
-        assert!(!p.supports_user_name);
-
-        let messages = vec![ChatMessage::user_named("hello", "rokku")];
-        let serialized = p.serialize_messages_for_request(&messages);
-        assert!(
-            serialized[0].get("name").is_none(),
-            "Mistral URL-based detection must strip name field"
-        );
-    }
-
     /// MiniMax rejects chat histories containing inconsistent user `name` values.
     #[test]
     fn minimax_provider_strips_user_names_from_group_chat_history() {
-        let p = provider("MiniMax-M2.7", "minimax", "https://api.minimax.io/v1");
+        let p = provider("MiniMax-M2.7", "minimax", "https://api.minimax.io/v1")
+            .with_supports_user_name(false);
         assert!(!p.supports_user_name);
 
         let messages = vec![
@@ -973,24 +957,6 @@ mod tests {
         assert_eq!(serialized.len(), 3);
         assert!(serialized[0].get("name").is_none());
         assert!(serialized[2].get("name").is_none());
-    }
-
-    /// Custom-named provider pointing at a MiniMax URL also strips names.
-    #[test]
-    fn minimax_url_detection_strips_user_names() {
-        let p = provider(
-            "MiniMax-M2.7",
-            "custom-minimax",
-            "https://api.minimax.io/v1",
-        );
-        assert!(!p.supports_user_name);
-
-        let messages = vec![ChatMessage::user_named("hello", "Alice")];
-        let serialized = p.serialize_messages_for_request(&messages);
-        assert!(
-            serialized[0].get("name").is_none(),
-            "MiniMax URL-based detection must strip name field"
-        );
     }
 
     /// OpenAI provider must preserve the (sanitized) `name` field.

--- a/crates/providers/src/openai/provider/request.rs
+++ b/crates/providers/src/openai/provider/request.rs
@@ -4,14 +4,7 @@ use tracing::warn;
 
 use {crate::raw_model_id, moltis_agents::model::ChatMessage};
 
-use super::OpenAiProvider;
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum SystemMessageRewriteStrategy {
-    None,
-    MergeLeadingSystem,
-    InlineIntoFirstUser,
-}
+use {super::OpenAiProvider, crate::openai::SystemMessageRewriteStrategy};
 
 impl OpenAiProvider {
     /// Returns `true` when this provider targets an Anthropic model via
@@ -97,40 +90,18 @@ impl OpenAiProvider {
         if let Some(explicit) = self.strict_tools_override {
             return explicit;
         }
-        if self.base_url.contains("openrouter.ai") {
-            return false;
-        }
-        if self.provider_name.eq_ignore_ascii_case("gemini")
-            || self.base_url.contains("googleapis.com")
-        {
-            return false;
-        }
-        true
+        self.default_strict_tools
     }
 
     fn requires_reasoning_content_on_tool_messages(&self) -> bool {
         if let Some(explicit) = self.reasoning_content_override {
             return explicit;
         }
-        self.provider_name.eq_ignore_ascii_case("moonshot")
-            || self.base_url.contains("moonshot.ai")
-            || self.base_url.contains("moonshot.cn")
-            || self.model.starts_with("kimi-")
-            || self.model.to_ascii_lowercase().starts_with("deepseek-v4")
-    }
-
-    /// Some providers (e.g. MiniMax) reject `role: "system"` in the messages
-    /// array. System content must be extracted and prepended to the first user
-    /// message instead (MiniMax silently ignores a top-level `"system"` field).
-    fn rejects_system_role(&self) -> bool {
-        self.model.starts_with("MiniMax-")
-            || self.provider_name.eq_ignore_ascii_case("minimax")
-            || self.base_url.to_ascii_lowercase().contains("minimax")
+        self.default_reasoning_content_on_tool_messages
     }
 
     fn requires_gemini_tool_call_extra_content(&self) -> bool {
-        self.provider_name.eq_ignore_ascii_case("gemini")
-            || self.base_url.contains("generativelanguage.googleapis.com")
+        self.requires_gemini_tool_call_extra_content
     }
 
     /// Whether this provider rejects `null` in JSON Schema `enum` arrays.
@@ -141,8 +112,7 @@ impl OpenAiProvider {
     /// patching so type-level nullability (`["string", "null"]`) remains
     /// but the redundant null is removed from enum arrays (issue #848).
     fn rejects_null_in_enums(&self) -> bool {
-        self.provider_name.eq_ignore_ascii_case("fireworks")
-            || self.base_url.to_ascii_lowercase().contains("fireworks.ai")
+        self.rejects_null_in_enums
     }
 
     /// Convert raw tool schemas into the provider-compatible Chat
@@ -165,43 +135,23 @@ impl OpenAiProvider {
         converted
     }
 
-    fn is_custom_openai_compatible_provider(&self) -> bool {
-        self.provider_name.starts_with("custom-")
-    }
-
-    fn is_alibaba_qwen_backend(&self) -> bool {
-        self.provider_name.eq_ignore_ascii_case("alibaba-coding")
-            || self.provider_name.eq_ignore_ascii_case("alibaba")
-            || self.provider_name.eq_ignore_ascii_case("dashscope-coding")
-            || self.base_url.contains("dashscope.aliyuncs.com")
-            || self.base_url.contains("alibabacloud.com")
-    }
-
-    fn is_qwen_single_system_backend(&self) -> bool {
-        self.provider_name.eq_ignore_ascii_case("ollama")
-            || self.provider_name.to_ascii_lowercase().contains("ollama")
-            || self.is_custom_openai_compatible_provider()
-            || self.is_alibaba_qwen_backend()
-    }
-
     /// Some backends ship chat templates that only accept a single system
     /// message at the front of the conversation. Qwen-based OpenAI-compatible
     /// backends commonly behave this way (e.g. llama.cpp chat templates).
     fn requires_single_leading_system_message(&self) -> bool {
+        if !self.qwen_models_require_single_leading_system {
+            return false;
+        }
         raw_model_id(&self.model)
             .to_ascii_lowercase()
             .contains("qwen")
-            && self.is_qwen_single_system_backend()
     }
 
     fn system_message_rewrite_strategy(&self) -> SystemMessageRewriteStrategy {
-        if self.rejects_system_role() {
-            return SystemMessageRewriteStrategy::InlineIntoFirstUser;
-        }
         if self.requires_single_leading_system_message() {
             return SystemMessageRewriteStrategy::MergeLeadingSystem;
         }
-        SystemMessageRewriteStrategy::None
+        self.system_message_rewrite_strategy
     }
 
     /// Rewrite system messages for providers with stricter chat template rules.
@@ -519,7 +469,8 @@ mod tests {
             "qwen3:0.6b",
             "custom-ollama-qwen",
             "http://127.0.0.1:11435/v1",
-        );
+        )
+        .with_qwen_models_require_single_leading_system(true);
         let mut body = serde_json::json!({
             "messages": [
                 {"role": "system", "content": "You are a helpful assistant."},
@@ -546,7 +497,8 @@ mod tests {
 
     #[test]
     fn system_message_rewrite_minimax_inlines_messages_into_first_user_message() {
-        let provider = provider("MiniMax-M2.7", "minimax", "https://api.minimax.io/v1");
+        let provider = provider("MiniMax-M2.7", "minimax", "https://api.minimax.io/v1")
+            .with_system_message_rewrite(SystemMessageRewriteStrategy::InlineIntoFirstUser);
         let mut body = serde_json::json!({
             "messages": [
                 {"role": "system", "content": "You are a helpful assistant."},
@@ -614,7 +566,8 @@ mod tests {
             "qwen3.5-plus",
             "alibaba-coding",
             "https://coding-intl.dashscope.aliyuncs.com/v1",
-        );
+        )
+        .with_qwen_models_require_single_leading_system(true);
         let mut body = serde_json::json!({
             "messages": [
                 {"role": "system", "content": "sys1"},
@@ -670,7 +623,8 @@ mod tests {
             "accounts/fireworks/models/glm-5p1",
             "fireworks",
             "https://api.fireworks.ai/inference/v1",
-        );
+        )
+        .with_rejects_null_in_enums(true);
         assert!(
             p.needs_strict_tools(),
             "Native Fireworks models should use strict tools by default"
@@ -683,7 +637,8 @@ mod tests {
             "accounts/fireworks/models/glm-5p1",
             "fireworks",
             "https://api.fireworks.ai/inference/v1",
-        );
+        )
+        .with_rejects_null_in_enums(true);
         assert!(
             p.rejects_null_in_enums(),
             "Fireworks should reject null in enums (issue #848)"
@@ -691,15 +646,16 @@ mod tests {
     }
 
     #[test]
-    fn custom_fireworks_rejects_null_in_enums_via_base_url() {
+    fn fireworks_rejects_null_in_enums_from_provider_flag() {
         let p = provider(
             "accounts/fireworks/routers/kimi-k2p5-turbo",
-            "custom-fireworks-ai",
+            "fireworks",
             "https://api.fireworks.ai/inference/v1",
-        );
+        )
+        .with_rejects_null_in_enums(true);
         assert!(
             p.rejects_null_in_enums(),
-            "Custom Fireworks provider should be detected via base URL (issue #848)"
+            "Fireworks provider flag should reject null in enums (issue #848)"
         );
     }
 
@@ -718,7 +674,8 @@ mod tests {
             "gemini-3.1-flash-lite-preview",
             "gemini",
             "https://generativelanguage.googleapis.com/v1beta/openai",
-        );
+        )
+        .with_gemini_tool_call_extra_content(true);
         let mut metadata = serde_json::Map::new();
         metadata.insert("thought_signature".to_string(), serde_json::json!("sig123"));
         let messages =
@@ -755,13 +712,15 @@ mod tests {
 
     #[test]
     fn moonshot_direct_auto_detects_reasoning_content() {
-        let p = provider("kimi-k2.5", "moonshot", "https://api.moonshot.ai/v1");
+        let p = provider("kimi-k2.5", "moonshot", "https://api.moonshot.ai/v1")
+            .with_default_reasoning_content(true);
         assert!(p.requires_reasoning_content_on_tool_messages());
     }
 
     #[test]
     fn deepseek_v4_auto_detects_reasoning_content() {
-        let p = provider("deepseek-v4-flash", "deepseek", "https://api.deepseek.com");
+        let p = provider("deepseek-v4-flash", "deepseek", "https://api.deepseek.com")
+            .with_default_reasoning_content(true);
         assert!(
             p.requires_reasoning_content_on_tool_messages(),
             "DeepSeek V4 thinking-mode tool calls require reasoning_content replay (issue #959)"
@@ -876,7 +835,8 @@ mod tests {
 
     #[test]
     fn deepseek_v4_replays_persisted_tool_reasoning_content() {
-        let p = provider("deepseek-v4-flash", "deepseek", "https://api.deepseek.com");
+        let p = provider("deepseek-v4-flash", "deepseek", "https://api.deepseek.com")
+            .with_default_reasoning_content(true);
         let persisted = vec![
             serde_json::json!({"role": "user", "content": "What is the weather?"}),
             serde_json::json!({
@@ -991,7 +951,8 @@ mod tests {
             "accounts/fireworks/models/glm-5p1",
             "fireworks",
             "https://api.fireworks.ai/inference/v1",
-        );
+        )
+        .with_rejects_null_in_enums(true);
 
         let messages = vec![
             ChatMessage::user("What's the weather?"),

--- a/crates/providers/src/openai/provider/request.rs
+++ b/crates/providers/src/openai/provider/request.rs
@@ -97,7 +97,13 @@ impl OpenAiProvider {
         if let Some(explicit) = self.reasoning_content_override {
             return explicit;
         }
-        self.default_reasoning_content_on_tool_messages
+        if self.default_reasoning_content_on_tool_messages {
+            return true;
+        }
+        let raw_model = raw_model_id(&self.model).to_ascii_lowercase();
+        self.reasoning_content_model_prefixes
+            .iter()
+            .any(|prefix| raw_model.starts_with(prefix))
     }
 
     fn requires_gemini_tool_call_extra_content(&self) -> bool {
@@ -720,10 +726,20 @@ mod tests {
     #[test]
     fn deepseek_v4_auto_detects_reasoning_content() {
         let p = provider("deepseek-v4-flash", "deepseek", "https://api.deepseek.com")
-            .with_default_reasoning_content(true);
+            .with_reasoning_content_model_prefixes(&["deepseek-v4"]);
         assert!(
             p.requires_reasoning_content_on_tool_messages(),
             "DeepSeek V4 thinking-mode tool calls require reasoning_content replay (issue #959)"
+        );
+    }
+
+    #[test]
+    fn deepseek_non_v4_does_not_auto_detect_reasoning_content() {
+        let p = provider("deepseek-chat", "deepseek", "https://api.deepseek.com")
+            .with_reasoning_content_model_prefixes(&["deepseek-v4"]);
+        assert!(
+            !p.requires_reasoning_content_on_tool_messages(),
+            "DeepSeek reasoning_content replay should stay scoped to V4 thinking models"
         );
     }
 
@@ -836,7 +852,7 @@ mod tests {
     #[test]
     fn deepseek_v4_replays_persisted_tool_reasoning_content() {
         let p = provider("deepseek-v4-flash", "deepseek", "https://api.deepseek.com")
-            .with_default_reasoning_content(true);
+            .with_reasoning_content_model_prefixes(&["deepseek-v4"]);
         let persisted = vec![
             serde_json::json!({"role": "user", "content": "What is the weather?"}),
             serde_json::json!({

--- a/crates/providers/src/registry/registration.rs
+++ b/crates/providers/src/registry/registration.rs
@@ -339,6 +339,7 @@ impl ProviderRegistry {
                     name.clone(),
                 )
                 .with_stream_transport(entry.stream_transport)
+                .with_qwen_models_require_single_leading_system(true)
                 .with_context_window_overrides(
                     self.global_cw_overrides.clone(),
                     extract_cw_overrides(&entry.model_overrides),
@@ -1118,6 +1119,7 @@ impl ProviderRegistry {
                 )
                 .with_stream_transport(entry.stream_transport)
                 .with_cache_retention(entry.cache_retention)
+                .with_qwen_models_require_single_leading_system(true)
                 .with_context_window_overrides(
                     self.global_cw_overrides.clone(),
                     extract_cw_overrides(&entry.model_overrides),

--- a/crates/providers/src/registry/registration.rs
+++ b/crates/providers/src/registry/registration.rs
@@ -32,6 +32,9 @@ use crate::{
     anthropic, async_openai_provider, config_helpers::*, discovered_model::*, genai_provider,
     model_capabilities::*, model_catalogs::*, model_id::*, ollama::*, openai, opencode_zen,
 };
+
+const CUSTOM_REASONING_CONTENT_MODEL_PREFIXES: &[&str] = &["kimi-", "deepseek-v4"];
+
 impl ProviderRegistry {
     /// Register models from a [`RediscoveryResult`], skipping those already
     /// present. All I/O (model list fetches, Ollama probes) must be completed
@@ -340,6 +343,7 @@ impl ProviderRegistry {
                     name.clone(),
                 )
                 .with_stream_transport(entry.stream_transport)
+                .with_reasoning_content_model_prefixes(CUSTOM_REASONING_CONTENT_MODEL_PREFIXES)
                 .with_qwen_models_require_single_leading_system(true)
                 .with_context_window_overrides(
                     self.global_cw_overrides.clone(),
@@ -1120,6 +1124,7 @@ impl ProviderRegistry {
                 )
                 .with_stream_transport(entry.stream_transport)
                 .with_cache_retention(entry.cache_retention)
+                .with_reasoning_content_model_prefixes(CUSTOM_REASONING_CONTENT_MODEL_PREFIXES)
                 .with_qwen_models_require_single_leading_system(true)
                 .with_context_window_overrides(
                     self.global_cw_overrides.clone(),

--- a/crates/providers/src/registry/registration.rs
+++ b/crates/providers/src/registry/registration.rs
@@ -264,6 +264,7 @@ impl ProviderRegistry {
                 .with_supports_user_name(def.supports_user_name)
                 .with_default_strict_tools(def.default_strict_tools)
                 .with_default_reasoning_content(def.default_reasoning_content_on_tool_messages)
+                .with_reasoning_content_model_prefixes(def.reasoning_content_model_prefixes)
                 .with_rejects_null_in_enums(def.rejects_null_in_enums)
                 .with_gemini_tool_call_extra_content(def.requires_gemini_tool_call_extra_content)
                 .with_system_message_rewrite(def.system_message_rewrite)

--- a/crates/providers/src/registry/registration.rs
+++ b/crates/providers/src/registry/registration.rs
@@ -262,6 +262,14 @@ impl ProviderRegistry {
                 .with_stream_transport(stream_transport)
                 .with_cache_retention(cache_retention)
                 .with_supports_user_name(def.supports_user_name)
+                .with_default_strict_tools(def.default_strict_tools)
+                .with_default_reasoning_content(def.default_reasoning_content_on_tool_messages)
+                .with_rejects_null_in_enums(def.rejects_null_in_enums)
+                .with_gemini_tool_call_extra_content(def.requires_gemini_tool_call_extra_content)
+                .with_system_message_rewrite(def.system_message_rewrite)
+                .with_qwen_models_require_single_leading_system(
+                    def.qwen_models_require_single_leading_system,
+                )
                 .with_context_window_overrides(
                     self.global_cw_overrides.clone(),
                     config

--- a/crates/providers/src/registry/registration.rs
+++ b/crates/providers/src/registry/registration.rs
@@ -261,6 +261,7 @@ impl ProviderRegistry {
                 )
                 .with_stream_transport(stream_transport)
                 .with_cache_retention(cache_retention)
+                .with_supports_user_name(def.supports_user_name)
                 .with_context_window_overrides(
                     self.global_cw_overrides.clone(),
                     config


### PR DESCRIPTION
## Summary
- Disable OpenAI-compatible user `name` fields for MiniMax providers to avoid MiniMax 2013 errors in group-chat histories with multiple senders.
- Move known OpenAI-compatible provider request quirks into provider catalog metadata instead of ad-hoc provider/model/base-URL matching.
- Add regression coverage for MiniMax user-name stripping and provider metadata defaults.

## Validation
### Completed
- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p moltis-providers minimax_`
- [x] `cargo test -p moltis-providers strict_name_providers_disable_user_names`
- [x] `cargo test -p moltis-providers`

### Remaining
- [ ] Full CI suite

## Manual QA
- Not run; covered by provider serialization and catalog tests.