### PR TITLE
feat(channels): add gated tmux control command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7507,6 +7507,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "thiserror 2.0.18",
+ "time",
  "tokio",
  "tokio-stream",
  "tokio-test",

--- a/crates/channels/src/commands.rs
+++ b/crates/channels/src/commands.rs
@@ -192,6 +192,16 @@ pub fn all_commands() -> &'static [CommandDef] {
             arg: None,
         },
         CommandDef {
+            name: "tmux",
+            description: "Control an attached tmux pane",
+            arg: Some(CommandArg {
+                name: "action",
+                description: "status, capture, or send",
+                choices: &[],
+                required: true,
+            }),
+        },
+        CommandDef {
             name: "update",
             description: "Update moltis to latest or specified version",
             arg: Some(CommandArg {
@@ -378,6 +388,7 @@ mod tests {
             "sh",
             "stop",
             "peek",
+            "tmux",
             "update",
             "rollback",
             "btw",

--- a/crates/config/src/schema.rs
+++ b/crates/config/src/schema.rs
@@ -362,6 +362,9 @@ pub struct MoltisConfig {
 #[serde(default)]
 pub struct ExternalAgentsConfig {
     pub enabled: bool,
+    /// Allow approved channel users to control tmux panes with `/tmux`.
+    /// Disabled by default because channel input becomes terminal input.
+    pub channel_tmux_control: bool,
     #[serde(default)]
     pub agents: HashMap<String, ExternalAgentConfig>,
 }

--- a/crates/config/src/template.rs
+++ b/crates/config/src/template.rs
@@ -677,6 +677,7 @@ port = {port}                           # Port number (auto-generated for this i
 
 [external_agents]
 # enabled = false                   # Enable external agent bridge
+# channel_tmux_control = false      # Allow allowlisted channel users to run /tmux
 
 # Per-agent configuration (key = agent kind)
 # [external_agents.agents.claude-code]

--- a/crates/config/src/validate/schema_map.rs
+++ b/crates/config/src/validate/schema_map.rs
@@ -422,6 +422,7 @@ pub(super) fn build_schema_map() -> KnownKeys {
             "external_agents",
             Struct(HashMap::from([
                 ("enabled", Leaf),
+                ("channel_tmux_control", Leaf),
                 ("agents", Map(Box::new(external_agent_entry()))),
             ])),
         ),

--- a/crates/external-agents/Cargo.toml
+++ b/crates/external-agents/Cargo.toml
@@ -16,21 +16,22 @@ tracing     = ["dep:tracing"]
 
 [dependencies]
 agent-client-protocol = { workspace = true }
-anyhow          = { workspace = true }
-async-trait     = { workspace = true }
-futures         = { workspace = true }
-moltis-config   = { workspace = true }
-moltis-metrics  = { optional = true, workspace = true }
-moltis-sessions = { workspace = true }
-serde           = { workspace = true }
-serde_json      = { workspace = true }
-sha2            = { workspace = true }
-thiserror       = { workspace = true }
-tokio           = { workspace = true }
-tokio-stream    = { workspace = true }
-tokio-util      = { features = ["compat"], workspace = true }
-tracing         = { optional = true, workspace = true }
-which           = { workspace = true }
+anyhow                = { workspace = true }
+async-trait           = { workspace = true }
+futures               = { workspace = true }
+moltis-config         = { workspace = true }
+moltis-metrics        = { optional = true, workspace = true }
+moltis-sessions       = { workspace = true }
+serde                 = { workspace = true }
+serde_json            = { workspace = true }
+sha2                  = { workspace = true }
+thiserror             = { workspace = true }
+time                  = { workspace = true }
+tokio                 = { workspace = true }
+tokio-stream          = { workspace = true }
+tokio-util            = { features = ["compat"], workspace = true }
+tracing               = { optional = true, workspace = true }
+which                 = { workspace = true }
 
 [dev-dependencies]
 tokio-test = { workspace = true }

--- a/crates/external-agents/src/lib.rs
+++ b/crates/external-agents/src/lib.rs
@@ -10,6 +10,7 @@ pub mod bridge;
 pub mod error;
 pub mod registry;
 pub mod runtimes;
+pub mod tmux;
 pub mod transport;
 pub mod types;
 

--- a/crates/external-agents/src/tmux.rs
+++ b/crates/external-agents/src/tmux.rs
@@ -1,0 +1,314 @@
+use std::{process::Command, time::SystemTime};
+
+pub const MOLTIS_HOST_TERMINAL_TMUX_SOCKET_NAME: &str = "moltis-host-terminal";
+pub const MOLTIS_HOST_TERMINAL_TMUX_CONFIG_PATH: &str = "/dev/null";
+
+/// Coarse state of a tmux pane before channel input is sent.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TmuxPaneState {
+    ReadyPrompt,
+    PermissionPrompt,
+    Busy,
+    Unknown,
+}
+
+/// Result of attempting to deliver channel input to a live tmux pane.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TmuxDeliveryStatus {
+    Applied,
+    Busy,
+    Rejected,
+    Timeout,
+    Unknown,
+}
+
+/// Explicit delivery receipt for channel-to-terminal control.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TmuxDeliveryReceipt {
+    pub status: TmuxDeliveryStatus,
+    pub pane_state_before: TmuxPaneState,
+    pub pane_state_after: TmuxPaneState,
+}
+
+/// Validated tmux pane target.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TmuxTarget(String);
+
+impl TmuxTarget {
+    /// Create a target from a tmux target string.
+    ///
+    /// This intentionally accepts only the small subset needed for channel
+    /// control: session/window/pane names, indexes, and tmux ids. The value is
+    /// still passed as an argv item, not through a shell.
+    pub fn new(target: impl Into<String>) -> anyhow::Result<Self> {
+        let target = target.into();
+        let trimmed = target.trim();
+        if trimmed.is_empty() {
+            anyhow::bail!("tmux target cannot be empty");
+        }
+        if trimmed.len() > 128 {
+            anyhow::bail!("tmux target must be 128 bytes or fewer");
+        }
+        if !trimmed.chars().all(is_allowed_target_char) {
+            anyhow::bail!("tmux target contains unsupported characters");
+        }
+        Ok(Self(trimmed.to_string()))
+    }
+
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+/// Minimal tmux controller for driving live terminal sessions.
+#[derive(Debug, Clone)]
+pub struct TmuxController {
+    socket_name: Option<String>,
+    config_path: Option<String>,
+}
+
+impl TmuxController {
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            socket_name: None,
+            config_path: None,
+        }
+    }
+
+    /// Controller for the same tmux server used by Moltis' web host terminal.
+    #[must_use]
+    pub fn moltis_host_terminal() -> Self {
+        Self {
+            socket_name: Some(MOLTIS_HOST_TERMINAL_TMUX_SOCKET_NAME.to_string()),
+            config_path: Some(MOLTIS_HOST_TERMINAL_TMUX_CONFIG_PATH.to_string()),
+        }
+    }
+
+    #[must_use]
+    pub fn with_socket_name(socket_name: impl Into<String>) -> Self {
+        Self {
+            socket_name: Some(socket_name.into()),
+            config_path: None,
+        }
+    }
+
+    #[must_use]
+    pub fn with_config_path(mut self, config_path: impl Into<String>) -> Self {
+        self.config_path = Some(config_path.into());
+        self
+    }
+
+    #[must_use]
+    pub fn is_available(&self) -> bool {
+        which::which("tmux").is_ok()
+    }
+
+    pub fn capture_pane(&self, target: &TmuxTarget) -> anyhow::Result<String> {
+        let output = self
+            .tmux_command()
+            .args(["capture-pane", "-p", "-J", "-t", target.as_str()])
+            .output()?;
+        command_stdout(output, "capture tmux pane")
+    }
+
+    pub fn send_text_with_receipt(
+        &self,
+        target: &TmuxTarget,
+        text: &str,
+    ) -> anyhow::Result<TmuxDeliveryReceipt> {
+        if text.trim().is_empty() {
+            anyhow::bail!("tmux input cannot be empty");
+        }
+        let before = self.capture_pane(target).unwrap_or_default();
+        let pane_state_before = classify_pane_state(&before);
+        if pane_state_before == TmuxPaneState::Busy {
+            return Ok(TmuxDeliveryReceipt {
+                status: TmuxDeliveryStatus::Busy,
+                pane_state_before,
+                pane_state_after: pane_state_before,
+            });
+        }
+
+        let buffer_name = tmux_buffer_name();
+        let set_buffer = self
+            .tmux_command()
+            .args(["set-buffer", "-b", &buffer_name, "--", text])
+            .output()?;
+        command_success(&set_buffer, "set tmux buffer")?;
+
+        let paste = self
+            .tmux_command()
+            .args([
+                "paste-buffer",
+                "-d",
+                "-b",
+                &buffer_name,
+                "-t",
+                target.as_str(),
+            ])
+            .output()?;
+        command_success(&paste, "paste tmux buffer")?;
+
+        let enter = self
+            .tmux_command()
+            .args(["send-keys", "-t", target.as_str(), "Enter"])
+            .output()?;
+        command_success(&enter, "send tmux enter")?;
+
+        let after = self.capture_pane(target).unwrap_or_default();
+        let pane_state_after = classify_pane_state(&after);
+        let status = if !after.is_empty() && after != before {
+            TmuxDeliveryStatus::Applied
+        } else if pane_state_before == TmuxPaneState::Unknown {
+            TmuxDeliveryStatus::Unknown
+        } else {
+            TmuxDeliveryStatus::Applied
+        };
+
+        Ok(TmuxDeliveryReceipt {
+            status,
+            pane_state_before,
+            pane_state_after,
+        })
+    }
+
+    fn tmux_command(&self) -> Command {
+        let mut command = Command::new("tmux");
+        if let Some(socket_name) = &self.socket_name {
+            command.args(["-L", socket_name]);
+        }
+        if let Some(config_path) = &self.config_path {
+            command.args(["-f", config_path]);
+        }
+        command
+    }
+}
+
+impl Default for TmuxController {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[must_use]
+pub fn classify_pane_state(output: &str) -> TmuxPaneState {
+    let visible = strip_ansi(output).to_lowercase();
+    let trimmed = visible.trim_end();
+    if trimmed.is_empty() {
+        return TmuxPaneState::Unknown;
+    }
+    if trimmed.contains("do you want to proceed")
+        || trimmed.contains("allow this")
+        || trimmed.contains("permission")
+    {
+        return TmuxPaneState::PermissionPrompt;
+    }
+    if trimmed.ends_with("$") || trimmed.ends_with("#") || trimmed.ends_with(">") {
+        return TmuxPaneState::ReadyPrompt;
+    }
+    if trimmed.contains("thinking")
+        || trimmed.contains("running")
+        || trimmed.contains("esc to interrupt")
+        || trimmed.contains("ctrl-c")
+    {
+        return TmuxPaneState::Busy;
+    }
+    TmuxPaneState::Unknown
+}
+
+fn command_success(output: &std::process::Output, action: &str) -> anyhow::Result<()> {
+    if output.status.success() {
+        return Ok(());
+    }
+    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+    if stderr.is_empty() {
+        anyhow::bail!("failed to {action}: {}", output.status);
+    }
+    anyhow::bail!("failed to {action}: {stderr}");
+}
+
+fn command_stdout(output: std::process::Output, action: &str) -> anyhow::Result<String> {
+    command_success(&output, action)?;
+    Ok(String::from_utf8_lossy(&output.stdout).to_string())
+}
+
+fn is_allowed_target_char(ch: char) -> bool {
+    ch.is_ascii_alphanumeric() || matches!(ch, '_' | '-' | '.' | ':' | '@' | '%' | '/')
+}
+
+fn strip_ansi(value: &str) -> String {
+    let mut output = String::with_capacity(value.len());
+    let mut chars = value.chars().peekable();
+    while let Some(ch) = chars.next() {
+        if ch == '\u{1b}' && chars.peek() == Some(&'[') {
+            let _ = chars.next();
+            for next in chars.by_ref() {
+                if ('@'..='~').contains(&next) {
+                    break;
+                }
+            }
+            continue;
+        }
+        output.push(ch);
+    }
+    output
+}
+
+fn tmux_buffer_name() -> String {
+    let nanos = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or_default();
+    format!("moltis-channel-{nanos}-{}", std::process::id())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn target_accepts_common_tmux_targets() {
+        for target in ["moltis", "moltis:0", "moltis:0.1", "@12", "%34"] {
+            assert_eq!(TmuxTarget::new(target).unwrap().as_str(), target);
+        }
+    }
+
+    #[test]
+    fn target_rejects_shell_like_values() {
+        for target in ["", "moltis;rm -rf /", "$(touch x)", "name with spaces"] {
+            assert!(TmuxTarget::new(target).is_err());
+        }
+    }
+
+    #[test]
+    fn classify_ready_shell_prompt() {
+        assert_eq!(classify_pane_state("~/repo $"), TmuxPaneState::ReadyPrompt);
+        assert_eq!(classify_pane_state("root #"), TmuxPaneState::ReadyPrompt);
+    }
+
+    #[test]
+    fn classify_permission_prompt() {
+        assert_eq!(
+            classify_pane_state("Do you want to proceed?\n> 1. Yes"),
+            TmuxPaneState::PermissionPrompt
+        );
+    }
+
+    #[test]
+    fn classify_busy_pane() {
+        assert_eq!(
+            classify_pane_state("Thinking... press Esc to interrupt"),
+            TmuxPaneState::Busy
+        );
+    }
+
+    #[test]
+    fn ansi_sequences_do_not_hide_state() {
+        assert_eq!(
+            classify_pane_state("\u{1b}[32m~/repo $\u{1b}[0m"),
+            TmuxPaneState::ReadyPrompt
+        );
+    }
+}

--- a/crates/external-agents/src/tmux.rs
+++ b/crates/external-agents/src/tmux.rs
@@ -122,7 +122,7 @@ impl TmuxController {
         if text.trim().is_empty() {
             anyhow::bail!("tmux input cannot be empty");
         }
-        let before = self.capture_pane(target).unwrap_or_default();
+        let before = self.capture_pane(target)?;
         let pane_state_before = classify_pane_state(&before);
         if pane_state_before == TmuxPaneState::Busy {
             return Ok(TmuxDeliveryReceipt {
@@ -158,7 +158,7 @@ impl TmuxController {
             .output()?;
         command_success(&enter, "send tmux enter")?;
 
-        let after = self.capture_pane(target).unwrap_or_default();
+        let after = self.capture_pane(target)?;
         let pane_state_after = classify_pane_state(&after);
         let status = if after != before {
             TmuxDeliveryStatus::Applied
@@ -209,7 +209,6 @@ pub fn classify_pane_state(output: &str) -> TmuxPaneState {
         return TmuxPaneState::ReadyPrompt;
     }
     if trimmed.contains("thinking")
-        || trimmed.contains("running")
         || trimmed.contains("esc to interrupt")
         || trimmed.contains("ctrl-c")
     {
@@ -314,6 +313,14 @@ mod tests {
         assert_eq!(
             classify_pane_state("Thinking... press Esc to interrupt"),
             TmuxPaneState::Busy
+        );
+    }
+
+    #[test]
+    fn classify_running_text_as_unknown_without_interrupt_hint() {
+        assert_eq!(
+            classify_pane_state("Tests are running"),
+            TmuxPaneState::Unknown
         );
     }
 

--- a/crates/external-agents/src/tmux.rs
+++ b/crates/external-agents/src/tmux.rs
@@ -268,7 +268,11 @@ mod tests {
     #[test]
     fn target_accepts_common_tmux_targets() {
         for target in ["moltis", "moltis:0", "moltis:0.1", "@12", "%34"] {
-            assert_eq!(TmuxTarget::new(target).unwrap().as_str(), target);
+            let parsed = match TmuxTarget::new(target) {
+                Ok(parsed) => parsed,
+                Err(error) => panic!("expected valid tmux target {target}: {error}"),
+            };
+            assert_eq!(parsed.as_str(), target);
         }
     }
 

--- a/crates/external-agents/src/tmux.rs
+++ b/crates/external-agents/src/tmux.rs
@@ -1,4 +1,4 @@
-use std::{process::Command, time::SystemTime};
+use std::process::Command;
 
 pub const MOLTIS_HOST_TERMINAL_TMUX_SOCKET_NAME: &str = "moltis-host-terminal";
 pub const MOLTIS_HOST_TERMINAL_TMUX_CONFIG_PATH: &str = "/dev/null";
@@ -17,8 +17,6 @@ pub enum TmuxPaneState {
 pub enum TmuxDeliveryStatus {
     Applied,
     Busy,
-    Rejected,
-    Timeout,
     Unknown,
 }
 
@@ -62,6 +60,9 @@ impl TmuxTarget {
 }
 
 /// Minimal tmux controller for driving live terminal sessions.
+///
+/// This intentionally shells out to the tmux CLI to target the same named
+/// socket/config used by the existing web host-terminal implementation.
 #[derive(Debug, Clone)]
 pub struct TmuxController {
     socket_name: Option<String>,
@@ -159,12 +160,10 @@ impl TmuxController {
 
         let after = self.capture_pane(target).unwrap_or_default();
         let pane_state_after = classify_pane_state(&after);
-        let status = if !after.is_empty() && after != before {
+        let status = if after != before {
             TmuxDeliveryStatus::Applied
-        } else if pane_state_before == TmuxPaneState::Unknown {
-            TmuxDeliveryStatus::Unknown
         } else {
-            TmuxDeliveryStatus::Applied
+            TmuxDeliveryStatus::Unknown
         };
 
         Ok(TmuxDeliveryReceipt {
@@ -200,8 +199,9 @@ pub fn classify_pane_state(output: &str) -> TmuxPaneState {
         return TmuxPaneState::Unknown;
     }
     if trimmed.contains("do you want to proceed")
-        || trimmed.contains("allow this")
-        || trimmed.contains("permission")
+        || trimmed.contains("allow this action")
+        || trimmed.contains("allow this operation")
+        || trimmed.contains("grant permission")
     {
         return TmuxPaneState::PermissionPrompt;
     }
@@ -257,10 +257,7 @@ fn strip_ansi(value: &str) -> String {
 }
 
 fn tmux_buffer_name() -> String {
-    let nanos = SystemTime::now()
-        .duration_since(SystemTime::UNIX_EPOCH)
-        .map(|duration| duration.as_nanos())
-        .unwrap_or_default();
+    let nanos = time::OffsetDateTime::now_utc().unix_timestamp_nanos();
     format!("moltis-channel-{nanos}-{}", std::process::id())
 }
 
@@ -293,6 +290,18 @@ mod tests {
         assert_eq!(
             classify_pane_state("Do you want to proceed?\n> 1. Yes"),
             TmuxPaneState::PermissionPrompt
+        );
+        assert_eq!(
+            classify_pane_state("Allow this action?\n1. Yes"),
+            TmuxPaneState::PermissionPrompt
+        );
+    }
+
+    #[test]
+    fn classify_permission_denied_as_ready_prompt() {
+        assert_eq!(
+            classify_pane_state("ls /root\nPermission denied\n~/repo $"),
+            TmuxPaneState::ReadyPrompt
         );
     }
 

--- a/crates/gateway/src/channel_events/commands/control_handlers.rs
+++ b/crates/gateway/src/channel_events/commands/control_handlers.rs
@@ -3,6 +3,10 @@ use std::sync::Arc;
 use {
     moltis_channels::{ChannelReplyTarget, Error as ChannelError, Result as ChannelResult},
     moltis_config::ModePreset,
+    moltis_external_agents::tmux::{
+        TmuxController, TmuxDeliveryReceipt, TmuxDeliveryStatus, TmuxPaneState, TmuxTarget,
+        classify_pane_state,
+    },
     moltis_sessions::metadata::SqliteSessionMetadata,
     moltis_tools::image_cache::ImageBuilder,
 };
@@ -39,6 +43,89 @@ fn sorted_mode_presets(config: &moltis_config::MoltisConfig) -> Vec<(String, Mod
             .then_with(|| left_id.cmp(right_id))
     });
     modes
+}
+
+enum TmuxChannelCommand {
+    Status { target: TmuxTarget },
+    Capture { target: TmuxTarget },
+    Send { target: TmuxTarget, text: String },
+}
+
+fn parse_tmux_channel_command(args: &str) -> ChannelResult<TmuxChannelCommand> {
+    let args = args.trim();
+    let Some((action, rest)) = args.split_once(char::is_whitespace) else {
+        return Err(ChannelError::invalid_input(
+            "usage: /tmux status <target>, /tmux capture <target>, or /tmux send <target> <text>",
+        ));
+    };
+    let rest = rest.trim_start();
+    let (target, text) = rest
+        .split_once(char::is_whitespace)
+        .map(|(target, text)| (target, text.trim_start()))
+        .unwrap_or((rest, ""));
+    if action.is_empty() || target.is_empty() {
+        return Err(ChannelError::invalid_input(
+            "usage: /tmux status <target>, /tmux capture <target>, or /tmux send <target> <text>",
+        ));
+    }
+    let target = TmuxTarget::new(target).map_err(ChannelError::invalid_input)?;
+    match action {
+        "status" => Ok(TmuxChannelCommand::Status { target }),
+        "capture" => Ok(TmuxChannelCommand::Capture { target }),
+        "send" => {
+            let text = text.trim();
+            if text.is_empty() {
+                return Err(ChannelError::invalid_input(
+                    "usage: /tmux send <target> <text>",
+                ));
+            }
+            Ok(TmuxChannelCommand::Send {
+                target,
+                text: text.to_string(),
+            })
+        },
+        _ => Err(ChannelError::invalid_input(
+            "unknown /tmux action. Use status, capture, or send.",
+        )),
+    }
+}
+
+fn format_tmux_pane_state(state: TmuxPaneState) -> &'static str {
+    match state {
+        TmuxPaneState::ReadyPrompt => "ready",
+        TmuxPaneState::PermissionPrompt => "permission_prompt",
+        TmuxPaneState::Busy => "busy",
+        TmuxPaneState::Unknown => "unknown",
+    }
+}
+
+fn format_tmux_delivery_status(status: TmuxDeliveryStatus) -> &'static str {
+    match status {
+        TmuxDeliveryStatus::Applied => "applied",
+        TmuxDeliveryStatus::Busy => "busy",
+        TmuxDeliveryStatus::Rejected => "rejected",
+        TmuxDeliveryStatus::Timeout => "timeout",
+        TmuxDeliveryStatus::Unknown => "unknown",
+    }
+}
+
+fn format_tmux_receipt(receipt: &TmuxDeliveryReceipt) -> String {
+    format!(
+        "tmux delivery: {}\nbefore: {}\nafter: {}",
+        format_tmux_delivery_status(receipt.status),
+        format_tmux_pane_state(receipt.pane_state_before),
+        format_tmux_pane_state(receipt.pane_state_after),
+    )
+}
+
+fn truncate_tmux_capture(mut capture: String) -> String {
+    const LIMIT: usize = 3500;
+    if capture.len() <= LIMIT {
+        return capture;
+    }
+    let keep_from = capture.floor_char_boundary(capture.len() - LIMIT);
+    capture = capture[keep_from..].to_string();
+    format!("[truncated]\n{capture}")
 }
 
 pub(in crate::channel_events) async fn handle_approvals(
@@ -793,6 +880,58 @@ pub(in crate::channel_events) async fn handle_peek(
     }
 }
 
+pub(in crate::channel_events) async fn handle_tmux(
+    state: &Arc<GatewayState>,
+    reply_to: &ChannelReplyTarget,
+    sender_id: Option<&str>,
+    args: &str,
+) -> ChannelResult<String> {
+    if !state.config.external_agents.enabled || !state.config.external_agents.channel_tmux_control {
+        return Err(ChannelError::invalid_input(
+            "/tmux is disabled. Set external_agents.enabled = true and external_agents.channel_tmux_control = true to enable it.",
+        ));
+    }
+    let authorized = match sender_id {
+        Some(sid) => is_sender_on_allowlist(state, &reply_to.account_id, sid).await,
+        None => false,
+    };
+    if !authorized {
+        return Err(ChannelError::invalid_input(
+            "You are not authorized to control tmux. Only users on this bot's allowlist can use /tmux.",
+        ));
+    }
+
+    let command = parse_tmux_channel_command(args)?;
+    let controller = TmuxController::moltis_host_terminal();
+    if !controller.is_available() {
+        return Err(ChannelError::unavailable("tmux is not installed"));
+    }
+
+    tokio::task::spawn_blocking(move || -> anyhow::Result<String> {
+        match command {
+            TmuxChannelCommand::Status { target } => {
+                let capture = controller.capture_pane(&target)?;
+                Ok(format!(
+                    "tmux pane {}: {}",
+                    target.as_str(),
+                    format_tmux_pane_state(classify_pane_state(&capture))
+                ))
+            },
+            TmuxChannelCommand::Capture { target } => {
+                let capture = controller.capture_pane(&target)?;
+                Ok(truncate_tmux_capture(capture))
+            },
+            TmuxChannelCommand::Send { target, text } => {
+                let receipt = controller.send_text_with_receipt(&target, &text)?;
+                Ok(format_tmux_receipt(&receipt))
+            },
+        }
+    })
+    .await
+    .map_err(|e| ChannelError::external("tmux worker", e))?
+    .map_err(ChannelError::unavailable)
+}
+
 /// Handle `/tts` commands.
 ///
 /// Subcommands:
@@ -852,6 +991,37 @@ pub(in crate::channel_events) async fn handle_tts(
             "unknown /tts subcommand: {other}\n\
              Usage:\n  /tts persona [<id>|off]\n  /tts provider [<id>]\n  /tts chat [on|off|default]"
         ))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_tmux_status_command() {
+        let parsed = parse_tmux_channel_command("status moltis:0.1").unwrap();
+        match parsed {
+            TmuxChannelCommand::Status { target } => assert_eq!(target.as_str(), "moltis:0.1"),
+            _ => panic!("expected status command"),
+        }
+    }
+
+    #[test]
+    fn parse_tmux_send_keeps_message_spaces() {
+        let parsed = parse_tmux_channel_command("send   %12   hello from telegram").unwrap();
+        match parsed {
+            TmuxChannelCommand::Send { target, text } => {
+                assert_eq!(target.as_str(), "%12");
+                assert_eq!(text, "hello from telegram");
+            },
+            _ => panic!("expected send command"),
+        }
+    }
+
+    #[test]
+    fn parse_tmux_rejects_missing_text() {
+        assert!(parse_tmux_channel_command("send %12").is_err());
     }
 }
 

--- a/crates/gateway/src/channel_events/commands/control_handlers.rs
+++ b/crates/gateway/src/channel_events/commands/control_handlers.rs
@@ -103,8 +103,6 @@ fn format_tmux_delivery_status(status: TmuxDeliveryStatus) -> &'static str {
     match status {
         TmuxDeliveryStatus::Applied => "applied",
         TmuxDeliveryStatus::Busy => "busy",
-        TmuxDeliveryStatus::Rejected => "rejected",
-        TmuxDeliveryStatus::Timeout => "timeout",
         TmuxDeliveryStatus::Unknown => "unknown",
     }
 }

--- a/crates/gateway/src/channel_events/commands/control_handlers.rs
+++ b/crates/gateway/src/channel_events/commands/control_handlers.rs
@@ -992,37 +992,6 @@ pub(in crate::channel_events) async fn handle_tts(
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn parse_tmux_status_command() {
-        let parsed = parse_tmux_channel_command("status moltis:0.1").unwrap();
-        match parsed {
-            TmuxChannelCommand::Status { target } => assert_eq!(target.as_str(), "moltis:0.1"),
-            _ => panic!("expected status command"),
-        }
-    }
-
-    #[test]
-    fn parse_tmux_send_keeps_message_spaces() {
-        let parsed = parse_tmux_channel_command("send   %12   hello from telegram").unwrap();
-        match parsed {
-            TmuxChannelCommand::Send { target, text } => {
-                assert_eq!(target.as_str(), "%12");
-                assert_eq!(text, "hello from telegram");
-            },
-            _ => panic!("expected send command"),
-        }
-    }
-
-    #[test]
-    fn parse_tmux_rejects_missing_text() {
-        assert!(parse_tmux_channel_command("send %12").is_err());
-    }
-}
-
 async fn handle_tts_persona(state: &Arc<GatewayState>, args: &str) -> ChannelResult<String> {
     let Some(ref store) = state.services.voice_persona_store else {
         return Err(ChannelError::unavailable("voice personas not available"));
@@ -1194,5 +1163,43 @@ async fn handle_tts_chat(
         other => Err(ChannelError::invalid_input(format!(
             "unknown /tts chat mode: {other}\nUsage: /tts chat [on|off|default]"
         ))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse_tmux_command_ok(input: &str) -> TmuxChannelCommand {
+        match parse_tmux_channel_command(input) {
+            Ok(command) => command,
+            Err(error) => panic!("expected valid /tmux command {input}: {error}"),
+        }
+    }
+
+    #[test]
+    fn parse_tmux_status_command() {
+        let parsed = parse_tmux_command_ok("status moltis:0.1");
+        match parsed {
+            TmuxChannelCommand::Status { target } => assert_eq!(target.as_str(), "moltis:0.1"),
+            _ => panic!("expected status command"),
+        }
+    }
+
+    #[test]
+    fn parse_tmux_send_keeps_message_spaces() {
+        let parsed = parse_tmux_command_ok("send   %12   hello from telegram");
+        match parsed {
+            TmuxChannelCommand::Send { target, text } => {
+                assert_eq!(target.as_str(), "%12");
+                assert_eq!(text, "hello from telegram");
+            },
+            _ => panic!("expected send command"),
+        }
+    }
+
+    #[test]
+    fn parse_tmux_rejects_missing_text() {
+        assert!(parse_tmux_channel_command("send %12").is_err());
     }
 }

--- a/crates/gateway/src/channel_events/commands/dispatch.rs
+++ b/crates/gateway/src/channel_events/commands/dispatch.rs
@@ -116,6 +116,7 @@ pub(in crate::channel_events) async fn dispatch_command(
         "sh" => control_handlers::handle_sh(state, &session_key, args).await,
         "stop" => control_handlers::handle_stop(state, &session_key).await,
         "peek" => control_handlers::handle_peek(state, &session_key).await,
+        "tmux" => control_handlers::handle_tmux(state, &reply_to, sender_id, args).await,
         "tts" => control_handlers::handle_tts(state, &session_key, args).await,
         "update" => control_handlers::handle_update(state, &reply_to, sender_id, args).await,
 
@@ -167,6 +168,7 @@ mod tests {
             "sh",
             "stop",
             "peek",
+            "tmux",
             "update",
             "rollback",
             "btw",

--- a/docs/src/external-agents.md
+++ b/docs/src/external-agents.md
@@ -15,6 +15,9 @@ Enable the bridge in `moltis.toml`:
 ```toml
 [external_agents]
 enabled = true
+# Disabled by default. When true, allowlisted channel users can use /tmux
+# to inspect or send input to a live tmux pane.
+channel_tmux_control = false
 
 [external_agents.agents.claude-code]
 binary = "claude"
@@ -35,5 +38,16 @@ Moltis keeps live external sessions in memory while the gateway process is runni
 Current limitations:
 
 - Claude Code persistence uses print-mode `--resume`; it does not yet keep an interactive PTY alive.
-- ACP terminal capability is not enabled yet; ACP servers can read/write text files through the client bridge, but terminal requests are rejected.
+- ACP terminal requests run bounded commands and capture output; they are not interactive PTY sessions.
+- `/tmux` channel control is an explicit opt-in for live terminal control. It requires `external_agents.enabled = true`, `external_agents.channel_tmux_control = true`, and an allowlisted channel sender.
 - Live external processes are not restored automatically after a Moltis gateway restart.
+
+Channel tmux control supports:
+
+```text
+/tmux status <target>
+/tmux capture <target>
+/tmux send <target> <text>
+```
+
+Use tmux target strings such as `moltis:0.1`, `@12`, or `%34`. Delivery returns an explicit receipt (`applied`, `busy`, `unknown`, and related states) instead of assuming `tmux send-keys` means the application consumed the input.

--- a/docs/src/external-agents.md
+++ b/docs/src/external-agents.md
@@ -50,4 +50,4 @@ Channel tmux control supports:
 /tmux send <target> <text>
 ```
 
-Use tmux target strings such as `moltis:0.1`, `@12`, or `%34`. Delivery returns an explicit receipt (`applied`, `busy`, `unknown`, and related states) instead of assuming `tmux send-keys` means the application consumed the input.
+Use tmux target strings such as `moltis:0.1`, `@12`, or `%34`. Delivery returns an explicit receipt (`applied`, `busy`, or `unknown`) instead of assuming `tmux send-keys` means the application consumed the input.


### PR DESCRIPTION
## Summary
- Add an opt-in `/tmux` channel command for allowlisted users to inspect or send input to the Moltis host-terminal tmux server.
- Add reusable tmux control primitives with target validation, pane state classification, and explicit delivery receipts.
- Document the ACP versus live tmux control boundary and add the `external_agents.channel_tmux_control` config gate.

## Validation
### Completed
- [x] `cargo fmt --package moltis-external-agents --package moltis-gateway --package moltis-config --package moltis-channels -- --check`
- [x] `cargo test -p moltis-external-agents tmux`
- [x] `cargo test -p moltis-channels commands`
- [x] `cargo test -p moltis-config external_agents`
- [x] `cargo test -p moltis-gateway parse_tmux`
- [x] `cargo test -p moltis-gateway all_registered_commands_have_dispatch_arms`
- [x] `cargo clippy -p moltis-external-agents --all-targets -- -D warnings`
- [x] `cargo clippy -p moltis-gateway --all-targets -- -D warnings`
- [x] `./scripts/local-validate.sh 1082`

### Remaining
- [ ] Manual live channel-to-tmux QA against a running gateway

## Manual QA
- Not run. Unit coverage and full local validation passed; live Telegram-to-tmux behavior still needs an operator-owned gateway session.