### PR TITLE
fix(cron): preserve host execution target

### DIFF
--- a/crates/chat/src/run_with_tools.rs
+++ b/crates/chat/src/run_with_tools.rs
@@ -242,8 +242,8 @@ pub(crate) async fn run_with_tools(
 
     // Apply per-agent sandbox mode override, then determine sandbox mode.
     let session_is_sandboxed = if let Some(router) = state.sandbox_router() {
-        // If the agent preset has a sandbox mode override, apply it as a
-        // per-session override so the exec tool inherits the agent's policy.
+        // If the agent preset has a sandbox mode override, apply it as an
+        // agent-scoped override so explicit session/cron policy still wins.
         // - "all"      → force sandbox on
         // - "off"      → force sandbox off
         // - "non-main" → remove override, let the router's global NonMain
@@ -252,17 +252,17 @@ pub(crate) async fn run_with_tools(
         if let Some(preset) = persona.config.agents.get_preset(agent_id) {
             match preset.sandbox.mode {
                 Some(moltis_config::schema::PresetSandboxMode::All) => {
-                    router.set_override(session_key, true).await
+                    router.set_agent_override(session_key, true).await
                 },
                 Some(moltis_config::schema::PresetSandboxMode::Off) => {
-                    router.set_override(session_key, false).await
+                    router.set_agent_override(session_key, false).await
                 },
-                _ => router.remove_override(session_key).await,
+                _ => router.remove_agent_override(session_key).await,
             }
         } else {
-            // No preset for this agent — clear any stale override from
-            // a previously assigned agent so the global mode applies.
-            router.remove_override(session_key).await;
+            // No preset for this agent — clear only stale agent policy. Explicit
+            // session/cron overrides still control this session.
+            router.remove_agent_override(session_key).await;
         }
         router.is_sandboxed(session_key).await
     } else {

--- a/crates/tools/src/sandbox/router.rs
+++ b/crates/tools/src/sandbox/router.rs
@@ -670,8 +670,10 @@ pub struct SandboxRouter {
     /// All available backends, keyed by backend name.
     /// The default backend is also present in this map.
     backends: HashMap<String, Arc<dyn Sandbox>>,
-    /// Per-session overrides: true = sandboxed, false = direct execution.
+    /// Explicit per-session overrides: true = sandboxed, false = direct execution.
     overrides: RwLock<HashMap<String, bool>>,
+    /// Agent preset overrides. Explicit per-session overrides take precedence.
+    agent_overrides: RwLock<HashMap<String, bool>>,
     /// Per-session backend override: session_key -> backend_name.
     backend_overrides: RwLock<HashMap<String, String>>,
     /// Per-session image overrides.
@@ -716,6 +718,7 @@ impl SandboxRouter {
             default_backend,
             backends,
             overrides: RwLock::new(HashMap::new()),
+            agent_overrides: RwLock::new(HashMap::new()),
             backend_overrides: RwLock::new(HashMap::new()),
             image_overrides: RwLock::new(HashMap::new()),
             backend_image_overrides: RwLock::new(HashMap::new()),
@@ -739,6 +742,7 @@ impl SandboxRouter {
             default_backend: backend,
             backends,
             overrides: RwLock::new(HashMap::new()),
+            agent_overrides: RwLock::new(HashMap::new()),
             backend_overrides: RwLock::new(HashMap::new()),
             image_overrides: RwLock::new(HashMap::new()),
             backend_image_overrides: RwLock::new(HashMap::new()),
@@ -840,6 +844,9 @@ impl SandboxRouter {
         if let Some(&override_val) = self.overrides.read().await.get(session_key) {
             return override_val;
         }
+        if let Some(&override_val) = self.agent_overrides.read().await.get(session_key) {
+            return override_val;
+        }
         match self.config.mode {
             SandboxMode::Off => false,
             SandboxMode::All => true,
@@ -858,6 +865,19 @@ impl SandboxRouter {
     /// Remove a per-session override (revert to global mode).
     pub async fn remove_override(&self, session_key: &str) {
         self.overrides.write().await.remove(session_key);
+    }
+
+    /// Set a sandbox override from an agent preset.
+    pub async fn set_agent_override(&self, session_key: &str, enabled: bool) {
+        self.agent_overrides
+            .write()
+            .await
+            .insert(session_key.to_string(), enabled);
+    }
+
+    /// Remove an agent preset override without clearing explicit session policy.
+    pub async fn remove_agent_override(&self, session_key: &str) {
+        self.agent_overrides.write().await.remove(session_key);
     }
 
     /// Derive a SandboxId for a given session key.
@@ -906,6 +926,7 @@ impl SandboxRouter {
 
         backend.cleanup(&id).await?;
         self.remove_override(session_key).await;
+        self.remove_agent_override(session_key).await;
         self.remove_backend_override(session_key).await;
         self.remove_image_override(session_key).await;
         self.clear_prepared_session(session_key).await;

--- a/crates/tools/src/sandbox/tests/docker_router.rs
+++ b/crates/tools/src/sandbox/tests/docker_router.rs
@@ -401,6 +401,22 @@ async fn test_sandbox_router_agent_override_falls_back_to_mode() {
 }
 
 #[tokio::test]
+async fn test_sandbox_router_agent_override_beats_global_off() {
+    let config = SandboxConfig {
+        mode: SandboxMode::Off,
+        ..Default::default()
+    };
+    let router = router_with_real_backend(config);
+    assert!(!router.is_sandboxed("main").await);
+
+    router.set_agent_override("main", true).await;
+    assert!(router.is_sandboxed("main").await);
+
+    router.remove_agent_override("main").await;
+    assert!(!router.is_sandboxed("main").await);
+}
+
+#[tokio::test]
 async fn test_sandbox_router_no_runtime_returns_false() {
     let backend: Arc<dyn Sandbox> = Arc::new(NoSandbox);
     let config = SandboxConfig {

--- a/crates/tools/src/sandbox/tests/docker_router.rs
+++ b/crates/tools/src/sandbox/tests/docker_router.rs
@@ -369,6 +369,38 @@ async fn test_sandbox_router_override_overrides_mode() {
 }
 
 #[tokio::test]
+async fn test_sandbox_router_explicit_override_overrides_agent_override() {
+    let config = SandboxConfig {
+        mode: SandboxMode::NonMain,
+        ..Default::default()
+    };
+    let router = router_with_real_backend(config);
+    assert!(router.is_sandboxed("cron:test").await);
+
+    router.set_override("cron:test", false).await;
+    router.set_agent_override("cron:test", true).await;
+    assert!(!router.is_sandboxed("cron:test").await);
+
+    router.remove_agent_override("cron:test").await;
+    assert!(!router.is_sandboxed("cron:test").await);
+}
+
+#[tokio::test]
+async fn test_sandbox_router_agent_override_falls_back_to_mode() {
+    let config = SandboxConfig {
+        mode: SandboxMode::NonMain,
+        ..Default::default()
+    };
+    let router = router_with_real_backend(config);
+
+    router.set_agent_override("cron:test", false).await;
+    assert!(!router.is_sandboxed("cron:test").await);
+
+    router.remove_agent_override("cron:test").await;
+    assert!(router.is_sandboxed("cron:test").await);
+}
+
+#[tokio::test]
 async fn test_sandbox_router_no_runtime_returns_false() {
     let backend: Arc<dyn Sandbox> = Arc::new(NoSandbox);
     let config = SandboxConfig {


### PR DESCRIPTION
## Summary
- Preserve explicit cron/session sandbox overrides separately from agent preset sandbox policy.
- Prevent agent preset resolution from clearing cron jobs configured with Execution Target: Host.
- Add router regression coverage for non-main cron-like sessions.

## Validation
### Completed
- [x] `cargo test -p moltis-tools sandbox_router -- --nocapture`
- [x] `cargo test -p moltis-chat --lib`
- [x] `cargo fmt --all -- --check`

### Remaining
- [ ] Full `just lint`
- [ ] Full `just test`

## Manual QA
- Not run locally. Suggested check: create a cron job with Session Target: Isolated and Execution Target: Host, run it, and verify exec commands run on the host rather than a sandbox.

Fixes #1072