### PR TITLE
Cap persisted tool results before rehydration

### DIFF
--- a/crates/agents/src/model/convert.rs
+++ b/crates/agents/src/model/convert.rs
@@ -1,4 +1,4 @@
-use crate::multimodal::parse_data_uri;
+use crate::{multimodal::parse_data_uri, runner::sanitize_tool_result};
 
 use super::{
     chat::{ChatMessage, ContentPart, UserContent},
@@ -56,7 +56,16 @@ fn document_absolute_path_from_media_ref(media_ref: &str) -> String {
 /// `outputTokens`, `channel`) are silently dropped — they only exist in
 /// the persisted JSON, not in `ChatMessage`.
 pub fn values_to_chat_messages(values: &[serde_json::Value]) -> Vec<ChatMessage> {
-    values_to_chat_messages_inner(values, true)
+    values_to_chat_messages_inner(values, true, None)
+}
+
+/// Convert persisted JSON messages (from session store) to typed `ChatMessage`s,
+/// sanitizing tool results before they are sent back to an LLM provider.
+pub fn values_to_chat_messages_with_tool_result_limit(
+    values: &[serde_json::Value],
+    max_tool_result_bytes: usize,
+) -> Vec<ChatMessage> {
+    values_to_chat_messages_inner(values, true, Some(max_tool_result_bytes))
 }
 
 /// Convert provider-format JSON messages to typed `ChatMessage`s without
@@ -65,12 +74,22 @@ pub fn values_to_chat_messages(values: &[serde_json::Value]) -> Vec<ChatMessage>
 /// Hook-modified LLM payloads are already provider-bound, so preserve their
 /// tool messages exactly instead of applying session-store orphan filtering.
 pub fn provider_values_to_chat_messages(values: &[serde_json::Value]) -> Vec<ChatMessage> {
-    values_to_chat_messages_inner(values, false)
+    values_to_chat_messages_inner(values, false, None)
+}
+
+fn maybe_limit_tool_result_content(
+    content: String,
+    max_tool_result_bytes: Option<usize>,
+) -> String {
+    max_tool_result_bytes
+        .map(|max_bytes| sanitize_tool_result(&content, max_bytes))
+        .unwrap_or(content)
 }
 
 fn values_to_chat_messages_inner(
     values: &[serde_json::Value],
     filter_orphan_tool_results: bool,
+    max_tool_result_bytes: Option<usize>,
 ) -> Vec<ChatMessage> {
     let mut messages = Vec::with_capacity(values.len());
     // Track tool_call IDs emitted by assistant messages so we only include
@@ -237,6 +256,7 @@ fn values_to_chat_messages_inner(
                 } else {
                     val["content"].to_string()
                 };
+                let content = maybe_limit_tool_result_content(content, max_tool_result_bytes);
                 messages.push(ChatMessage::tool(tool_call_id, content));
             },
             // tool_result entries are persisted tool execution output; convert
@@ -269,6 +289,7 @@ fn values_to_chat_messages_inner(
                 } else {
                     String::new()
                 };
+                let content = maybe_limit_tool_result_content(content, max_tool_result_bytes);
                 messages.push(ChatMessage::tool(tool_call_id, content));
             },
             // notice entries are UI-only informational messages.

--- a/crates/agents/src/model/mod.rs
+++ b/crates/agents/src/model/mod.rs
@@ -16,6 +16,7 @@ pub use chat::{ChatMessage, ContentPart, UserContent};
 mod convert;
 pub use convert::{
     extract_tool_call_metadata, provider_values_to_chat_messages, values_to_chat_messages,
+    values_to_chat_messages_with_tool_result_limit,
 };
 
 mod stream;
@@ -629,6 +630,220 @@ mod tests {
         assert!(matches!(&msgs[1], ChatMessage::Assistant { .. }));
         assert!(matches!(&msgs[2], ChatMessage::Tool { .. }));
         assert!(matches!(&msgs[3], ChatMessage::Assistant { .. }));
+    }
+
+    #[test]
+    fn convert_caps_persisted_string_tool_result_when_limit_is_set() {
+        let values = vec![
+            serde_json::json!({"role": "user", "content": "search"}),
+            serde_json::json!({
+                "role": "assistant",
+                "content": null,
+                "tool_calls": [{
+                    "id": "call_1",
+                    "function": {"name": "Grep", "arguments": "{}"}
+                }]
+            }),
+            serde_json::json!({
+                "role": "tool_result",
+                "tool_call_id": "call_1",
+                "tool_name": "Grep",
+                "success": true,
+                "result": "x".repeat(200)
+            }),
+        ];
+
+        let msgs = values_to_chat_messages_with_tool_result_limit(&values, 32);
+
+        match &msgs[2] {
+            ChatMessage::Tool { content, .. } => {
+                assert!(content.starts_with(&"x".repeat(32)));
+                assert!(content.contains("[truncated"));
+                assert!(content.contains("200 bytes total"));
+                assert!(content.len() < 96);
+            },
+            other => panic!("expected tool message, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn convert_caps_persisted_structured_tool_result_when_limit_is_set() {
+        let values = vec![
+            serde_json::json!({"role": "user", "content": "run command"}),
+            serde_json::json!({
+                "role": "assistant",
+                "content": null,
+                "tool_calls": [{
+                    "id": "call_1",
+                    "function": {"name": "exec", "arguments": "{}"}
+                }]
+            }),
+            serde_json::json!({
+                "role": "tool_result",
+                "tool_call_id": "call_1",
+                "tool_name": "exec",
+                "success": true,
+                "result": {"stdout": "x".repeat(200), "exit_code": 0}
+            }),
+        ];
+
+        let msgs = values_to_chat_messages_with_tool_result_limit(&values, 64);
+
+        match &msgs[2] {
+            ChatMessage::Tool { content, .. } => {
+                assert!(content.contains("[truncated"));
+                assert!(content.contains("bytes total"));
+                assert!(!content.contains(&"x".repeat(200)));
+                assert!(content.len() < 140);
+            },
+            other => panic!("expected tool message, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn convert_caps_persisted_tool_error_when_limit_is_set() {
+        let values = vec![
+            serde_json::json!({"role": "user", "content": "run command"}),
+            serde_json::json!({
+                "role": "assistant",
+                "content": null,
+                "tool_calls": [{
+                    "id": "call_1",
+                    "function": {"name": "exec", "arguments": "{}"}
+                }]
+            }),
+            serde_json::json!({
+                "role": "tool_result",
+                "tool_call_id": "call_1",
+                "tool_name": "exec",
+                "success": false,
+                "error": "boom".repeat(100)
+            }),
+        ];
+
+        let msgs = values_to_chat_messages_with_tool_result_limit(&values, 40);
+
+        match &msgs[2] {
+            ChatMessage::Tool { content, .. } => {
+                assert!(content.starts_with("Error: boom"));
+                assert!(content.contains("[truncated"));
+                assert!(!content.contains(&"boom".repeat(100)));
+            },
+            other => panic!("expected tool message, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn convert_caps_persisted_tool_role_content_when_limit_is_set() {
+        let values = vec![
+            serde_json::json!({"role": "user", "content": "search"}),
+            serde_json::json!({
+                "role": "assistant",
+                "content": null,
+                "tool_calls": [{
+                    "id": "call_1",
+                    "function": {"name": "Grep", "arguments": "{}"}
+                }]
+            }),
+            serde_json::json!({
+                "role": "tool",
+                "tool_call_id": "call_1",
+                "content": "z".repeat(200)
+            }),
+        ];
+
+        let msgs = values_to_chat_messages_with_tool_result_limit(&values, 24);
+
+        match &msgs[2] {
+            ChatMessage::Tool { content, .. } => {
+                assert!(content.starts_with(&"z".repeat(24)));
+                assert!(content.contains("[truncated"));
+                assert!(content.contains("200 bytes total"));
+            },
+            other => panic!("expected tool message, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn convert_tool_result_limit_preserves_char_boundaries() {
+        let values = vec![
+            serde_json::json!({"role": "user", "content": "search"}),
+            serde_json::json!({
+                "role": "assistant",
+                "content": null,
+                "tool_calls": [{
+                    "id": "call_1",
+                    "function": {"name": "Grep", "arguments": "{}"}
+                }]
+            }),
+            serde_json::json!({
+                "role": "tool_result",
+                "tool_call_id": "call_1",
+                "tool_name": "Grep",
+                "success": true,
+                "result": "é".repeat(100)
+            }),
+        ];
+
+        let msgs = values_to_chat_messages_with_tool_result_limit(&values, 3);
+
+        match &msgs[2] {
+            ChatMessage::Tool { content, .. } => {
+                assert!(content.starts_with('é'));
+                assert!(content.contains("[truncated"));
+                assert!(content.contains("200 bytes total"));
+            },
+            other => panic!("expected tool message, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn convert_tool_result_limit_preserves_orphan_filtering() {
+        let values = vec![
+            serde_json::json!({"role": "user", "content": "run ls"}),
+            serde_json::json!({
+                "role": "tool_result",
+                "tool_call_id": "call_orphan",
+                "tool_name": "exec",
+                "success": true,
+                "result": "x".repeat(200)
+            }),
+            serde_json::json!({"role": "assistant", "content": "done"}),
+        ];
+
+        let msgs = values_to_chat_messages_with_tool_result_limit(&values, 32);
+
+        assert_eq!(msgs.len(), 2);
+        assert!(matches!(&msgs[0], ChatMessage::User { .. }));
+        assert!(matches!(&msgs[1], ChatMessage::Assistant { .. }));
+    }
+
+    #[test]
+    fn provider_conversion_preserves_tool_result_without_session_limit() {
+        let values = vec![
+            serde_json::json!({
+                "role": "assistant",
+                "content": null,
+                "tool_calls": [{
+                    "id": "call_1",
+                    "function": {"name": "Grep", "arguments": "{}"}
+                }]
+            }),
+            serde_json::json!({
+                "role": "tool_result",
+                "tool_call_id": "call_1",
+                "tool_name": "Grep",
+                "success": true,
+                "result": "x".repeat(200)
+            }),
+        ];
+
+        let msgs = provider_values_to_chat_messages(&values);
+
+        match &msgs[1] {
+            ChatMessage::Tool { content, .. } => assert_eq!(content, &"x".repeat(200)),
+            other => panic!("expected tool message, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/chat/src/agent_loop.rs
+++ b/crates/chat/src/agent_loop.rs
@@ -536,15 +536,17 @@ pub(crate) async fn compact_session(
     session_key: &str,
     config: &moltis_config::CompactionConfig,
     provider: Option<&dyn moltis_agents::model::LlmProvider>,
+    max_tool_result_bytes: usize,
 ) -> error::Result<compaction_run::CompactionOutcome> {
     let history = store
         .read(session_key)
         .await
         .map_err(|source| error::Error::external("failed to read session history", source))?;
 
-    let mut outcome = compaction_run::run_compaction(&history, config, provider)
-        .await
-        .map_err(|e| error::Error::message(e.to_string()))?;
+    let mut outcome =
+        compaction_run::run_compaction(&history, config, provider, max_tool_result_bytes)
+            .await
+            .map_err(|e| error::Error::message(e.to_string()))?;
 
     // Enforce summary budget discipline on the compacted history.
     outcome.history = compress_summary_in_history(outcome.history);

--- a/crates/chat/src/compaction_run/deterministic.rs
+++ b/crates/chat/src/compaction_run/deterministic.rs
@@ -61,7 +61,7 @@ mod tests {
             mode: CompactionMode::Deterministic,
             ..Default::default()
         };
-        let outcome = super::super::run_compaction(&history, &config, None)
+        let outcome = super::super::run_compaction(&history, &config, None, 50_000)
             .await
             .expect("deterministic dispatch succeeds");
         assert_eq!(

--- a/crates/chat/src/compaction_run/llm_replace.rs
+++ b/crates/chat/src/compaction_run/llm_replace.rs
@@ -6,7 +6,10 @@
 //! the pre-PR behaviour or need maximum token reduction.
 
 use {
-    moltis_agents::model::{ChatMessage, LlmProvider, StreamEvent, Usage, values_to_chat_messages},
+    moltis_agents::model::{
+        ChatMessage, LlmProvider, StreamEvent, Usage,
+        values_to_chat_messages_with_tool_result_limit,
+    },
     moltis_config::{CompactionConfig, CompactionMode},
     serde_json::Value,
     tokio_stream::StreamExt,
@@ -27,6 +30,7 @@ pub(super) async fn run(
     history: &[Value],
     config: &CompactionConfig,
     provider: &dyn LlmProvider,
+    max_tool_result_bytes: usize,
 ) -> Result<CompactionOutcome, CompactionRunError> {
     let mut summary_messages = vec![ChatMessage::system(
         "You are a conversation summarizer. The messages that follow are a \
@@ -34,7 +38,10 @@ pub(super) async fn run(
          and context. After the conversation, you will receive a final \
          instruction.",
     )];
-    summary_messages.extend(values_to_chat_messages(history));
+    summary_messages.extend(values_to_chat_messages_with_tool_result_limit(
+        history,
+        max_tool_result_bytes,
+    ));
     summary_messages.push(ChatMessage::user(
         "Summarize the conversation above into a concise form. Output only \
          the summary, no preamble.",
@@ -108,13 +115,53 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn llm_replace_uses_provider_cap_for_summary_input_tool_results() {
+        const NEEDLE: &str = "summary-input-needle-after-prune-threshold";
+        let history = vec![
+            json!({"role": "user", "content": "inspect tool output"}),
+            json!({
+                "role": "assistant",
+                "content": null,
+                "tool_calls": [{
+                    "id": "call_1",
+                    "function": {"name": "exec", "arguments": "{}"}
+                }]
+            }),
+            json!({
+                "role": "tool_result",
+                "tool_call_id": "call_1",
+                "tool_name": "exec",
+                "success": true,
+                "result": format!("{}{}", "x".repeat(240), NEEDLE)
+            }),
+            json!({"role": "user", "content": "summarize that"}),
+        ];
+        let config = CompactionConfig {
+            mode: CompactionMode::LlmReplace,
+            tool_prune_char_threshold: 20,
+            ..Default::default()
+        };
+        let provider = StubProvider::new_ok("stubbed summary body").with_needle(NEEDLE);
+
+        let outcome = super::super::run_compaction(&history, &config, Some(&provider), 1024)
+            .await
+            .expect("llm_replace succeeds with stub provider");
+
+        assert_eq!(outcome.effective_mode, CompactionMode::LlmReplace);
+        assert!(
+            provider.saw_needle(),
+            "llm_replace summary prompt should use provider cap, not the stored-history prune threshold"
+        );
+    }
+
+    #[tokio::test]
     async fn llm_replace_mode_without_provider_returns_provider_required() {
         let history = sample_history();
         let config = CompactionConfig {
             mode: CompactionMode::LlmReplace,
             ..Default::default()
         };
-        let err = super::super::run_compaction(&history, &config, None)
+        let err = super::super::run_compaction(&history, &config, None, 50_000)
             .await
             .unwrap_err();
         match err {
@@ -131,7 +178,7 @@ mod tests {
             ..Default::default()
         };
         let provider = StubProvider::new_ok("stubbed summary body");
-        let outcome = super::super::run_compaction(&history, &config, Some(&provider))
+        let outcome = super::super::run_compaction(&history, &config, Some(&provider), 50_000)
             .await
             .expect("llm_replace succeeds with stub provider");
         assert_eq!(outcome.effective_mode, CompactionMode::LlmReplace);

--- a/crates/chat/src/compaction_run/recency_preserving.rs
+++ b/crates/chat/src/compaction_run/recency_preserving.rs
@@ -143,7 +143,7 @@ mod tests {
             mode: CompactionMode::RecencyPreserving,
             ..Default::default()
         };
-        let err = super::super::run_compaction(&history, &config, None)
+        let err = super::super::run_compaction(&history, &config, None, 50_000)
             .await
             .unwrap_err();
         match err {
@@ -229,7 +229,7 @@ mod tests {
             tool_prune_char_threshold: 20,
             ..Default::default()
         };
-        let outcome = super::super::run_compaction(&history, &config, None)
+        let outcome = super::super::run_compaction(&history, &config, None, 50_000)
             .await
             .unwrap();
         let result = outcome.history;

--- a/crates/chat/src/compaction_run/runner.rs
+++ b/crates/chat/src/compaction_run/runner.rs
@@ -192,6 +192,7 @@ pub(crate) async fn run_compaction(
     history: &[Value],
     config: &CompactionConfig,
     provider: Option<&dyn LlmProvider>,
+    max_tool_result_bytes: usize,
 ) -> Result<CompactionOutcome, CompactionRunError> {
     if history.is_empty() {
         return Err(CompactionRunError::EmptyHistory);
@@ -231,7 +232,14 @@ pub(crate) async fn run_compaction(
                 let provider =
                     provider.ok_or(CompactionRunError::ProviderRequired { mode: "structured" })?;
                 let context_window = provider.context_window();
-                structured::run(history, config, context_window, provider).await
+                structured::run(
+                    history,
+                    config,
+                    context_window,
+                    provider,
+                    max_tool_result_bytes,
+                )
+                .await
             }
             #[cfg(not(feature = "llm-compaction"))]
             {
@@ -245,7 +253,7 @@ pub(crate) async fn run_compaction(
                 let provider = provider.ok_or(CompactionRunError::ProviderRequired {
                     mode: "llm_replace",
                 })?;
-                llm_replace::run(history, config, provider).await
+                llm_replace::run(history, config, provider, max_tool_result_bytes).await
             }
             #[cfg(not(feature = "llm-compaction"))]
             {
@@ -279,7 +287,9 @@ mod tests {
     #[tokio::test]
     async fn empty_history_returns_empty_history_error() {
         let config = CompactionConfig::default();
-        let err = run_compaction(&[], &config, None).await.unwrap_err();
+        let err = run_compaction(&[], &config, None, 50_000)
+            .await
+            .unwrap_err();
         assert!(matches!(err, CompactionRunError::EmptyHistory));
     }
 
@@ -290,7 +300,7 @@ mod tests {
             mode: CompactionMode::LlmReplace,
             ..Default::default()
         };
-        let err = run_compaction(&sample_history(), &config, None)
+        let err = run_compaction(&sample_history(), &config, None, 50_000)
             .await
             .unwrap_err();
         match err {
@@ -306,7 +316,7 @@ mod tests {
             mode: CompactionMode::Structured,
             ..Default::default()
         };
-        let err = run_compaction(&sample_history(), &config, None)
+        let err = run_compaction(&sample_history(), &config, None, 50_000)
             .await
             .unwrap_err();
         match err {

--- a/crates/chat/src/compaction_run/structured.rs
+++ b/crates/chat/src/compaction_run/structured.rs
@@ -14,7 +14,10 @@
 //! `safeguard` compaction.
 
 use {
-    moltis_agents::model::{ChatMessage, LlmProvider, StreamEvent, Usage, values_to_chat_messages},
+    moltis_agents::model::{
+        ChatMessage, LlmProvider, StreamEvent, Usage,
+        values_to_chat_messages_with_tool_result_limit,
+    },
     moltis_config::{CompactionConfig, CompactionMode},
     serde_json::Value,
     tokio_stream::StreamExt,
@@ -206,6 +209,7 @@ pub(super) async fn run(
     config: &CompactionConfig,
     context_window: u32,
     provider: &dyn LlmProvider,
+    max_tool_result_bytes: usize,
 ) -> Result<CompactionOutcome, CompactionRunError> {
     // Warn once if the user configured `summary_model` or a non-default
     // `max_summary_tokens`: those fields are reserved for the auxiliary
@@ -251,7 +255,10 @@ pub(super) async fn run(
     // (prevents prompt injection via role prefixes in user content), and a
     // final user directive selects the template.
     let mut summary_messages = vec![ChatMessage::system(STRUCTURED_SYSTEM_INSTRUCTIONS)];
-    summary_messages.extend(values_to_chat_messages(middle));
+    summary_messages.extend(values_to_chat_messages_with_tool_result_limit(
+        middle,
+        max_tool_result_bytes,
+    ));
     summary_messages.push(match previous_summary {
         Some(prev) => ChatMessage::user(iterative_instructions(prev)),
         None => ChatMessage::user(first_compaction_instructions()),
@@ -365,13 +372,59 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn structured_mode_uses_provider_cap_for_summary_input_tool_results() {
+        const NEEDLE: &str = "structured-summary-input-needle-after-prune-threshold";
+        let mut history = vec![
+            mk_user("inspect tool output"),
+            json!({
+                "role": "assistant",
+                "content": null,
+                "tool_calls": [{
+                    "id": "call_1",
+                    "function": {"name": "exec", "arguments": "{}"}
+                }]
+            }),
+            json!({
+                "role": "tool_result",
+                "tool_call_id": "call_1",
+                "tool_name": "exec",
+                "success": true,
+                "result": format!("{}{}", "x".repeat(240), NEEDLE)
+            }),
+        ];
+        for i in 0..5 {
+            history.push(mk_user(&format!("tail user {i}")));
+            history.push(mk_assistant(&format!("tail assistant {i}")));
+        }
+
+        let config = CompactionConfig {
+            mode: CompactionMode::Structured,
+            protect_head: 1,
+            protect_tail_min: 2,
+            tool_prune_char_threshold: 20,
+            ..Default::default()
+        };
+        let provider = StubProvider::new_ok("## Goal\nstub output").with_needle(NEEDLE);
+
+        let outcome = super::super::run_compaction(&history, &config, Some(&provider), 1024)
+            .await
+            .expect("structured succeeds with stub provider");
+
+        assert_eq!(outcome.effective_mode, CompactionMode::Structured);
+        assert!(
+            provider.saw_needle(),
+            "structured summary prompt should use provider cap, not the stored-history prune threshold"
+        );
+    }
+
+    #[tokio::test]
     async fn structured_mode_without_provider_returns_provider_required() {
         let history = sample_history();
         let config = CompactionConfig {
             mode: CompactionMode::Structured,
             ..Default::default()
         };
-        let err = super::super::run_compaction(&history, &config, None)
+        let err = super::super::run_compaction(&history, &config, None, 50_000)
             .await
             .unwrap_err();
         match err {
@@ -396,7 +449,7 @@ mod tests {
         };
         let provider =
             StubProvider::new_ok("## Goal\nTest compaction\n## Progress\n### Done\nAll the things");
-        let outcome = super::super::run_compaction(&history, &config, Some(&provider))
+        let outcome = super::super::run_compaction(&history, &config, Some(&provider), 50_000)
             .await
             .expect("structured succeeds with stub provider");
 
@@ -459,7 +512,7 @@ mod tests {
             ..Default::default()
         };
         let provider = StubProvider::new_ok("## Goal\nstub output").with_needle(NEEDLE);
-        let _ = super::super::run_compaction(&history, &config, Some(&provider))
+        let _ = super::super::run_compaction(&history, &config, Some(&provider), 50_000)
             .await
             .expect("structured succeeds with stub provider");
 
@@ -484,7 +537,7 @@ mod tests {
             ..Default::default()
         };
         let provider = StubProvider::new_error("simulated provider outage");
-        let outcome = super::super::run_compaction(&history, &config, Some(&provider))
+        let outcome = super::super::run_compaction(&history, &config, Some(&provider), 50_000)
             .await
             .expect("structured falls back to recency_preserving on llm error");
 
@@ -526,7 +579,7 @@ mod tests {
             ..Default::default()
         };
         let provider = StubProvider::new_empty_summary();
-        let outcome = super::super::run_compaction(&history, &config, Some(&provider))
+        let outcome = super::super::run_compaction(&history, &config, Some(&provider), 50_000)
             .await
             .expect("structured falls back on empty summary");
         assert_eq!(outcome.effective_mode, CompactionMode::RecencyPreserving);

--- a/crates/chat/src/run_with_tools.rs
+++ b/crates/chat/src/run_with_tools.rs
@@ -16,7 +16,7 @@ use {
 use {
     moltis_agents::{
         AgentRunError, UserContent,
-        model::{AgentToolControls, values_to_chat_messages},
+        model::{AgentToolControls, values_to_chat_messages_with_tool_result_limit},
         prompt::{
             PromptRuntimeContext, build_system_prompt_minimal_runtime_details,
             build_system_prompt_with_session_runtime_details,
@@ -857,7 +857,10 @@ pub(crate) async fn run_with_tools(
         .insert(session_key.to_string(), event_forwarder);
 
     // Convert persisted JSON history to typed ChatMessages for the LLM provider.
-    let chat_history = values_to_chat_messages(history_raw);
+    let chat_history = values_to_chat_messages_with_tool_result_limit(
+        history_raw,
+        persona.config.tools.max_tool_result_bytes,
+    );
 
     let hist = if chat_history.is_empty() {
         None
@@ -963,6 +966,7 @@ pub(crate) async fn run_with_tools(
                 session_key,
                 &persona.config.chat.compaction,
                 Some(&*provider_ref),
+                persona.config.tools.max_tool_result_bytes,
             )
             .await
             {
@@ -1007,7 +1011,10 @@ pub(crate) async fn run_with_tools(
 
                     // Reload compacted history and retry.
                     let compacted_history_raw = store.read(session_key).await.unwrap_or_default();
-                    let compacted_chat = values_to_chat_messages(&compacted_history_raw);
+                    let compacted_chat = values_to_chat_messages_with_tool_result_limit(
+                        &compacted_history_raw,
+                        persona.config.tools.max_tool_result_bytes,
+                    );
                     let retry_hist = if compacted_chat.is_empty() {
                         None
                     } else {

--- a/crates/chat/src/service/chat_impl.rs
+++ b/crates/chat/src/service/chat_impl.rs
@@ -18,7 +18,7 @@ use {
 use {
     moltis_agents::{
         ChatMessage, UserContent,
-        model::values_to_chat_messages,
+        model::values_to_chat_messages_with_tool_result_limit,
         prompt::{
             build_system_prompt_minimal_runtime_details,
             build_system_prompt_with_session_runtime_details,
@@ -517,13 +517,17 @@ impl ChatService for LiveChatService {
         if let Some(mm) = self.state.memory_manager()
             && let Ok(provider) = self.resolve_provider(&session_key, &history).await
         {
-            let write_mode = moltis_config::discover_and_load().memory.agent_write_mode;
+            let config = moltis_config::discover_and_load();
+            let write_mode = config.memory.agent_write_mode;
             if !memory_write_mode_allows_save(write_mode) {
                 debug!(
                     "compact: agent-authored memory writes disabled, skipping silent memory turn"
                 );
             } else {
-                let chat_history_for_memory = values_to_chat_messages(&history);
+                let chat_history_for_memory = values_to_chat_messages_with_tool_result_limit(
+                    &history,
+                    config.tools.max_tool_result_bytes,
+                );
                 let writer: Arc<dyn moltis_agents::memory_writer::MemoryWriter> =
                     Arc::new(AgentScopedMemoryWriter::new(
                         Arc::clone(mm),
@@ -563,10 +567,14 @@ impl ChatService for LiveChatService {
         // error in that case.
         let provider_arc = self.resolve_provider(&session_key, &history).await.ok();
 
-        let outcome =
-            compaction_run::run_compaction(&history, compaction_config, provider_arc.as_deref())
-                .await
-                .map_err(|e| ServiceError::message(e.to_string()))?;
+        let outcome = compaction_run::run_compaction(
+            &history,
+            compaction_config,
+            provider_arc.as_deref(),
+            persona.config.tools.max_tool_result_bytes,
+        )
+        .await
+        .map_err(|e| ServiceError::message(e.to_string()))?;
 
         let compacted = outcome.history.clone();
 
@@ -1233,10 +1241,14 @@ impl ChatService for LiveChatService {
             .collect();
 
         // Build the full messages array: system prompt + conversation history.
-        // `values_to_chat_messages` handles `tool_result` → `tool` conversion.
+        // `values_to_chat_messages_with_tool_result_limit` handles `tool_result` →
+        // `tool` conversion and keeps persisted tool output within provider limits.
         let mut messages = Vec::with_capacity(1 + history.len());
         messages.push(ChatMessage::system(system_prompt));
-        messages.extend(values_to_chat_messages(&history));
+        messages.extend(values_to_chat_messages_with_tool_result_limit(
+            &history,
+            persona.config.tools.max_tool_result_bytes,
+        ));
 
         let openai_messages: Vec<Value> = messages.iter().map(|m| m.to_openai_value()).collect();
         let message_count = openai_messages.len();

--- a/crates/chat/src/service/chat_impl/send.rs
+++ b/crates/chat/src/service/chat_impl/send.rs
@@ -32,7 +32,10 @@ use crate::{
 
 use {super::*, crate::service::build_persisted_assistant_message};
 
-use {crate::memory_tools::AgentScopedMemoryWriter, moltis_agents::model::values_to_chat_messages};
+use {
+    crate::memory_tools::AgentScopedMemoryWriter,
+    moltis_agents::model::values_to_chat_messages_with_tool_result_limit,
+};
 
 impl LiveChatService {
     #[tracing::instrument(skip(self, params), fields(session_id))]
@@ -1162,6 +1165,7 @@ impl LiveChatService {
             // Capture config values before persona is moved into the agent future.
             let auto_extract_interval = persona.config.memory.auto_extract_interval;
             let extraction_write_mode = persona.config.memory.agent_write_mode;
+            let extraction_max_tool_result_bytes = persona.config.tools.max_tool_result_bytes;
             let auto_title_enabled = persona.config.chat.auto_title;
             let agent_fut = async {
                 if stream_only {
@@ -1292,6 +1296,7 @@ impl LiveChatService {
                     // Uses config values captured before persona was moved.
                     let interval = auto_extract_interval;
                     let write_mode = extraction_write_mode;
+                    let max_tool_result_bytes = extraction_max_tool_result_bytes;
                     // A "turn" = user + assistant = 2 messages.
                     let turn_number = count / 2;
                     if interval > 0
@@ -1315,7 +1320,10 @@ impl LiveChatService {
                                 Vec::new()
                             };
                         if !recent.is_empty() {
-                            let chat_msgs = values_to_chat_messages(&recent);
+                            let chat_msgs = values_to_chat_messages_with_tool_result_limit(
+                                &recent,
+                                max_tool_result_bytes,
+                            );
                             let agent_id = session_agent_id_clone.clone();
                             let mm = Arc::clone(mm);
                             let prov = Arc::clone(&provider_for_extraction);

--- a/crates/chat/src/streaming.rs
+++ b/crates/chat/src/streaming.rs
@@ -16,7 +16,10 @@ use {
 use {
     moltis_agents::{
         ChatMessage, UserContent,
-        model::{StreamEvent, push_capped_provider_raw_event, values_to_chat_messages},
+        model::{
+            StreamEvent, push_capped_provider_raw_event,
+            values_to_chat_messages_with_tool_result_limit,
+        },
         prompt::{PromptRuntimeContext, build_system_prompt_minimal_runtime_details},
     },
     moltis_sessions::store::SessionStore,
@@ -210,7 +213,10 @@ pub(crate) async fn run_streaming(
     let mut messages: Vec<ChatMessage> = Vec::new();
     messages.push(ChatMessage::system(system_prompt));
     // Convert persisted JSON history to typed ChatMessages for the LLM provider.
-    messages.extend(values_to_chat_messages(history_raw));
+    messages.extend(values_to_chat_messages_with_tool_result_limit(
+        history_raw,
+        persona.config.tools.max_tool_result_bytes,
+    ));
     messages.push(ChatMessage::User {
         content: effective_user_content,
         name: sender_name,

--- a/crates/gateway/src/channel_events/commands/quick_actions.rs
+++ b/crates/gateway/src/channel_events/commands/quick_actions.rs
@@ -55,7 +55,10 @@ pub(in crate::channel_events) async fn handle_btw(
     // Read recent session history for context (last ~20 messages).
     let context_msgs = if let Some(ref store) = state.services.session_store {
         let history = store.read(session_key).await.unwrap_or_default();
-        let chat_msgs = moltis_agents::model::values_to_chat_messages(&history);
+        let chat_msgs = moltis_agents::model::values_to_chat_messages_with_tool_result_limit(
+            &history,
+            state.config.tools.max_tool_result_bytes,
+        );
         let tail_start = chat_msgs.len().saturating_sub(20);
         chat_msgs[tail_start..].to_vec()
     } else {

--- a/crates/gateway/src/session/summary.rs
+++ b/crates/gateway/src/session/summary.rs
@@ -74,7 +74,10 @@ pub(crate) async fn run_session_summary_if_enabled(state: &Arc<GatewayState>, se
         .and_then(|e| e.agent_id)
         .unwrap_or_else(|| "main".to_string());
 
-    let chat_msgs = moltis_agents::model::values_to_chat_messages(&history);
+    let chat_msgs = moltis_agents::model::values_to_chat_messages_with_tool_result_limit(
+        &history,
+        config.tools.max_tool_result_bytes,
+    );
     let writer: Arc<dyn moltis_agents::memory_writer::MemoryWriter> = Arc::new(
         moltis_chat::AgentScopedMemoryWriter::new(Arc::clone(mm), agent_id, write_mode),
     );

--- a/crates/gateway/src/session/title.rs
+++ b/crates/gateway/src/session/title.rs
@@ -118,7 +118,10 @@ pub(crate) async fn generate_title_for_session(
         }
     };
 
-    let chat_msgs = moltis_agents::model::values_to_chat_messages(&history);
+    let chat_msgs = moltis_agents::model::values_to_chat_messages_with_tool_result_limit(
+        &history,
+        state.config.tools.max_tool_result_bytes,
+    );
     let title = moltis_agents::title::generate_title(provider, &chat_msgs).await?;
     // Persist the title as the session label and read back the
     // entry atomically so the broadcast version is consistent.


### PR DESCRIPTION
## Summary

- cap persisted `tool` and `tool_result` content when session history is rehydrated into provider-bound `ChatMessage`s
- apply the capped conversion to normal chat, streaming chat, retry-after-compaction, prompt inspection, silent memory turns, and LLM-backed compaction prompts
- keep provider-format conversion unbounded so hook-modified provider payloads are preserved exactly

## Testing

- RED: `cargo test -p moltis-agents model::tests::convert_caps_persisted_string_tool_result_when_limit_is_set -- --nocapture` failed before implementation with missing `values_to_chat_messages_with_tool_result_limit`
- `cargo test -p moltis-agents model::tests`
- `cargo test -p moltis-agents`
- `cargo test -p moltis-chat`
- `cargo fmt --check`
- `git diff --check`
