### PR TITLE
fix(skills): track bundled skill disables individually

### DIFF
--- a/crates/chat/src/prompt.rs
+++ b/crates/chat/src/prompt.rs
@@ -291,10 +291,11 @@ pub(crate) async fn discover_skills_if_enabled(
         fs_discoverer.discover().await
     };
 
-    let disabled_cats = &config.skills.disabled_bundled_categories;
+    let has_bundled_disables = !config.skills.disabled_bundled_categories.is_empty()
+        || !config.skills.disabled_bundled_skills.is_empty();
 
     match skills {
-        Ok(skills) if disabled_cats.is_empty() => skills,
+        Ok(skills) if !has_bundled_disables => skills,
         Ok(skills) => skills
             .into_iter()
             .filter(|s| {
@@ -302,10 +303,9 @@ pub(crate) async fn discover_skills_if_enabled(
                 if s.source != Some(moltis_skills::types::SkillSource::Bundled) {
                     return true;
                 }
-                // Keep the skill if its category is not in the disabled list.
-                s.category
-                    .as_deref()
-                    .is_none_or(|cat| !disabled_cats.iter().any(|d| d == cat))
+                config
+                    .skills
+                    .is_bundled_skill_enabled(&s.name, s.category.as_deref())
             })
             .collect(),
         Err(e) => {

--- a/crates/config/src/schema/runtime.rs
+++ b/crates/config/src/schema/runtime.rs
@@ -99,6 +99,9 @@ pub struct SkillsConfig {
     /// `crates/skills/src/assets/` (e.g. `"gaming"`, `"social-media"`).
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub disabled_bundled_categories: Vec<String>,
+    /// Bundled skill names that the user has explicitly disabled.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub disabled_bundled_skills: Vec<String>,
 }
 
 impl Default for SkillsConfig {
@@ -110,7 +113,26 @@ impl Default for SkillsConfig {
             enable_agent_sidecar_files: false,
             enable_self_improvement: true,
             disabled_bundled_categories: Vec::new(),
+            disabled_bundled_skills: Vec::new(),
         }
+    }
+}
+
+impl SkillsConfig {
+    #[must_use]
+    pub fn is_bundled_skill_enabled(&self, name: &str, category: Option<&str>) -> bool {
+        let category_enabled = category.is_none_or(|cat| {
+            !self
+                .disabled_bundled_categories
+                .iter()
+                .any(|disabled| disabled == cat)
+        });
+        let skill_enabled = !self
+            .disabled_bundled_skills
+            .iter()
+            .any(|disabled| disabled == name);
+
+        category_enabled && skill_enabled
     }
 }
 

--- a/crates/config/src/template.rs
+++ b/crates/config/src/template.rs
@@ -511,6 +511,8 @@ port = {port}                           # Port number (auto-generated for this i
 # enabled = true                    # Enable skills system
 # search_paths = []                 # Additional directories to search for skills
 # auto_load = []                    # Skills to always load
+# disabled_bundled_categories = []   # Bundled skill categories to disable
+# disabled_bundled_skills = []       # Individual bundled skills to disable by name
 
 # ══════════════════════════════════════════════════════════════════════════════
 # MCP SERVERS

--- a/crates/config/src/validate/schema_map.rs
+++ b/crates/config/src/validate/schema_map.rs
@@ -439,6 +439,7 @@ pub(super) fn build_schema_map() -> KnownKeys {
                 ("enable_agent_sidecar_files", Leaf),
                 ("enable_self_improvement", Leaf),
                 ("disabled_bundled_categories", Leaf),
+                ("disabled_bundled_skills", Leaf),
             ])),
         ),
         (

--- a/crates/gateway/src/services/skills/service.rs
+++ b/crates/gateway/src/services/skills/service.rs
@@ -1142,7 +1142,15 @@ impl SkillsService for NoopSkillsService {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use {super::*, serial_test::serial};
+
+    struct ConfigDirGuard;
+
+    impl Drop for ConfigDirGuard {
+        fn drop(&mut self) {
+            moltis_config::clear_config_dir();
+        }
+    }
 
     #[test]
     fn risky_install_pattern_detects_piped_shell() {
@@ -1155,5 +1163,80 @@ mod tests {
     #[test]
     fn risky_install_pattern_allows_plain_package_install() {
         assert_eq!(risky_install_pattern("cargo install ripgrep"), None);
+    }
+
+    #[cfg(feature = "bundled-skills")]
+    #[tokio::test]
+    #[serial]
+    async fn disabling_one_bundled_skill_does_not_disable_category() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        moltis_config::set_config_dir(dir.path().to_path_buf());
+        let _guard = ConfigDirGuard;
+
+        let service = NoopSkillsService;
+        let result = service
+            .skill_disable(serde_json::json!({ "source": "bundled", "skill": "apple-notes" }))
+            .await
+            .expect("disable bundled skill");
+
+        assert_eq!(
+            result.get("skill").and_then(Value::as_str),
+            Some("apple-notes")
+        );
+
+        let config = moltis_config::discover_and_load();
+        assert!(config.skills.disabled_bundled_categories.is_empty());
+        assert_eq!(config.skills.disabled_bundled_skills, vec![
+            "apple-notes".to_string()
+        ]);
+        assert!(
+            !config
+                .skills
+                .is_bundled_skill_enabled("apple-notes", Some("apple"))
+        );
+        assert!(
+            config
+                .skills
+                .is_bundled_skill_enabled("apple-reminders", Some("apple"))
+        );
+    }
+
+    #[cfg(feature = "bundled-skills")]
+    #[tokio::test]
+    #[serial]
+    async fn bundled_category_toggle_preserves_individual_disables() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        moltis_config::set_config_dir(dir.path().to_path_buf());
+        let _guard = ConfigDirGuard;
+
+        let service = NoopSkillsService;
+        service
+            .skill_disable(serde_json::json!({ "source": "bundled", "skill": "apple-notes" }))
+            .await
+            .expect("disable bundled skill");
+        service
+            .bundled_toggle_category(serde_json::json!({ "category": "apple", "enabled": false }))
+            .await
+            .expect("disable bundled category");
+        service
+            .bundled_toggle_category(serde_json::json!({ "category": "apple", "enabled": true }))
+            .await
+            .expect("enable bundled category");
+
+        let config = moltis_config::discover_and_load();
+        assert!(config.skills.disabled_bundled_categories.is_empty());
+        assert_eq!(config.skills.disabled_bundled_skills, vec![
+            "apple-notes".to_string()
+        ]);
+        assert!(
+            !config
+                .skills
+                .is_bundled_skill_enabled("apple-notes", Some("apple"))
+        );
+        assert!(
+            config
+                .skills
+                .is_bundled_skill_enabled("apple-reminders", Some("apple"))
+        );
     }
 }

--- a/crates/gateway/src/services/skills/service.rs
+++ b/crates/gateway/src/services/skills/service.rs
@@ -1224,12 +1224,8 @@ mod tests {
             .expect("enable bundled skill while category is disabled");
         assert_eq!(
             still_disabled.get("enabled").and_then(Value::as_bool),
-            Some(false)
+            Some(true)
         );
-        service
-            .bundled_toggle_category(serde_json::json!({ "category": "apple", "enabled": true }))
-            .await
-            .expect("enable bundled category");
 
         let config = moltis_config::discover_and_load();
         assert!(config.skills.disabled_bundled_categories.is_empty());

--- a/crates/gateway/src/services/skills/service.rs
+++ b/crates/gateway/src/services/skills/service.rs
@@ -1218,6 +1218,14 @@ mod tests {
             .bundled_toggle_category(serde_json::json!({ "category": "apple", "enabled": false }))
             .await
             .expect("disable bundled category");
+        let still_disabled = service
+            .skill_enable(serde_json::json!({ "source": "bundled", "skill": "apple-reminders" }))
+            .await
+            .expect("enable bundled skill while category is disabled");
+        assert_eq!(
+            still_disabled.get("enabled").and_then(Value::as_bool),
+            Some(false)
+        );
         service
             .bundled_toggle_category(serde_json::json!({ "category": "apple", "enabled": true }))
             .await

--- a/crates/gateway/src/services/skills/skills_helpers.rs
+++ b/crates/gateway/src/services/skills/skills_helpers.rs
@@ -205,6 +205,7 @@ pub(super) fn toggle_bundled_skill(params: &Value, enabled: bool) -> ServiceResu
         let category = skill.category.clone();
 
         let skill_name = skill_name.to_string();
+        let mut effective_enabled = enabled;
         if let Err(e) = moltis_config::update_config(|cfg| {
             if enabled {
                 cfg.skills
@@ -218,6 +219,9 @@ pub(super) fn toggle_bundled_skill(params: &Value, enabled: bool) -> ServiceResu
             {
                 cfg.skills.disabled_bundled_skills.push(skill_name.clone());
             }
+            effective_enabled = cfg
+                .skills
+                .is_bundled_skill_enabled(&skill_name, category.as_deref());
         }) {
             return Err(format!("failed to save config: {e}").into());
         }
@@ -228,12 +232,12 @@ pub(super) fn toggle_bundled_skill(params: &Value, enabled: bool) -> ServiceResu
                 "source": "bundled",
                 "skill": skill_name,
                 "category": category,
-                "enabled": enabled,
+                "enabled": effective_enabled,
             }),
         );
 
         Ok(
-            serde_json::json!({ "source": "bundled", "skill": skill_name, "category": category, "enabled": enabled }),
+            serde_json::json!({ "source": "bundled", "skill": skill_name, "category": category, "enabled": effective_enabled }),
         )
     }
     #[cfg(not(feature = "bundled-skills"))]

--- a/crates/gateway/src/services/skills/skills_helpers.rs
+++ b/crates/gateway/src/services/skills/skills_helpers.rs
@@ -159,13 +159,9 @@ pub(super) fn skill_detail_bundled(skill_name: &str) -> ServiceResult {
     let elig = check_requirements(meta);
 
     let config = moltis_config::discover_and_load();
-    let enabled = meta.category.as_deref().is_none_or(|cat| {
-        !config
-            .skills
-            .disabled_bundled_categories
-            .iter()
-            .any(|c| c == cat)
-    });
+    let enabled = config
+        .skills
+        .is_bundled_skill_enabled(&meta.name, meta.category.as_deref());
 
     Ok(serde_json::json!({
         "name": meta.name,
@@ -188,8 +184,8 @@ pub(super) fn skill_detail_bundled(skill_name: &str) -> ServiceResult {
     }))
 }
 
-/// Toggle a bundled skill by adding/removing its category from
-/// `disabled_bundled_categories` in config. Bundled skills are not tracked
+/// Toggle a bundled skill by adding/removing its name from
+/// `disabled_bundled_skills` in config. Bundled skills are not tracked
 /// in the manifest, so `toggle_skill()` cannot handle them.
 pub(super) fn toggle_bundled_skill(params: &Value, enabled: bool) -> ServiceResult {
     let skill_name = params
@@ -211,19 +207,19 @@ pub(super) fn toggle_bundled_skill(params: &Value, enabled: bool) -> ServiceResu
             .clone()
             .ok_or_else(|| format!("bundled skill '{skill_name}' has no category"))?;
 
-        let cat_clone = category.clone();
+        let skill_name = skill_name.to_string();
         if let Err(e) = moltis_config::update_config(|cfg| {
             if enabled {
                 cfg.skills
-                    .disabled_bundled_categories
-                    .retain(|c| c != &cat_clone);
+                    .disabled_bundled_skills
+                    .retain(|name| name != &skill_name);
             } else if !cfg
                 .skills
-                .disabled_bundled_categories
+                .disabled_bundled_skills
                 .iter()
-                .any(|c| c == &cat_clone)
+                .any(|name| name == &skill_name)
             {
-                cfg.skills.disabled_bundled_categories.push(cat_clone);
+                cfg.skills.disabled_bundled_skills.push(skill_name.clone());
             }
         }) {
             return Err(format!("failed to save config: {e}").into());

--- a/crates/gateway/src/services/skills/skills_helpers.rs
+++ b/crates/gateway/src/services/skills/skills_helpers.rs
@@ -202,10 +202,7 @@ pub(super) fn toggle_bundled_skill(params: &Value, enabled: bool) -> ServiceResu
             .iter()
             .find(|s| s.name == skill_name)
             .ok_or_else(|| format!("bundled skill '{skill_name}' not found"))?;
-        let category = skill
-            .category
-            .clone()
-            .ok_or_else(|| format!("bundled skill '{skill_name}' has no category"))?;
+        let category = skill.category.clone();
 
         let skill_name = skill_name.to_string();
         if let Err(e) = moltis_config::update_config(|cfg| {

--- a/crates/gateway/src/services/skills/skills_helpers.rs
+++ b/crates/gateway/src/services/skills/skills_helpers.rs
@@ -211,6 +211,11 @@ pub(super) fn toggle_bundled_skill(params: &Value, enabled: bool) -> ServiceResu
                 cfg.skills
                     .disabled_bundled_skills
                     .retain(|name| name != &skill_name);
+                if let Some(category) = &category {
+                    cfg.skills
+                        .disabled_bundled_categories
+                        .retain(|name| name != category);
+                }
             } else if !cfg
                 .skills
                 .disabled_bundled_skills

--- a/crates/web/src/api.rs
+++ b/crates/web/src/api.rs
@@ -602,8 +602,6 @@ pub async fn api_skills_handler(State(state): State<AppState>) -> impl IntoRespo
         .unwrap_or_default();
 
     let config = moltis_config::discover_and_load();
-    let disabled_cats = &config.skills.disabled_bundled_categories;
-
     let mut skills = enabled_from_manifest(moltis_skills::manifest::ManifestStore::default_path());
 
     {
@@ -638,10 +636,9 @@ pub async fn api_skills_handler(State(state): State<AppState>) -> impl IntoRespo
                 let protected = moltis_gateway::services::is_protected_discovered_skill(&s.name);
                 let is_bundled = s.source == Some(moltis_skills::types::SkillSource::Bundled);
                 let enabled = if is_bundled {
-                    // Bundled skills are enabled unless their category is disabled.
-                    s.category
-                        .as_deref()
-                        .is_none_or(|cat| !disabled_cats.iter().any(|d| d == cat))
+                    config
+                        .skills
+                        .is_bundled_skill_enabled(&s.name, s.category.as_deref())
                 } else {
                     true
                 };


### PR DESCRIPTION
## Summary
- Fixes #1083 by storing individual bundled skill disables separately from category disables.
- Applies the same bundled enable-state helper in chat discovery, the web API, and skill detail responses.
- Adds regression coverage for disabling one Apple skill without disabling the Apple category.

## Validation

### Completed
- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p moltis-gateway bundled`
- [x] `cargo test -p moltis-config disabled_bundled`
- [x] `cargo check -p moltis-chat`
- [x] `just build-web-assets`

### Remaining
- [ ] `cargo check -p moltis-web` currently fails on existing unrelated `moltis_voice` feature/import errors in `moltis-gateway`.

## Manual QA
- Not run. Regression is covered by service tests that verify disabling `apple-notes` leaves `apple-reminders` enabled and category re-enable preserves individual disables.