### PR TITLE
fix(web): include clicked response in message forks

### DIFF
--- a/crates/web/ui/e2e/specs/sessions.spec.js
+++ b/crates/web/ui/e2e/specs/sessions.spec.js
@@ -333,20 +333,21 @@ test.describe("Session management", () => {
 			window.__capturedForkParams = null;
 			window.__origForkWsSend = ws.send.bind(ws);
 			ws.send = (payload) => {
+				let parsed;
 				try {
-					const parsed = JSON.parse(payload);
-					if (parsed?.method === "sessions.fork") {
-						window.__capturedForkParams = parsed.params;
-						const resolver = stateModule.pending?.[parsed.id];
-						if (typeof resolver !== "function") {
-							throw new Error("sessions.fork test expected a pending RPC resolver function");
-						}
-						delete stateModule.pending[parsed.id];
-						resolver({ ok: true, payload: { sessionKey: "session:fork-capture" } });
-						return;
-					}
+					parsed = JSON.parse(payload);
 				} catch (_err) {
-					// Fall through to the original sender.
+					return window.__origForkWsSend(payload);
+				}
+				if (parsed?.method === "sessions.fork") {
+					window.__capturedForkParams = parsed.params;
+					const resolver = stateModule.pending?.[parsed.id];
+					if (typeof resolver !== "function") {
+						throw new Error("sessions.fork test expected a pending RPC resolver function");
+					}
+					delete stateModule.pending[parsed.id];
+					resolver({ ok: true, payload: { sessionKey: "session:fork-capture" } });
+					return;
 				}
 				return window.__origForkWsSend(payload);
 			};

--- a/crates/web/ui/e2e/specs/sessions.spec.js
+++ b/crates/web/ui/e2e/specs/sessions.spec.js
@@ -338,10 +338,11 @@ test.describe("Session management", () => {
 					if (parsed?.method === "sessions.fork") {
 						window.__capturedForkParams = parsed.params;
 						const resolver = stateModule.pending?.[parsed.id];
-						if (typeof resolver === "function") {
-							delete stateModule.pending[parsed.id];
-							resolver({ ok: true, payload: { sessionKey: "session:fork-capture" } });
+						if (typeof resolver !== "function") {
+							throw new Error("sessions.fork test expected a pending RPC resolver function");
 						}
+						delete stateModule.pending[parsed.id];
+						resolver({ ok: true, payload: { sessionKey: "session:fork-capture" } });
 						return;
 					}
 				} catch (_err) {
@@ -361,6 +362,7 @@ test.describe("Session management", () => {
 				{ timeout: 5_000 },
 			)
 			.toEqual({ key: sessionKey, forkPoint: 2 });
+		await expect(page.getByText("Forked into new session", { exact: true })).toBeVisible();
 
 		expect(pageErrors).toEqual([]);
 	});

--- a/crates/web/ui/e2e/specs/sessions.spec.js
+++ b/crates/web/ui/e2e/specs/sessions.spec.js
@@ -294,6 +294,77 @@ test.describe("Session management", () => {
 		expect(pageErrors).toEqual([]);
 	});
 
+	test("assistant response fork sends boundary after the clicked response", async ({ page }) => {
+		const pageErrors = watchPageErrors(page);
+		await navigateAndWait(page, "/");
+		await waitForWsConnected(page);
+
+		await createSession(page);
+		const sessionPath = new URL(page.url()).pathname;
+		const sessionKey = sessionPath.replace(/^\/chats\//, "").replace(/\//g, ":");
+		const assistantText = "fork should include this assistant response";
+
+		await expectRpcOk(page, "system-event", {
+			event: "chat",
+			payload: {
+				sessionKey,
+				state: "final",
+				text: assistantText,
+				messageIndex: 1,
+				model: "test-model",
+				provider: "test-provider",
+				replyMedium: "text",
+				runId: "run-fork-response",
+			},
+		});
+
+		const assistant = page.locator("#messages .msg.assistant").filter({ hasText: assistantText });
+		await expect(assistant).toBeVisible({ timeout: 5_000 });
+
+		await page.evaluate(async () => {
+			const appScript = document.querySelector('script[type="module"][src*="js/app.js"]');
+			if (!appScript) throw new Error("app module script not found");
+			const appUrl = new URL(appScript.src, window.location.origin);
+			const prefix = appUrl.href.slice(0, appUrl.href.length - "js/app.js".length);
+			const stateModule = await import(`${prefix}js/state.js`);
+			const ws = stateModule.ws;
+			if (!ws) throw new Error("websocket unavailable");
+
+			window.__capturedForkParams = null;
+			window.__origForkWsSend = ws.send.bind(ws);
+			ws.send = (payload) => {
+				try {
+					const parsed = JSON.parse(payload);
+					if (parsed?.method === "sessions.fork") {
+						window.__capturedForkParams = parsed.params;
+						const resolver = stateModule.pending?.[parsed.id];
+						if (typeof resolver === "function") {
+							delete stateModule.pending[parsed.id];
+							resolver({ ok: true, payload: { sessionKey: "session:fork-capture" } });
+						}
+						return;
+					}
+				} catch (_err) {
+					// Fall through to the original sender.
+				}
+				return window.__origForkWsSend(payload);
+			};
+		});
+
+		await assistant.locator('.msg-action-btn[title="Fork into new session"]').click();
+		await expect
+			.poll(
+				() =>
+					page.evaluate(() => {
+						return window.__capturedForkParams || null;
+					}),
+				{ timeout: 5_000 },
+			)
+			.toEqual({ key: sessionKey, forkPoint: 2 });
+
+		expect(pageErrors).toEqual([]);
+	});
+
 	test("main session shows clear but hides delete, non-main shows delete but hides clear", async ({ page }) => {
 		const pageErrors = watchPageErrors(page);
 		await page.goto("/");

--- a/crates/web/ui/src/message-actions.ts
+++ b/crates/web/ui/src/message-actions.ts
@@ -141,9 +141,10 @@ export function appendMessageActions(ctx: MessageActionContext): void {
 	// ── Fork button ──────────────────────────────────────────
 	const forkBtn = actionButton("icon-git-fork", "Fork into new session");
 	forkBtn.addEventListener("click", () => {
+		const forkPoint = Number.isInteger(ctx.messageIndex) ? (ctx.messageIndex as number) + 1 : undefined;
 		sendRpc("sessions.fork", {
 			key: sessionKey,
-			forkPoint: ctx.messageIndex,
+			...(forkPoint !== undefined ? { forkPoint } : {}),
 		}).then((res) => {
 			if (res.ok) {
 				showToast("Forked into new session", "success");


### PR DESCRIPTION
## Summary
- Fix message-level session forks to use the exclusive boundary after the clicked assistant response.
- Add a Playwright regression covering the assistant response fork payload.

Fixes #1075

## Validation
### Completed
- [x] `npm ci`
- [x] `biome check --write crates/web/ui/src/message-actions.ts crates/web/ui/e2e/specs/sessions.spec.js` (completed with existing complexity warnings)
- [x] `cd crates/web/ui && npm run build`
- [x] `cd crates/web/ui && npx tsc --noEmit`
- [x] `cd crates/web/ui && npm run build:all`
- [x] `cargo build --bin moltis`
- [x] `cd crates/web/ui && npx playwright test e2e/specs/sessions.spec.js -g "assistant response fork sends boundary after the clicked response"`

### Remaining
- [ ] Full `npx playwright test`
- [ ] Full workspace validation

## Manual QA
- Fork from an assistant response and verify the new session includes that response, not only the preceding prompt.