### PR TITLE
refactor(providers): use explicit OpenAI capabilities

### DIFF
--- a/crates/providers/src/model_capabilities.rs
+++ b/crates/providers/src/model_capabilities.rs
@@ -283,6 +283,8 @@ pub fn supports_reasoning_for_model(model_id: &str) -> bool {
 /// without a provider instance or re-running the heuristic.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, serde::Serialize)]
 pub struct ModelCapabilities {
+    /// Supports chat/text-generation requests.
+    pub text_generation: bool,
     /// Supports OpenAI-style function/tool calling.
     pub tools: bool,
     /// Supports image/vision inputs.
@@ -296,6 +298,7 @@ impl ModelCapabilities {
     #[must_use]
     pub fn infer(model_id: &str) -> Self {
         Self {
+            text_generation: is_chat_capable_model(model_id),
             tools: supports_tools_for_model(model_id),
             vision: supports_vision_for_model(model_id),
             reasoning: supports_reasoning_for_model(model_id),

--- a/crates/providers/src/model_capabilities.rs
+++ b/crates/providers/src/model_capabilities.rs
@@ -174,6 +174,9 @@ pub fn is_chat_capable_model(model_id: &str) -> bool {
 /// exposing mixed catalogs report accurate tool support.
 pub fn supports_tools_for_model(model_id: &str) -> bool {
     let id = capability_model_id(model_id);
+    if !is_chat_capable_model(model_id) {
+        return false;
+    }
     // Legacy completions-only models — no tool support
     if id.starts_with("babbage") || id.starts_with("davinci") {
         return false;
@@ -538,6 +541,10 @@ mod tests {
         assert!(!supports_tools_for_model("tts-1"));
         assert!(!supports_tools_for_model("tts-1-hd"));
         assert!(!supports_tools_for_model("whisper-1"));
+        assert!(!supports_tools_for_model("chatgpt-image-latest"));
+        assert!(!supports_tools_for_model("gpt-4o-audio-preview"));
+        assert!(!supports_tools_for_model("gemini-3.1-flash-live-preview"));
+        assert!(!supports_tools_for_model("gemini-3.1-flash-image-preview"));
         assert!(!supports_tools_for_model("text-embedding-3-large"));
         assert!(!supports_tools_for_model("claude-embeddings-v1"));
         assert!(!supports_tools_for_model("omni-moderation-latest"));

--- a/crates/providers/src/model_catalogs.rs
+++ b/crates/providers/src/model_catalogs.rs
@@ -63,14 +63,12 @@ pub(crate) const ZAI_MODELS: &[(&str, &str)] = &[
     ("glm-4-32b-0414-128k", "GLM-4 32B 128K"),
 ];
 
-/// Whether a model is a Fireworks Fire Pass router for Kimi/Moonshot.
+/// Fireworks Kimi router model-ID prefixes.
 ///
 /// These models proxy through Fireworks to Moonshot's Kimi API, which has
 /// different schema and message requirements (no strict tools, needs
 /// `reasoning_content`). Issue #810.
-pub(crate) fn is_fireworks_kimi_router(def: &OpenAiCompatDef, model_id: &str) -> bool {
-    def.config_name == "fireworks" && model_id.contains("/routers/") && model_id.contains("kimi")
-}
+const FIREWORKS_KIMI_ROUTER_PREFIXES: &[&str] = &["accounts/fireworks/routers/kimi"];
 
 /// Known Fireworks models.
 pub(crate) const FIREWORKS_MODELS: &[(&str, &str)] = &[
@@ -308,6 +306,10 @@ pub(crate) const OPENAI_COMPAT_PROVIDERS: &[OpenAiCompatDef] = &[
         models: FIREWORKS_MODELS,
         capabilities: OpenAiProviderCapabilities {
             rejects_null_in_enums: true,
+            // Kimi router models proxy to Moonshot which requires
+            // reasoning_content and rejects strict tool schemas (#810).
+            reasoning_content_model_prefixes: FIREWORKS_KIMI_ROUTER_PREFIXES,
+            non_strict_tools_model_prefixes: FIREWORKS_KIMI_ROUTER_PREFIXES,
             ..OpenAiProviderCapabilities::DEFAULT
         },
         ..OpenAiCompatDef::DEFAULT
@@ -561,43 +563,24 @@ mod tests {
     }
 
     #[test]
-    fn is_fireworks_kimi_router_detects_router_model() {
+    fn fireworks_kimi_router_prefixes_cover_router_models() {
         let fireworks = OPENAI_COMPAT_PROVIDERS
             .iter()
             .find(|d| d.config_name == "fireworks")
             .expect("fireworks entry must exist");
-        assert!(is_fireworks_kimi_router(
-            fireworks,
-            "accounts/fireworks/routers/kimi-k2p5-turbo"
-        ));
-    }
 
-    #[test]
-    fn is_fireworks_kimi_router_rejects_native_model() {
-        let fireworks = OPENAI_COMPAT_PROVIDERS
-            .iter()
-            .find(|d| d.config_name == "fireworks")
-            .expect("fireworks entry must exist");
-        assert!(!is_fireworks_kimi_router(
-            fireworks,
-            "accounts/fireworks/models/glm-5p1"
-        ));
-        assert!(!is_fireworks_kimi_router(
-            fireworks,
-            "accounts/fireworks/models/kimi-k2p5"
-        ));
-    }
+        let prefixes = fireworks.capabilities.reasoning_content_model_prefixes;
+        let matches = |id: &str| prefixes.iter().any(|p| id.starts_with(p));
 
-    #[test]
-    fn is_fireworks_kimi_router_rejects_other_providers() {
-        let deepseek = OPENAI_COMPAT_PROVIDERS
-            .iter()
-            .find(|d| d.config_name == "deepseek")
-            .expect("deepseek entry must exist");
-        assert!(!is_fireworks_kimi_router(
-            deepseek,
-            "accounts/fireworks/routers/kimi-k2p5-turbo"
-        ));
+        assert!(matches("accounts/fireworks/routers/kimi-k2p5-turbo"));
+        assert!(!matches("accounts/fireworks/models/glm-5p1"));
+        assert!(!matches("accounts/fireworks/models/kimi-k2p5"));
+
+        // non_strict_tools_model_prefixes should use the same prefixes
+        assert_eq!(
+            fireworks.capabilities.reasoning_content_model_prefixes,
+            fireworks.capabilities.non_strict_tools_model_prefixes,
+        );
     }
 
     /// Cross-validate that every provider registered in this crate appears in

--- a/crates/providers/src/model_catalogs.rs
+++ b/crates/providers/src/model_catalogs.rs
@@ -160,18 +160,10 @@ pub(crate) struct OpenAiCompatDef {
     /// Also ensures model discovery is always attempted (never short-circuited
     /// by the empty-catalog heuristic).
     pub(crate) local_only: bool,
-    /// Whether this provider accepts the OpenAI-compatible `name` field on user messages.
-    pub(crate) supports_user_name: bool,
-    /// Default strict tool schema mode before config overrides.
-    pub(crate) default_strict_tools: bool,
     /// Whether assistant tool-call messages need `reasoning_content` on replay.
     pub(crate) default_reasoning_content_on_tool_messages: bool,
     /// Raw model-id prefixes that need `reasoning_content` on tool-call replay.
     pub(crate) reasoning_content_model_prefixes: &'static [&'static str],
-    /// Whether this provider rejects `null` entries inside JSON Schema enum arrays.
-    pub(crate) rejects_null_in_enums: bool,
-    /// Whether provider metadata should be nested as Gemini `extra_content`.
-    pub(crate) requires_gemini_tool_call_extra_content: bool,
     /// Provider-specific system-message rewrite behavior.
     pub(crate) system_message_rewrite: SystemMessageRewriteStrategy,
     /// Whether Qwen-family models on this provider need one leading system message.
@@ -190,12 +182,8 @@ impl OpenAiCompatDef {
         supports_model_discovery: true,
         requires_api_key: true,
         local_only: false,
-        supports_user_name: true,
-        default_strict_tools: true,
         default_reasoning_content_on_tool_messages: false,
         reasoning_content_model_prefixes: &[],
-        rejects_null_in_enums: false,
-        requires_gemini_tool_call_extra_content: false,
         system_message_rewrite: SystemMessageRewriteStrategy::None,
         qwen_models_require_single_leading_system: false,
         capabilities: OpenAiProviderCapabilities::DEFAULT,
@@ -209,7 +197,6 @@ pub(crate) const OPENAI_COMPAT_PROVIDERS: &[OpenAiCompatDef] = &[
         env_base_url_key: "MISTRAL_BASE_URL",
         default_base_url: "https://api.mistral.ai/v1",
         models: MISTRAL_MODELS,
-        supports_user_name: false,
         capabilities: OpenAiProviderCapabilities {
             supports_user_name: false,
             rate_limit_policy: RateLimitPolicy::Mistral,
@@ -222,7 +209,6 @@ pub(crate) const OPENAI_COMPAT_PROVIDERS: &[OpenAiCompatDef] = &[
         env_key: "OPENROUTER_API_KEY",
         env_base_url_key: "OPENROUTER_BASE_URL",
         default_base_url: "https://openrouter.ai/api/v1",
-        default_strict_tools: false,
         capabilities: OpenAiProviderCapabilities {
             default_strict_tools: false,
             cache_control_policy: CacheControlPolicy::OpenRouterAnthropic,
@@ -246,7 +232,6 @@ pub(crate) const OPENAI_COMPAT_PROVIDERS: &[OpenAiCompatDef] = &[
         models: MINIMAX_MODELS,
         // MiniMax API does not expose a /models endpoint (returns 404).
         supports_model_discovery: false,
-        supports_user_name: false,
         capabilities: OpenAiProviderCapabilities {
             supports_user_name: false,
             ..OpenAiProviderCapabilities::DEFAULT
@@ -293,9 +278,8 @@ pub(crate) const OPENAI_COMPAT_PROVIDERS: &[OpenAiCompatDef] = &[
         default_base_url: "https://cloud-api.near.ai/v1",
         models: &[],
         supports_model_discovery: true,
-        // NEAR AI does not support the `strict` field in tool schemas.
-        default_strict_tools: false,
         capabilities: OpenAiProviderCapabilities {
+            // NEAR AI does not support the `strict` field in tool schemas.
             default_strict_tools: false,
             omits_strict_tool_field: true,
             reasoning_effort_policy: ReasoningEffortPolicy::Unsupported,
@@ -330,7 +314,6 @@ pub(crate) const OPENAI_COMPAT_PROVIDERS: &[OpenAiCompatDef] = &[
         env_base_url_key: "FIREWORKS_BASE_URL",
         default_base_url: "https://api.fireworks.ai/inference/v1",
         models: FIREWORKS_MODELS,
-        rejects_null_in_enums: true,
         capabilities: OpenAiProviderCapabilities {
             rejects_null_in_enums: true,
             ..OpenAiProviderCapabilities::DEFAULT
@@ -375,8 +358,6 @@ pub(crate) const OPENAI_COMPAT_PROVIDERS: &[OpenAiCompatDef] = &[
         env_base_url_key: "GEMINI_BASE_URL",
         default_base_url: "https://generativelanguage.googleapis.com/v1beta/openai",
         models: GEMINI_MODELS,
-        default_strict_tools: false,
-        requires_gemini_tool_call_extra_content: true,
         capabilities: OpenAiProviderCapabilities {
             default_strict_tools: false,
             requires_gemini_tool_call_extra_content: true,
@@ -495,8 +476,6 @@ mod tests {
             .find(|d| d.config_name == "minimax")
             .expect("minimax entry must exist");
 
-        assert!(!mistral.supports_user_name);
-        assert!(!minimax.supports_user_name);
         assert!(!mistral.capabilities.supports_user_name);
         assert!(!minimax.capabilities.supports_user_name);
     }

--- a/crates/providers/src/model_catalogs.rs
+++ b/crates/providers/src/model_catalogs.rs
@@ -160,14 +160,6 @@ pub(crate) struct OpenAiCompatDef {
     /// Also ensures model discovery is always attempted (never short-circuited
     /// by the empty-catalog heuristic).
     pub(crate) local_only: bool,
-    /// Whether assistant tool-call messages need `reasoning_content` on replay.
-    pub(crate) default_reasoning_content_on_tool_messages: bool,
-    /// Raw model-id prefixes that need `reasoning_content` on tool-call replay.
-    pub(crate) reasoning_content_model_prefixes: &'static [&'static str],
-    /// Provider-specific system-message rewrite behavior.
-    pub(crate) system_message_rewrite: SystemMessageRewriteStrategy,
-    /// Whether Qwen-family models on this provider need one leading system message.
-    pub(crate) qwen_models_require_single_leading_system: bool,
     /// Explicit provider behavior policies. Never inferred from provider name or URL.
     pub(crate) capabilities: OpenAiProviderCapabilities,
 }
@@ -182,10 +174,6 @@ impl OpenAiCompatDef {
         supports_model_discovery: true,
         requires_api_key: true,
         local_only: false,
-        default_reasoning_content_on_tool_messages: false,
-        reasoning_content_model_prefixes: &[],
-        system_message_rewrite: SystemMessageRewriteStrategy::None,
-        qwen_models_require_single_leading_system: false,
         capabilities: OpenAiProviderCapabilities::DEFAULT,
     };
 }
@@ -234,9 +222,9 @@ pub(crate) const OPENAI_COMPAT_PROVIDERS: &[OpenAiCompatDef] = &[
         supports_model_discovery: false,
         capabilities: OpenAiProviderCapabilities {
             supports_user_name: false,
+            system_message_rewrite: SystemMessageRewriteStrategy::InlineIntoFirstUser,
             ..OpenAiProviderCapabilities::DEFAULT
         },
-        system_message_rewrite: SystemMessageRewriteStrategy::InlineIntoFirstUser,
         ..OpenAiCompatDef::DEFAULT
     },
     OpenAiCompatDef {
@@ -245,7 +233,10 @@ pub(crate) const OPENAI_COMPAT_PROVIDERS: &[OpenAiCompatDef] = &[
         env_base_url_key: "MOONSHOT_BASE_URL",
         default_base_url: "https://api.moonshot.ai/v1",
         models: MOONSHOT_MODELS,
-        default_reasoning_content_on_tool_messages: true,
+        capabilities: OpenAiProviderCapabilities {
+            default_reasoning_content_on_tool_messages: true,
+            ..OpenAiProviderCapabilities::DEFAULT
+        },
         ..OpenAiCompatDef::DEFAULT
     },
     OpenAiCompatDef {
@@ -302,9 +293,9 @@ pub(crate) const OPENAI_COMPAT_PROVIDERS: &[OpenAiCompatDef] = &[
         env_base_url_key: "DEEPSEEK_BASE_URL",
         default_base_url: "https://api.deepseek.com",
         models: DEEPSEEK_MODELS,
-        reasoning_content_model_prefixes: &["deepseek-v4"],
         capabilities: OpenAiProviderCapabilities {
             reasoning_effort_policy: ReasoningEffortPolicy::DeepSeek,
+            reasoning_content_model_prefixes: &["deepseek-v4"],
             ..OpenAiProviderCapabilities::DEFAULT
         },
         ..OpenAiCompatDef::DEFAULT
@@ -328,9 +319,9 @@ pub(crate) const OPENAI_COMPAT_PROVIDERS: &[OpenAiCompatDef] = &[
         default_base_url: "http://localhost:11434/v1",
         requires_api_key: false,
         local_only: true,
-        qwen_models_require_single_leading_system: true,
         capabilities: OpenAiProviderCapabilities {
             probe_fallback_policy: ProbeFallbackPolicy::OllamaNativeShow,
+            qwen_models_require_single_leading_system: true,
             ..OpenAiProviderCapabilities::DEFAULT
         },
         ..OpenAiCompatDef::DEFAULT
@@ -350,7 +341,10 @@ pub(crate) const OPENAI_COMPAT_PROVIDERS: &[OpenAiCompatDef] = &[
         env_base_url_key: "ALIBABA_CODING_BASE_URL",
         default_base_url: "https://coding-intl.dashscope.aliyuncs.com/v1",
         models: ALIBABA_CODING_MODELS,
-        qwen_models_require_single_leading_system: true,
+        capabilities: OpenAiProviderCapabilities {
+            qwen_models_require_single_leading_system: true,
+            ..OpenAiProviderCapabilities::DEFAULT
+        },
         ..OpenAiCompatDef::DEFAULT
     },
     OpenAiCompatDef {
@@ -488,8 +482,11 @@ mod tests {
             .find(|d| d.config_name == "deepseek")
             .expect("deepseek entry must exist");
 
-        assert!(!deepseek.default_reasoning_content_on_tool_messages);
-        assert_eq!(deepseek.reasoning_content_model_prefixes, &["deepseek-v4"]);
+        assert!(!deepseek.capabilities.default_reasoning_content_on_tool_messages);
+        assert_eq!(
+            deepseek.capabilities.reasoning_content_model_prefixes,
+            &["deepseek-v4"]
+        );
     }
 
     #[test]

--- a/crates/providers/src/model_catalogs.rs
+++ b/crates/providers/src/model_catalogs.rs
@@ -1,8 +1,8 @@
 //! Static model catalogs and OpenAI-compatible provider definitions.
 
 use crate::openai::{
-    CacheControlPolicy, OpenAiProviderCapabilities, ProbeFallbackPolicy, RateLimitPolicy,
-    ReasoningEffortPolicy, SystemMessageRewriteStrategy,
+    CacheControlPolicy, OpenAiProviderCapabilities, ProbeFallbackPolicy, ProbeOutputCapPolicy,
+    RateLimitPolicy, ReasoningEffortPolicy, SystemMessageRewriteStrategy,
 };
 
 /// Known Anthropic Claude models (model_id, display_name).
@@ -282,6 +282,7 @@ pub(crate) const OPENAI_COMPAT_PROVIDERS: &[OpenAiCompatDef] = &[
             // NEAR AI does not support the `strict` field in tool schemas.
             default_strict_tools: false,
             omits_strict_tool_field: true,
+            probe_output_cap_policy: ProbeOutputCapPolicy::MaxTokens,
             reasoning_effort_policy: ReasoningEffortPolicy::Unsupported,
             ..OpenAiProviderCapabilities::DEFAULT
         },
@@ -520,6 +521,10 @@ mod tests {
         assert!(!nearai.local_only);
         assert!(nearai.supports_model_discovery);
         assert!(nearai.capabilities.omits_strict_tool_field);
+        assert_eq!(
+            nearai.capabilities.probe_output_cap_policy,
+            ProbeOutputCapPolicy::MaxTokens
+        );
         assert_eq!(
             nearai.capabilities.reasoning_effort_policy,
             ReasoningEffortPolicy::Unsupported

--- a/crates/providers/src/model_catalogs.rs
+++ b/crates/providers/src/model_catalogs.rs
@@ -1,6 +1,9 @@
 //! Static model catalogs and OpenAI-compatible provider definitions.
 
-use crate::openai::SystemMessageRewriteStrategy;
+use crate::openai::{
+    CacheControlPolicy, OpenAiProviderCapabilities, ProbeFallbackPolicy, RateLimitPolicy,
+    ReasoningEffortPolicy, SystemMessageRewriteStrategy,
+};
 
 /// Known Anthropic Claude models (model_id, display_name).
 /// Current models listed first, then legacy models.
@@ -173,6 +176,8 @@ pub(crate) struct OpenAiCompatDef {
     pub(crate) system_message_rewrite: SystemMessageRewriteStrategy,
     /// Whether Qwen-family models on this provider need one leading system message.
     pub(crate) qwen_models_require_single_leading_system: bool,
+    /// Explicit provider behavior policies. Never inferred from provider name or URL.
+    pub(crate) capabilities: OpenAiProviderCapabilities,
 }
 
 impl OpenAiCompatDef {
@@ -193,6 +198,7 @@ impl OpenAiCompatDef {
         requires_gemini_tool_call_extra_content: false,
         system_message_rewrite: SystemMessageRewriteStrategy::None,
         qwen_models_require_single_leading_system: false,
+        capabilities: OpenAiProviderCapabilities::DEFAULT,
     };
 }
 
@@ -204,6 +210,11 @@ pub(crate) const OPENAI_COMPAT_PROVIDERS: &[OpenAiCompatDef] = &[
         default_base_url: "https://api.mistral.ai/v1",
         models: MISTRAL_MODELS,
         supports_user_name: false,
+        capabilities: OpenAiProviderCapabilities {
+            supports_user_name: false,
+            rate_limit_policy: RateLimitPolicy::Mistral,
+            ..OpenAiProviderCapabilities::DEFAULT
+        },
         ..OpenAiCompatDef::DEFAULT
     },
     OpenAiCompatDef {
@@ -212,6 +223,11 @@ pub(crate) const OPENAI_COMPAT_PROVIDERS: &[OpenAiCompatDef] = &[
         env_base_url_key: "OPENROUTER_BASE_URL",
         default_base_url: "https://openrouter.ai/api/v1",
         default_strict_tools: false,
+        capabilities: OpenAiProviderCapabilities {
+            default_strict_tools: false,
+            cache_control_policy: CacheControlPolicy::OpenRouterAnthropic,
+            ..OpenAiProviderCapabilities::DEFAULT
+        },
         ..OpenAiCompatDef::DEFAULT
     },
     OpenAiCompatDef {
@@ -275,6 +291,12 @@ pub(crate) const OPENAI_COMPAT_PROVIDERS: &[OpenAiCompatDef] = &[
         supports_model_discovery: true,
         // NEAR AI does not support the `strict` field in tool schemas.
         default_strict_tools: false,
+        capabilities: OpenAiProviderCapabilities {
+            default_strict_tools: false,
+            omits_strict_tool_field: true,
+            reasoning_effort_policy: ReasoningEffortPolicy::Unsupported,
+            ..OpenAiProviderCapabilities::DEFAULT
+        },
         ..OpenAiCompatDef::DEFAULT
     },
     OpenAiCompatDef {
@@ -292,6 +314,10 @@ pub(crate) const OPENAI_COMPAT_PROVIDERS: &[OpenAiCompatDef] = &[
         default_base_url: "https://api.deepseek.com",
         models: DEEPSEEK_MODELS,
         reasoning_content_model_prefixes: &["deepseek-v4"],
+        capabilities: OpenAiProviderCapabilities {
+            reasoning_effort_policy: ReasoningEffortPolicy::DeepSeek,
+            ..OpenAiProviderCapabilities::DEFAULT
+        },
         ..OpenAiCompatDef::DEFAULT
     },
     OpenAiCompatDef {
@@ -301,6 +327,10 @@ pub(crate) const OPENAI_COMPAT_PROVIDERS: &[OpenAiCompatDef] = &[
         default_base_url: "https://api.fireworks.ai/inference/v1",
         models: FIREWORKS_MODELS,
         rejects_null_in_enums: true,
+        capabilities: OpenAiProviderCapabilities {
+            rejects_null_in_enums: true,
+            ..OpenAiProviderCapabilities::DEFAULT
+        },
         ..OpenAiCompatDef::DEFAULT
     },
     OpenAiCompatDef {
@@ -311,6 +341,10 @@ pub(crate) const OPENAI_COMPAT_PROVIDERS: &[OpenAiCompatDef] = &[
         requires_api_key: false,
         local_only: true,
         qwen_models_require_single_leading_system: true,
+        capabilities: OpenAiProviderCapabilities {
+            probe_fallback_policy: ProbeFallbackPolicy::OllamaNativeShow,
+            ..OpenAiProviderCapabilities::DEFAULT
+        },
         ..OpenAiCompatDef::DEFAULT
     },
     OpenAiCompatDef {
@@ -339,6 +373,11 @@ pub(crate) const OPENAI_COMPAT_PROVIDERS: &[OpenAiCompatDef] = &[
         models: GEMINI_MODELS,
         default_strict_tools: false,
         requires_gemini_tool_call_extra_content: true,
+        capabilities: OpenAiProviderCapabilities {
+            default_strict_tools: false,
+            requires_gemini_tool_call_extra_content: true,
+            ..OpenAiProviderCapabilities::DEFAULT
+        },
         ..OpenAiCompatDef::DEFAULT
     },
 ];
@@ -495,6 +534,11 @@ mod tests {
         assert!(nearai.requires_api_key);
         assert!(!nearai.local_only);
         assert!(nearai.supports_model_discovery);
+        assert!(nearai.capabilities.omits_strict_tool_field);
+        assert_eq!(
+            nearai.capabilities.reasoning_effort_policy,
+            ReasoningEffortPolicy::Unsupported
+        );
     }
 
     #[test]

--- a/crates/providers/src/model_catalogs.rs
+++ b/crates/providers/src/model_catalogs.rs
@@ -484,11 +484,14 @@ mod tests {
             .find(|d| d.config_name == "deepseek")
             .expect("deepseek entry must exist");
 
-        assert!(!deepseek.capabilities.default_reasoning_content_on_tool_messages);
-        assert_eq!(
-            deepseek.capabilities.reasoning_content_model_prefixes,
-            &["deepseek-v4"]
+        assert!(
+            !deepseek
+                .capabilities
+                .default_reasoning_content_on_tool_messages
         );
+        assert_eq!(deepseek.capabilities.reasoning_content_model_prefixes, &[
+            "deepseek-v4"
+        ]);
     }
 
     #[test]

--- a/crates/providers/src/model_catalogs.rs
+++ b/crates/providers/src/model_catalogs.rs
@@ -247,6 +247,10 @@ pub(crate) const OPENAI_COMPAT_PROVIDERS: &[OpenAiCompatDef] = &[
         // MiniMax API does not expose a /models endpoint (returns 404).
         supports_model_discovery: false,
         supports_user_name: false,
+        capabilities: OpenAiProviderCapabilities {
+            supports_user_name: false,
+            ..OpenAiProviderCapabilities::DEFAULT
+        },
         system_message_rewrite: SystemMessageRewriteStrategy::InlineIntoFirstUser,
         ..OpenAiCompatDef::DEFAULT
     },
@@ -493,6 +497,8 @@ mod tests {
 
         assert!(!mistral.supports_user_name);
         assert!(!minimax.supports_user_name);
+        assert!(!mistral.capabilities.supports_user_name);
+        assert!(!minimax.capabilities.supports_user_name);
     }
 
     #[test]

--- a/crates/providers/src/nearai.rs
+++ b/crates/providers/src/nearai.rs
@@ -2,11 +2,40 @@
 
 use {
     crate::{DiscoveredModel, ModelCapabilities, is_chat_capable_model, supports_vision_for_model},
+    reqwest::StatusCode,
     serde::Deserialize,
     std::{collections::HashSet, sync::mpsc, time::Duration},
+    thiserror::Error,
 };
 
 const MODEL_LIST_PATH: &str = "/model/list";
+
+#[derive(Debug, Error)]
+pub enum NearAiError {
+    #[error("failed to request NEAR AI model list from {endpoint}: {source}")]
+    Request {
+        endpoint: String,
+        #[source]
+        source: reqwest::Error,
+    },
+    #[error("failed to read NEAR AI model list response from {endpoint}: {source}")]
+    ResponseBody {
+        endpoint: String,
+        #[source]
+        source: reqwest::Error,
+    },
+    #[error("NEAR AI model list API at {endpoint} returned HTTP {status}")]
+    HttpStatus {
+        endpoint: String,
+        status: StatusCode,
+    },
+    #[error("failed to parse NEAR AI model list JSON: {0}")]
+    Parse(#[from] serde_json::Error),
+    #[error("NEAR AI model list API returned no chat models")]
+    NoChatModels,
+    #[error("failed to create NEAR AI model discovery runtime: {0}")]
+    Runtime(#[from] std::io::Error),
+}
 
 #[derive(Debug, Deserialize)]
 struct NearAiModelList {
@@ -44,6 +73,12 @@ struct NearAiArchitecture {
     output_modalities: Vec<String>,
 }
 
+#[derive(Debug, Clone, Copy)]
+struct NearAiCatalogCapabilities {
+    text_generation: bool,
+    vision: bool,
+}
+
 fn normalize_base_url(url: &str) -> String {
     url.trim_end_matches('/').to_string()
 }
@@ -79,26 +114,49 @@ fn is_tee_model(metadata: &NearAiModelMetadata) -> bool {
     metadata.verifiable || metadata.attestation_supported
 }
 
-fn is_text_generation_model(model_id: &str, metadata: &NearAiModelMetadata) -> bool {
+fn is_known_non_chat_model(model_id: &str) -> bool {
     let lower_id = model_id.to_ascii_lowercase();
-    if lower_id == "openai/privacy-filter" || lower_id.contains("reranker") {
-        return false;
-    }
+    lower_id == "openai/privacy-filter" || lower_id.contains("reranker")
+}
+
+fn catalog_capabilities_for(
+    model_id: &str,
+    metadata: &NearAiModelMetadata,
+) -> NearAiCatalogCapabilities {
     if !is_chat_capable_model(model_id) {
-        return false;
+        return NearAiCatalogCapabilities {
+            text_generation: false,
+            vision: false,
+        };
     }
 
     let Some(architecture) = metadata.architecture.as_ref() else {
-        return true;
+        return NearAiCatalogCapabilities {
+            text_generation: true,
+            vision: supports_vision_for_model(model_id),
+        };
     };
+
+    let vision = has_modality(&architecture.input_modalities, "image");
     if architecture.input_modalities.is_empty() && architecture.output_modalities.is_empty() {
-        return false;
+        return NearAiCatalogCapabilities {
+            text_generation: false,
+            vision,
+        };
     }
-    if has_modality(&architecture.input_modalities, "audio") {
-        return false;
+    let text_generation = !has_modality(&architecture.input_modalities, "audio")
+        && (architecture.output_modalities.is_empty()
+            || has_modality(&architecture.output_modalities, "text"));
+
+    NearAiCatalogCapabilities {
+        text_generation,
+        vision,
     }
-    architecture.output_modalities.is_empty()
-        || has_modality(&architecture.output_modalities, "text")
+}
+
+fn is_text_generation_model(model_id: &str, metadata: &NearAiModelMetadata) -> bool {
+    !is_known_non_chat_model(model_id)
+        && catalog_capabilities_for(model_id, metadata).text_generation
 }
 
 fn display_name_for(model: &NearAiModel) -> String {
@@ -113,21 +171,15 @@ fn display_name_for(model: &NearAiModel) -> String {
 }
 
 fn capabilities_for(model: &NearAiModel) -> ModelCapabilities {
-    let vision = model
-        .metadata
-        .architecture
-        .as_ref()
-        .map(|architecture| has_modality(&architecture.input_modalities, "image"))
-        .unwrap_or_else(|| supports_vision_for_model(&model.model_id));
-
+    let catalog_capabilities = catalog_capabilities_for(&model.model_id, &model.metadata);
     ModelCapabilities {
         tools: false,
-        vision,
+        vision: catalog_capabilities.vision,
         reasoning: false,
     }
 }
 
-fn parse_models_payload(payload: &str) -> anyhow::Result<Vec<DiscoveredModel>> {
+fn parse_models_payload(payload: &str) -> Result<Vec<DiscoveredModel>, NearAiError> {
     let parsed: NearAiModelList = serde_json::from_str(payload)?;
     let mut seen = HashSet::new();
     let mut models: Vec<DiscoveredModel> = parsed
@@ -153,22 +205,33 @@ fn parse_models_payload(payload: &str) -> anyhow::Result<Vec<DiscoveredModel>> {
 }
 
 /// Fetch available chat models from NEAR AI Cloud's public model catalog.
-pub async fn fetch_models_from_api(base_url: String) -> anyhow::Result<Vec<DiscoveredModel>> {
+pub async fn fetch_models_from_api(base_url: String) -> Result<Vec<DiscoveredModel>, NearAiError> {
     let client = crate::shared_http_client();
+    let endpoint = model_list_endpoint(&base_url);
     let response = client
-        .get(model_list_endpoint(&base_url))
+        .get(&endpoint)
         .timeout(Duration::from_secs(15))
         .header("Accept", "application/json")
         .send()
-        .await?;
+        .await
+        .map_err(|source| NearAiError::Request {
+            endpoint: endpoint.clone(),
+            source,
+        })?;
     let status = response.status();
-    let body = response.text().await?;
+    let body = response
+        .text()
+        .await
+        .map_err(|source| NearAiError::ResponseBody {
+            endpoint: endpoint.clone(),
+            source,
+        })?;
     if !status.is_success() {
-        anyhow::bail!("NEAR AI model list API error HTTP {status}");
+        return Err(NearAiError::HttpStatus { endpoint, status });
     }
     let models = parse_models_payload(&body)?;
     if models.is_empty() {
-        anyhow::bail!("NEAR AI model list API returned no chat models");
+        return Err(NearAiError::NoChatModels);
     }
     Ok(models)
 }
@@ -176,13 +239,13 @@ pub async fn fetch_models_from_api(base_url: String) -> anyhow::Result<Vec<Disco
 /// Spawn NEAR AI model discovery in a background thread and return immediately.
 pub fn start_model_discovery(
     base_url: String,
-) -> mpsc::Receiver<anyhow::Result<Vec<DiscoveredModel>>> {
+) -> mpsc::Receiver<Result<Vec<DiscoveredModel>, NearAiError>> {
     let (tx, rx) = mpsc::sync_channel(1);
     std::thread::spawn(move || {
         let result = tokio::runtime::Builder::new_current_thread()
             .enable_all()
             .build()
-            .map_err(anyhow::Error::from)
+            .map_err(NearAiError::from)
             .and_then(|rt| rt.block_on(fetch_models_from_api(base_url)));
         let _ = tx.send(result);
     });

--- a/crates/providers/src/nearai.rs
+++ b/crates/providers/src/nearai.rs
@@ -11,7 +11,7 @@ use {
 const MODEL_LIST_PATH: &str = "/model/list";
 
 #[derive(Debug, Error)]
-pub enum NearAiError {
+pub enum Error {
     #[error("failed to request NEAR AI model list from {endpoint}: {source}")]
     Request {
         endpoint: String,
@@ -179,7 +179,7 @@ fn capabilities_for(model: &NearAiModel) -> ModelCapabilities {
     }
 }
 
-fn parse_models_payload(payload: &str) -> Result<Vec<DiscoveredModel>, NearAiError> {
+fn parse_models_payload(payload: &str) -> Result<Vec<DiscoveredModel>, Error> {
     let parsed: NearAiModelList = serde_json::from_str(payload)?;
     let mut seen = HashSet::new();
     let mut models: Vec<DiscoveredModel> = parsed
@@ -205,7 +205,7 @@ fn parse_models_payload(payload: &str) -> Result<Vec<DiscoveredModel>, NearAiErr
 }
 
 /// Fetch available chat models from NEAR AI Cloud's public model catalog.
-pub async fn fetch_models_from_api(base_url: String) -> Result<Vec<DiscoveredModel>, NearAiError> {
+pub async fn fetch_models_from_api(base_url: String) -> Result<Vec<DiscoveredModel>, Error> {
     let client = crate::shared_http_client();
     let endpoint = model_list_endpoint(&base_url);
     let response = client
@@ -214,7 +214,7 @@ pub async fn fetch_models_from_api(base_url: String) -> Result<Vec<DiscoveredMod
         .header("Accept", "application/json")
         .send()
         .await
-        .map_err(|source| NearAiError::Request {
+        .map_err(|source| Error::Request {
             endpoint: endpoint.clone(),
             source,
         })?;
@@ -222,16 +222,16 @@ pub async fn fetch_models_from_api(base_url: String) -> Result<Vec<DiscoveredMod
     let body = response
         .text()
         .await
-        .map_err(|source| NearAiError::ResponseBody {
+        .map_err(|source| Error::ResponseBody {
             endpoint: endpoint.clone(),
             source,
         })?;
     if !status.is_success() {
-        return Err(NearAiError::HttpStatus { endpoint, status });
+        return Err(Error::HttpStatus { endpoint, status });
     }
     let models = parse_models_payload(&body)?;
     if models.is_empty() {
-        return Err(NearAiError::NoChatModels);
+        return Err(Error::NoChatModels);
     }
     Ok(models)
 }
@@ -239,13 +239,13 @@ pub async fn fetch_models_from_api(base_url: String) -> Result<Vec<DiscoveredMod
 /// Spawn NEAR AI model discovery in a background thread and return immediately.
 pub fn start_model_discovery(
     base_url: String,
-) -> mpsc::Receiver<Result<Vec<DiscoveredModel>, NearAiError>> {
+) -> mpsc::Receiver<Result<Vec<DiscoveredModel>, Error>> {
     let (tx, rx) = mpsc::sync_channel(1);
     std::thread::spawn(move || {
         let result = tokio::runtime::Builder::new_current_thread()
             .enable_all()
             .build()
-            .map_err(NearAiError::from)
+            .map_err(Error::from)
             .and_then(|rt| rt.block_on(fetch_models_from_api(base_url)));
         let _ = tx.send(result);
     });

--- a/crates/providers/src/nearai.rs
+++ b/crates/providers/src/nearai.rs
@@ -1,7 +1,7 @@
 //! NEAR AI Cloud model discovery helpers.
 
 use {
-    crate::{DiscoveredModel, ModelCapabilities, is_chat_capable_model, supports_vision_for_model},
+    crate::{DiscoveredModel, ModelCapabilities},
     reqwest::StatusCode,
     serde::Deserialize,
     std::{collections::HashSet, sync::mpsc, time::Duration},
@@ -12,18 +12,8 @@ const MODEL_LIST_PATH: &str = "/model/list";
 
 #[derive(Debug, Error)]
 pub enum Error {
-    #[error("failed to request NEAR AI model list from {endpoint}: {source}")]
-    Request {
-        endpoint: String,
-        #[source]
-        source: reqwest::Error,
-    },
-    #[error("failed to read NEAR AI model list response from {endpoint}: {source}")]
-    ResponseBody {
-        endpoint: String,
-        #[source]
-        source: reqwest::Error,
-    },
+    #[error("NEAR AI model list request failed: {0}")]
+    Request(#[from] reqwest::Error),
     #[error("NEAR AI model list API at {endpoint} returned HTTP {status}")]
     HttpStatus {
         endpoint: String,
@@ -73,12 +63,6 @@ struct NearAiArchitecture {
     output_modalities: Vec<String>,
 }
 
-#[derive(Debug, Clone, Copy)]
-struct NearAiCatalogCapabilities {
-    text_generation: bool,
-    vision: bool,
-}
-
 fn normalize_base_url(url: &str) -> String {
     url.trim_end_matches('/').to_string()
 }
@@ -119,39 +103,33 @@ fn is_known_non_chat_model(model_id: &str) -> bool {
     lower_id == "openai/privacy-filter" || lower_id.contains("reranker")
 }
 
-fn catalog_capabilities_for(
-    model_id: &str,
-    metadata: &NearAiModelMetadata,
-) -> NearAiCatalogCapabilities {
-    if !is_chat_capable_model(model_id) {
-        return NearAiCatalogCapabilities {
+fn catalog_capabilities_for(model_id: &str, metadata: &NearAiModelMetadata) -> ModelCapabilities {
+    let mut capabilities = ModelCapabilities::infer(model_id);
+    capabilities.tools = false;
+    capabilities.reasoning = false;
+
+    if !capabilities.text_generation {
+        return ModelCapabilities {
             text_generation: false,
             vision: false,
+            ..capabilities
         };
     }
 
     let Some(architecture) = metadata.architecture.as_ref() else {
-        return NearAiCatalogCapabilities {
-            text_generation: true,
-            vision: supports_vision_for_model(model_id),
-        };
+        return capabilities;
     };
 
-    let vision = has_modality(&architecture.input_modalities, "image");
+    capabilities.vision = has_modality(&architecture.input_modalities, "image");
     if architecture.input_modalities.is_empty() && architecture.output_modalities.is_empty() {
-        return NearAiCatalogCapabilities {
-            text_generation: false,
-            vision,
-        };
+        capabilities.text_generation = false;
+        return capabilities;
     }
-    let text_generation = !has_modality(&architecture.input_modalities, "audio")
+    capabilities.text_generation = !has_modality(&architecture.input_modalities, "audio")
         && (architecture.output_modalities.is_empty()
             || has_modality(&architecture.output_modalities, "text"));
 
-    NearAiCatalogCapabilities {
-        text_generation,
-        vision,
-    }
+    capabilities
 }
 
 fn is_text_generation_model(model_id: &str, metadata: &NearAiModelMetadata) -> bool {
@@ -170,15 +148,6 @@ fn display_name_for(model: &NearAiModel) -> String {
         .to_string()
 }
 
-fn capabilities_for(model: &NearAiModel) -> ModelCapabilities {
-    let catalog_capabilities = catalog_capabilities_for(&model.model_id, &model.metadata);
-    ModelCapabilities {
-        tools: false,
-        vision: catalog_capabilities.vision,
-        reasoning: false,
-    }
-}
-
 fn parse_models_payload(payload: &str) -> Result<Vec<DiscoveredModel>, Error> {
     let parsed: NearAiModelList = serde_json::from_str(payload)?;
     let mut seen = HashSet::new();
@@ -191,7 +160,7 @@ fn parse_models_payload(payload: &str) -> Result<Vec<DiscoveredModel>, Error> {
             let recommended = is_tee_model(&model.metadata);
             DiscoveredModel::new(model.model_id.clone(), display_name_for(&model))
                 .with_recommended(recommended)
-                .with_capabilities(capabilities_for(&model))
+                .with_capabilities(catalog_capabilities_for(&model.model_id, &model.metadata))
         })
         .collect();
 
@@ -213,19 +182,9 @@ pub async fn fetch_models_from_api(base_url: String) -> Result<Vec<DiscoveredMod
         .timeout(Duration::from_secs(15))
         .header("Accept", "application/json")
         .send()
-        .await
-        .map_err(|source| Error::Request {
-            endpoint: endpoint.clone(),
-            source,
-        })?;
+        .await?;
     let status = response.status();
-    let body = response
-        .text()
-        .await
-        .map_err(|source| Error::ResponseBody {
-            endpoint: endpoint.clone(),
-            source,
-        })?;
+    let body = response.text().await?;
     if !status.is_success() {
         return Err(Error::HttpStatus { endpoint, status });
     }
@@ -242,11 +201,12 @@ pub fn start_model_discovery(
 ) -> mpsc::Receiver<Result<Vec<DiscoveredModel>, Error>> {
     let (tx, rx) = mpsc::sync_channel(1);
     std::thread::spawn(move || {
-        let result = tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .map_err(Error::from)
-            .and_then(|rt| rt.block_on(fetch_models_from_api(base_url)));
+        let result = (|| {
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()?;
+            rt.block_on(fetch_models_from_api(base_url))
+        })();
         let _ = tx.send(result);
     });
     rx

--- a/crates/providers/src/openai/mod.rs
+++ b/crates/providers/src/openai/mod.rs
@@ -57,6 +57,12 @@ pub(crate) struct OpenAiProviderCapabilities {
     pub(crate) requires_gemini_tool_call_extra_content: bool,
     pub(crate) default_reasoning_content_on_tool_messages: bool,
     pub(crate) reasoning_content_model_prefixes: &'static [&'static str],
+    /// Model-id prefixes that should disable strict tool schemas.
+    ///
+    /// Checked by `needs_strict_tools()` before falling back to
+    /// `default_strict_tools`. Used for Fireworks Kimi router models
+    /// that proxy to Moonshot (which rejects strict schemas).
+    pub(crate) non_strict_tools_model_prefixes: &'static [&'static str],
     pub(crate) system_message_rewrite: SystemMessageRewriteStrategy,
     pub(crate) qwen_models_require_single_leading_system: bool,
     pub(crate) rate_limit_policy: RateLimitPolicy,
@@ -76,6 +82,7 @@ impl OpenAiProviderCapabilities {
         requires_gemini_tool_call_extra_content: false,
         default_reasoning_content_on_tool_messages: false,
         reasoning_content_model_prefixes: &[],
+        non_strict_tools_model_prefixes: &[],
         system_message_rewrite: SystemMessageRewriteStrategy::None,
         qwen_models_require_single_leading_system: false,
         rate_limit_policy: RateLimitPolicy::None,

--- a/crates/providers/src/openai/mod.rs
+++ b/crates/providers/src/openai/mod.rs
@@ -12,6 +12,66 @@ pub use {
 use moltis_agents::model::ModelMetadata;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RateLimitPolicy {
+    None,
+    Mistral,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ReasoningEffortPolicy {
+    OpenAi,
+    DeepSeek,
+    Unsupported,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CacheControlPolicy {
+    None,
+    OpenRouterAnthropic,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ProbeFallbackPolicy {
+    None,
+    OllamaNativeShow,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ResponsesWebSocketPolicy {
+    Unsupported,
+    OpenAiPlatform,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct OpenAiProviderCapabilities {
+    pub(crate) supports_user_name: bool,
+    pub(crate) default_strict_tools: bool,
+    pub(crate) omits_strict_tool_field: bool,
+    pub(crate) rejects_null_in_enums: bool,
+    pub(crate) requires_gemini_tool_call_extra_content: bool,
+    pub(crate) rate_limit_policy: RateLimitPolicy,
+    pub(crate) reasoning_effort_policy: ReasoningEffortPolicy,
+    pub(crate) cache_control_policy: CacheControlPolicy,
+    pub(crate) probe_fallback_policy: ProbeFallbackPolicy,
+    pub(crate) responses_websocket_policy: ResponsesWebSocketPolicy,
+}
+
+impl OpenAiProviderCapabilities {
+    pub(crate) const DEFAULT: Self = Self {
+        supports_user_name: true,
+        default_strict_tools: true,
+        omits_strict_tool_field: false,
+        rejects_null_in_enums: false,
+        requires_gemini_tool_call_extra_content: false,
+        rate_limit_policy: RateLimitPolicy::None,
+        reasoning_effort_policy: ReasoningEffortPolicy::OpenAi,
+        cache_control_policy: CacheControlPolicy::None,
+        probe_fallback_policy: ProbeFallbackPolicy::None,
+        responses_websocket_policy: ResponsesWebSocketPolicy::Unsupported,
+    };
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum SystemMessageRewriteStrategy {
     None,
     MergeLeadingSystem,
@@ -36,16 +96,12 @@ pub struct OpenAiProvider {
     strict_tools_override: Option<bool>,
     /// Explicit override for reasoning_content requirement. `None` = auto-detect.
     reasoning_content_override: Option<bool>,
-    /// Default strict tool schema mode for this provider.
-    default_strict_tools: bool,
+    /// Explicit provider behavior policies. Never inferred from provider name or URL.
+    capabilities: OpenAiProviderCapabilities,
     /// Whether assistant tool-call messages need `reasoning_content` on replay.
     default_reasoning_content_on_tool_messages: bool,
     /// Raw model-id prefixes that need `reasoning_content` on tool-call replay.
     reasoning_content_model_prefixes: &'static [&'static str],
-    /// Whether this provider rejects `null` entries in JSON Schema enum arrays.
-    rejects_null_in_enums: bool,
-    /// Whether tool-call metadata should be nested as Gemini extra_content.
-    requires_gemini_tool_call_extra_content: bool,
     /// Provider-specific system-message rewrite behavior.
     system_message_rewrite_strategy: SystemMessageRewriteStrategy,
     /// Whether Qwen-family models on this provider need one leading system message.
@@ -55,12 +111,6 @@ pub struct OpenAiProvider {
     /// Provider-scoped per-model context window overrides from
     /// `[providers.<name>.model_overrides.<id>]` config.
     context_window_provider: std::collections::HashMap<String, u32>,
-    /// Whether this provider accepts the `name` field on user messages.
-    ///
-    /// OpenAI and most compatible providers accept it (with character
-    /// restrictions handled by sanitization).  Mistral rejects it outright.
-    /// Defaults to `true`; set to `false` via `with_supports_user_name(false)`.
-    pub(crate) supports_user_name: bool,
     /// Optional override for the completion-based probe timeout (seconds).
     /// `None` uses the trait default (30s).
     probe_timeout_secs: Option<u64>,

--- a/crates/providers/src/openai/mod.rs
+++ b/crates/providers/src/openai/mod.rs
@@ -55,6 +55,10 @@ pub(crate) struct OpenAiProviderCapabilities {
     pub(crate) omits_strict_tool_field: bool,
     pub(crate) rejects_null_in_enums: bool,
     pub(crate) requires_gemini_tool_call_extra_content: bool,
+    pub(crate) default_reasoning_content_on_tool_messages: bool,
+    pub(crate) reasoning_content_model_prefixes: &'static [&'static str],
+    pub(crate) system_message_rewrite: SystemMessageRewriteStrategy,
+    pub(crate) qwen_models_require_single_leading_system: bool,
     pub(crate) rate_limit_policy: RateLimitPolicy,
     pub(crate) reasoning_effort_policy: ReasoningEffortPolicy,
     pub(crate) cache_control_policy: CacheControlPolicy,
@@ -70,6 +74,10 @@ impl OpenAiProviderCapabilities {
         omits_strict_tool_field: false,
         rejects_null_in_enums: false,
         requires_gemini_tool_call_extra_content: false,
+        default_reasoning_content_on_tool_messages: false,
+        reasoning_content_model_prefixes: &[],
+        system_message_rewrite: SystemMessageRewriteStrategy::None,
+        qwen_models_require_single_leading_system: false,
         rate_limit_policy: RateLimitPolicy::None,
         reasoning_effort_policy: ReasoningEffortPolicy::OpenAi,
         cache_control_policy: CacheControlPolicy::None,
@@ -108,14 +116,6 @@ pub struct OpenAiProvider {
     capabilities: OpenAiProviderCapabilities,
     /// Resolved model capabilities. Never inferred from provider name or URL.
     model_capabilities: ModelCapabilities,
-    /// Whether assistant tool-call messages need `reasoning_content` on replay.
-    default_reasoning_content_on_tool_messages: bool,
-    /// Raw model-id prefixes that need `reasoning_content` on tool-call replay.
-    reasoning_content_model_prefixes: &'static [&'static str],
-    /// Provider-specific system-message rewrite behavior.
-    system_message_rewrite_strategy: SystemMessageRewriteStrategy,
-    /// Whether Qwen-family models on this provider need one leading system message.
-    qwen_models_require_single_leading_system: bool,
     /// Global per-model context window overrides from `[models.<id>]` config.
     context_window_global: std::collections::HashMap<String, u32>,
     /// Provider-scoped per-model context window overrides from

--- a/crates/providers/src/openai/mod.rs
+++ b/crates/providers/src/openai/mod.rs
@@ -37,6 +37,12 @@ pub(crate) enum ProbeFallbackPolicy {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ProbeOutputCapPolicy {
+    MaxTokens,
+    ReasoningModelsUseMaxCompletionTokens,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum ResponsesWebSocketPolicy {
     Unsupported,
     OpenAiPlatform,
@@ -53,6 +59,7 @@ pub(crate) struct OpenAiProviderCapabilities {
     pub(crate) reasoning_effort_policy: ReasoningEffortPolicy,
     pub(crate) cache_control_policy: CacheControlPolicy,
     pub(crate) probe_fallback_policy: ProbeFallbackPolicy,
+    pub(crate) probe_output_cap_policy: ProbeOutputCapPolicy,
     pub(crate) responses_websocket_policy: ResponsesWebSocketPolicy,
 }
 
@@ -67,6 +74,7 @@ impl OpenAiProviderCapabilities {
         reasoning_effort_policy: ReasoningEffortPolicy::OpenAi,
         cache_control_policy: CacheControlPolicy::None,
         probe_fallback_policy: ProbeFallbackPolicy::None,
+        probe_output_cap_policy: ProbeOutputCapPolicy::ReasoningModelsUseMaxCompletionTokens,
         responses_websocket_policy: ResponsesWebSocketPolicy::Unsupported,
     };
 }

--- a/crates/providers/src/openai/mod.rs
+++ b/crates/providers/src/openai/mod.rs
@@ -9,7 +9,7 @@ pub use {
     },
 };
 
-use moltis_agents::model::ModelMetadata;
+use {crate::ModelCapabilities, moltis_agents::model::ModelMetadata};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum RateLimitPolicy {
@@ -98,6 +98,8 @@ pub struct OpenAiProvider {
     reasoning_content_override: Option<bool>,
     /// Explicit provider behavior policies. Never inferred from provider name or URL.
     capabilities: OpenAiProviderCapabilities,
+    /// Resolved model capabilities. Never inferred from provider name or URL.
+    model_capabilities: ModelCapabilities,
     /// Whether assistant tool-call messages need `reasoning_content` on replay.
     default_reasoning_content_on_tool_messages: bool,
     /// Raw model-id prefixes that need `reasoning_content` on tool-call replay.

--- a/crates/providers/src/openai/provider/completion.rs
+++ b/crates/providers/src/openai/provider/completion.rs
@@ -12,7 +12,6 @@ use crate::{
         parse_tool_calls, split_responses_instructions_and_input, strip_think_tags,
         to_responses_api_tools,
     },
-    raw_model_id,
 };
 
 use moltis_agents::model::{
@@ -43,15 +42,10 @@ fn should_warn_on_api_error(status: reqwest::StatusCode, body_text: &str) -> boo
 
 impl OpenAiProvider {
     fn apply_probe_output_cap_chat(&self, body: &mut serde_json::Value) {
-        let raw = raw_model_id(&self.model).to_ascii_lowercase();
-        let capability = raw.rsplit('/').next().unwrap_or(raw.as_str());
         let uses_max_completion_tokens = !matches!(
             self.capabilities.reasoning_effort_policy,
             ReasoningEffortPolicy::Unsupported
-        ) && (capability.starts_with("gpt-5")
-            || capability.starts_with("o1")
-            || capability.starts_with("o3")
-            || capability.starts_with("o4"));
+        ) && self.model_capabilities.reasoning;
         if uses_max_completion_tokens {
             // GPT-5 and reasoning models need a higher minimum output cap.
             // Values below ~10 can trigger 400 errors on some models.
@@ -642,6 +636,42 @@ mod tests {
 
         assert_eq!(body["max_completion_tokens"], 16);
         assert!(body.get("max_tokens").is_none());
+    }
+
+    #[test]
+    fn probe_output_cap_uses_resolved_model_reasoning_capability() {
+        let provider = provider("custom-reasoner", "custom", "https://example.invalid/v1")
+            .with_model_capabilities(crate::ModelCapabilities {
+                reasoning: true,
+                ..crate::ModelCapabilities::infer("custom-reasoner")
+            });
+        let mut body = serde_json::json!({
+            "model": "custom-reasoner",
+            "messages": [{"role": "user", "content": "ping"}],
+        });
+
+        provider.apply_probe_output_cap_chat(&mut body);
+
+        assert_eq!(body["max_completion_tokens"], 16);
+        assert!(body.get("max_tokens").is_none());
+    }
+
+    #[test]
+    fn probe_output_cap_does_not_infer_reasoning_from_model_name_when_capability_false() {
+        let provider = provider("gpt-5.2", "custom", "https://example.invalid/v1")
+            .with_model_capabilities(crate::ModelCapabilities {
+                reasoning: false,
+                ..crate::ModelCapabilities::infer("gpt-5.2")
+            });
+        let mut body = serde_json::json!({
+            "model": "gpt-5.2",
+            "messages": [{"role": "user", "content": "ping"}],
+        });
+
+        provider.apply_probe_output_cap_chat(&mut body);
+
+        assert_eq!(body["max_tokens"], 1);
+        assert!(body.get("max_completion_tokens").is_none());
     }
 
     #[test]

--- a/crates/providers/src/openai/provider/completion.rs
+++ b/crates/providers/src/openai/provider/completion.rs
@@ -20,7 +20,7 @@ use moltis_agents::model::{
 
 use {
     super::OpenAiProvider,
-    crate::openai::{ProbeFallbackPolicy, ReasoningEffortPolicy},
+    crate::openai::{ProbeFallbackPolicy, ProbeOutputCapPolicy},
 };
 
 fn is_chat_endpoint_unsupported_model_error(body_text: &str) -> bool {
@@ -42,11 +42,11 @@ fn should_warn_on_api_error(status: reqwest::StatusCode, body_text: &str) -> boo
 
 impl OpenAiProvider {
     fn apply_probe_output_cap_chat(&self, body: &mut serde_json::Value) {
-        let uses_max_completion_tokens = !matches!(
-            self.capabilities.reasoning_effort_policy,
-            ReasoningEffortPolicy::Unsupported
-        ) && self.model_capabilities.reasoning;
-        if uses_max_completion_tokens {
+        if matches!(
+            self.capabilities.probe_output_cap_policy,
+            ProbeOutputCapPolicy::ReasoningModelsUseMaxCompletionTokens
+        ) && self.model_capabilities.reasoning
+        {
             // GPT-5 and reasoning models need a higher minimum output cap.
             // Values below ~10 can trigger 400 errors on some models.
             body["max_completion_tokens"] = serde_json::json!(16);
@@ -606,7 +606,7 @@ mod tests {
             "https://cloud-api.near.ai/v1",
         )
         .with_capabilities(crate::openai::OpenAiProviderCapabilities {
-            reasoning_effort_policy: ReasoningEffortPolicy::Unsupported,
+            probe_output_cap_policy: ProbeOutputCapPolicy::MaxTokens,
             ..crate::openai::OpenAiProviderCapabilities::DEFAULT
         });
         let mut body = serde_json::json!({

--- a/crates/providers/src/openai/provider/completion.rs
+++ b/crates/providers/src/openai/provider/completion.rs
@@ -19,7 +19,10 @@ use moltis_agents::model::{
     AgentToolControls, ChatMessage, CompletionResponse, Usage, decode_tool_call_arguments_from_str,
 };
 
-use super::OpenAiProvider;
+use {
+    super::OpenAiProvider,
+    crate::openai::{ProbeFallbackPolicy, ReasoningEffortPolicy},
+};
 
 fn is_chat_endpoint_unsupported_model_error(body_text: &str) -> bool {
     let lower = body_text.to_ascii_lowercase();
@@ -42,11 +45,13 @@ impl OpenAiProvider {
     fn apply_probe_output_cap_chat(&self, body: &mut serde_json::Value) {
         let raw = raw_model_id(&self.model).to_ascii_lowercase();
         let capability = raw.rsplit('/').next().unwrap_or(raw.as_str());
-        let uses_max_completion_tokens = !self.is_nearai_provider()
-            && (capability.starts_with("gpt-5")
-                || capability.starts_with("o1")
-                || capability.starts_with("o3")
-                || capability.starts_with("o4"));
+        let uses_max_completion_tokens = !matches!(
+            self.capabilities.reasoning_effort_policy,
+            ReasoningEffortPolicy::Unsupported
+        ) && (capability.starts_with("gpt-5")
+            || capability.starts_with("o1")
+            || capability.starts_with("o3")
+            || capability.starts_with("o4"));
         if uses_max_completion_tokens {
             // GPT-5 and reasoning models need a higher minimum output cap.
             // Values below ~10 can trigger 400 errors on some models.
@@ -101,7 +106,10 @@ impl OpenAiProvider {
             // exist but aren't wired to /v1/chat/completions.  Fall back
             // to the native `/api/show` endpoint before giving up.
             if status == reqwest::StatusCode::NOT_FOUND
-                && self.provider_name.eq_ignore_ascii_case("ollama")
+                && matches!(
+                    self.capabilities.probe_fallback_policy,
+                    ProbeFallbackPolicy::OllamaNativeShow
+                )
             {
                 return self.probe_ollama_native().await;
             }
@@ -602,7 +610,11 @@ mod tests {
             "openai/gpt-oss-120b",
             "nearai",
             "https://cloud-api.near.ai/v1",
-        );
+        )
+        .with_capabilities(crate::openai::OpenAiProviderCapabilities {
+            reasoning_effort_policy: ReasoningEffortPolicy::Unsupported,
+            ..crate::openai::OpenAiProviderCapabilities::DEFAULT
+        });
         let mut body = serde_json::json!({
             "model": "openai/gpt-oss-120b",
             "messages": [{"role": "user", "content": "ping"}],
@@ -612,6 +624,24 @@ mod tests {
 
         assert_eq!(body["max_tokens"], 1);
         assert!(body.get("max_completion_tokens").is_none());
+    }
+
+    #[test]
+    fn custom_provider_with_nearai_url_still_uses_default_probe_output_cap() {
+        let provider = provider(
+            "openai/gpt-5.2",
+            "custom-nearai",
+            "https://cloud-api.near.ai/v1",
+        );
+        let mut body = serde_json::json!({
+            "model": "openai/gpt-5.2",
+            "messages": [{"role": "user", "content": "ping"}],
+        });
+
+        provider.apply_probe_output_cap_chat(&mut body);
+
+        assert_eq!(body["max_completion_tokens"], 16);
+        assert!(body.get("max_tokens").is_none());
     }
 
     #[test]

--- a/crates/providers/src/openai/provider/core.rs
+++ b/crates/providers/src/openai/provider/core.rs
@@ -19,7 +19,10 @@ use moltis_agents::model::{
     ToolChoice,
 };
 
-use super::super::{OpenAiProvider, SystemMessageRewriteStrategy};
+use super::super::{
+    OpenAiProvider, OpenAiProviderCapabilities, RateLimitPolicy, ReasoningEffortPolicy,
+    SystemMessageRewriteStrategy,
+};
 
 impl OpenAiProvider {
     pub fn new(api_key: secrecy::Secret<String>, model: String, base_url: String) -> Self {
@@ -37,16 +40,16 @@ impl OpenAiProvider {
             cache_retention: moltis_config::CacheRetention::Short,
             strict_tools_override: None,
             reasoning_content_override: None,
-            default_strict_tools: true,
+            capabilities: OpenAiProviderCapabilities {
+                responses_websocket_policy: super::super::ResponsesWebSocketPolicy::OpenAiPlatform,
+                ..OpenAiProviderCapabilities::DEFAULT
+            },
             default_reasoning_content_on_tool_messages: false,
             reasoning_content_model_prefixes: &[],
-            rejects_null_in_enums: false,
-            requires_gemini_tool_call_extra_content: false,
             system_message_rewrite_strategy: SystemMessageRewriteStrategy::None,
             qwen_models_require_single_leading_system: false,
             context_window_global: std::collections::HashMap::new(),
             context_window_provider: std::collections::HashMap::new(),
-            supports_user_name: true,
             probe_timeout_secs: None,
         }
     }
@@ -71,18 +74,21 @@ impl OpenAiProvider {
             cache_retention: moltis_config::CacheRetention::Short,
             strict_tools_override: None,
             reasoning_content_override: None,
-            default_strict_tools: true,
+            capabilities: OpenAiProviderCapabilities::DEFAULT,
             default_reasoning_content_on_tool_messages: false,
             reasoning_content_model_prefixes: &[],
-            rejects_null_in_enums: false,
-            requires_gemini_tool_call_extra_content: false,
             system_message_rewrite_strategy: SystemMessageRewriteStrategy::None,
             qwen_models_require_single_leading_system: false,
             context_window_global: std::collections::HashMap::new(),
             context_window_provider: std::collections::HashMap::new(),
-            supports_user_name: true,
             probe_timeout_secs: None,
         }
+    }
+
+    #[must_use]
+    pub(crate) fn with_capabilities(mut self, capabilities: OpenAiProviderCapabilities) -> Self {
+        self.capabilities = capabilities;
+        self
     }
 
     #[must_use]
@@ -126,13 +132,13 @@ impl OpenAiProvider {
     /// Defaults to `true` for most providers; auto-set to `false` for Mistral.
     #[must_use]
     pub fn with_supports_user_name(mut self, supported: bool) -> Self {
-        self.supports_user_name = supported;
+        self.capabilities.supports_user_name = supported;
         self
     }
 
     #[must_use]
     pub(crate) fn with_default_strict_tools(mut self, strict: bool) -> Self {
-        self.default_strict_tools = strict;
+        self.capabilities.default_strict_tools = strict;
         self
     }
 
@@ -153,13 +159,13 @@ impl OpenAiProvider {
 
     #[must_use]
     pub(crate) fn with_rejects_null_in_enums(mut self, rejects: bool) -> Self {
-        self.rejects_null_in_enums = rejects;
+        self.capabilities.rejects_null_in_enums = rejects;
         self
     }
 
     #[must_use]
     pub(crate) fn with_gemini_tool_call_extra_content(mut self, required: bool) -> Self {
-        self.requires_gemini_tool_call_extra_content = required;
+        self.capabilities.requires_gemini_tool_call_extra_content = required;
         self
     }
 
@@ -200,30 +206,10 @@ impl OpenAiProvider {
         self
     }
 
-    fn is_deepseek_provider(&self) -> bool {
-        self.provider_name.eq_ignore_ascii_case("deepseek")
-            || self
-                .base_url
-                .to_ascii_lowercase()
-                .contains("api.deepseek.com")
-    }
-
-    pub(super) fn is_nearai_provider(&self) -> bool {
-        self.provider_name.eq_ignore_ascii_case("nearai")
-            || self
-                .base_url
-                .to_ascii_lowercase()
-                .contains("cloud-api.near.ai")
-    }
-
-    fn is_mistral_provider(&self) -> bool {
-        self.provider_name.eq_ignore_ascii_case("mistral")
-            || self.base_url.to_ascii_lowercase().contains("mistral.ai")
-    }
-
-    async fn wait_for_mistral_slot(&self) {
-        if !self.is_mistral_provider() {
-            return;
+    async fn wait_for_rate_limit_slot(&self) {
+        match self.capabilities.rate_limit_policy {
+            RateLimitPolicy::None => return,
+            RateLimitPolicy::Mistral => {},
         }
 
         static LAST_MISTRAL_REQUEST: std::sync::OnceLock<
@@ -245,13 +231,14 @@ impl OpenAiProvider {
         *last_request = Some(tokio::time::Instant::now());
     }
 
-    fn mistral_retry_delay(
+    fn rate_limit_retry_delay(
         &self,
         attempt: usize,
         headers: &reqwest::header::HeaderMap,
     ) -> Option<Duration> {
-        if !self.is_mistral_provider() || attempt >= 2 {
-            return None;
+        match self.capabilities.rate_limit_policy {
+            RateLimitPolicy::Mistral if attempt < 2 => {},
+            RateLimitPolicy::None | RateLimitPolicy::Mistral => return None,
         }
 
         let retry_after = retry_after_ms_from_headers(headers)
@@ -266,7 +253,7 @@ impl OpenAiProvider {
     ) -> reqwest::Result<reqwest::Response> {
         let url = self.chat_completions_url();
         for attempt in 0..3 {
-            self.wait_for_mistral_slot().await;
+            self.wait_for_rate_limit_slot().await;
 
             let response = self
                 .client
@@ -278,7 +265,7 @@ impl OpenAiProvider {
                 .await?;
 
             if response.status() == reqwest::StatusCode::TOO_MANY_REQUESTS
-                && let Some(delay) = self.mistral_retry_delay(attempt, response.headers())
+                && let Some(delay) = self.rate_limit_retry_delay(attempt, response.headers())
             {
                 tracing::debug!(
                     provider = %self.provider_name,
@@ -314,38 +301,35 @@ impl OpenAiProvider {
     /// are clamped to the nearest supported value.
     pub(crate) fn reasoning_effort_str(&self) -> Option<&'static str> {
         use moltis_agents::model::ReasoningEffort;
-        if self.is_nearai_provider() {
-            return None;
-        }
-        if self.is_deepseek_provider() {
-            return self.reasoning_effort.map(|e| match e {
+        match self.capabilities.reasoning_effort_policy {
+            ReasoningEffortPolicy::Unsupported => None,
+            ReasoningEffortPolicy::DeepSeek => self.reasoning_effort.map(|e| match e {
                 ReasoningEffort::Minimal
                 | ReasoningEffort::Low
                 | ReasoningEffort::Medium
                 | ReasoningEffort::High => "high",
                 ReasoningEffort::ExtraHigh => "max",
-            });
+            }),
+            ReasoningEffortPolicy::OpenAi => self.reasoning_effort.map(|e| match e {
+                ReasoningEffort::Minimal => {
+                    tracing::debug!(
+                        model = %self.model,
+                        "reasoning effort Minimal clamped to \"low\" (OpenAI minimum)"
+                    );
+                    "low"
+                },
+                ReasoningEffort::Low => "low",
+                ReasoningEffort::Medium => "medium",
+                ReasoningEffort::High => "high",
+                ReasoningEffort::ExtraHigh => {
+                    tracing::debug!(
+                        model = %self.model,
+                        "reasoning effort ExtraHigh clamped to \"high\" (OpenAI maximum)"
+                    );
+                    "high"
+                },
+            }),
         }
-
-        self.reasoning_effort.map(|e| match e {
-            ReasoningEffort::Minimal => {
-                tracing::debug!(
-                    model = %self.model,
-                    "reasoning effort Minimal clamped to \"low\" (OpenAI minimum)"
-                );
-                "low"
-            },
-            ReasoningEffort::Low => "low",
-            ReasoningEffort::Medium => "medium",
-            ReasoningEffort::High => "high",
-            ReasoningEffort::ExtraHigh => {
-                tracing::debug!(
-                    model = %self.model,
-                    "reasoning effort ExtraHigh clamped to \"high\" (OpenAI maximum)"
-                );
-                "high"
-            },
-        })
     }
 
     /// Apply `reasoning_effort` for the **Chat Completions** API (used by
@@ -355,7 +339,10 @@ impl OpenAiProvider {
     pub(crate) fn apply_reasoning_effort_chat(&self, body: &mut serde_json::Value) {
         if let Some(effort) = self.reasoning_effort_str() {
             body["reasoning_effort"] = serde_json::json!(effort);
-            if self.is_deepseek_provider() {
+            if matches!(
+                self.capabilities.reasoning_effort_policy,
+                ReasoningEffortPolicy::DeepSeek
+            ) {
                 body["thinking"] = serde_json::json!({ "type": "enabled" });
             }
         }
@@ -408,7 +395,10 @@ impl LlmProvider for OpenAiProvider {
         self: std::sync::Arc<Self>,
         effort: moltis_agents::model::ReasoningEffort,
     ) -> Option<std::sync::Arc<dyn LlmProvider>> {
-        if self.is_nearai_provider() {
+        if matches!(
+            self.capabilities.reasoning_effort_policy,
+            ReasoningEffortPolicy::Unsupported
+        ) {
             return None;
         }
         Some(std::sync::Arc::new(Self {
@@ -427,16 +417,13 @@ impl LlmProvider for OpenAiProvider {
             context_window_provider: self.context_window_provider.clone(),
             strict_tools_override: self.strict_tools_override,
             reasoning_content_override: self.reasoning_content_override,
-            default_strict_tools: self.default_strict_tools,
+            capabilities: self.capabilities,
             default_reasoning_content_on_tool_messages: self
                 .default_reasoning_content_on_tool_messages,
             reasoning_content_model_prefixes: self.reasoning_content_model_prefixes,
-            rejects_null_in_enums: self.rejects_null_in_enums,
-            requires_gemini_tool_call_extra_content: self.requires_gemini_tool_call_extra_content,
             system_message_rewrite_strategy: self.system_message_rewrite_strategy,
             qwen_models_require_single_leading_system: self
                 .qwen_models_require_single_leading_system,
-            supports_user_name: self.supports_user_name,
             probe_timeout_secs: self.probe_timeout_secs,
         }))
     }
@@ -686,18 +673,41 @@ mod tests {
 
     #[test]
     fn nearai_does_not_accept_reasoning_effort_suffixes() {
-        let provider = Arc::new(OpenAiProvider::new_with_name(
-            secrecy::Secret::new("test-key".to_string()),
-            "openai/gpt-oss-120b".to_string(),
-            "https://cloud-api.near.ai/v1".to_string(),
-            "nearai".to_string(),
-        ));
+        let provider = Arc::new(
+            OpenAiProvider::new_with_name(
+                secrecy::Secret::new("test-key".to_string()),
+                "openai/gpt-oss-120b".to_string(),
+                "https://cloud-api.near.ai/v1".to_string(),
+                "nearai".to_string(),
+            )
+            .with_capabilities(OpenAiProviderCapabilities {
+                reasoning_effort_policy: ReasoningEffortPolicy::Unsupported,
+                ..OpenAiProviderCapabilities::DEFAULT
+            }),
+        );
 
         assert!(
             provider
                 .with_reasoning_effort(ReasoningEffort::High)
                 .is_none(),
             "NEAR AI Cloud does not support the OpenAI reasoning_effort field"
+        );
+    }
+
+    #[test]
+    fn custom_provider_with_nearai_url_keeps_default_reasoning_effort_support() {
+        let provider = Arc::new(OpenAiProvider::new_with_name(
+            secrecy::Secret::new("test-key".to_string()),
+            "openai/gpt-oss-120b".to_string(),
+            "https://cloud-api.near.ai/v1".to_string(),
+            "custom-nearai".to_string(),
+        ));
+
+        assert!(
+            provider
+                .with_reasoning_effort(ReasoningEffort::High)
+                .is_some(),
+            "provider URLs must not enable provider-specific reasoning behavior"
         );
     }
 }

--- a/crates/providers/src/openai/provider/core.rs
+++ b/crates/providers/src/openai/provider/core.rs
@@ -20,7 +20,6 @@ use moltis_agents::model::{
 
 use super::super::{
     OpenAiProvider, OpenAiProviderCapabilities, RateLimitPolicy, ReasoningEffortPolicy,
-    SystemMessageRewriteStrategy,
 };
 
 impl OpenAiProvider {
@@ -56,10 +55,6 @@ impl OpenAiProvider {
             reasoning_content_override: None,
             capabilities: OpenAiProviderCapabilities::DEFAULT,
             model_capabilities,
-            default_reasoning_content_on_tool_messages: false,
-            reasoning_content_model_prefixes: &[],
-            system_message_rewrite_strategy: SystemMessageRewriteStrategy::None,
-            qwen_models_require_single_leading_system: false,
             context_window_global: std::collections::HashMap::new(),
             context_window_provider: std::collections::HashMap::new(),
             probe_timeout_secs: None,
@@ -114,36 +109,6 @@ impl OpenAiProvider {
         self
     }
 
-    #[must_use]
-    pub(crate) fn with_default_reasoning_content(mut self, required: bool) -> Self {
-        self.default_reasoning_content_on_tool_messages = required;
-        self
-    }
-
-    #[must_use]
-    pub(crate) fn with_reasoning_content_model_prefixes(
-        mut self,
-        prefixes: &'static [&'static str],
-    ) -> Self {
-        self.reasoning_content_model_prefixes = prefixes;
-        self
-    }
-
-    #[must_use]
-    pub(crate) fn with_system_message_rewrite(
-        mut self,
-        strategy: SystemMessageRewriteStrategy,
-    ) -> Self {
-        self.system_message_rewrite_strategy = strategy;
-        self
-    }
-
-    #[must_use]
-    pub(crate) fn with_qwen_models_require_single_leading_system(mut self, required: bool) -> Self {
-        self.qwen_models_require_single_leading_system = required;
-        self
-    }
-
     /// Set the completion-based probe timeout override (seconds).
     #[must_use]
     pub fn with_probe_timeout_secs(mut self, secs: Option<u64>) -> Self {
@@ -172,12 +137,6 @@ impl OpenAiProvider {
             reasoning_content_override: self.reasoning_content_override,
             capabilities: self.capabilities,
             model_capabilities: self.model_capabilities,
-            default_reasoning_content_on_tool_messages: self
-                .default_reasoning_content_on_tool_messages,
-            reasoning_content_model_prefixes: self.reasoning_content_model_prefixes,
-            system_message_rewrite_strategy: self.system_message_rewrite_strategy,
-            qwen_models_require_single_leading_system: self
-                .qwen_models_require_single_leading_system,
             context_window_global: self.context_window_global.clone(),
             context_window_provider: self.context_window_provider.clone(),
             probe_timeout_secs: self.probe_timeout_secs,

--- a/crates/providers/src/openai/provider/core.rs
+++ b/crates/providers/src/openai/provider/core.rs
@@ -25,34 +25,12 @@ use super::super::{
 
 impl OpenAiProvider {
     pub fn new(api_key: secrecy::Secret<String>, model: String, base_url: String) -> Self {
-        let model_capabilities = ModelCapabilities::infer(&model);
-        Self {
-            api_key,
-            model,
-            base_url,
-            provider_name: "openai".into(),
-            client: crate::shared_http_client(),
-            stream_transport: ProviderStreamTransport::Sse,
-            wire_api: WireApi::ChatCompletions,
-            metadata_cache: tokio::sync::OnceCell::new(),
-            tool_mode_override: None,
-            reasoning_effort: None,
-            cache_retention: moltis_config::CacheRetention::Short,
-            strict_tools_override: None,
-            reasoning_content_override: None,
-            capabilities: OpenAiProviderCapabilities {
+        Self::new_with_name(api_key, model, base_url, "openai".into()).with_capabilities(
+            OpenAiProviderCapabilities {
                 responses_websocket_policy: super::super::ResponsesWebSocketPolicy::OpenAiPlatform,
                 ..OpenAiProviderCapabilities::DEFAULT
             },
-            model_capabilities,
-            default_reasoning_content_on_tool_messages: false,
-            reasoning_content_model_prefixes: &[],
-            system_message_rewrite_strategy: SystemMessageRewriteStrategy::None,
-            qwen_models_require_single_leading_system: false,
-            context_window_global: std::collections::HashMap::new(),
-            context_window_provider: std::collections::HashMap::new(),
-            probe_timeout_secs: None,
-        }
+        )
     }
 
     pub fn new_with_name(
@@ -173,6 +151,39 @@ impl OpenAiProvider {
         self
     }
 
+    /// Create a copy of this provider with a fresh metadata cache.
+    ///
+    /// Centralises the field-by-field copy so callers like
+    /// `with_reasoning_effort` stay in sync when new fields are added.
+    fn fork(&self) -> Self {
+        Self {
+            api_key: self.api_key.clone(),
+            model: self.model.clone(),
+            base_url: self.base_url.clone(),
+            provider_name: self.provider_name.clone(),
+            client: self.client,
+            stream_transport: self.stream_transport,
+            wire_api: self.wire_api,
+            metadata_cache: tokio::sync::OnceCell::new(),
+            tool_mode_override: self.tool_mode_override,
+            reasoning_effort: self.reasoning_effort,
+            cache_retention: self.cache_retention,
+            strict_tools_override: self.strict_tools_override,
+            reasoning_content_override: self.reasoning_content_override,
+            capabilities: self.capabilities,
+            model_capabilities: self.model_capabilities,
+            default_reasoning_content_on_tool_messages: self
+                .default_reasoning_content_on_tool_messages,
+            reasoning_content_model_prefixes: self.reasoning_content_model_prefixes,
+            system_message_rewrite_strategy: self.system_message_rewrite_strategy,
+            qwen_models_require_single_leading_system: self
+                .qwen_models_require_single_leading_system,
+            context_window_global: self.context_window_global.clone(),
+            context_window_provider: self.context_window_provider.clone(),
+            probe_timeout_secs: self.probe_timeout_secs,
+        }
+    }
+
     /// Set context window override maps extracted from config.
     ///
     /// `global` comes from `[models.<id>].context_window` and
@@ -194,12 +205,12 @@ impl OpenAiProvider {
             RateLimitPolicy::Mistral => {},
         }
 
-        static LAST_MISTRAL_REQUEST: std::sync::OnceLock<
+        static LAST_RATE_LIMITED_REQUEST: std::sync::OnceLock<
             tokio::sync::Mutex<Option<tokio::time::Instant>>,
         > = std::sync::OnceLock::new();
         const MIN_INTERVAL: Duration = Duration::from_millis(1_250);
 
-        let mut last_request = LAST_MISTRAL_REQUEST
+        let mut last_request = LAST_RATE_LIMITED_REQUEST
             .get_or_init(|| tokio::sync::Mutex::new(None))
             .lock()
             .await;
@@ -254,7 +265,7 @@ impl OpenAiProvider {
                     model = %self.model,
                     attempt = attempt + 1,
                     delay_ms = delay.as_millis(),
-                    "retrying Mistral request after rate limit"
+                    "retrying request after rate limit"
                 );
                 tokio::time::sleep(delay).await;
                 continue;
@@ -383,32 +394,9 @@ impl LlmProvider for OpenAiProvider {
         ) {
             return None;
         }
-        Some(std::sync::Arc::new(Self {
-            api_key: self.api_key.clone(),
-            model: self.model.clone(),
-            base_url: self.base_url.clone(),
-            provider_name: self.provider_name.clone(),
-            client: self.client,
-            stream_transport: self.stream_transport,
-            metadata_cache: tokio::sync::OnceCell::new(),
-            tool_mode_override: self.tool_mode_override,
-            reasoning_effort: Some(effort),
-            wire_api: self.wire_api,
-            cache_retention: self.cache_retention,
-            context_window_global: self.context_window_global.clone(),
-            context_window_provider: self.context_window_provider.clone(),
-            strict_tools_override: self.strict_tools_override,
-            reasoning_content_override: self.reasoning_content_override,
-            capabilities: self.capabilities,
-            model_capabilities: self.model_capabilities,
-            default_reasoning_content_on_tool_messages: self
-                .default_reasoning_content_on_tool_messages,
-            reasoning_content_model_prefixes: self.reasoning_content_model_prefixes,
-            system_message_rewrite_strategy: self.system_message_rewrite_strategy,
-            qwen_models_require_single_leading_system: self
-                .qwen_models_require_single_leading_system,
-            probe_timeout_secs: self.probe_timeout_secs,
-        }))
+        let mut forked = self.fork();
+        forked.reasoning_effort = Some(effort);
+        Some(std::sync::Arc::new(forked))
     }
 
     fn id(&self) -> &str {

--- a/crates/providers/src/openai/provider/core.rs
+++ b/crates/providers/src/openai/provider/core.rs
@@ -136,21 +136,6 @@ impl OpenAiProvider {
         self
     }
 
-    /// Set whether this provider accepts the `name` field on user messages.
-    ///
-    /// Defaults to `true` for most providers; auto-set to `false` for Mistral.
-    #[must_use]
-    pub fn with_supports_user_name(mut self, supported: bool) -> Self {
-        self.capabilities.supports_user_name = supported;
-        self
-    }
-
-    #[must_use]
-    pub(crate) fn with_default_strict_tools(mut self, strict: bool) -> Self {
-        self.capabilities.default_strict_tools = strict;
-        self
-    }
-
     #[must_use]
     pub(crate) fn with_default_reasoning_content(mut self, required: bool) -> Self {
         self.default_reasoning_content_on_tool_messages = required;
@@ -163,18 +148,6 @@ impl OpenAiProvider {
         prefixes: &'static [&'static str],
     ) -> Self {
         self.reasoning_content_model_prefixes = prefixes;
-        self
-    }
-
-    #[must_use]
-    pub(crate) fn with_rejects_null_in_enums(mut self, rejects: bool) -> Self {
-        self.capabilities.rejects_null_in_enums = rejects;
-        self
-    }
-
-    #[must_use]
-    pub(crate) fn with_gemini_tool_call_extra_content(mut self, required: bool) -> Self {
-        self.capabilities.requires_gemini_tool_call_extra_content = required;
         self
     }
 

--- a/crates/providers/src/openai/provider/core.rs
+++ b/crates/providers/src/openai/provider/core.rs
@@ -10,8 +10,7 @@ use {
 use tracing::debug;
 
 use crate::{
-    context_window_for_model_with_config, http::retry_after_ms_from_headers,
-    supports_tools_for_model, supports_vision_for_model,
+    ModelCapabilities, context_window_for_model_with_config, http::retry_after_ms_from_headers,
 };
 
 use moltis_agents::model::{
@@ -26,6 +25,7 @@ use super::super::{
 
 impl OpenAiProvider {
     pub fn new(api_key: secrecy::Secret<String>, model: String, base_url: String) -> Self {
+        let model_capabilities = ModelCapabilities::infer(&model);
         Self {
             api_key,
             model,
@@ -44,6 +44,7 @@ impl OpenAiProvider {
                 responses_websocket_policy: super::super::ResponsesWebSocketPolicy::OpenAiPlatform,
                 ..OpenAiProviderCapabilities::DEFAULT
             },
+            model_capabilities,
             default_reasoning_content_on_tool_messages: false,
             reasoning_content_model_prefixes: &[],
             system_message_rewrite_strategy: SystemMessageRewriteStrategy::None,
@@ -60,6 +61,7 @@ impl OpenAiProvider {
         base_url: String,
         provider_name: String,
     ) -> Self {
+        let model_capabilities = ModelCapabilities::infer(&model);
         Self {
             api_key,
             model,
@@ -75,6 +77,7 @@ impl OpenAiProvider {
             strict_tools_override: None,
             reasoning_content_override: None,
             capabilities: OpenAiProviderCapabilities::DEFAULT,
+            model_capabilities,
             default_reasoning_content_on_tool_messages: false,
             reasoning_content_model_prefixes: &[],
             system_message_rewrite_strategy: SystemMessageRewriteStrategy::None,
@@ -88,6 +91,12 @@ impl OpenAiProvider {
     #[must_use]
     pub(crate) fn with_capabilities(mut self, capabilities: OpenAiProviderCapabilities) -> Self {
         self.capabilities = capabilities;
+        self
+    }
+
+    #[must_use]
+    pub(crate) fn with_model_capabilities(mut self, capabilities: ModelCapabilities) -> Self {
+        self.model_capabilities = capabilities;
         self
     }
 
@@ -418,6 +427,7 @@ impl LlmProvider for OpenAiProvider {
             strict_tools_override: self.strict_tools_override,
             reasoning_content_override: self.reasoning_content_override,
             capabilities: self.capabilities,
+            model_capabilities: self.model_capabilities,
             default_reasoning_content_on_tool_messages: self
                 .default_reasoning_content_on_tool_messages,
             reasoning_content_model_prefixes: self.reasoning_content_model_prefixes,
@@ -436,7 +446,7 @@ impl LlmProvider for OpenAiProvider {
         match self.tool_mode_override {
             Some(moltis_config::ToolMode::Native) => true,
             Some(moltis_config::ToolMode::Text | moltis_config::ToolMode::Off) => false,
-            Some(moltis_config::ToolMode::Auto) | None => supports_tools_for_model(&self.model),
+            Some(moltis_config::ToolMode::Auto) | None => self.model_capabilities.tools,
         }
     }
 
@@ -453,7 +463,7 @@ impl LlmProvider for OpenAiProvider {
     }
 
     fn supports_vision(&self) -> bool {
-        supports_vision_for_model(&self.model)
+        self.model_capabilities.vision
     }
 
     async fn model_metadata(&self) -> anyhow::Result<ModelMetadata> {

--- a/crates/providers/src/openai/provider/request.rs
+++ b/crates/providers/src/openai/provider/request.rs
@@ -644,8 +644,7 @@ mod tests {
             "accounts/fireworks/models/glm-5p1",
             "fireworks",
             "https://api.fireworks.ai/inference/v1",
-        )
-        .with_rejects_null_in_enums(true);
+        );
         assert!(
             p.needs_strict_tools(),
             "Native Fireworks models should use strict tools by default"
@@ -659,7 +658,10 @@ mod tests {
             "fireworks",
             "https://api.fireworks.ai/inference/v1",
         )
-        .with_rejects_null_in_enums(true);
+        .with_capabilities(OpenAiProviderCapabilities {
+            rejects_null_in_enums: true,
+            ..OpenAiProviderCapabilities::DEFAULT
+        });
         assert!(
             p.rejects_null_in_enums(),
             "Fireworks should reject null in enums (issue #848)"
@@ -673,7 +675,10 @@ mod tests {
             "fireworks",
             "https://api.fireworks.ai/inference/v1",
         )
-        .with_rejects_null_in_enums(true);
+        .with_capabilities(OpenAiProviderCapabilities {
+            rejects_null_in_enums: true,
+            ..OpenAiProviderCapabilities::DEFAULT
+        });
         assert!(
             p.rejects_null_in_enums(),
             "Fireworks provider flag should reject null in enums (issue #848)"
@@ -1054,7 +1059,10 @@ mod tests {
             "mistral",
             "https://api.mistral.ai/v1",
         )
-        .with_supports_user_name(false);
+        .with_capabilities(OpenAiProviderCapabilities {
+            supports_user_name: false,
+            ..OpenAiProviderCapabilities::DEFAULT
+        });
         assert!(!p.capabilities.supports_user_name);
 
         let messages = vec![ChatMessage::user_named("hello", "rokku")];
@@ -1070,8 +1078,12 @@ mod tests {
     /// MiniMax rejects chat histories containing inconsistent user `name` values.
     #[test]
     fn minimax_provider_strips_user_names_from_group_chat_history() {
-        let p = provider("MiniMax-M2.7", "minimax", "https://api.minimax.io/v1")
-            .with_supports_user_name(false);
+        let p = provider("MiniMax-M2.7", "minimax", "https://api.minimax.io/v1").with_capabilities(
+            OpenAiProviderCapabilities {
+                supports_user_name: false,
+                ..OpenAiProviderCapabilities::DEFAULT
+            },
+        );
         assert!(!p.capabilities.supports_user_name);
 
         let messages = vec![
@@ -1114,11 +1126,15 @@ mod tests {
         assert_eq!(p.bearer_auth_header(), "Bearer test-key");
     }
 
-    /// `with_supports_user_name(false)` overrides the default.
+    /// Explicit capabilities can override the default.
     #[test]
     fn supports_user_name_can_be_overridden() {
-        let p = provider("gpt-4o", "openai", "https://api.openai.com/v1")
-            .with_supports_user_name(false);
+        let p = provider("gpt-4o", "openai", "https://api.openai.com/v1").with_capabilities(
+            OpenAiProviderCapabilities {
+                supports_user_name: false,
+                ..OpenAiProviderCapabilities::DEFAULT
+            },
+        );
 
         let messages = vec![ChatMessage::user_named("hello", "Alice")];
         let serialized = p.serialize_messages_for_request(&messages);
@@ -1136,7 +1152,10 @@ mod tests {
             "fireworks",
             "https://api.fireworks.ai/inference/v1",
         )
-        .with_rejects_null_in_enums(true);
+        .with_capabilities(OpenAiProviderCapabilities {
+            rejects_null_in_enums: true,
+            ..OpenAiProviderCapabilities::DEFAULT
+        });
 
         let messages = vec![
             ChatMessage::user("What's the weather?"),

--- a/crates/providers/src/openai/provider/request.rs
+++ b/crates/providers/src/openai/provider/request.rs
@@ -89,6 +89,17 @@ impl OpenAiProvider {
         if let Some(explicit) = self.strict_tools_override {
             return explicit;
         }
+        if !self.capabilities.non_strict_tools_model_prefixes.is_empty() {
+            let raw_model = raw_model_id(&self.model).to_ascii_lowercase();
+            if self
+                .capabilities
+                .non_strict_tools_model_prefixes
+                .iter()
+                .any(|prefix| raw_model.starts_with(prefix))
+            {
+                return false;
+            }
+        }
         self.capabilities.default_strict_tools
     }
 

--- a/crates/providers/src/openai/provider/request.rs
+++ b/crates/providers/src/openai/provider/request.rs
@@ -834,11 +834,12 @@ mod tests {
 
     #[test]
     fn moonshot_direct_auto_detects_reasoning_content() {
-        let p = provider("kimi-k2.5", "moonshot", "https://api.moonshot.ai/v1")
-            .with_capabilities(OpenAiProviderCapabilities {
+        let p = provider("kimi-k2.5", "moonshot", "https://api.moonshot.ai/v1").with_capabilities(
+            OpenAiProviderCapabilities {
                 default_reasoning_content_on_tool_messages: true,
                 ..OpenAiProviderCapabilities::DEFAULT
-            });
+            },
+        );
         assert!(p.requires_reasoning_content_on_tool_messages());
     }
 

--- a/crates/providers/src/openai/provider/request.rs
+++ b/crates/providers/src/openai/provider/request.rs
@@ -96,11 +96,12 @@ impl OpenAiProvider {
         if let Some(explicit) = self.reasoning_content_override {
             return explicit;
         }
-        if self.default_reasoning_content_on_tool_messages {
+        if self.capabilities.default_reasoning_content_on_tool_messages {
             return true;
         }
         let raw_model = raw_model_id(&self.model).to_ascii_lowercase();
-        self.reasoning_content_model_prefixes
+        self.capabilities
+            .reasoning_content_model_prefixes
             .iter()
             .any(|prefix| raw_model.starts_with(prefix))
     }
@@ -158,7 +159,7 @@ impl OpenAiProvider {
     /// message at the front of the conversation. Qwen-based OpenAI-compatible
     /// backends commonly behave this way (e.g. llama.cpp chat templates).
     fn requires_single_leading_system_message(&self) -> bool {
-        if !self.qwen_models_require_single_leading_system {
+        if !self.capabilities.qwen_models_require_single_leading_system {
             return false;
         }
         raw_model_id(&self.model)
@@ -170,7 +171,7 @@ impl OpenAiProvider {
         if self.requires_single_leading_system_message() {
             return SystemMessageRewriteStrategy::MergeLeadingSystem;
         }
-        self.system_message_rewrite_strategy
+        self.capabilities.system_message_rewrite
     }
 
     /// Rewrite system messages for providers with stricter chat template rules.
@@ -491,7 +492,10 @@ mod tests {
             "custom-ollama-qwen",
             "http://127.0.0.1:11435/v1",
         )
-        .with_qwen_models_require_single_leading_system(true);
+        .with_capabilities(OpenAiProviderCapabilities {
+            qwen_models_require_single_leading_system: true,
+            ..OpenAiProviderCapabilities::DEFAULT
+        });
         let mut body = serde_json::json!({
             "messages": [
                 {"role": "system", "content": "You are a helpful assistant."},
@@ -519,7 +523,10 @@ mod tests {
     #[test]
     fn system_message_rewrite_minimax_inlines_messages_into_first_user_message() {
         let provider = provider("MiniMax-M2.7", "minimax", "https://api.minimax.io/v1")
-            .with_system_message_rewrite(SystemMessageRewriteStrategy::InlineIntoFirstUser);
+            .with_capabilities(OpenAiProviderCapabilities {
+                system_message_rewrite: SystemMessageRewriteStrategy::InlineIntoFirstUser,
+                ..OpenAiProviderCapabilities::DEFAULT
+            });
         let mut body = serde_json::json!({
             "messages": [
                 {"role": "system", "content": "You are a helpful assistant."},
@@ -588,7 +595,10 @@ mod tests {
             "alibaba-coding",
             "https://coding-intl.dashscope.aliyuncs.com/v1",
         )
-        .with_qwen_models_require_single_leading_system(true);
+        .with_capabilities(OpenAiProviderCapabilities {
+            qwen_models_require_single_leading_system: true,
+            ..OpenAiProviderCapabilities::DEFAULT
+        });
         let mut body = serde_json::json!({
             "messages": [
                 {"role": "system", "content": "sys1"},
@@ -814,14 +824,20 @@ mod tests {
     #[test]
     fn moonshot_direct_auto_detects_reasoning_content() {
         let p = provider("kimi-k2.5", "moonshot", "https://api.moonshot.ai/v1")
-            .with_default_reasoning_content(true);
+            .with_capabilities(OpenAiProviderCapabilities {
+                default_reasoning_content_on_tool_messages: true,
+                ..OpenAiProviderCapabilities::DEFAULT
+            });
         assert!(p.requires_reasoning_content_on_tool_messages());
     }
 
     #[test]
     fn deepseek_v4_auto_detects_reasoning_content() {
         let p = provider("deepseek-v4-flash", "deepseek", "https://api.deepseek.com")
-            .with_reasoning_content_model_prefixes(&["deepseek-v4"]);
+            .with_capabilities(OpenAiProviderCapabilities {
+                reasoning_content_model_prefixes: &["deepseek-v4"],
+                ..OpenAiProviderCapabilities::DEFAULT
+            });
         assert!(
             p.requires_reasoning_content_on_tool_messages(),
             "DeepSeek V4 thinking-mode tool calls require reasoning_content replay (issue #959)"
@@ -831,7 +847,10 @@ mod tests {
     #[test]
     fn deepseek_non_v4_does_not_auto_detect_reasoning_content() {
         let p = provider("deepseek-chat", "deepseek", "https://api.deepseek.com")
-            .with_reasoning_content_model_prefixes(&["deepseek-v4"]);
+            .with_capabilities(OpenAiProviderCapabilities {
+                reasoning_content_model_prefixes: &["deepseek-v4"],
+                ..OpenAiProviderCapabilities::DEFAULT
+            });
         assert!(
             !p.requires_reasoning_content_on_tool_messages(),
             "DeepSeek reasoning_content replay should stay scoped to V4 thinking models"
@@ -1008,7 +1027,10 @@ mod tests {
     #[test]
     fn deepseek_v4_replays_persisted_tool_reasoning_content() {
         let p = provider("deepseek-v4-flash", "deepseek", "https://api.deepseek.com")
-            .with_reasoning_content_model_prefixes(&["deepseek-v4"]);
+            .with_capabilities(OpenAiProviderCapabilities {
+                reasoning_content_model_prefixes: &["deepseek-v4"],
+                ..OpenAiProviderCapabilities::DEFAULT
+            });
         let persisted = vec![
             serde_json::json!({"role": "user", "content": "What is the weather?"}),
             serde_json::json!({

--- a/crates/providers/src/openai/provider/request.rs
+++ b/crates/providers/src/openai/provider/request.rs
@@ -4,21 +4,20 @@ use tracing::warn;
 
 use {crate::raw_model_id, moltis_agents::model::ChatMessage};
 
-use {super::OpenAiProvider, crate::openai::SystemMessageRewriteStrategy};
+use {
+    super::OpenAiProvider,
+    crate::openai::{CacheControlPolicy, SystemMessageRewriteStrategy},
+};
 
 impl OpenAiProvider {
-    /// Returns `true` when this provider targets an Anthropic model via
-    /// OpenRouter, which supports prompt caching when `cache_control`
-    /// breakpoints are present in the message payload.
-    fn is_openrouter_anthropic(&self) -> bool {
-        self.base_url.contains("openrouter.ai") && self.model.starts_with("anthropic/")
-    }
-
     /// For OpenRouter Anthropic models, inject `cache_control` breakpoints
     /// on the system message and the last user message to enable prompt
     /// caching passthrough to Anthropic.
     pub(super) fn apply_openrouter_cache_control(&self, messages: &mut [serde_json::Value]) {
-        if !self.is_openrouter_anthropic()
+        if !matches!(
+            self.capabilities.cache_control_policy,
+            CacheControlPolicy::OpenRouterAnthropic
+        ) || !self.model.starts_with("anthropic/")
             || matches!(self.cache_retention, moltis_config::CacheRetention::None)
         {
             return;
@@ -90,7 +89,7 @@ impl OpenAiProvider {
         if let Some(explicit) = self.strict_tools_override {
             return explicit;
         }
-        self.default_strict_tools
+        self.capabilities.default_strict_tools
     }
 
     fn requires_reasoning_content_on_tool_messages(&self) -> bool {
@@ -107,12 +106,7 @@ impl OpenAiProvider {
     }
 
     fn requires_gemini_tool_call_extra_content(&self) -> bool {
-        self.requires_gemini_tool_call_extra_content
-            || self.provider_name.eq_ignore_ascii_case("gemini")
-            || self
-                .base_url
-                .to_ascii_lowercase()
-                .contains("generativelanguage.googleapis.com")
+        self.capabilities.requires_gemini_tool_call_extra_content
     }
 
     /// Whether this provider rejects `null` in JSON Schema `enum` arrays.
@@ -123,11 +117,11 @@ impl OpenAiProvider {
     /// patching so type-level nullability (`["string", "null"]`) remains
     /// but the redundant null is removed from enum arrays (issue #848).
     fn rejects_null_in_enums(&self) -> bool {
-        self.rejects_null_in_enums
+        self.capabilities.rejects_null_in_enums
     }
 
     fn omits_strict_tool_field(&self) -> bool {
-        self.is_nearai_provider()
+        self.capabilities.omits_strict_tool_field
     }
 
     /// Convert raw tool schemas into the provider-compatible Chat
@@ -279,7 +273,7 @@ impl OpenAiProvider {
     ) -> Vec<serde_json::Value> {
         let needs_reasoning_content = self.requires_reasoning_content_on_tool_messages();
         let needs_gemini_tool_call_extra_content = self.requires_gemini_tool_call_extra_content();
-        let strip_name = !self.supports_user_name;
+        let strip_name = !self.capabilities.supports_user_name;
         let mut remapped_tool_call_ids = HashMap::new();
         let mut used_tool_call_ids = HashSet::new();
         let mut out = Vec::with_capacity(messages.len());
@@ -458,6 +452,8 @@ fn assign_openai_tool_call_id(
 #[cfg(test)]
 mod tests {
     use std::sync::atomic::{AtomicU64, Ordering};
+
+    use crate::openai::{OpenAiProviderCapabilities, ReasoningEffortPolicy};
 
     use secrecy::Secret;
 
@@ -699,7 +695,11 @@ mod tests {
             "gemini-3.1-flash-lite",
             "gemini",
             "https://generativelanguage.googleapis.com/v1beta/openai",
-        );
+        )
+        .with_capabilities(OpenAiProviderCapabilities {
+            requires_gemini_tool_call_extra_content: true,
+            ..OpenAiProviderCapabilities::DEFAULT
+        });
         let mut metadata = serde_json::Map::new();
         metadata.insert("thought_signature".to_string(), serde_json::json!("sig123"));
         let messages =
@@ -719,6 +719,78 @@ mod tests {
             tool_call["extra_content"]["google"]["thought_signature"],
             "sig123"
         );
+    }
+
+    #[test]
+    fn custom_provider_with_gemini_url_does_not_get_gemini_extra_content() {
+        let p = provider(
+            "gemini-3.1-flash-lite",
+            "custom-gemini",
+            "https://generativelanguage.googleapis.com/v1beta/openai",
+        );
+        let mut metadata = serde_json::Map::new();
+        metadata.insert("thought_signature".to_string(), serde_json::json!("sig123"));
+
+        let messages =
+            p.serialize_messages_for_request(&[ChatMessage::assistant_with_tools(None, vec![
+                moltis_agents::model::ToolCall {
+                    id: "call_1".to_string(),
+                    name: "get_weather".to_string(),
+                    arguments: serde_json::json!({"location": "London"}),
+                    argument_diagnostic: None,
+                    metadata: Some(metadata),
+                },
+            ])]);
+
+        let tool_call = &messages[0]["tool_calls"][0];
+        assert_eq!(tool_call["thought_signature"], "sig123");
+        assert!(tool_call.get("extra_content").is_none());
+    }
+
+    #[test]
+    fn openrouter_cache_control_is_capability_driven() {
+        let p = provider(
+            "anthropic/claude-sonnet-4-20250514",
+            "aliased-openrouter",
+            "https://example.invalid/v1",
+        )
+        .with_capabilities(OpenAiProviderCapabilities {
+            cache_control_policy: CacheControlPolicy::OpenRouterAnthropic,
+            ..OpenAiProviderCapabilities::DEFAULT
+        });
+        let mut messages = vec![
+            serde_json::json!({"role": "system", "content": "sys"}),
+            serde_json::json!({"role": "user", "content": "hello"}),
+        ];
+
+        p.apply_openrouter_cache_control(&mut messages);
+
+        assert_eq!(
+            messages[0]["content"][0]["cache_control"],
+            serde_json::json!({"type": "ephemeral"})
+        );
+        assert_eq!(
+            messages[1]["content"][0]["cache_control"],
+            serde_json::json!({"type": "ephemeral"})
+        );
+    }
+
+    #[test]
+    fn custom_provider_with_openrouter_url_does_not_get_cache_control() {
+        let p = provider(
+            "anthropic/claude-sonnet-4-20250514",
+            "custom-openrouter",
+            "https://openrouter.ai/api/v1",
+        );
+        let mut messages = vec![
+            serde_json::json!({"role": "system", "content": "sys"}),
+            serde_json::json!({"role": "user", "content": "hello"}),
+        ];
+
+        p.apply_openrouter_cache_control(&mut messages);
+
+        assert_eq!(messages[0]["content"], "sys");
+        assert_eq!(messages[1]["content"], "hello");
     }
 
     #[test]
@@ -763,7 +835,11 @@ mod tests {
 
     #[test]
     fn deepseek_v4_reasoning_effort_enables_thinking_and_maps_xhigh_to_max() {
-        let mut p = provider("deepseek-v4-pro", "deepseek", "https://api.deepseek.com");
+        let mut p = provider("deepseek-v4-pro", "deepseek", "https://api.deepseek.com")
+            .with_capabilities(OpenAiProviderCapabilities {
+                reasoning_effort_policy: ReasoningEffortPolicy::DeepSeek,
+                ..OpenAiProviderCapabilities::DEFAULT
+            });
         p.reasoning_effort = Some(moltis_agents::model::ReasoningEffort::ExtraHigh);
         let mut body = serde_json::json!({
             "model": "deepseek-v4-pro",
@@ -784,7 +860,11 @@ mod tests {
             moltis_agents::model::ReasoningEffort::Medium,
             moltis_agents::model::ReasoningEffort::High,
         ] {
-            let mut p = provider("deepseek-v4-flash", "deepseek", "https://api.deepseek.com");
+            let mut p = provider("deepseek-v4-flash", "deepseek", "https://api.deepseek.com")
+                .with_capabilities(OpenAiProviderCapabilities {
+                    reasoning_effort_policy: ReasoningEffortPolicy::DeepSeek,
+                    ..OpenAiProviderCapabilities::DEFAULT
+                });
             p.reasoning_effort = Some(effort);
             assert_eq!(p.reasoning_effort_str(), Some("high"));
         }
@@ -836,7 +916,12 @@ mod tests {
             "zai-org/GLM-5.1-FP8",
             "nearai",
             "https://cloud-api.near.ai/v1",
-        );
+        )
+        .with_capabilities(OpenAiProviderCapabilities {
+            omits_strict_tool_field: true,
+            reasoning_effort_policy: ReasoningEffortPolicy::Unsupported,
+            ..OpenAiProviderCapabilities::DEFAULT
+        });
         let tools = vec![serde_json::json!({
             "name": "get_weather",
             "description": "Get weather",
@@ -853,6 +938,29 @@ mod tests {
             converted[0]["function"].get("strict").is_none(),
             "NEAR AI Cloud should not receive the unsupported strict tool field"
         );
+    }
+
+    #[test]
+    fn custom_provider_with_nearai_url_does_not_omit_strict_field() {
+        let p = provider(
+            "zai-org/GLM-5.1-FP8",
+            "custom-nearai",
+            "https://cloud-api.near.ai/v1",
+        );
+        let tools = vec![serde_json::json!({
+            "name": "get_weather",
+            "description": "Get weather",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "location": { "type": "string" }
+                }
+            }
+        })];
+
+        let converted = p.prepare_chat_tools(&tools);
+
+        assert_eq!(converted[0]["function"]["strict"], true);
     }
 
     /// Kimi router with reasoning_content=true must inject `reasoning_content`
@@ -947,7 +1055,7 @@ mod tests {
             "https://api.mistral.ai/v1",
         )
         .with_supports_user_name(false);
-        assert!(!p.supports_user_name);
+        assert!(!p.capabilities.supports_user_name);
 
         let messages = vec![ChatMessage::user_named("hello", "rokku")];
         let serialized = p.serialize_messages_for_request(&messages);
@@ -964,7 +1072,7 @@ mod tests {
     fn minimax_provider_strips_user_names_from_group_chat_history() {
         let p = provider("MiniMax-M2.7", "minimax", "https://api.minimax.io/v1")
             .with_supports_user_name(false);
-        assert!(!p.supports_user_name);
+        assert!(!p.capabilities.supports_user_name);
 
         let messages = vec![
             ChatMessage::user_named("hello", "Alice"),
@@ -982,7 +1090,7 @@ mod tests {
     #[test]
     fn openai_provider_preserves_user_name() {
         let p = provider("gpt-4o", "openai", "https://api.openai.com/v1");
-        assert!(p.supports_user_name);
+        assert!(p.capabilities.supports_user_name);
 
         let messages = vec![ChatMessage::user_named("hello", "Alice")];
         let serialized = p.serialize_messages_for_request(&messages);

--- a/crates/providers/src/openai/provider/websocket.rs
+++ b/crates/providers/src/openai/provider/websocket.rs
@@ -21,14 +21,14 @@ use crate::{
 
 use moltis_agents::model::{AgentToolControls, ChatMessage, StreamEvent, Usage};
 
-use super::OpenAiProvider;
+use {super::OpenAiProvider, crate::openai::ResponsesWebSocketPolicy};
 
 impl OpenAiProvider {
-    pub(super) fn is_openai_platform_base_url(&self) -> bool {
-        reqwest::Url::parse(&self.base_url)
-            .ok()
-            .and_then(|url| url.host_str().map(ToString::to_string))
-            .is_some_and(|host| host.eq_ignore_ascii_case("api.openai.com"))
+    pub(super) fn supports_responses_websocket(&self) -> bool {
+        matches!(
+            self.capabilities.responses_websocket_policy,
+            ResponsesWebSocketPolicy::OpenAiPlatform
+        )
     }
 
     pub(super) fn responses_websocket_url(&self) -> crate::error::Result<String> {
@@ -62,9 +62,9 @@ impl OpenAiProvider {
         // Fail fast and fall back to SSE before entering the async generator,
         // which avoids cloning messages/tools for the four sync-check paths.
         let (request, pool_key) = match (|| -> crate::error::Result<_> {
-            if !self.is_openai_platform_base_url() {
+            if !self.supports_responses_websocket() {
                 return Err(crate::error::Error::message(format!(
-                    "websocket mode is only supported for api.openai.com (got {})",
+                    "websocket mode is not supported for this provider (base_url: {})",
                     self.base_url
                 )));
             }

--- a/crates/providers/src/registry/core.rs
+++ b/crates/providers/src/registry/core.rs
@@ -267,7 +267,11 @@ pub async fn fetch_discoverable_models(
         } else if def.config_name == "nearai" {
             tasks.push((
                 def.config_name.into(),
-                Box::pin(nearai::fetch_models_from_api(base_url)),
+                Box::pin(async move {
+                    nearai::fetch_models_from_api(base_url)
+                        .await
+                        .map_err(anyhow::Error::from)
+                }),
             ));
         } else {
             tasks.push((
@@ -484,6 +488,21 @@ pub type PendingDiscoveries = Vec<(
     String,
     std::sync::mpsc::Receiver<anyhow::Result<Vec<DiscoveredModel>>>,
 )>;
+
+fn start_nearai_discovery(
+    base_url: String,
+) -> std::sync::mpsc::Receiver<anyhow::Result<Vec<DiscoveredModel>>> {
+    let typed_rx = nearai::start_model_discovery(base_url);
+    let (tx, rx) = std::sync::mpsc::sync_channel(1);
+    std::thread::spawn(move || {
+        let result = typed_rx
+            .recv()
+            .map_err(anyhow::Error::from)
+            .and_then(|result| result.map_err(anyhow::Error::from));
+        let _ = tx.send(result);
+    });
+    rx
+}
 
 impl ProviderRegistry {
     #[must_use]
@@ -1021,10 +1040,7 @@ impl ProviderRegistry {
                         ollama::start_ollama_discovery(&base_url),
                     ));
                 } else if def.config_name == "nearai" {
-                    pending.push((
-                        def.config_name.into(),
-                        nearai::start_model_discovery(base_url),
-                    ));
+                    pending.push((def.config_name.into(), start_nearai_discovery(base_url)));
                 } else {
                     pending.push((
                         def.config_name.into(),

--- a/crates/providers/src/registry/mod.rs
+++ b/crates/providers/src/registry/mod.rs
@@ -2,5 +2,7 @@
 
 mod core;
 pub mod registration;
+#[cfg(test)]
+mod tests;
 
 pub use self::core::*;

--- a/crates/providers/src/registry/registration.rs
+++ b/crates/providers/src/registry/registration.rs
@@ -102,6 +102,9 @@ impl ProviderRegistry {
                 .unwrap_or(ProviderStreamTransport::Sse);
 
             for model in models {
+                let caps = model
+                    .capabilities
+                    .unwrap_or_else(|| ModelCapabilities::infer(&model.id));
                 if self.has_provider_model(&provider_label, &model.id) {
                     continue;
                 }
@@ -118,6 +121,7 @@ impl ProviderRegistry {
                             openai::ResponsesWebSocketPolicy::OpenAiPlatform,
                         ..openai::OpenAiProviderCapabilities::DEFAULT
                     })
+                    .with_model_capabilities(caps)
                     .with_context_window_overrides(
                         self.global_cw_overrides.clone(),
                         config
@@ -133,9 +137,7 @@ impl ProviderRegistry {
                         display_name: model.display_name.clone(),
                         created_at: model.created_at,
                         recommended: model.recommended,
-                        capabilities: model
-                            .capabilities
-                            .unwrap_or_else(|| ModelCapabilities::infer(&model.id)),
+                        capabilities: caps,
                     },
                     provider,
                 );
@@ -167,6 +169,9 @@ impl ProviderRegistry {
                 .unwrap_or_default();
 
             for model in models {
+                let caps = model
+                    .capabilities
+                    .unwrap_or_else(|| ModelCapabilities::infer(&model.id));
                 if self.has_provider_model(&provider_label, &model.id) {
                     continue;
                 }
@@ -184,9 +189,7 @@ impl ProviderRegistry {
                         display_name: model.display_name.clone(),
                         created_at: model.created_at,
                         recommended: model.recommended,
-                        capabilities: model
-                            .capabilities
-                            .unwrap_or_else(|| ModelCapabilities::infer(&model.id)),
+                        capabilities: caps,
                     },
                     provider,
                 );
@@ -246,6 +249,9 @@ impl ProviderRegistry {
             };
 
             for model in models {
+                let caps = model
+                    .capabilities
+                    .unwrap_or_else(|| ModelCapabilities::infer(&model.id));
                 if self.has_provider_model(&provider_label, &model.id) {
                     continue;
                 }
@@ -269,6 +275,7 @@ impl ProviderRegistry {
                 )
                 .with_stream_transport(stream_transport)
                 .with_capabilities(def.capabilities)
+                .with_model_capabilities(caps)
                 .with_cache_retention(cache_retention)
                 .with_supports_user_name(def.supports_user_name)
                 .with_default_strict_tools(def.default_strict_tools)
@@ -308,9 +315,7 @@ impl ProviderRegistry {
                         display_name: model.display_name.clone(),
                         created_at: model.created_at,
                         recommended: model.recommended,
-                        capabilities: model
-                            .capabilities
-                            .unwrap_or_else(|| ModelCapabilities::infer(&model.id)),
+                        capabilities: caps,
                     },
                     Arc::new(oai),
                 );
@@ -339,6 +344,9 @@ impl ProviderRegistry {
             let custom_tool_mode = entry.tool_mode;
 
             for model in models {
+                let caps = model
+                    .capabilities
+                    .unwrap_or_else(|| ModelCapabilities::infer(&model.id));
                 if self.has_provider_model(name, &model.id) {
                     continue;
                 }
@@ -349,6 +357,7 @@ impl ProviderRegistry {
                     name.clone(),
                 )
                 .with_stream_transport(entry.stream_transport)
+                .with_model_capabilities(caps)
                 .with_reasoning_content_model_prefixes(CUSTOM_REASONING_CONTENT_MODEL_PREFIXES)
                 .with_qwen_models_require_single_leading_system(true)
                 .with_context_window_overrides(
@@ -368,9 +377,7 @@ impl ProviderRegistry {
                         display_name: model.display_name.clone(),
                         created_at: model.created_at,
                         recommended: model.recommended,
-                        capabilities: model
-                            .capabilities
-                            .unwrap_or_else(|| ModelCapabilities::infer(&model.id)),
+                        capabilities: caps,
                     },
                     Arc::new(oai),
                 );
@@ -857,6 +864,7 @@ impl ProviderRegistry {
                             openai::ResponsesWebSocketPolicy::OpenAiPlatform,
                         ..openai::OpenAiProviderCapabilities::DEFAULT
                     })
+                    .with_model_capabilities(caps)
                     .with_context_window_overrides(
                         self.global_cw_overrides.clone(),
                         config
@@ -1016,6 +1024,7 @@ impl ProviderRegistry {
                 )
                 .with_stream_transport(stream_transport)
                 .with_capabilities(def.capabilities)
+                .with_model_capabilities(caps)
                 .with_cache_retention(cache_retention)
                 .with_context_window_overrides(
                     self.global_cw_overrides.clone(),
@@ -1136,6 +1145,7 @@ impl ProviderRegistry {
                 )
                 .with_stream_transport(entry.stream_transport)
                 .with_cache_retention(entry.cache_retention)
+                .with_model_capabilities(caps)
                 .with_reasoning_content_model_prefixes(CUSTOM_REASONING_CONTENT_MODEL_PREFIXES)
                 .with_qwen_models_require_single_leading_system(true)
                 .with_context_window_overrides(

--- a/crates/providers/src/registry/registration.rs
+++ b/crates/providers/src/registry/registration.rs
@@ -277,12 +277,6 @@ impl ProviderRegistry {
                 .with_capabilities(def.capabilities)
                 .with_model_capabilities(caps)
                 .with_cache_retention(cache_retention)
-                .with_default_reasoning_content(def.default_reasoning_content_on_tool_messages)
-                .with_reasoning_content_model_prefixes(def.reasoning_content_model_prefixes)
-                .with_system_message_rewrite(def.system_message_rewrite)
-                .with_qwen_models_require_single_leading_system(
-                    def.qwen_models_require_single_leading_system,
-                )
                 .with_context_window_overrides(
                     self.global_cw_overrides.clone(),
                     config
@@ -302,6 +296,16 @@ impl ProviderRegistry {
                     .and_then(|e| e.probe_timeout_secs)
                 {
                     oai = oai.with_probe_timeout_secs(Some(timeout));
+                }
+                if is_fireworks_kimi_router(def, &model.id) {
+                    if config
+                        .get(def.config_name)
+                        .and_then(|e| e.strict_tools)
+                        .is_none()
+                    {
+                        oai = oai.with_strict_tools(false);
+                    }
+                    oai = oai.with_reasoning_content(true);
                 }
 
                 self.register(
@@ -353,9 +357,13 @@ impl ProviderRegistry {
                     name.clone(),
                 )
                 .with_stream_transport(entry.stream_transport)
+                .with_cache_retention(entry.cache_retention)
                 .with_model_capabilities(caps)
-                .with_reasoning_content_model_prefixes(CUSTOM_REASONING_CONTENT_MODEL_PREFIXES)
-                .with_qwen_models_require_single_leading_system(true)
+                .with_capabilities(openai::OpenAiProviderCapabilities {
+                    reasoning_content_model_prefixes: CUSTOM_REASONING_CONTENT_MODEL_PREFIXES,
+                    qwen_models_require_single_leading_system: true,
+                    ..openai::OpenAiProviderCapabilities::DEFAULT
+                })
                 .with_context_window_overrides(
                     self.global_cw_overrides.clone(),
                     extract_cw_overrides(&entry.model_overrides),
@@ -366,6 +374,10 @@ impl ProviderRegistry {
                 if !matches!(custom_tool_mode, moltis_config::ToolMode::Auto) {
                     oai = oai.with_tool_mode(custom_tool_mode);
                 }
+                if let Some(strict) = entry.strict_tools {
+                    oai = oai.with_strict_tools(strict);
+                }
+                oai = oai.with_probe_timeout_secs(entry.probe_timeout_secs);
                 self.register(
                     ModelInfo {
                         id: model.id.clone(),
@@ -1022,12 +1034,6 @@ impl ProviderRegistry {
                 .with_capabilities(def.capabilities)
                 .with_model_capabilities(caps)
                 .with_cache_retention(cache_retention)
-                .with_default_reasoning_content(def.default_reasoning_content_on_tool_messages)
-                .with_reasoning_content_model_prefixes(def.reasoning_content_model_prefixes)
-                .with_system_message_rewrite(def.system_message_rewrite)
-                .with_qwen_models_require_single_leading_system(
-                    def.qwen_models_require_single_leading_system,
-                )
                 .with_context_window_overrides(
                     self.global_cw_overrides.clone(),
                     config
@@ -1148,8 +1154,11 @@ impl ProviderRegistry {
                 .with_stream_transport(entry.stream_transport)
                 .with_cache_retention(entry.cache_retention)
                 .with_model_capabilities(caps)
-                .with_reasoning_content_model_prefixes(CUSTOM_REASONING_CONTENT_MODEL_PREFIXES)
-                .with_qwen_models_require_single_leading_system(true)
+                .with_capabilities(openai::OpenAiProviderCapabilities {
+                    reasoning_content_model_prefixes: CUSTOM_REASONING_CONTENT_MODEL_PREFIXES,
+                    qwen_models_require_single_leading_system: true,
+                    ..openai::OpenAiProviderCapabilities::DEFAULT
+                })
                 .with_context_window_overrides(
                     self.global_cw_overrides.clone(),
                     extract_cw_overrides(&entry.model_overrides),

--- a/crates/providers/src/registry/registration.rs
+++ b/crates/providers/src/registry/registration.rs
@@ -113,6 +113,11 @@ impl ProviderRegistry {
                         provider_label.clone(),
                     )
                     .with_stream_transport(stream_transport)
+                    .with_capabilities(openai::OpenAiProviderCapabilities {
+                        responses_websocket_policy:
+                            openai::ResponsesWebSocketPolicy::OpenAiPlatform,
+                        ..openai::OpenAiProviderCapabilities::DEFAULT
+                    })
                     .with_context_window_overrides(
                         self.global_cw_overrides.clone(),
                         config
@@ -263,6 +268,7 @@ impl ProviderRegistry {
                     provider_label.clone(),
                 )
                 .with_stream_transport(stream_transport)
+                .with_capabilities(def.capabilities)
                 .with_cache_retention(cache_retention)
                 .with_supports_user_name(def.supports_user_name)
                 .with_default_strict_tools(def.default_strict_tools)
@@ -846,6 +852,11 @@ impl ProviderRegistry {
                         provider_label.clone(),
                     )
                     .with_stream_transport(stream_transport)
+                    .with_capabilities(openai::OpenAiProviderCapabilities {
+                        responses_websocket_policy:
+                            openai::ResponsesWebSocketPolicy::OpenAiPlatform,
+                        ..openai::OpenAiProviderCapabilities::DEFAULT
+                    })
                     .with_context_window_overrides(
                         self.global_cw_overrides.clone(),
                         config
@@ -1004,6 +1015,7 @@ impl ProviderRegistry {
                     provider_label.clone(),
                 )
                 .with_stream_transport(stream_transport)
+                .with_capabilities(def.capabilities)
                 .with_cache_retention(cache_retention)
                 .with_context_window_overrides(
                     self.global_cw_overrides.clone(),

--- a/crates/providers/src/registry/registration.rs
+++ b/crates/providers/src/registry/registration.rs
@@ -297,16 +297,6 @@ impl ProviderRegistry {
                 {
                     oai = oai.with_probe_timeout_secs(Some(timeout));
                 }
-                if is_fireworks_kimi_router(def, &model.id) {
-                    if config
-                        .get(def.config_name)
-                        .and_then(|e| e.strict_tools)
-                        .is_none()
-                    {
-                        oai = oai.with_strict_tools(false);
-                    }
-                    oai = oai.with_reasoning_content(true);
-                }
 
                 self.register(
                     ModelInfo {
@@ -1054,20 +1044,6 @@ impl ProviderRegistry {
                     .and_then(|e| e.probe_timeout_secs)
                 {
                     oai = oai.with_probe_timeout_secs(Some(timeout));
-                }
-
-                // Fireworks Fire Pass router models for Kimi route to
-                // Moonshot, which rejects strict-mode schemas and requires
-                // reasoning_content on tool-call messages (issue #810).
-                if is_fireworks_kimi_router(def, &model_id) {
-                    if config
-                        .get(def.config_name)
-                        .and_then(|e| e.strict_tools)
-                        .is_none()
-                    {
-                        oai = oai.with_strict_tools(false);
-                    }
-                    oai = oai.with_reasoning_content(true);
                 }
 
                 let provider = Arc::new(oai);

--- a/crates/providers/src/registry/registration.rs
+++ b/crates/providers/src/registry/registration.rs
@@ -1022,6 +1022,12 @@ impl ProviderRegistry {
                 .with_capabilities(def.capabilities)
                 .with_model_capabilities(caps)
                 .with_cache_retention(cache_retention)
+                .with_default_reasoning_content(def.default_reasoning_content_on_tool_messages)
+                .with_reasoning_content_model_prefixes(def.reasoning_content_model_prefixes)
+                .with_system_message_rewrite(def.system_message_rewrite)
+                .with_qwen_models_require_single_leading_system(
+                    def.qwen_models_require_single_leading_system,
+                )
                 .with_context_window_overrides(
                     self.global_cw_overrides.clone(),
                     config

--- a/crates/providers/src/registry/registration.rs
+++ b/crates/providers/src/registry/registration.rs
@@ -34,6 +34,32 @@ use crate::{
 };
 
 const CUSTOM_REASONING_CONTENT_MODEL_PREFIXES: &[&str] = &["kimi-", "deepseek-v4"];
+const OPENAI_DEFAULT_BASE_URL: &str = "https://api.openai.com/v1";
+
+fn resolve_openai_base_url(
+    config: &ProvidersConfig,
+    env_overrides: &HashMap<String, String>,
+) -> (String, bool) {
+    if let Some(base_url) = config.get("openai").and_then(|e| e.base_url.clone()) {
+        return (base_url, true);
+    }
+    if let Some(base_url) = env_value(env_overrides, "OPENAI_BASE_URL") {
+        return (base_url, true);
+    }
+    (OPENAI_DEFAULT_BASE_URL.into(), false)
+}
+
+pub(crate) fn openai_builtin_capabilities(
+    base_url_overridden: bool,
+) -> openai::OpenAiProviderCapabilities {
+    if base_url_overridden {
+        return openai::OpenAiProviderCapabilities::DEFAULT;
+    }
+    openai::OpenAiProviderCapabilities {
+        responses_websocket_policy: openai::ResponsesWebSocketPolicy::OpenAiPlatform,
+        ..openai::OpenAiProviderCapabilities::DEFAULT
+    }
+}
 
 impl ProviderRegistry {
     /// Register models from a [`RediscoveryResult`], skipping those already
@@ -89,11 +115,8 @@ impl ProviderRegistry {
             && config.is_enabled("openai")
             && let Some(key) = resolve_api_key(config, "openai", "OPENAI_API_KEY", env_overrides)
         {
-            let base_url = config
-                .get("openai")
-                .and_then(|e| e.base_url.clone())
-                .or_else(|| env_value(env_overrides, "OPENAI_BASE_URL"))
-                .unwrap_or_else(|| "https://api.openai.com/v1".into());
+            let (base_url, base_url_overridden) = resolve_openai_base_url(config, env_overrides);
+            let capabilities = openai_builtin_capabilities(base_url_overridden);
             let alias = config.get("openai").and_then(|e| e.alias.clone());
             let provider_label = alias.unwrap_or_else(|| "openai".into());
             let stream_transport = config
@@ -116,11 +139,7 @@ impl ProviderRegistry {
                         provider_label.clone(),
                     )
                     .with_stream_transport(stream_transport)
-                    .with_capabilities(openai::OpenAiProviderCapabilities {
-                        responses_websocket_policy:
-                            openai::ResponsesWebSocketPolicy::OpenAiPlatform,
-                        ..openai::OpenAiProviderCapabilities::DEFAULT
-                    })
+                    .with_capabilities(capabilities)
                     .with_model_capabilities(caps)
                     .with_context_window_overrides(
                         self.global_cw_overrides.clone(),
@@ -470,11 +489,7 @@ impl ProviderRegistry {
             return;
         };
 
-        let base_url = config
-            .get("openai")
-            .and_then(|e| e.base_url.clone())
-            .or_else(|| env_value(env_overrides, "OPENAI_BASE_URL"))
-            .unwrap_or_else(|| "https://api.openai.com/v1".into());
+        let (base_url, _) = resolve_openai_base_url(config, env_overrides);
 
         let model_id = configured_models_for_provider(config, "openai")
             .into_iter()
@@ -806,11 +821,8 @@ impl ProviderRegistry {
         if config.is_enabled("openai")
             && let Some(key) = resolve_api_key(config, "openai", "OPENAI_API_KEY", env_overrides)
         {
-            let base_url = config
-                .get("openai")
-                .and_then(|e| e.base_url.clone())
-                .or_else(|| env_value(env_overrides, "OPENAI_BASE_URL"))
-                .unwrap_or_else(|| "https://api.openai.com/v1".into());
+            let (base_url, base_url_overridden) = resolve_openai_base_url(config, env_overrides);
+            let capabilities = openai_builtin_capabilities(base_url_overridden);
 
             // Get alias if configured (for metrics differentiation).
             let alias = config.get("openai").and_then(|e| e.alias.clone());
@@ -857,11 +869,7 @@ impl ProviderRegistry {
                         provider_label.clone(),
                     )
                     .with_stream_transport(stream_transport)
-                    .with_capabilities(openai::OpenAiProviderCapabilities {
-                        responses_websocket_policy:
-                            openai::ResponsesWebSocketPolicy::OpenAiPlatform,
-                        ..openai::OpenAiProviderCapabilities::DEFAULT
-                    })
+                    .with_capabilities(capabilities)
                     .with_model_capabilities(caps)
                     .with_context_window_overrides(
                         self.global_cw_overrides.clone(),

--- a/crates/providers/src/registry/registration.rs
+++ b/crates/providers/src/registry/registration.rs
@@ -277,12 +277,8 @@ impl ProviderRegistry {
                 .with_capabilities(def.capabilities)
                 .with_model_capabilities(caps)
                 .with_cache_retention(cache_retention)
-                .with_supports_user_name(def.supports_user_name)
-                .with_default_strict_tools(def.default_strict_tools)
                 .with_default_reasoning_content(def.default_reasoning_content_on_tool_messages)
                 .with_reasoning_content_model_prefixes(def.reasoning_content_model_prefixes)
-                .with_rejects_null_in_enums(def.rejects_null_in_enums)
-                .with_gemini_tool_call_extra_content(def.requires_gemini_tool_call_extra_content)
                 .with_system_message_rewrite(def.system_message_rewrite)
                 .with_qwen_models_require_single_leading_system(
                     def.qwen_models_require_single_leading_system,

--- a/crates/providers/src/registry/tests.rs
+++ b/crates/providers/src/registry/tests.rs
@@ -1,6 +1,6 @@
 use {
     super::ProviderRegistry,
-    moltis_agents::model::ChatMessage,
+    moltis_agents::model::{ChatMessage, ToolCall},
     moltis_config::schema::{ProviderEntry, ProvidersConfig},
     secrecy::Secret,
     serde_json::Value,
@@ -11,6 +11,8 @@ use {
         sync::mpsc,
     },
 };
+
+const FIREWORKS_KIMI_ROUTER: &str = "accounts/fireworks/routers/kimi-k2p5-turbo";
 
 fn capture_one_json_request() -> (String, mpsc::Receiver<Value>) {
     let listener = TcpListener::bind("127.0.0.1:0").expect("bind test server");
@@ -53,6 +55,56 @@ fn capture_one_json_request() -> (String, mpsc::Receiver<Value>) {
     (base_url, rx)
 }
 
+async fn capture_fireworks_kimi_request(strict_tools: Option<bool>) -> Value {
+    let (base_url, body_rx) = capture_one_json_request();
+    let mut config = ProvidersConfig {
+        offered: vec!["fireworks".into()],
+        ..ProvidersConfig::default()
+    };
+    config.providers.insert("fireworks".into(), ProviderEntry {
+        api_key: Some(Secret::new("test-key".into())),
+        base_url: Some(base_url),
+        models: vec![FIREWORKS_KIMI_ROUTER.into()],
+        strict_tools,
+        ..ProviderEntry::default()
+    });
+
+    let mut registry = ProviderRegistry::empty();
+    registry.register_openai_compatible_providers(&config, &HashMap::new(), &HashMap::new());
+    let provider = registry
+        .get(&format!("fireworks::{FIREWORKS_KIMI_ROUTER}"))
+        .expect("registered Fireworks Kimi router model");
+    provider
+        .complete(
+            &[
+                ChatMessage::user("weather?"),
+                ChatMessage::assistant_with_tools(Some("need weather".into()), vec![ToolCall {
+                    id: "call_1".into(),
+                    name: "get_weather".into(),
+                    arguments: serde_json::json!({"location": "Berlin"}),
+                    argument_diagnostic: None,
+                    metadata: None,
+                }]),
+                ChatMessage::tool("call_1", r#"{"temperature":20}"#),
+            ],
+            &[serde_json::json!({
+                "name": "get_weather",
+                "description": "Get weather",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "location": { "type": "string" }
+                    },
+                    "required": ["location"]
+                }
+            })],
+        )
+        .await
+        .expect("completion succeeds");
+
+    body_rx.recv().expect("captured request body")
+}
+
 #[tokio::test]
 async fn initial_openai_compat_registration_applies_provider_rewrite_quirks() {
     let (base_url, body_rx) = capture_one_json_request();
@@ -92,4 +144,24 @@ async fn initial_openai_compat_registration_applies_provider_rewrite_quirks() {
         messages[0]["content"],
         "[System Instructions]\nsys\n[End System Instructions]\n\nhello"
     );
+}
+
+#[tokio::test]
+async fn initial_fireworks_kimi_router_registration_applies_model_scoped_quirks() {
+    let body = capture_fireworks_kimi_request(None).await;
+
+    assert_eq!(body["tools"][0]["function"]["strict"], false);
+    let messages = body["messages"].as_array().expect("messages array");
+    let assistant_tool_message = messages
+        .iter()
+        .find(|message| message.get("tool_calls").is_some())
+        .expect("assistant tool-call message");
+    assert_eq!(assistant_tool_message["reasoning_content"], "need weather");
+}
+
+#[tokio::test]
+async fn explicit_strict_tools_overrides_fireworks_kimi_router_default() {
+    let body = capture_fireworks_kimi_request(Some(true)).await;
+
+    assert_eq!(body["tools"][0]["function"]["strict"], true);
 }

--- a/crates/providers/src/registry/tests.rs
+++ b/crates/providers/src/registry/tests.rs
@@ -1,5 +1,6 @@
 use {
-    super::ProviderRegistry,
+    super::{ProviderRegistry, registration::openai_builtin_capabilities},
+    crate::openai::ResponsesWebSocketPolicy,
     moltis_agents::model::{ChatMessage, ToolCall},
     moltis_config::schema::{ProviderEntry, ProvidersConfig},
     secrecy::Secret,
@@ -13,6 +14,22 @@ use {
 };
 
 const FIREWORKS_KIMI_ROUTER: &str = "accounts/fireworks/routers/kimi-k2p5-turbo";
+
+#[test]
+fn openai_default_base_url_enables_responses_websocket() {
+    assert_eq!(
+        openai_builtin_capabilities(false).responses_websocket_policy,
+        ResponsesWebSocketPolicy::OpenAiPlatform,
+    );
+}
+
+#[test]
+fn openai_custom_base_url_disables_responses_websocket() {
+    assert_eq!(
+        openai_builtin_capabilities(true).responses_websocket_policy,
+        ResponsesWebSocketPolicy::Unsupported,
+    );
+}
 
 fn capture_one_json_request() -> (String, mpsc::Receiver<Value>) {
     let listener = TcpListener::bind("127.0.0.1:0").expect("bind test server");

--- a/crates/providers/src/registry/tests.rs
+++ b/crates/providers/src/registry/tests.rs
@@ -1,0 +1,95 @@
+use {
+    super::ProviderRegistry,
+    moltis_agents::model::ChatMessage,
+    moltis_config::schema::{ProviderEntry, ProvidersConfig},
+    secrecy::Secret,
+    serde_json::Value,
+    std::{
+        collections::HashMap,
+        io::{Read, Write},
+        net::TcpListener,
+        sync::mpsc,
+    },
+};
+
+fn capture_one_json_request() -> (String, mpsc::Receiver<Value>) {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind test server");
+    let base_url = format!("http://{}", listener.local_addr().expect("local addr"));
+    let (tx, rx) = mpsc::sync_channel(1);
+    std::thread::spawn(move || {
+        let (mut stream, _) = listener.accept().expect("accept request");
+        let mut buffer = Vec::new();
+        let mut chunk = [0_u8; 4096];
+        let content_length = loop {
+            let read = stream.read(&mut chunk).expect("read request");
+            buffer.extend_from_slice(&chunk[..read]);
+            let headers = String::from_utf8_lossy(&buffer);
+            if let Some((head, _)) = headers.split_once("\r\n\r\n") {
+                break head
+                    .lines()
+                    .find_map(|line| {
+                        let (name, value) = line.split_once(':')?;
+                        name.eq_ignore_ascii_case("content-length")
+                            .then_some(value.trim())
+                    })
+                    .and_then(|value| value.parse::<usize>().ok())
+                    .expect("content length");
+            }
+        };
+        let body_start = buffer
+            .windows(4)
+            .position(|w| w == b"\r\n\r\n")
+            .expect("body")
+            + 4;
+        while buffer.len() - body_start < content_length {
+            let read = stream.read(&mut chunk).expect("read body");
+            buffer.extend_from_slice(&chunk[..read]);
+        }
+        let body = &buffer[body_start..body_start + content_length];
+        tx.send(serde_json::from_slice(body).expect("json body"))
+            .expect("send body");
+        stream.write_all(b"HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: 53\r\n\r\n{\"choices\":[{\"message\":{\"content\":\"ok\"}}],\"usage\":{}}").expect("write response");
+    });
+    (base_url, rx)
+}
+
+#[tokio::test]
+async fn initial_openai_compat_registration_applies_provider_rewrite_quirks() {
+    let (base_url, body_rx) = capture_one_json_request();
+    let mut config = ProvidersConfig {
+        offered: vec!["minimax".into()],
+        ..ProvidersConfig::default()
+    };
+    config.providers.insert("minimax".into(), ProviderEntry {
+        api_key: Some(Secret::new("test-key".into())),
+        base_url: Some(base_url),
+        models: vec!["MiniMax-M2.7".into()],
+        ..ProviderEntry::default()
+    });
+
+    let mut registry = ProviderRegistry::empty();
+    registry.register_openai_compatible_providers(&config, &HashMap::new(), &HashMap::new());
+    let provider = registry
+        .get("minimax::MiniMax-M2.7")
+        .expect("registered minimax model");
+    provider
+        .complete(
+            &[
+                ChatMessage::system("sys"),
+                ChatMessage::user_named("hello", "Alice"),
+            ],
+            &[],
+        )
+        .await
+        .expect("completion succeeds");
+
+    let body = body_rx.recv().expect("captured request body");
+    let messages = body["messages"].as_array().expect("messages array");
+    assert_eq!(messages.len(), 1);
+    assert_eq!(messages[0]["role"], "user");
+    assert!(messages[0].get("name").is_none());
+    assert_eq!(
+        messages[0]["content"],
+        "[System Instructions]\nsys\n[End System Instructions]\n\nhello"
+    );
+}


### PR DESCRIPTION
## Summary
- Replace OpenAI-compatible provider URL/name behavior checks with explicit capability policies.
- Wire built-in provider and resolved model capabilities through registration while keeping custom providers on strict defaults.
- Add regression tests proving known provider URLs and model names do not implicitly enable provider/model-specific behavior.

## Validation
### Completed
- [x] `cargo test -p moltis-providers openai`
- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p moltis-providers`
- [x] `./scripts/local-validate.sh 1090` (failed only on existing file-size gate: `crates/providers/src/openai_codex.rs` is 1555 lines > 1500; this PR does not touch that file)

### Remaining
- [ ] CI
- [ ] Resolve or acknowledge existing `crates/providers/src/openai_codex.rs` file-size gate failure

## Manual QA
- Not run; this is covered by provider unit tests for request shaping and capability selection.