### PR TITLE
fix(discord): log silent voice message drops

### DIFF
--- a/crates/discord/src/handler/implementation.rs
+++ b/crates/discord/src/handler/implementation.rs
@@ -658,21 +658,20 @@ fn set_bot_presence(ctx: &Context, account_id: &str, config: &DiscordAccountConf
 #[async_trait]
 impl EventHandler for Handler {
     async fn message(&self, ctx: Context, msg: Message) {
+        // Ignore messages from bots (including ourselves).
+        if msg.author.bot {
+            return;
+        }
+
         info!(
             account_id = %self.account_id,
             message_id = msg.id.get(),
-            author_bot = msg.author.bot,
             content_len = msg.content.len(),
             attachment_count = msg.attachments.len(),
             flags = ?msg.flags,
             kind = ?msg.kind,
             "discord raw message event received"
         );
-
-        // Ignore messages from bots (including ourselves).
-        if msg.author.bot {
-            return;
-        }
 
         let accounts_lock_wait_start = std::time::Instant::now();
         let (config, event_sink, message_log, bot_user_id) = {
@@ -733,6 +732,7 @@ impl EventHandler for Handler {
                 message_id,
                 chat_id,
                 peer_id,
+                text_len = text.len(),
                 content_len = msg.content.len(),
                 attachment_count = msg.attachments.len(),
                 flags = ?msg.flags,

--- a/crates/discord/src/handler/implementation.rs
+++ b/crates/discord/src/handler/implementation.rs
@@ -6,7 +6,7 @@ use {
         },
         async_trait,
         gateway::ActivityData,
-        model::user::OnlineStatus as SerenityOnlineStatus,
+        model::{event::MessageUpdateEvent, user::OnlineStatus as SerenityOnlineStatus},
     },
     tracing::{debug, info, warn},
 };
@@ -267,6 +267,10 @@ fn select_media_attachment(attachments: &[Attachment]) -> Option<&Attachment> {
         return Some(a);
     }
     attachments.iter().find(|a| attachment_is_image(a))
+}
+
+fn should_drop_empty_discord_message(text: &str, attachments: &[Attachment]) -> bool {
+    text.is_empty() && attachments.is_empty()
 }
 
 /// Normalize an audio attachment to a short format string the STT provider
@@ -654,6 +658,17 @@ fn set_bot_presence(ctx: &Context, account_id: &str, config: &DiscordAccountConf
 #[async_trait]
 impl EventHandler for Handler {
     async fn message(&self, ctx: Context, msg: Message) {
+        info!(
+            account_id = %self.account_id,
+            message_id = msg.id.get(),
+            author_bot = msg.author.bot,
+            content_len = msg.content.len(),
+            attachment_count = msg.attachments.len(),
+            flags = ?msg.flags,
+            kind = ?msg.kind,
+            "discord raw message event received"
+        );
+
         // Ignore messages from bots (including ourselves).
         if msg.author.bot {
             return;
@@ -712,7 +727,18 @@ impl EventHandler for Handler {
 
         // Drop truly empty messages (no text and no attachments). Messages with
         // attachments but no caption still need processing (e.g. voice notes).
-        if text.is_empty() && msg.attachments.is_empty() {
+        if should_drop_empty_discord_message(&text, &msg.attachments) {
+            warn!(
+                account_id = %self.account_id,
+                message_id,
+                chat_id,
+                peer_id,
+                content_len = msg.content.len(),
+                attachment_count = msg.attachments.len(),
+                flags = ?msg.flags,
+                kind = ?msg.kind,
+                "discord dropping empty message event"
+            );
             return;
         }
 
@@ -729,6 +755,8 @@ impl EventHandler for Handler {
             is_guild,
             bot_mentioned,
             text_len = text.len(),
+            attachment_count = msg.attachments.len(),
+            flags = ?msg.flags,
             ingress_lag_ms,
             accounts_lock_wait_ms,
             "discord inbound message received"
@@ -1074,6 +1102,24 @@ impl EventHandler for Handler {
             sink.dispatch_to_chat_with_attachments(&body, attachments, reply_to, meta)
                 .await;
         }
+    }
+
+    async fn message_update(
+        &self,
+        _ctx: Context,
+        _old_if_available: Option<Message>,
+        _new: Option<Message>,
+        event: MessageUpdateEvent,
+    ) {
+        info!(
+            account_id = %self.account_id,
+            message_id = event.id.get(),
+            channel_id = event.channel_id.get(),
+            content_len = event.content.as_ref().map(String::len),
+            attachment_count = event.attachments.as_ref().map(Vec::len),
+            flags = ?event.flags,
+            "discord message update event received"
+        );
     }
 
     async fn ready(&self, ctx: Context, ready: Ready) {

--- a/crates/discord/src/handler/tests.rs
+++ b/crates/discord/src/handler/tests.rs
@@ -437,6 +437,25 @@ fn select_media_picks_image_when_no_audio() {
     assert_eq!(picked.filename, "pic.jpg");
 }
 
+#[test]
+fn empty_message_without_attachments_is_droppable() {
+    assert!(should_drop_empty_discord_message("", &[]));
+}
+
+#[test]
+fn attachments_only_message_is_not_droppable() {
+    let doc = make_attachment(Some("application/pdf"), "spec.pdf");
+
+    assert!(!should_drop_empty_discord_message("", &[doc]));
+}
+
+#[test]
+fn voice_attachment_only_message_is_not_droppable() {
+    let voice = make_attachment(Some("audio/ogg"), "voice-message.ogg");
+
+    assert!(!should_drop_empty_discord_message("", &[voice]));
+}
+
 // ── resolve_discord_inbound_media via mock sink ──────────────────
 //
 // These tests exercise the branching logic without hitting the network.


### PR DESCRIPTION
## Summary
- Add Discord raw message and message update diagnostics to distinguish gateway drops from handler drops.
- Warn before dropping truly empty Discord messages and include attachment/flag metadata in inbound logs.
- Add regression tests proving attachments-only and voice-attachment-only messages are not treated as empty drops.

## Validation
### Completed
- [x] `cargo test -p moltis-discord`
- [x] `cargo fmt --all -- --check`

### Remaining
- [ ] Production Discord voice-message log capture with `RUST_LOG=moltis_discord=debug,serenity::gateway=debug`

## Manual QA
- Not run locally; requires a configured Discord bot and live voice-message traffic.

Closes #817