### PR TITLE
[codex] Separate Telegram progress stream from final replies

### DIFF
--- a/crates/agents/src/runner/helpers.rs
+++ b/crates/agents/src/runner/helpers.rs
@@ -122,6 +122,10 @@ pub enum RunnerEvent {
     /// LLM returned reasoning/status text alongside tool calls.
     ThinkingText(String),
     TextDelta(String),
+    /// Text from an iteration that continued into tool calls.
+    ProgressText(String),
+    /// Text from the final iteration of the run.
+    FinalText(String),
     Iteration(usize),
     SubAgentStart {
         task: String,

--- a/crates/agents/src/runner/streaming.rs
+++ b/crates/agents/src/runner/streaming.rs
@@ -19,7 +19,7 @@ use crate::{
         AgentToolControls, ChatMessage, LlmProvider, StreamEvent, ToolCall, ToolChoice, Usage,
         UserContent, decode_tool_call_arguments_from_str, push_capped_provider_raw_event,
     },
-    response_sanitizer::recover_tool_calls_from_content,
+    response_sanitizer::{clean_response, recover_tool_calls_from_content},
     tool_arg_validator::validate_tool_args,
     tool_loop_detector::ToolCallFingerprint,
     tool_parsing::{
@@ -316,7 +316,8 @@ pub async fn run_agent_loop_streaming_with_limits(
                 StreamEvent::Delta(text) => {
                     accumulated_text.push_str(&text);
                     if let Some(cb) = on_event {
-                        cb(RunnerEvent::TextDelta(text));
+                        cb(RunnerEvent::TextDelta(text.clone()));
+                        cb(RunnerEvent::FinalText(text));
                     }
                 },
                 StreamEvent::ProviderRaw(raw) => {
@@ -616,11 +617,20 @@ pub async fn run_agent_loop_streaming_with_limits(
 
             // When the final iteration produced no text but a previous iteration
             // streamed answer text alongside tool calls, use that as the response.
-            let final_text = if accumulated_text.is_empty() && !last_answer_text.is_empty() {
+            let used_fallback_text = accumulated_text.is_empty() && !last_answer_text.is_empty();
+            let final_text = if used_fallback_text {
                 std::mem::take(&mut last_answer_text)
             } else {
                 accumulated_text
             };
+            if used_fallback_text {
+                let streamed_final_text = clean_response(&final_text);
+                if let Some(cb) = on_event
+                    && !streamed_final_text.is_empty()
+                {
+                    cb(RunnerEvent::FinalText(streamed_final_text));
+                }
+            }
             info!(
                 iterations,
                 tool_calls = total_tool_calls,
@@ -653,10 +663,13 @@ pub async fn run_agent_loop_streaming_with_limits(
             (None, false)
         };
         if let Some(ref text) = text_for_msg
-            && is_actual_reasoning
             && let Some(cb) = on_event
         {
-            cb(RunnerEvent::ThinkingText(text.clone()));
+            if is_actual_reasoning {
+                cb(RunnerEvent::ThinkingText(text.clone()));
+            } else {
+                cb(RunnerEvent::ProgressText(text.clone()));
+            }
         }
         messages.push(ChatMessage::assistant_with_tools(
             text_for_msg,

--- a/crates/agents/src/runner/tests/basic.rs
+++ b/crates/agents/src/runner/tests/basic.rs
@@ -407,6 +407,92 @@ impl LlmProvider for StreamingUsageProvider {
     }
 }
 
+struct StreamingChunksProvider;
+
+#[async_trait]
+impl LlmProvider for StreamingChunksProvider {
+    fn name(&self) -> &str {
+        "streaming-chunks"
+    }
+
+    fn id(&self) -> &str {
+        "streaming-chunks-model"
+    }
+
+    async fn complete(
+        &self,
+        _messages: &[ChatMessage],
+        _tools: &[serde_json::Value],
+    ) -> Result<CompletionResponse> {
+        Ok(CompletionResponse {
+            text: Some("unused".into()),
+            tool_calls: vec![],
+            usage: Usage::default(),
+        })
+    }
+
+    fn stream(
+        &self,
+        _messages: Vec<ChatMessage>,
+    ) -> Pin<Box<dyn Stream<Item = StreamEvent> + Send + '_>> {
+        Box::pin(tokio_stream::empty())
+    }
+
+    fn stream_with_tools(
+        &self,
+        _messages: Vec<ChatMessage>,
+        _tools: Vec<serde_json::Value>,
+    ) -> Pin<Box<dyn Stream<Item = StreamEvent> + Send + '_>> {
+        Box::pin(tokio_stream::iter(vec![
+            StreamEvent::Delta("cached ".into()),
+            StreamEvent::Delta("reply".into()),
+            StreamEvent::Done(Usage::default()),
+        ]))
+    }
+}
+
+#[tokio::test]
+async fn test_streaming_runner_emits_final_text_chunks_live() {
+    let provider = Arc::new(StreamingChunksProvider);
+    let tools = ToolRegistry::new();
+    let events: Arc<std::sync::Mutex<Vec<RunnerEvent>>> =
+        Arc::new(std::sync::Mutex::new(Vec::new()));
+    let events_clone = Arc::clone(&events);
+    let on_event: OnEvent = Box::new(move |event| {
+        events_clone.lock().unwrap().push(event);
+    });
+
+    let result = run_agent_loop_streaming(
+        provider,
+        &tools,
+        "You are a test bot.",
+        &UserContent::text("another"),
+        Some(&on_event),
+        None,
+        None,
+        None,
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(result.text, "cached reply");
+    let final_chunks: Vec<String> = events
+        .lock()
+        .unwrap()
+        .iter()
+        .filter_map(|event| match event {
+            RunnerEvent::FinalText(text) => Some(text.clone()),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(final_chunks, vec![
+        "cached ".to_string(),
+        "reply".to_string()
+    ]);
+}
+
 #[tokio::test]
 async fn test_streaming_runner_preserves_cache_usage() {
     let provider = Arc::new(StreamingUsageProvider);

--- a/crates/channels/src/plugin.rs
+++ b/crates/channels/src/plugin.rs
@@ -1057,6 +1057,15 @@ pub trait ChannelStreamOutbound: Send + Sync {
     async fn streams_final_replies(&self, _account_id: &str) -> bool {
         true
     }
+
+    /// Whether this stream consumes progress deltas separately from final text.
+    ///
+    /// Channels that only append streamed text should leave this disabled to
+    /// avoid receiving the same pre-tool draft once as final text and again as
+    /// reclassified progress.
+    async fn receives_progress_deltas(&self, _account_id: &str) -> bool {
+        false
+    }
 }
 
 #[cfg(test)]

--- a/crates/channels/src/plugin.rs
+++ b/crates/channels/src/plugin.rs
@@ -1047,6 +1047,14 @@ pub trait ChannelStreamOutbound: Send + Sync {
     async fn is_stream_enabled(&self, _account_id: &str) -> bool {
         true
     }
+
+    /// Whether this stream already delivered the final reply text.
+    ///
+    /// Some channels use streaming for temporary progress updates only. Those
+    /// streams should not suppress the normal final reply delivery path.
+    async fn streams_final_replies(&self, _account_id: &str) -> bool {
+        true
+    }
 }
 
 #[cfg(test)]

--- a/crates/channels/src/plugin.rs
+++ b/crates/channels/src/plugin.rs
@@ -1017,8 +1017,10 @@ pub struct ChannelHealthSnapshot {
 /// Stream event for edit-in-place streaming.
 #[derive(Debug, Clone)]
 pub enum StreamEvent {
-    /// A chunk of text to append.
+    /// A chunk of final reply text to append.
     Delta(String),
+    /// A chunk of intermediate progress text to append.
+    ProgressDelta(String),
     /// Stream is complete.
     Done,
     /// An error occurred.

--- a/crates/channels/src/registry.rs
+++ b/crates/channels/src/registry.rs
@@ -510,6 +510,13 @@ impl ChannelStreamOutbound for RegistryOutboundRouter {
         };
         stream_out.streams_final_replies(account_id).await
     }
+
+    async fn receives_progress_deltas(&self, account_id: &str) -> bool {
+        let Some(stream_out) = self.registry.resolve_stream(account_id).await else {
+            return false;
+        };
+        stream_out.receives_progress_deltas(account_id).await
+    }
 }
 
 #[cfg(test)]
@@ -560,6 +567,7 @@ mod tests {
         accounts: std::sync::Mutex<HashMap<String, serde_json::Value>>,
         outbound: NullOutbound,
         streams_final_replies: bool,
+        receives_progress_deltas: bool,
     }
 
     impl TestPlugin {
@@ -569,6 +577,7 @@ mod tests {
                 accounts: std::sync::Mutex::new(HashMap::new()),
                 outbound: NullOutbound,
                 streams_final_replies: true,
+                receives_progress_deltas: false,
             }
         }
 
@@ -578,6 +587,7 @@ mod tests {
                 accounts: std::sync::Mutex::new(HashMap::new()),
                 outbound: NullOutbound,
                 streams_final_replies: false,
+                receives_progress_deltas: true,
             }
         }
     }
@@ -648,6 +658,7 @@ mod tests {
         fn shared_stream_outbound(&self) -> Arc<dyn ChannelStreamOutbound> {
             Arc::new(NullStreamOutbound {
                 streams_final_replies: self.streams_final_replies,
+                receives_progress_deltas: self.receives_progress_deltas,
             })
         }
     }
@@ -685,6 +696,7 @@ mod tests {
 
     struct NullStreamOutbound {
         streams_final_replies: bool,
+        receives_progress_deltas: bool,
     }
 
     #[async_trait]
@@ -706,6 +718,10 @@ mod tests {
 
         async fn streams_final_replies(&self, _: &str) -> bool {
             self.streams_final_replies
+        }
+
+        async fn receives_progress_deltas(&self, _: &str) -> bool {
+            self.receives_progress_deltas
         }
     }
 
@@ -900,6 +916,7 @@ mod tests {
         let router = RegistryOutboundRouter::new(Arc::clone(&registry));
 
         assert!(!router.streams_final_replies("bot1").await);
+        assert!(router.receives_progress_deltas("bot1").await);
     }
 
     #[tokio::test]

--- a/crates/channels/src/registry.rs
+++ b/crates/channels/src/registry.rs
@@ -503,6 +503,13 @@ impl ChannelStreamOutbound for RegistryOutboundRouter {
         };
         stream_out.is_stream_enabled(account_id).await
     }
+
+    async fn streams_final_replies(&self, account_id: &str) -> bool {
+        let Some(stream_out) = self.registry.resolve_stream(account_id).await else {
+            return true;
+        };
+        stream_out.streams_final_replies(account_id).await
+    }
 }
 
 #[cfg(test)]
@@ -552,6 +559,7 @@ mod tests {
         id: String,
         accounts: std::sync::Mutex<HashMap<String, serde_json::Value>>,
         outbound: NullOutbound,
+        streams_final_replies: bool,
     }
 
     impl TestPlugin {
@@ -560,6 +568,16 @@ mod tests {
                 id: id.to_string(),
                 accounts: std::sync::Mutex::new(HashMap::new()),
                 outbound: NullOutbound,
+                streams_final_replies: true,
+            }
+        }
+
+        fn new_progress_stream(id: &str) -> Self {
+            Self {
+                id: id.to_string(),
+                accounts: std::sync::Mutex::new(HashMap::new()),
+                outbound: NullOutbound,
+                streams_final_replies: false,
             }
         }
     }
@@ -628,7 +646,9 @@ mod tests {
         }
 
         fn shared_stream_outbound(&self) -> Arc<dyn ChannelStreamOutbound> {
-            Arc::new(NullStreamOutbound)
+            Arc::new(NullStreamOutbound {
+                streams_final_replies: self.streams_final_replies,
+            })
         }
     }
 
@@ -663,7 +683,9 @@ mod tests {
         }
     }
 
-    struct NullStreamOutbound;
+    struct NullStreamOutbound {
+        streams_final_replies: bool,
+    }
 
     #[async_trait]
     impl ChannelStreamOutbound for NullStreamOutbound {
@@ -680,6 +702,10 @@ mod tests {
                 }
             }
             Ok(())
+        }
+
+        async fn streams_final_replies(&self, _: &str) -> bool {
+            self.streams_final_replies
         }
     }
 
@@ -854,6 +880,26 @@ mod tests {
 
         let result = router.send_stream("bot1", "42", None, rx).await;
         assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn stream_router_forwards_final_reply_semantics() {
+        let mut registry = ChannelRegistry::new();
+        registry
+            .register(Arc::new(RwLock::new(TestPlugin::new_progress_stream(
+                "telegram",
+            ))))
+            .await;
+
+        registry
+            .start_account("telegram", "bot1", serde_json::json!({}))
+            .await
+            .unwrap();
+
+        let registry = Arc::new(registry);
+        let router = RegistryOutboundRouter::new(Arc::clone(&registry));
+
+        assert!(!router.streams_final_replies("bot1").await);
     }
 
     #[tokio::test]

--- a/crates/chat/src/agent_loop.rs
+++ b/crates/chat/src/agent_loop.rs
@@ -210,6 +210,10 @@ impl ChannelStreamDispatcher {
             }
 
             let key = ChannelReplyTargetKey::from(&target);
+            let streams_final_replies = self
+                .outbound
+                .streams_final_replies(&target.account_id)
+                .await;
             let (tx, rx) = mpsc::channel(CHANNEL_STREAM_BUFFER_SIZE);
             let outbound = Arc::clone(&self.outbound);
             let completed = Arc::clone(&self.completed);
@@ -228,7 +232,9 @@ impl ChannelStreamDispatcher {
                     .await
                 {
                     Ok(()) => {
-                        completed.lock().await.insert(key_for_insert);
+                        if streams_final_replies {
+                            completed.lock().await.insert(key_for_insert);
+                        }
                     },
                     Err(e) => {
                         warn!(

--- a/crates/chat/src/agent_loop.rs
+++ b/crates/chat/src/agent_loop.rs
@@ -149,6 +149,7 @@ impl From<&moltis_channels::ChannelReplyTarget> for ChannelReplyTargetKey {
 
 struct ChannelStreamWorker {
     sender: moltis_channels::StreamSender,
+    receives_progress_deltas: bool,
 }
 
 /// Fan out model deltas to channel stream workers (Telegram/Discord edit-in-place).
@@ -214,6 +215,10 @@ impl ChannelStreamDispatcher {
                 .outbound
                 .streams_final_replies(&target.account_id)
                 .await;
+            let receives_progress_deltas = self
+                .outbound
+                .receives_progress_deltas(&target.account_id)
+                .await;
             let (tx, rx) = mpsc::channel(CHANNEL_STREAM_BUFFER_SIZE);
             let outbound = Arc::clone(&self.outbound);
             let completed = Arc::clone(&self.completed);
@@ -225,7 +230,10 @@ impl ChannelStreamDispatcher {
             let chat_for_log = target.chat_id.clone();
             let thread_for_log = target.thread_id.clone();
 
-            self.workers.push(ChannelStreamWorker { sender: tx });
+            self.workers.push(ChannelStreamWorker {
+                sender: tx,
+                receives_progress_deltas,
+            });
             self.tasks.push(tokio::spawn(async move {
                 match outbound
                     .send_stream(&account_id, &to, reply_to.as_deref(), rx)
@@ -267,11 +275,12 @@ impl ChannelStreamDispatcher {
             return;
         }
         self.ensure_started().await;
-        self.send_to_workers(
-            moltis_channels::StreamEvent::ProgressDelta(delta.to_string()),
-            "progress delta",
-        )
-        .await;
+        let event = moltis_channels::StreamEvent::ProgressDelta(delta.to_string());
+        for worker in &self.workers {
+            if worker.receives_progress_deltas && worker.sender.send(event.clone()).await.is_err() {
+                debug!("channel stream progress delta dropped: worker closed");
+            }
+        }
     }
 
     async fn send_to_workers(&mut self, event: moltis_channels::StreamEvent, label: &str) {

--- a/crates/chat/src/agent_loop.rs
+++ b/crates/chat/src/agent_loop.rs
@@ -163,7 +163,7 @@ pub(crate) struct ChannelStreamDispatcher {
     tasks: Vec<tokio::task::JoinHandle<()>>,
     completed: Arc<Mutex<HashSet<ChannelReplyTargetKey>>>,
     started: bool,
-    sent_delta: bool,
+    sent_final_delta: bool,
 }
 
 impl ChannelStreamDispatcher {
@@ -187,7 +187,7 @@ impl ChannelStreamDispatcher {
             tasks: Vec::new(),
             completed: Arc::new(Mutex::new(HashSet::new())),
             started: false,
-            sent_delta: false,
+            sent_final_delta: false,
         };
         dispatcher.ensure_started().await;
         Some(dispatcher)
@@ -253,12 +253,31 @@ impl ChannelStreamDispatcher {
         if delta.is_empty() {
             return;
         }
-        self.sent_delta = true;
+        self.sent_final_delta = true;
         self.ensure_started().await;
-        let event = moltis_channels::StreamEvent::Delta(delta.to_string());
+        self.send_to_workers(
+            moltis_channels::StreamEvent::Delta(delta.to_string()),
+            "delta",
+        )
+        .await;
+    }
+
+    pub(crate) async fn send_progress_delta(&mut self, delta: &str) {
+        if delta.is_empty() {
+            return;
+        }
+        self.ensure_started().await;
+        self.send_to_workers(
+            moltis_channels::StreamEvent::ProgressDelta(delta.to_string()),
+            "progress delta",
+        )
+        .await;
+    }
+
+    async fn send_to_workers(&mut self, event: moltis_channels::StreamEvent, label: &str) {
         for worker in &self.workers {
             if worker.sender.send(event.clone()).await.is_err() {
-                debug!("channel stream delta dropped: worker closed");
+                debug!("channel stream {label} dropped: worker closed");
             }
         }
     }
@@ -290,7 +309,7 @@ impl ChannelStreamDispatcher {
     }
 
     pub(crate) async fn completed_target_keys(&self) -> HashSet<ChannelReplyTargetKey> {
-        if !self.sent_delta {
+        if !self.sent_final_delta {
             return HashSet::new();
         }
         self.completed.lock().await.clone()

--- a/crates/chat/src/run_with_tools.rs
+++ b/crates/chat/src/run_with_tools.rs
@@ -713,9 +713,6 @@ pub(crate) async fn run_with_tools(
                     {
                         draft.append_text(&text);
                     }
-                    if let Some(ref dispatcher) = channel_stream_for_events {
-                        dispatcher.lock().await.send_delta(&text).await;
-                    }
                     serde_json::json!({
                         "runId": run_id,
                         "sessionKey": sk,
@@ -723,6 +720,18 @@ pub(crate) async fn run_with_tools(
                         "text": text,
                         "seq": seq,
                     })
+                },
+                RunnerEvent::ProgressText(text) => {
+                    if let Some(ref dispatcher) = channel_stream_for_events {
+                        dispatcher.lock().await.send_progress_delta(&text).await;
+                    }
+                    continue;
+                },
+                RunnerEvent::FinalText(text) => {
+                    if let Some(ref dispatcher) = channel_stream_for_events {
+                        dispatcher.lock().await.send_delta(&text).await;
+                    }
+                    continue;
                 },
                 RunnerEvent::Iteration(n) => serde_json::json!({
                     "runId": run_id,

--- a/crates/discord/src/outbound.rs
+++ b/crates/discord/src/outbound.rs
@@ -695,7 +695,7 @@ impl ChannelStreamOutbound for DiscordOutbound {
                 event = stream.recv() => {
                     let Some(event) = event else { break };
                     match event {
-                        StreamEvent::Delta(delta) => {
+                        StreamEvent::Delta(delta) | StreamEvent::ProgressDelta(delta) => {
                             accumulated.push_str(&delta);
 
                             // Phase 1: initial send once we have enough text.

--- a/crates/matrix/src/outbound.rs
+++ b/crates/matrix/src/outbound.rs
@@ -282,7 +282,9 @@ impl MatrixOutbound {
 
         while let Some(event) = stream.recv().await {
             match event {
-                StreamEvent::Delta(chunk) => buffer.push_str(&chunk),
+                StreamEvent::Delta(chunk) | StreamEvent::ProgressDelta(chunk) => {
+                    buffer.push_str(&chunk)
+                },
                 StreamEvent::Done => break,
                 StreamEvent::Error(error) => {
                     warn!("stream error: {error}");
@@ -608,7 +610,7 @@ impl ChannelStreamOutbound for MatrixOutbound {
                 }
                 event = stream.recv() => {
                     match event {
-                        Some(StreamEvent::Delta(chunk)) => {
+                        Some(StreamEvent::Delta(chunk) | StreamEvent::ProgressDelta(chunk)) => {
                             buffer.push_str(&chunk);
 
                             if sent_event_id.is_none() && buffer.len() >= min_initial_chars {

--- a/crates/msteams/src/outbound.rs
+++ b/crates/msteams/src/outbound.rs
@@ -347,7 +347,7 @@ impl MsTeamsOutbound {
             };
 
             match event {
-                Some(StreamEvent::Delta(delta)) => {
+                Some(StreamEvent::Delta(delta) | StreamEvent::ProgressDelta(delta)) => {
                     session.push_delta(&delta);
 
                     if session.ready_for_initial_post() {
@@ -708,7 +708,9 @@ impl ChannelStreamOutbound for MsTeamsOutbound {
                 let mut text = String::new();
                 while let Some(event) = stream.recv().await {
                     match event {
-                        StreamEvent::Delta(delta) => text.push_str(&delta),
+                        StreamEvent::Delta(delta) | StreamEvent::ProgressDelta(delta) => {
+                            text.push_str(&delta)
+                        },
                         StreamEvent::Done => break,
                         StreamEvent::Error(err) => {
                             debug!(account_id, chat_id = to, "Teams stream error: {err}");

--- a/crates/nostr/src/outbound.rs
+++ b/crates/nostr/src/outbound.rs
@@ -118,7 +118,9 @@ impl ChannelStreamOutbound for NostrOutbound {
 
         while let Some(event) = stream.recv().await {
             match event {
-                StreamEvent::Delta(chunk) => buffer.push_str(&chunk),
+                StreamEvent::Delta(chunk) | StreamEvent::ProgressDelta(chunk) => {
+                    buffer.push_str(&chunk)
+                },
                 StreamEvent::Done => break,
                 StreamEvent::Error(e) => {
                     tracing::warn!(account_id, "stream error: {e}");

--- a/crates/signal/src/outbound.rs
+++ b/crates/signal/src/outbound.rs
@@ -202,7 +202,9 @@ impl ChannelStreamOutbound for SignalOutbound {
         let mut buffer = String::new();
         while let Some(event) = stream.recv().await {
             match event {
-                StreamEvent::Delta(chunk) => buffer.push_str(&chunk),
+                StreamEvent::Delta(chunk) | StreamEvent::ProgressDelta(chunk) => {
+                    buffer.push_str(&chunk)
+                },
                 StreamEvent::Done => break,
                 StreamEvent::Error(e) => {
                     tracing::warn!(account_id, "Signal stream error: {e}");

--- a/crates/slack/src/outbound.rs
+++ b/crates/slack/src/outbound.rs
@@ -121,7 +121,7 @@ impl SlackOutbound {
 
         loop {
             match stream.recv().await {
-                Some(StreamEvent::Delta(chunk)) => {
+                Some(StreamEvent::Delta(chunk) | StreamEvent::ProgressDelta(chunk)) => {
                     pending.push_str(&chunk);
 
                     // Throttle appends to avoid rate limits.
@@ -180,7 +180,7 @@ impl SlackOutbound {
 
         loop {
             match stream.recv().await {
-                Some(StreamEvent::Delta(chunk)) => {
+                Some(StreamEvent::Delta(chunk) | StreamEvent::ProgressDelta(chunk)) => {
                     accumulated.push_str(&chunk);
 
                     match &sent_ts {
@@ -786,7 +786,9 @@ impl ChannelStreamOutbound for SlackOutbound {
                 let mut accumulated = String::new();
                 loop {
                     match stream.recv().await {
-                        Some(StreamEvent::Delta(chunk)) => accumulated.push_str(&chunk),
+                        Some(StreamEvent::Delta(chunk) | StreamEvent::ProgressDelta(chunk)) => {
+                            accumulated.push_str(&chunk)
+                        },
                         Some(StreamEvent::Error(e)) => {
                             accumulated.push_str(&format!("\n\n:warning: {e}"));
                             break;

--- a/crates/telegram/src/config.rs
+++ b/crates/telegram/src/config.rs
@@ -10,6 +10,8 @@ use {
     serde::{Deserialize, Serialize, ser::SerializeStruct},
 };
 
+pub(crate) const DEFAULT_STREAM_PROGRESS_MAX_CHARS: usize = 3500;
+
 /// Per-channel model/provider override.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct ChannelOverride {
@@ -80,6 +82,10 @@ pub struct TelegramAccountConfig {
     /// streamed message. Helps avoid early push notifications with tiny drafts.
     pub stream_min_initial_chars: usize,
 
+    /// Maximum number of recent progress characters to show in the temporary
+    /// progress message. Older progress is discarded from the visible tail.
+    pub stream_progress_max_chars: usize,
+
     /// Default model ID for this bot's sessions (e.g. "claude-sonnet-4-5-20250929").
     /// When set, channel messages use this model instead of the first registered provider.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -132,7 +138,7 @@ pub struct RedactedConfig<'a>(pub &'a TelegramAccountConfig);
 impl Serialize for RedactedConfig<'_> {
     fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         let c = self.0;
-        let mut count = 13; // always-present fields
+        let mut count = 14; // always-present fields
         count += c.model.is_some() as usize;
         count += c.model_provider.is_some() as usize;
         count += c.agent_id.is_some() as usize;
@@ -149,6 +155,7 @@ impl Serialize for RedactedConfig<'_> {
         s.serialize_field("edit_throttle_ms", &c.edit_throttle_ms)?;
         s.serialize_field("stream_notify_on_complete", &c.stream_notify_on_complete)?;
         s.serialize_field("stream_min_initial_chars", &c.stream_min_initial_chars)?;
+        s.serialize_field("stream_progress_max_chars", &c.stream_progress_max_chars)?;
         if c.model.is_some() {
             s.serialize_field("model", &c.model)?;
         }
@@ -250,6 +257,7 @@ impl Default for TelegramAccountConfig {
             edit_throttle_ms: 2000,
             stream_notify_on_complete: false,
             stream_min_initial_chars: 30,
+            stream_progress_max_chars: DEFAULT_STREAM_PROGRESS_MAX_CHARS,
             model: None,
             model_provider: None,
             agent_id: None,
@@ -279,6 +287,7 @@ mod tests {
         assert_eq!(cfg.edit_throttle_ms, 2000);
         assert!(!cfg.stream_notify_on_complete);
         assert_eq!(cfg.stream_min_initial_chars, 30);
+        assert_eq!(cfg.stream_progress_max_chars, 3500);
     }
 
     #[test]
@@ -289,6 +298,7 @@ mod tests {
             "stream_mode": "off",
             "stream_notify_on_complete": true,
             "stream_min_initial_chars": 42,
+            "stream_progress_max_chars": 1234,
             "allowlist": ["user1", "user2"]
         }"#;
         let cfg: TelegramAccountConfig = serde_json::from_str(json).unwrap();
@@ -297,6 +307,7 @@ mod tests {
         assert_eq!(cfg.stream_mode, StreamMode::Off);
         assert!(cfg.stream_notify_on_complete);
         assert_eq!(cfg.stream_min_initial_chars, 42);
+        assert_eq!(cfg.stream_progress_max_chars, 1234);
         assert_eq!(cfg.allowlist, vec!["user1", "user2"]);
         // defaults for unspecified fields
         assert_eq!(cfg.group_policy, GroupPolicy::Open);
@@ -404,6 +415,7 @@ mod tests {
             redacted["stream_mode"],
             serde_json::to_value(&cfg.stream_mode).unwrap()
         );
+        assert_eq!(redacted["stream_progress_max_chars"], 3500);
 
         // Storage path still exposes the token
         let storage = serde_json::to_value(&cfg).unwrap();

--- a/crates/telegram/src/config.rs
+++ b/crates/telegram/src/config.rs
@@ -247,7 +247,7 @@ impl Default for TelegramAccountConfig {
             allowlist: Vec::new(),
             group_allowlist: Vec::new(),
             stream_mode: StreamMode::default(),
-            edit_throttle_ms: 300,
+            edit_throttle_ms: 2000,
             stream_notify_on_complete: false,
             stream_min_initial_chars: 30,
             model: None,
@@ -276,7 +276,7 @@ mod tests {
         assert_eq!(cfg.group_policy, GroupPolicy::Open);
         assert_eq!(cfg.mention_mode, MentionMode::Mention);
         assert_eq!(cfg.stream_mode, StreamMode::EditInPlace);
-        assert_eq!(cfg.edit_throttle_ms, 300);
+        assert_eq!(cfg.edit_throttle_ms, 2000);
         assert!(!cfg.stream_notify_on_complete);
         assert_eq!(cfg.stream_min_initial_chars, 30);
     }

--- a/crates/telegram/src/markdown.rs
+++ b/crates/telegram/src/markdown.rs
@@ -456,7 +456,7 @@ fn peek_n(chars: &mut std::iter::Peekable<std::str::Chars<'_>>, n: usize) -> Str
 }
 
 /// Escape HTML special characters.
-fn escape_html(text: &str) -> String {
+pub(crate) fn escape_html(text: &str) -> String {
     text.replace('&', "&amp;")
         .replace('<', "&lt;")
         .replace('>', "&gt;")

--- a/crates/telegram/src/outbound/mod.rs
+++ b/crates/telegram/src/outbound/mod.rs
@@ -38,15 +38,13 @@ const TYPING_REFRESH_INTERVAL: Duration = Duration::from_secs(4);
 #[derive(Debug, Clone, Copy)]
 struct StreamSendConfig {
     edit_throttle_ms: u64,
-    notify_on_complete: bool,
     min_initial_chars: usize,
 }
 
 impl Default for StreamSendConfig {
     fn default() -> Self {
         Self {
-            edit_throttle_ms: 300,
-            notify_on_complete: false,
+            edit_throttle_ms: 2000,
             min_initial_chars: 30,
         }
     }
@@ -84,7 +82,6 @@ impl TelegramOutbound {
             .get(account_id)
             .map(|s| StreamSendConfig {
                 edit_throttle_ms: s.config.edit_throttle_ms,
-                notify_on_complete: s.config.stream_notify_on_complete,
                 min_initial_chars: s.config.stream_min_initial_chars,
             })
             .unwrap_or_default()

--- a/crates/telegram/src/outbound/mod.rs
+++ b/crates/telegram/src/outbound/mod.rs
@@ -40,6 +40,7 @@ struct StreamSendConfig {
     edit_throttle_ms: u64,
     min_initial_chars: usize,
     progress_max_chars: usize,
+    notify_on_complete: bool,
 }
 
 impl Default for StreamSendConfig {
@@ -48,6 +49,7 @@ impl Default for StreamSendConfig {
             edit_throttle_ms: 2000,
             min_initial_chars: 30,
             progress_max_chars: DEFAULT_STREAM_PROGRESS_MAX_CHARS,
+            notify_on_complete: false,
         }
     }
 }
@@ -86,6 +88,7 @@ impl TelegramOutbound {
                 edit_throttle_ms: s.config.edit_throttle_ms,
                 min_initial_chars: s.config.stream_min_initial_chars,
                 progress_max_chars: s.config.stream_progress_max_chars,
+                notify_on_complete: s.config.stream_notify_on_complete,
             })
             .unwrap_or_default()
     }

--- a/crates/telegram/src/outbound/mod.rs
+++ b/crates/telegram/src/outbound/mod.rs
@@ -22,7 +22,7 @@ use {
     teloxide::{prelude::*, types::ReplyParameters},
 };
 
-use crate::state::AccountStateMap;
+use crate::{config::DEFAULT_STREAM_PROGRESS_MAX_CHARS, state::AccountStateMap};
 
 /// Outbound message sender for Telegram.
 pub struct TelegramOutbound {
@@ -39,6 +39,7 @@ const TYPING_REFRESH_INTERVAL: Duration = Duration::from_secs(4);
 struct StreamSendConfig {
     edit_throttle_ms: u64,
     min_initial_chars: usize,
+    progress_max_chars: usize,
 }
 
 impl Default for StreamSendConfig {
@@ -46,6 +47,7 @@ impl Default for StreamSendConfig {
         Self {
             edit_throttle_ms: 2000,
             min_initial_chars: 30,
+            progress_max_chars: DEFAULT_STREAM_PROGRESS_MAX_CHARS,
         }
     }
 }
@@ -83,6 +85,7 @@ impl TelegramOutbound {
             .map(|s| StreamSendConfig {
                 edit_throttle_ms: s.config.edit_throttle_ms,
                 min_initial_chars: s.config.stream_min_initial_chars,
+                progress_max_chars: s.config.stream_progress_max_chars,
             })
             .unwrap_or_default()
     }

--- a/crates/telegram/src/outbound/retry.rs
+++ b/crates/telegram/src/outbound/retry.rs
@@ -100,56 +100,6 @@ impl TelegramOutbound {
         }
     }
 
-    pub(crate) async fn edit_chunk_with_fallback(
-        &self,
-        bot: &Bot,
-        account_id: &str,
-        to: &str,
-        chat_id: ChatId,
-        message_id: MessageId,
-        chunk: &str,
-    ) -> Result<()> {
-        match self
-            .run_telegram_request_with_retry(account_id, to, "edit message (html)", || {
-                let html_req = bot
-                    .edit_message_text(chat_id, message_id, chunk)
-                    .parse_mode(ParseMode::Html);
-                async move { html_req.await }
-            })
-            .await
-        {
-            Ok(_) => Ok(()),
-            Err(e) => {
-                if is_message_not_modified_error(&e) {
-                    return Ok(());
-                }
-                let plain_chunk = telegram_html_to_plain_text(chunk);
-                warn!(
-                    account_id,
-                    chat_id = to,
-                    error = %e,
-                    "telegram HTML edit failed, retrying as plain text"
-                );
-                match self
-                    .run_telegram_request_with_retry(account_id, to, "edit message (plain)", || {
-                        let plain_req = bot.edit_message_text(chat_id, message_id, &plain_chunk);
-                        async move { plain_req.await }
-                    })
-                    .await
-                {
-                    Ok(_) => Ok(()),
-                    Err(plain_err) => {
-                        if is_message_not_modified_error(&plain_err) {
-                            Ok(())
-                        } else {
-                            Err(ChannelError::external("edit message (plain)", plain_err))
-                        }
-                    },
-                }
-            },
-        }
-    }
-
     pub(crate) async fn run_telegram_request_with_retry<T, F, Fut>(
         &self,
         account_id: &str,

--- a/crates/telegram/src/outbound/stream.rs
+++ b/crates/telegram/src/outbound/stream.rs
@@ -925,8 +925,8 @@ impl ChannelStreamOutbound for TelegramOutbound {
             .is_some_and(|s| s.config.stream_mode != StreamMode::Off)
     }
 
-    async fn streams_final_replies(&self, account_id: &str) -> bool {
-        self.is_stream_enabled(account_id).await
+    async fn streams_final_replies(&self, _account_id: &str) -> bool {
+        false
     }
 
     async fn receives_progress_deltas(&self, account_id: &str) -> bool {

--- a/crates/telegram/src/outbound/stream.rs
+++ b/crates/telegram/src/outbound/stream.rs
@@ -409,6 +409,7 @@ impl TelegramOutbound {
         rendered_html: &str,
         now: tokio::time::Instant,
         throttle: Duration,
+        final_delivery: bool,
     ) -> Result<()> {
         if rendered_html.is_empty() {
             final_state.mark_final_observed(now, rendered_html);
@@ -419,6 +420,28 @@ impl TelegramOutbound {
             let result = self
                 .edit_progress_chunk_once(bot, account_id, to, chat_id, msg_id, rendered_html)
                 .await;
+            if final_delivery && result != ProgressEditResult::Applied {
+                warn!(
+                    account_id,
+                    chat_id = to,
+                    "telegram final stream edit failed at completion; sending fallback final message"
+                );
+                let message_id = self
+                    .send_chunk_with_fallback(
+                        bot,
+                        account_id,
+                        to,
+                        chat_id,
+                        thread_id,
+                        rendered_html,
+                        reply_params,
+                        !stream_cfg.notify_on_complete,
+                    )
+                    .await?;
+                final_state.message_id = Some(message_id);
+                final_state.mark_final_sent(now, rendered_html);
+                return Ok(());
+            }
             record_final_edit_result(final_state, now, rendered_html, throttle, result);
             return Ok(());
         }
@@ -515,6 +538,55 @@ impl TelegramOutbound {
             .await?;
         }
         Ok(())
+    }
+
+    async fn finish_final_stream_message(
+        &self,
+        bot: &Bot,
+        account_id: &str,
+        to: &str,
+        chat_id: ChatId,
+        thread_id: Option<ThreadId>,
+        reply_params: Option<&ReplyParameters>,
+        stream_cfg: StreamSendConfig,
+        progress_message_id: &mut Option<MessageId>,
+        final_state: &mut StreamFinalState,
+        throttle: Duration,
+    ) -> Result<()> {
+        if final_state.accumulated.is_empty() {
+            return Ok(());
+        }
+
+        let display = final_state.current_final_html();
+        let now = tokio::time::Instant::now();
+        if final_state.message_id.is_none() || final_state.rendered_html_changed(&display) {
+            self.flush_final_stream_message(
+                bot,
+                account_id,
+                to,
+                chat_id,
+                thread_id,
+                reply_params,
+                stream_cfg,
+                progress_message_id,
+                final_state,
+                &display,
+                now,
+                throttle,
+                true,
+            )
+            .await?;
+        }
+        self.send_remaining_final_chunks(
+            bot,
+            account_id,
+            to,
+            chat_id,
+            thread_id,
+            reply_params,
+            final_state,
+        )
+        .await
     }
 }
 
@@ -625,7 +697,22 @@ impl ChannelStreamOutbound for TelegramOutbound {
         loop {
             tokio::select! {
                 event = stream.recv() => {
-                    let Some(event) = event else { break };
+                    let Some(event) = event else {
+                        self.finish_final_stream_message(
+                            &bot,
+                            account_id,
+                            to,
+                            chat_id,
+                            thread_id,
+                            rp.as_ref(),
+                            stream_cfg,
+                            &mut progress_message_id,
+                            &mut final_state,
+                            throttle,
+                        )
+                        .await?;
+                        break;
+                    };
                     match event {
                         StreamEvent::ProgressDelta(delta) => {
                             if final_state.message_id.is_some() || !final_state.accumulated.is_empty() {
@@ -717,6 +804,7 @@ impl ChannelStreamOutbound for TelegramOutbound {
                                         &display,
                                         now,
                                         throttle,
+                                        false,
                                     )
                                     .await?;
                                 }
@@ -739,6 +827,7 @@ impl ChannelStreamOutbound for TelegramOutbound {
                                         &display,
                                         now,
                                         throttle,
+                                        false,
                                     )
                                     .await?;
                                 } else {
@@ -747,39 +836,19 @@ impl ChannelStreamOutbound for TelegramOutbound {
                             }
                         },
                         StreamEvent::Done => {
-                            if !final_state.accumulated.is_empty() {
-                                let display = final_state.current_final_html();
-                                let now = tokio::time::Instant::now();
-                                if final_state.message_id.is_none()
-                                    || final_state.rendered_html_changed(&display)
-                                {
-                                    self.flush_final_stream_message(
-                                        &bot,
-                                        account_id,
-                                        to,
-                                        chat_id,
-                                        thread_id,
-                                        rp.as_ref(),
-                                        stream_cfg,
-                                        &mut progress_message_id,
-                                        &mut final_state,
-                                        &display,
-                                        now,
-                                        throttle,
-                                    )
-                                    .await?;
-                                }
-                                self.send_remaining_final_chunks(
-                                    &bot,
-                                    account_id,
-                                    to,
-                                    chat_id,
-                                    thread_id,
-                                    rp.as_ref(),
-                                    &final_state,
-                                )
-                                .await?;
-                            }
+                            self.finish_final_stream_message(
+                                &bot,
+                                account_id,
+                                to,
+                                chat_id,
+                                thread_id,
+                                rp.as_ref(),
+                                stream_cfg,
+                                &mut progress_message_id,
+                                &mut final_state,
+                                throttle,
+                            )
+                            .await?;
                             break;
                         },
                         StreamEvent::Error(e) => {
@@ -809,6 +878,7 @@ impl ChannelStreamOutbound for TelegramOutbound {
                                 &display,
                                 now,
                                 throttle,
+                                false,
                             )
                             .await?;
                         } else {
@@ -856,6 +926,10 @@ impl ChannelStreamOutbound for TelegramOutbound {
     }
 
     async fn streams_final_replies(&self, account_id: &str) -> bool {
+        self.is_stream_enabled(account_id).await
+    }
+
+    async fn receives_progress_deltas(&self, account_id: &str) -> bool {
         self.is_stream_enabled(account_id).await
     }
 }

--- a/crates/telegram/src/outbound/stream.rs
+++ b/crates/telegram/src/outbound/stream.rs
@@ -26,16 +26,31 @@ use super::{TYPING_REFRESH_INTERVAL, TelegramOutbound};
 const MIN_PROGRESS_FLUSH_INTERVAL: Duration = Duration::from_millis(250);
 
 pub(super) fn has_reached_stream_min_initial_chars(
-    accumulated: &str,
+    seen_chars: usize,
     min_initial_chars: usize,
 ) -> bool {
-    accumulated.chars().count() >= min_initial_chars
+    seen_chars >= min_initial_chars
 }
 
-pub(super) fn format_stream_progress_html(accumulated: &str) -> String {
-    let body = markdown::markdown_to_telegram_html(accumulated);
-    let html = format!("<b>Progress update</b>\n\n{body}");
-    markdown::truncate_at_char_boundary(&html, TELEGRAM_MAX_MESSAGE_LEN).to_string()
+pub(super) fn format_stream_progress_html(progress: &str, older_progress_hidden: bool) -> String {
+    fn build(progress: &str, older_progress_hidden: bool) -> (String, bool) {
+        let marker = if older_progress_hidden {
+            "<i>Older progress hidden.</i>\n\n"
+        } else {
+            ""
+        };
+        let prefix = format!("<b>Progress update</b>\n\n{marker}");
+        let available = TELEGRAM_MAX_MESSAGE_LEN.saturating_sub(prefix.len());
+        let (tail, truncated_by_limit) = escaped_recent_tail(progress, available);
+        (format!("{prefix}{tail}"), truncated_by_limit)
+    }
+
+    let (html, truncated_by_limit) = build(progress, older_progress_hidden);
+    if truncated_by_limit && !older_progress_hidden {
+        build(progress, true).0
+    } else {
+        html
+    }
 }
 
 pub(super) fn stream_progress_cleanup_html() -> &'static str {
@@ -44,10 +59,13 @@ pub(super) fn stream_progress_cleanup_html() -> &'static str {
 
 pub(super) struct StreamProgressState {
     accumulated: String,
+    seen_chars: usize,
     last_progress_at: Option<tokio::time::Instant>,
     last_rendered_html: Option<String>,
     defer_until: Option<tokio::time::Instant>,
     min_initial_chars: usize,
+    max_chars: usize,
+    older_progress_hidden: bool,
     dirty: bool,
 }
 
@@ -59,25 +77,32 @@ enum ProgressEditResult {
 }
 
 impl StreamProgressState {
-    pub(super) fn new(min_initial_chars: usize) -> Self {
+    pub(super) fn new(min_initial_chars: usize, max_chars: usize) -> Self {
         Self {
             accumulated: String::new(),
+            seen_chars: 0,
             last_progress_at: None,
             last_rendered_html: None,
             defer_until: None,
             min_initial_chars,
+            max_chars: max_chars.max(1),
+            older_progress_hidden: false,
             dirty: false,
         }
     }
 
     pub(super) fn push_delta(&mut self, delta: &str) {
+        self.seen_chars += delta.chars().count();
         self.accumulated.push_str(delta);
+        if trim_to_recent_chars(&mut self.accumulated, self.max_chars) {
+            self.older_progress_hidden = true;
+        }
         self.dirty = true;
     }
 
     pub(super) fn should_send_initial_progress(&self) -> bool {
         self.last_progress_at.is_none()
-            && has_reached_stream_min_initial_chars(&self.accumulated, self.min_initial_chars)
+            && has_reached_stream_min_initial_chars(self.seen_chars, self.min_initial_chars)
     }
 
     pub(super) fn should_flush_progress(
@@ -96,8 +121,8 @@ impl StreamProgressState {
         self.dirty && now.saturating_duration_since(last_progress_at) >= throttle
     }
 
-    fn current_progress_html(&self) -> String {
-        format_stream_progress_html(&self.accumulated)
+    pub(super) fn current_progress_html(&self) -> String {
+        format_stream_progress_html(&self.accumulated, self.older_progress_hidden)
     }
 
     pub(super) fn mark_progress_sent(&mut self, now: tokio::time::Instant, rendered_html: &str) {
@@ -249,6 +274,51 @@ fn record_progress_edit_result(
     }
 }
 
+fn escaped_recent_tail(text: &str, max_len: usize) -> (String, bool) {
+    let total_chars = text.chars().count();
+    let mut escaped_len = 0usize;
+    let mut reversed = Vec::new();
+
+    for ch in text.chars().rev() {
+        let ch_len = escaped_char_len(ch);
+        if escaped_len + ch_len > max_len {
+            break;
+        }
+        escaped_len += ch_len;
+        reversed.push(ch);
+    }
+
+    let truncated = reversed.len() < total_chars;
+    reversed.reverse();
+    let raw: String = reversed.into_iter().collect();
+    (markdown::escape_html(&raw), truncated)
+}
+
+fn escaped_char_len(ch: char) -> usize {
+    match ch {
+        '&' => "&amp;".len(),
+        '<' => "&lt;".len(),
+        '>' => "&gt;".len(),
+        _ => ch.len_utf8(),
+    }
+}
+
+fn trim_to_recent_chars(text: &mut String, max_chars: usize) -> bool {
+    let char_count = text.chars().count();
+    if char_count <= max_chars {
+        return false;
+    }
+
+    let remove_chars = char_count - max_chars;
+    let Some((byte_start, _)) = text.char_indices().nth(remove_chars) else {
+        text.clear();
+        return true;
+    };
+    let tail = text.split_off(byte_start);
+    *text = tail;
+    true
+}
+
 #[async_trait]
 impl ChannelStreamOutbound for TelegramOutbound {
     async fn send_stream(
@@ -267,7 +337,8 @@ impl ChannelStreamOutbound for TelegramOutbound {
         let _ = bot.send_chat_action(chat_id, ChatAction::Typing).await;
         let mut progress_message_id: Option<teloxide::types::MessageId> = None;
 
-        let mut progress = StreamProgressState::new(stream_cfg.min_initial_chars);
+        let mut progress =
+            StreamProgressState::new(stream_cfg.min_initial_chars, stream_cfg.progress_max_chars);
         let throttle =
             Duration::from_millis(stream_cfg.edit_throttle_ms).max(MIN_PROGRESS_FLUSH_INTERVAL);
         let mut typing_interval = tokio::time::interval(TYPING_REFRESH_INTERVAL);

--- a/crates/telegram/src/outbound/stream.rs
+++ b/crates/telegram/src/outbound/stream.rs
@@ -5,7 +5,7 @@ use {
     std::time::Duration,
     teloxide::{
         prelude::*,
-        types::{ChatAction, ParseMode},
+        types::{ChatAction, ChatId, MessageId, ParseMode, ReplyParameters, ThreadId},
     },
     tracing::{debug, warn},
 };
@@ -21,7 +21,7 @@ use crate::{
     topic::parse_chat_target,
 };
 
-use super::{TYPING_REFRESH_INTERVAL, TelegramOutbound};
+use super::{StreamSendConfig, TYPING_REFRESH_INTERVAL, TelegramOutbound};
 
 const MIN_PROGRESS_FLUSH_INTERVAL: Duration = Duration::from_millis(250);
 
@@ -39,8 +39,16 @@ pub(super) fn format_stream_progress_html(progress: &str, older_progress_hidden:
         } else {
             ""
         };
-        let prefix = format!("<b>Progress update</b>\n\n{marker}");
+        let prefix = marker.to_string();
         let available = TELEGRAM_MAX_MESSAGE_LEN.saturating_sub(prefix.len());
+        let chunks = markdown::chunk_markdown_html(progress, available);
+        if chunks.len() <= 1 {
+            return (
+                format!("{prefix}{}", chunks.into_iter().next().unwrap_or_default()),
+                false,
+            );
+        }
+
         let (tail, truncated_by_limit) = escaped_recent_tail(progress, available);
         (format!("{prefix}{tail}"), truncated_by_limit)
     }
@@ -54,7 +62,7 @@ pub(super) fn format_stream_progress_html(progress: &str, older_progress_hidden:
 }
 
 pub(super) fn stream_progress_cleanup_html() -> &'static str {
-    "<i>Progress update complete; final answer follows.</i>"
+    "<i>Final answer follows.</i>"
 }
 
 pub(super) struct StreamProgressState {
@@ -98,6 +106,15 @@ impl StreamProgressState {
             self.older_progress_hidden = true;
         }
         self.dirty = true;
+    }
+
+    fn replace_text(&mut self, text: &str) {
+        self.accumulated.clear();
+        self.seen_chars = 0;
+        self.older_progress_hidden = false;
+        self.last_rendered_html = None;
+        self.defer_until = None;
+        self.push_delta(text);
     }
 
     pub(super) fn should_send_initial_progress(&self) -> bool {
@@ -155,6 +172,96 @@ impl StreamProgressState {
     }
 }
 
+struct StreamFinalState {
+    accumulated: String,
+    seen_chars: usize,
+    last_progress_at: Option<tokio::time::Instant>,
+    last_rendered_html: Option<String>,
+    defer_until: Option<tokio::time::Instant>,
+    min_initial_chars: usize,
+    dirty: bool,
+    message_id: Option<MessageId>,
+}
+
+impl StreamFinalState {
+    fn new(min_initial_chars: usize) -> Self {
+        Self {
+            accumulated: String::new(),
+            seen_chars: 0,
+            last_progress_at: None,
+            last_rendered_html: None,
+            defer_until: None,
+            min_initial_chars,
+            dirty: false,
+            message_id: None,
+        }
+    }
+
+    fn push_delta(&mut self, delta: &str) {
+        self.seen_chars += delta.chars().count();
+        self.accumulated.push_str(delta);
+        self.dirty = true;
+    }
+
+    fn should_send_initial_final(&self) -> bool {
+        self.message_id.is_none()
+            && has_reached_stream_min_initial_chars(self.seen_chars, self.min_initial_chars)
+    }
+
+    fn should_flush_final(&self, now: tokio::time::Instant, throttle: Duration) -> bool {
+        let Some(last_progress_at) = self.last_progress_at else {
+            return false;
+        };
+        if let Some(defer_until) = self.defer_until
+            && now < defer_until
+        {
+            return false;
+        }
+        self.dirty && now.saturating_duration_since(last_progress_at) >= throttle
+    }
+
+    fn current_final_html(&self) -> String {
+        render_stream_final_html(&self.accumulated)
+    }
+
+    fn mark_final_sent(&mut self, now: tokio::time::Instant, rendered_html: &str) {
+        self.last_progress_at = Some(now);
+        self.last_rendered_html = Some(rendered_html.to_string());
+        self.defer_until = None;
+        self.dirty = false;
+    }
+
+    fn mark_final_observed(&mut self, now: tokio::time::Instant, rendered_html: &str) {
+        self.mark_final_sent(now, rendered_html);
+    }
+
+    fn defer_final_until(&mut self, until: tokio::time::Instant) {
+        self.defer_until = match self.defer_until {
+            Some(existing) if existing > until => Some(existing),
+            _ => Some(until),
+        };
+    }
+
+    fn rendered_html_changed(&self, rendered_html: &str) -> bool {
+        match self.last_rendered_html.as_deref() {
+            Some(last) => last != rendered_html,
+            None => true,
+        }
+    }
+
+    fn reset(&mut self) {
+        let min_initial_chars = self.min_initial_chars;
+        *self = Self::new(min_initial_chars);
+    }
+}
+
+fn render_stream_final_html(text: &str) -> String {
+    markdown::chunk_markdown_html(text, TELEGRAM_MAX_MESSAGE_LEN)
+        .into_iter()
+        .next()
+        .unwrap_or_default()
+}
+
 impl TelegramOutbound {
     async fn edit_progress_chunk_once(
         &self,
@@ -162,7 +269,7 @@ impl TelegramOutbound {
         account_id: &str,
         to: &str,
         chat_id: ChatId,
-        message_id: teloxide::types::MessageId,
+        message_id: MessageId,
         chunk: &str,
     ) -> ProgressEditResult {
         match bot
@@ -202,7 +309,7 @@ impl TelegramOutbound {
         account_id: &str,
         to: &str,
         chat_id: ChatId,
-        message_id: teloxide::types::MessageId,
+        message_id: MessageId,
     ) -> bool {
         match bot.delete_message(chat_id, message_id).await {
             Ok(_) => return true,
@@ -256,6 +363,159 @@ impl TelegramOutbound {
             },
         }
     }
+
+    async fn delete_progress_message(
+        &self,
+        bot: &Bot,
+        account_id: &str,
+        to: &str,
+        chat_id: ChatId,
+        message_id: MessageId,
+    ) -> bool {
+        match bot.delete_message(chat_id, message_id).await {
+            Ok(_) => true,
+            Err(error) => {
+                if let Some(wait) = super::retry::retry_after_duration(&error) {
+                    warn!(
+                        account_id,
+                        chat_id = to,
+                        retry_after_secs = wait.as_secs(),
+                        "telegram progress delete rate limited; progress message may remain visible"
+                    );
+                } else {
+                    warn!(
+                        account_id,
+                        chat_id = to,
+                        error = %error,
+                        "telegram progress delete failed; progress message may remain visible"
+                    );
+                }
+                false
+            },
+        }
+    }
+
+    async fn flush_final_stream_message(
+        &self,
+        bot: &Bot,
+        account_id: &str,
+        to: &str,
+        chat_id: ChatId,
+        thread_id: Option<ThreadId>,
+        reply_params: Option<&ReplyParameters>,
+        stream_cfg: StreamSendConfig,
+        progress_message_id: &mut Option<MessageId>,
+        final_state: &mut StreamFinalState,
+        rendered_html: &str,
+        now: tokio::time::Instant,
+        throttle: Duration,
+    ) -> Result<()> {
+        if rendered_html.is_empty() {
+            final_state.mark_final_observed(now, rendered_html);
+            return Ok(());
+        }
+
+        if let Some(msg_id) = final_state.message_id {
+            let result = self
+                .edit_progress_chunk_once(bot, account_id, to, chat_id, msg_id, rendered_html)
+                .await;
+            record_final_edit_result(final_state, now, rendered_html, throttle, result);
+            return Ok(());
+        }
+
+        if let Some(progress_msg_id) = *progress_message_id {
+            if stream_cfg.notify_on_complete {
+                if self
+                    .delete_progress_message(bot, account_id, to, chat_id, progress_msg_id)
+                    .await
+                {
+                    *progress_message_id = None;
+                }
+                let message_id = self
+                    .send_chunk_with_fallback(
+                        bot,
+                        account_id,
+                        to,
+                        chat_id,
+                        thread_id,
+                        rendered_html,
+                        reply_params,
+                        false,
+                    )
+                    .await?;
+                final_state.message_id = Some(message_id);
+                final_state.mark_final_sent(now, rendered_html);
+                return Ok(());
+            }
+
+            let result = self
+                .edit_progress_chunk_once(
+                    bot,
+                    account_id,
+                    to,
+                    chat_id,
+                    progress_msg_id,
+                    rendered_html,
+                )
+                .await;
+            match result {
+                ProgressEditResult::Applied => {
+                    final_state.message_id = Some(progress_msg_id);
+                    *progress_message_id = None;
+                    final_state.mark_final_sent(now, rendered_html);
+                    return Ok(());
+                },
+                ProgressEditResult::RateLimited(wait) => {
+                    final_state.defer_final_until(now + wait.max(throttle));
+                },
+                ProgressEditResult::Failed => final_state.defer_final_until(now + throttle),
+            }
+        }
+
+        let message_id = self
+            .send_chunk_with_fallback(
+                bot,
+                account_id,
+                to,
+                chat_id,
+                thread_id,
+                rendered_html,
+                reply_params,
+                !stream_cfg.notify_on_complete,
+            )
+            .await?;
+        final_state.message_id = Some(message_id);
+        final_state.mark_final_sent(now, rendered_html);
+        Ok(())
+    }
+
+    async fn send_remaining_final_chunks(
+        &self,
+        bot: &Bot,
+        account_id: &str,
+        to: &str,
+        chat_id: ChatId,
+        thread_id: Option<ThreadId>,
+        reply_params: Option<&ReplyParameters>,
+        final_state: &StreamFinalState,
+    ) -> Result<()> {
+        let chunks =
+            markdown::chunk_markdown_html(&final_state.accumulated, TELEGRAM_MAX_MESSAGE_LEN);
+        for chunk in chunks.into_iter().skip(1) {
+            self.send_chunk_with_fallback(
+                bot,
+                account_id,
+                to,
+                chat_id,
+                thread_id,
+                &chunk,
+                reply_params,
+                true,
+            )
+            .await?;
+        }
+        Ok(())
+    }
 }
 
 fn record_progress_edit_result(
@@ -271,6 +531,22 @@ fn record_progress_edit_result(
             progress.defer_progress_until(now + wait.max(throttle))
         },
         ProgressEditResult::Failed => progress.defer_progress_until(now + throttle),
+    }
+}
+
+fn record_final_edit_result(
+    final_state: &mut StreamFinalState,
+    now: tokio::time::Instant,
+    rendered_html: &str,
+    throttle: Duration,
+    result: ProgressEditResult,
+) {
+    match result {
+        ProgressEditResult::Applied => final_state.mark_final_sent(now, rendered_html),
+        ProgressEditResult::RateLimited(wait) => {
+            final_state.defer_final_until(now + wait.max(throttle))
+        },
+        ProgressEditResult::Failed => final_state.defer_final_until(now + throttle),
     }
 }
 
@@ -333,26 +609,50 @@ impl ChannelStreamOutbound for TelegramOutbound {
         let rp = self.reply_params(account_id, reply_to);
         let stream_cfg = self.stream_send_config(account_id);
 
-        // Send typing indicator
         let _ = bot.send_chat_action(chat_id, ChatAction::Typing).await;
-        let mut progress_message_id: Option<teloxide::types::MessageId> = None;
+        let mut progress_message_id: Option<MessageId> = None;
 
         let mut progress =
             StreamProgressState::new(stream_cfg.min_initial_chars, stream_cfg.progress_max_chars);
+        let mut final_state = StreamFinalState::new(stream_cfg.min_initial_chars);
         let throttle =
             Duration::from_millis(stream_cfg.edit_throttle_ms).max(MIN_PROGRESS_FLUSH_INTERVAL);
         let mut typing_interval = tokio::time::interval(TYPING_REFRESH_INTERVAL);
-        typing_interval.tick().await; // consume the immediate first tick
+        typing_interval.tick().await;
         let mut flush_interval = tokio::time::interval(throttle);
-        flush_interval.tick().await; // consume the immediate first tick
+        flush_interval.tick().await;
 
         loop {
             tokio::select! {
                 event = stream.recv() => {
                     let Some(event) = event else { break };
                     match event {
-                        StreamEvent::Delta(delta) => {
-                            progress.push_delta(&delta);
+                        StreamEvent::ProgressDelta(delta) => {
+                            if final_state.message_id.is_some() || !final_state.accumulated.is_empty() {
+                                let draft_message_id = final_state.message_id.take();
+                                final_state.reset();
+                                progress.replace_text(&delta);
+                                if let Some(msg_id) = draft_message_id {
+                                    progress_message_id = Some(msg_id);
+                                    let now = tokio::time::Instant::now();
+                                    let display = progress.current_progress_html();
+                                    let result = self
+                                        .edit_progress_chunk_once(
+                                            &bot, account_id, to, chat_id, msg_id, &display,
+                                        )
+                                        .await;
+                                    record_progress_edit_result(
+                                        &mut progress,
+                                        now,
+                                        &display,
+                                        throttle,
+                                        result,
+                                    );
+                                    continue;
+                                }
+                            } else {
+                                progress.push_delta(&delta);
+                            }
                             if progress_message_id.is_none() {
                                 if progress.should_send_initial_progress() {
                                     let display = progress.current_progress_html();
@@ -398,7 +698,88 @@ impl ChannelStreamOutbound for TelegramOutbound {
                                 }
                             }
                         },
+                        StreamEvent::Delta(delta) => {
+                            final_state.push_delta(&delta);
+                            let now = tokio::time::Instant::now();
+                            if final_state.message_id.is_none() {
+                                if final_state.should_send_initial_final() {
+                                    let display = final_state.current_final_html();
+                                    self.flush_final_stream_message(
+                                        &bot,
+                                        account_id,
+                                        to,
+                                        chat_id,
+                                        thread_id,
+                                        rp.as_ref(),
+                                        stream_cfg,
+                                        &mut progress_message_id,
+                                        &mut final_state,
+                                        &display,
+                                        now,
+                                        throttle,
+                                    )
+                                    .await?;
+                                }
+                                continue;
+                            }
+
+                            if final_state.should_flush_final(now, throttle) {
+                                let display = final_state.current_final_html();
+                                if final_state.rendered_html_changed(&display) {
+                                    self.flush_final_stream_message(
+                                        &bot,
+                                        account_id,
+                                        to,
+                                        chat_id,
+                                        thread_id,
+                                        rp.as_ref(),
+                                        stream_cfg,
+                                        &mut progress_message_id,
+                                        &mut final_state,
+                                        &display,
+                                        now,
+                                        throttle,
+                                    )
+                                    .await?;
+                                } else {
+                                    final_state.mark_final_observed(now, &display);
+                                }
+                            }
+                        },
                         StreamEvent::Done => {
+                            if !final_state.accumulated.is_empty() {
+                                let display = final_state.current_final_html();
+                                let now = tokio::time::Instant::now();
+                                if final_state.message_id.is_none()
+                                    || final_state.rendered_html_changed(&display)
+                                {
+                                    self.flush_final_stream_message(
+                                        &bot,
+                                        account_id,
+                                        to,
+                                        chat_id,
+                                        thread_id,
+                                        rp.as_ref(),
+                                        stream_cfg,
+                                        &mut progress_message_id,
+                                        &mut final_state,
+                                        &display,
+                                        now,
+                                        throttle,
+                                    )
+                                    .await?;
+                                }
+                                self.send_remaining_final_chunks(
+                                    &bot,
+                                    account_id,
+                                    to,
+                                    chat_id,
+                                    thread_id,
+                                    rp.as_ref(),
+                                    &final_state,
+                                )
+                                .await?;
+                            }
                             break;
                         },
                         StreamEvent::Error(e) => {
@@ -408,13 +789,32 @@ impl ChannelStreamOutbound for TelegramOutbound {
                     }
                 }
                 _ = typing_interval.tick() => {
-                    // Re-send typing indicator to keep it visible during
-                    // long-running tool execution or pauses in the stream.
                     let _ = bot.send_chat_action(chat_id, ChatAction::Typing).await;
                 }
                 _ = flush_interval.tick() => {
                     let now = tokio::time::Instant::now();
-                    if progress.should_flush_progress(now, throttle) {
+                    if final_state.should_flush_final(now, throttle) {
+                        let display = final_state.current_final_html();
+                        if final_state.rendered_html_changed(&display) {
+                            self.flush_final_stream_message(
+                                &bot,
+                                account_id,
+                                to,
+                                chat_id,
+                                thread_id,
+                                rp.as_ref(),
+                                stream_cfg,
+                                &mut progress_message_id,
+                                &mut final_state,
+                                &display,
+                                now,
+                                throttle,
+                            )
+                            .await?;
+                        } else {
+                            final_state.mark_final_observed(now, &display);
+                        }
+                    } else if progress.should_flush_progress(now, throttle) {
                         let display = progress.current_progress_html();
                         if progress.rendered_html_changed(&display)
                             && let Some(msg_id) = progress_message_id
@@ -455,7 +855,7 @@ impl ChannelStreamOutbound for TelegramOutbound {
             .is_some_and(|s| s.config.stream_mode != StreamMode::Off)
     }
 
-    async fn streams_final_replies(&self, _account_id: &str) -> bool {
-        false
+    async fn streams_final_replies(&self, account_id: &str) -> bool {
+        self.is_stream_enabled(account_id).await
     }
 }

--- a/crates/telegram/src/outbound/stream.rs
+++ b/crates/telegram/src/outbound/stream.rs
@@ -107,6 +107,14 @@ impl StreamProgressState {
         self.dirty = false;
     }
 
+    pub(super) fn mark_progress_observed(
+        &mut self,
+        now: tokio::time::Instant,
+        rendered_html: &str,
+    ) {
+        self.mark_progress_sent(now, rendered_html);
+    }
+
     pub(super) fn defer_progress_until(&mut self, until: tokio::time::Instant) {
         self.defer_until = match self.defer_until {
             Some(existing) if existing > until => Some(existing),
@@ -163,36 +171,36 @@ impl TelegramOutbound {
         }
     }
 
-    async fn cleanup_progress_message(
+    pub(super) async fn cleanup_progress_message(
         &self,
         bot: &Bot,
         account_id: &str,
         to: &str,
         chat_id: ChatId,
         message_id: teloxide::types::MessageId,
-    ) {
+    ) -> bool {
         match bot.delete_message(chat_id, message_id).await {
-            Ok(_) => return,
+            Ok(_) => return true,
             Err(error) => {
                 if let Some(wait) = super::retry::retry_after_duration(&error) {
                     warn!(
                         account_id,
                         chat_id = to,
                         retry_after_secs = wait.as_secs(),
-                        "telegram progress delete rate limited; marking progress obsolete"
+                        "telegram progress delete rate limited; trying cleanup marker edit"
                     );
                 } else {
                     warn!(
                         account_id,
                         chat_id = to,
                         error = %error,
-                        "telegram progress delete failed; marking progress obsolete"
+                        "telegram progress delete failed; trying cleanup marker edit"
                     );
                 }
             },
         }
 
-        let _ = self
+        match self
             .edit_progress_chunk_once(
                 bot,
                 account_id,
@@ -201,7 +209,27 @@ impl TelegramOutbound {
                 message_id,
                 stream_progress_cleanup_html(),
             )
-            .await;
+            .await
+        {
+            ProgressEditResult::Applied => true,
+            ProgressEditResult::RateLimited(wait) => {
+                warn!(
+                    account_id,
+                    chat_id = to,
+                    retry_after_secs = wait.as_secs(),
+                    "telegram progress cleanup edit also rate limited; message may remain visible"
+                );
+                false
+            },
+            ProgressEditResult::Failed => {
+                warn!(
+                    account_id,
+                    chat_id = to,
+                    "telegram progress cleanup edit also failed; message may remain visible"
+                );
+                false
+            },
+        }
     }
 }
 
@@ -294,6 +322,8 @@ impl ChannelStreamOutbound for TelegramOutbound {
                                         throttle,
                                         result,
                                     );
+                                } else {
+                                    progress.mark_progress_observed(now, &display);
                                 }
                             }
                         },
@@ -330,6 +360,8 @@ impl ChannelStreamOutbound for TelegramOutbound {
                                 throttle,
                                 result,
                             );
+                        } else {
+                            progress.mark_progress_observed(now, &display);
                         }
                     }
                 }
@@ -337,7 +369,8 @@ impl ChannelStreamOutbound for TelegramOutbound {
         }
 
         if let Some(msg_id) = progress_message_id {
-            self.cleanup_progress_message(&bot, account_id, to, chat_id, msg_id)
+            let _ = self
+                .cleanup_progress_message(&bot, account_id, to, chat_id, msg_id)
                 .await;
         }
 

--- a/crates/telegram/src/outbound/stream.rs
+++ b/crates/telegram/src/outbound/stream.rs
@@ -3,8 +3,11 @@
 use {
     async_trait::async_trait,
     std::time::Duration,
-    teloxide::{prelude::*, types::ChatAction},
-    tracing::debug,
+    teloxide::{
+        prelude::*,
+        types::{ChatAction, ParseMode},
+    },
+    tracing::{debug, warn},
 };
 
 use moltis_channels::{
@@ -20,6 +23,8 @@ use crate::{
 
 use super::{TYPING_REFRESH_INTERVAL, TelegramOutbound};
 
+const MIN_PROGRESS_FLUSH_INTERVAL: Duration = Duration::from_millis(250);
+
 pub(super) fn has_reached_stream_min_initial_chars(
     accumulated: &str,
     min_initial_chars: usize,
@@ -27,12 +32,193 @@ pub(super) fn has_reached_stream_min_initial_chars(
     accumulated.chars().count() >= min_initial_chars
 }
 
-pub(super) fn should_send_stream_completion_notification(
-    notify_on_complete: bool,
-    has_streamed_text: bool,
-    sent_non_silent_completion_chunks: bool,
-) -> bool {
-    notify_on_complete && has_streamed_text && !sent_non_silent_completion_chunks
+pub(super) fn format_stream_progress_html(accumulated: &str) -> String {
+    let body = markdown::markdown_to_telegram_html(accumulated);
+    let html = format!("<b>Progress update</b>\n\n{body}");
+    markdown::truncate_at_char_boundary(&html, TELEGRAM_MAX_MESSAGE_LEN).to_string()
+}
+
+pub(super) fn stream_progress_cleanup_html() -> &'static str {
+    "<i>Progress update complete; final answer follows.</i>"
+}
+
+pub(super) struct StreamProgressState {
+    accumulated: String,
+    last_progress_at: Option<tokio::time::Instant>,
+    last_rendered_html: Option<String>,
+    defer_until: Option<tokio::time::Instant>,
+    min_initial_chars: usize,
+    dirty: bool,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ProgressEditResult {
+    Applied,
+    RateLimited(Duration),
+    Failed,
+}
+
+impl StreamProgressState {
+    pub(super) fn new(min_initial_chars: usize) -> Self {
+        Self {
+            accumulated: String::new(),
+            last_progress_at: None,
+            last_rendered_html: None,
+            defer_until: None,
+            min_initial_chars,
+            dirty: false,
+        }
+    }
+
+    pub(super) fn push_delta(&mut self, delta: &str) {
+        self.accumulated.push_str(delta);
+        self.dirty = true;
+    }
+
+    pub(super) fn should_send_initial_progress(&self) -> bool {
+        self.last_progress_at.is_none()
+            && has_reached_stream_min_initial_chars(&self.accumulated, self.min_initial_chars)
+    }
+
+    pub(super) fn should_flush_progress(
+        &self,
+        now: tokio::time::Instant,
+        throttle: Duration,
+    ) -> bool {
+        let Some(last_progress_at) = self.last_progress_at else {
+            return false;
+        };
+        if let Some(defer_until) = self.defer_until
+            && now < defer_until
+        {
+            return false;
+        }
+        self.dirty && now.saturating_duration_since(last_progress_at) >= throttle
+    }
+
+    fn current_progress_html(&self) -> String {
+        format_stream_progress_html(&self.accumulated)
+    }
+
+    pub(super) fn mark_progress_sent(&mut self, now: tokio::time::Instant, rendered_html: &str) {
+        self.last_progress_at = Some(now);
+        self.last_rendered_html = Some(rendered_html.to_string());
+        self.defer_until = None;
+        self.dirty = false;
+    }
+
+    pub(super) fn defer_progress_until(&mut self, until: tokio::time::Instant) {
+        self.defer_until = match self.defer_until {
+            Some(existing) if existing > until => Some(existing),
+            _ => Some(until),
+        };
+    }
+
+    fn rendered_html_changed(&self, rendered_html: &str) -> bool {
+        match self.last_rendered_html.as_deref() {
+            Some(last) => last != rendered_html,
+            None => true,
+        }
+    }
+}
+
+impl TelegramOutbound {
+    async fn edit_progress_chunk_once(
+        &self,
+        bot: &Bot,
+        account_id: &str,
+        to: &str,
+        chat_id: ChatId,
+        message_id: teloxide::types::MessageId,
+        chunk: &str,
+    ) -> ProgressEditResult {
+        match bot
+            .edit_message_text(chat_id, message_id, chunk)
+            .parse_mode(ParseMode::Html)
+            .await
+        {
+            Ok(_) => ProgressEditResult::Applied,
+            Err(error) if super::retry::is_message_not_modified_error(&error) => {
+                ProgressEditResult::Applied
+            },
+            Err(error) => {
+                if let Some(wait) = super::retry::retry_after_duration(&error) {
+                    warn!(
+                        account_id,
+                        chat_id = to,
+                        retry_after_secs = wait.as_secs(),
+                        "telegram progress edit rate limited; skipping intermediate update"
+                    );
+                    return ProgressEditResult::RateLimited(wait);
+                } else {
+                    warn!(
+                        account_id,
+                        chat_id = to,
+                        error = %error,
+                        "telegram progress edit failed; skipping intermediate update"
+                    );
+                }
+                ProgressEditResult::Failed
+            },
+        }
+    }
+
+    async fn cleanup_progress_message(
+        &self,
+        bot: &Bot,
+        account_id: &str,
+        to: &str,
+        chat_id: ChatId,
+        message_id: teloxide::types::MessageId,
+    ) {
+        match bot.delete_message(chat_id, message_id).await {
+            Ok(_) => return,
+            Err(error) => {
+                if let Some(wait) = super::retry::retry_after_duration(&error) {
+                    warn!(
+                        account_id,
+                        chat_id = to,
+                        retry_after_secs = wait.as_secs(),
+                        "telegram progress delete rate limited; marking progress obsolete"
+                    );
+                } else {
+                    warn!(
+                        account_id,
+                        chat_id = to,
+                        error = %error,
+                        "telegram progress delete failed; marking progress obsolete"
+                    );
+                }
+            },
+        }
+
+        let _ = self
+            .edit_progress_chunk_once(
+                bot,
+                account_id,
+                to,
+                chat_id,
+                message_id,
+                stream_progress_cleanup_html(),
+            )
+            .await;
+    }
+}
+
+fn record_progress_edit_result(
+    progress: &mut StreamProgressState,
+    now: tokio::time::Instant,
+    rendered_html: &str,
+    throttle: Duration,
+    result: ProgressEditResult,
+) {
+    match result {
+        ProgressEditResult::Applied => progress.mark_progress_sent(now, rendered_html),
+        ProgressEditResult::RateLimited(wait) => {
+            progress.defer_progress_until(now + wait.max(throttle))
+        },
+        ProgressEditResult::Failed => progress.defer_progress_until(now + throttle),
+    }
 }
 
 #[async_trait]
@@ -51,13 +237,15 @@ impl ChannelStreamOutbound for TelegramOutbound {
 
         // Send typing indicator
         let _ = bot.send_chat_action(chat_id, ChatAction::Typing).await;
-        let mut stream_message_id: Option<teloxide::types::MessageId> = None;
+        let mut progress_message_id: Option<teloxide::types::MessageId> = None;
 
-        let mut accumulated = String::new();
-        let mut last_edit = tokio::time::Instant::now();
-        let throttle = Duration::from_millis(stream_cfg.edit_throttle_ms);
+        let mut progress = StreamProgressState::new(stream_cfg.min_initial_chars);
+        let throttle =
+            Duration::from_millis(stream_cfg.edit_throttle_ms).max(MIN_PROGRESS_FLUSH_INTERVAL);
         let mut typing_interval = tokio::time::interval(TYPING_REFRESH_INTERVAL);
         typing_interval.tick().await; // consume the immediate first tick
+        let mut flush_interval = tokio::time::interval(throttle);
+        flush_interval.tick().await; // consume the immediate first tick
 
         loop {
             tokio::select! {
@@ -65,17 +253,10 @@ impl ChannelStreamOutbound for TelegramOutbound {
                     let Some(event) = event else { break };
                     match event {
                         StreamEvent::Delta(delta) => {
-                            accumulated.push_str(&delta);
-                            if stream_message_id.is_none() {
-                                if has_reached_stream_min_initial_chars(
-                                    &accumulated,
-                                    stream_cfg.min_initial_chars,
-                                ) {
-                                    let html = markdown::markdown_to_telegram_html(&accumulated);
-                                    let display = markdown::truncate_at_char_boundary(
-                                        &html,
-                                        TELEGRAM_MAX_MESSAGE_LEN,
-                                    );
+                            progress.push_delta(&delta);
+                            if progress_message_id.is_none() {
+                                if progress.should_send_initial_progress() {
+                                    let display = progress.current_progress_html();
                                     let message_id = self
                                         .send_chunk_with_fallback(
                                             &bot,
@@ -83,29 +264,36 @@ impl ChannelStreamOutbound for TelegramOutbound {
                                             to,
                                             chat_id,
                                             thread_id,
-                                            display,
+                                            &display,
                                             rp.as_ref(),
-                                            false,
+                                            true,
                                         )
                                         .await?;
-                                    stream_message_id = Some(message_id);
-                                    last_edit = tokio::time::Instant::now();
+                                    let now = tokio::time::Instant::now();
+                                    progress_message_id = Some(message_id);
+                                    progress.mark_progress_sent(now, &display);
                                 }
                                 continue;
                             }
 
-                            if last_edit.elapsed() >= throttle {
-                                let html = markdown::markdown_to_telegram_html(&accumulated);
-                                // Telegram rejects edits with identical content; truncate to limit.
-                                let display =
-                                    markdown::truncate_at_char_boundary(&html, TELEGRAM_MAX_MESSAGE_LEN);
-                                if let Some(msg_id) = stream_message_id {
-                                    let _ = self
-                                        .edit_chunk_with_fallback(
-                                            &bot, account_id, to, chat_id, msg_id, display,
+                            let now = tokio::time::Instant::now();
+                            if progress.should_flush_progress(now, throttle) {
+                                let display = progress.current_progress_html();
+                                if progress.rendered_html_changed(&display)
+                                    && let Some(msg_id) = progress_message_id
+                                {
+                                    let result = self
+                                        .edit_progress_chunk_once(
+                                            &bot, account_id, to, chat_id, msg_id, &display,
                                         )
                                         .await;
-                                    last_edit = tokio::time::Instant::now();
+                                    record_progress_edit_result(
+                                        &mut progress,
+                                        now,
+                                        &display,
+                                        throttle,
+                                        result,
+                                    );
                                 }
                             }
                         },
@@ -123,66 +311,34 @@ impl ChannelStreamOutbound for TelegramOutbound {
                     // long-running tool execution or pauses in the stream.
                     let _ = bot.send_chat_action(chat_id, ChatAction::Typing).await;
                 }
+                _ = flush_interval.tick() => {
+                    let now = tokio::time::Instant::now();
+                    if progress.should_flush_progress(now, throttle) {
+                        let display = progress.current_progress_html();
+                        if progress.rendered_html_changed(&display)
+                            && let Some(msg_id) = progress_message_id
+                        {
+                            let result = self
+                                .edit_progress_chunk_once(
+                                    &bot, account_id, to, chat_id, msg_id, &display,
+                                )
+                                .await;
+                            record_progress_edit_result(
+                                &mut progress,
+                                now,
+                                &display,
+                                throttle,
+                                result,
+                            );
+                        }
+                    }
+                }
             }
         }
 
-        // Final edit with complete content
-        if !accumulated.is_empty() {
-            let chunks = markdown::chunk_markdown_html(&accumulated, TELEGRAM_MAX_MESSAGE_LEN);
-            let mut sent_non_silent_completion_chunks = false;
-            if let Some((first, rest)) = chunks.split_first() {
-                if let Some(msg_id) = stream_message_id {
-                    self.edit_chunk_with_fallback(&bot, account_id, to, chat_id, msg_id, first)
-                        .await?;
-                } else {
-                    self.send_chunk_with_fallback(
-                        &bot,
-                        account_id,
-                        to,
-                        chat_id,
-                        thread_id,
-                        first,
-                        rp.as_ref(),
-                        false,
-                    )
-                    .await?;
-                    sent_non_silent_completion_chunks = true;
-                }
-
-                // Send remaining chunks as new messages.
-                for chunk in rest {
-                    self.send_chunk_with_fallback(
-                        &bot,
-                        account_id,
-                        to,
-                        chat_id,
-                        thread_id,
-                        chunk,
-                        rp.as_ref(),
-                        false,
-                    )
-                    .await?;
-                    sent_non_silent_completion_chunks = true;
-                }
-            }
-
-            if should_send_stream_completion_notification(
-                stream_cfg.notify_on_complete,
-                true,
-                sent_non_silent_completion_chunks,
-            ) {
-                self.send_chunk_with_fallback(
-                    &bot,
-                    account_id,
-                    to,
-                    chat_id,
-                    thread_id,
-                    "Reply complete.",
-                    rp.as_ref(),
-                    false,
-                )
-                .await?;
-            }
+        if let Some(msg_id) = progress_message_id {
+            self.cleanup_progress_message(&bot, account_id, to, chat_id, msg_id)
+                .await;
         }
 
         Ok(())
@@ -193,5 +349,9 @@ impl ChannelStreamOutbound for TelegramOutbound {
         accounts
             .get(account_id)
             .is_some_and(|s| s.config.stream_mode != StreamMode::Off)
+    }
+
+    async fn streams_final_replies(&self, _account_id: &str) -> bool {
+        false
     }
 }

--- a/crates/telegram/src/outbound/tests.rs
+++ b/crates/telegram/src/outbound/tests.rs
@@ -466,9 +466,32 @@ fn stream_progress_cleanup_marker_points_to_final_answer() {
 #[tokio::test]
 async fn telegram_streaming_does_not_replace_final_delivery() {
     let accounts: AccountStateMap = Arc::new(std::sync::RwLock::new(HashMap::new()));
-    let outbound = TelegramOutbound { accounts };
+    let outbound = Arc::new(TelegramOutbound {
+        accounts: Arc::clone(&accounts),
+    });
+    let account_id = "enabled-account";
 
-    assert!(!outbound.streams_final_replies("missing").await);
+    {
+        let mut map = accounts.write().expect("accounts write lock");
+        map.insert(account_id.to_string(), AccountState {
+            bot: teloxide::Bot::new("test-token"),
+            bot_username: Some("test_bot".to_string()),
+            account_id: account_id.to_string(),
+            config: TelegramAccountConfig {
+                token: Secret::new("test-token".to_string()),
+                dm_policy: DmPolicy::Open,
+                ..Default::default()
+            },
+            outbound: Arc::clone(&outbound),
+            cancel: CancellationToken::new(),
+            message_log: None,
+            event_sink: None,
+            otp: Mutex::new(OtpState::new(300)),
+        });
+    }
+
+    assert!(outbound.is_stream_enabled(account_id).await);
+    assert!(!outbound.streams_final_replies(account_id).await);
 }
 
 #[tokio::test]

--- a/crates/telegram/src/outbound/tests.rs
+++ b/crates/telegram/src/outbound/tests.rs
@@ -95,6 +95,7 @@ struct MockTelegramStreamApi {
     requests: Arc<Mutex<Vec<StreamApiRequest>>>,
     fail_delete: bool,
     fail_cleanup_edit: bool,
+    fail_edit_text: Option<String>,
 }
 
 async fn send_message_handler(
@@ -208,7 +209,9 @@ async fn stream_lifecycle_handler(
             .lock()
             .expect("lock stream requests")
             .push(StreamApiRequest::EditMessage { text: text.clone() });
-        if state.fail_cleanup_edit && text == stream_progress_cleanup_html() {
+        if (state.fail_cleanup_edit && text == stream_progress_cleanup_html())
+            || state.fail_edit_text.as_deref() == Some(text.as_str())
+        {
             return (
                 StatusCode::BAD_REQUEST,
                 Json(serde_json::json!({
@@ -475,6 +478,7 @@ async fn cleanup_progress_message_reports_failed_delete_and_failed_marker_edit()
         requests: Arc::clone(&recorded_requests),
         fail_delete: true,
         fail_cleanup_edit: true,
+        fail_edit_text: None,
     };
     let app = Router::new()
         .route("/{*path}", post(stream_lifecycle_handler))
@@ -531,11 +535,20 @@ async fn run_stream_lifecycle(
     notify_on_complete: bool,
     events: Vec<(StreamEvent, Duration)>,
 ) -> Vec<StreamApiRequest> {
+    run_stream_lifecycle_with_edit_failure(notify_on_complete, events, None).await
+}
+
+async fn run_stream_lifecycle_with_edit_failure(
+    notify_on_complete: bool,
+    events: Vec<(StreamEvent, Duration)>,
+    fail_edit_text: Option<String>,
+) -> Vec<StreamApiRequest> {
     let recorded_requests = Arc::new(Mutex::new(Vec::<StreamApiRequest>::new()));
     let mock_api = MockTelegramStreamApi {
         requests: Arc::clone(&recorded_requests),
         fail_delete: false,
         fail_cleanup_edit: false,
+        fail_edit_text,
     };
     let app = Router::new()
         .route("/{*path}", post(stream_lifecycle_handler))
@@ -688,6 +701,36 @@ async fn send_stream_sends_remaining_final_chunks_on_done() {
         "long streamed finals must continue after the edited first message"
     );
     assert!(sent_texts.iter().any(|text| text.contains("tail-marker")));
+}
+
+#[tokio::test]
+async fn send_stream_sends_fallback_final_message_when_completion_edit_fails() {
+    let final_text = "part one part two";
+    let requests = run_stream_lifecycle_with_edit_failure(
+        false,
+        vec![
+            (
+                StreamEvent::Delta("part one".to_string()),
+                Duration::from_millis(600),
+            ),
+            (
+                StreamEvent::Delta(" part two".to_string()),
+                Duration::from_millis(25),
+            ),
+            (StreamEvent::Done, Duration::ZERO),
+        ],
+        Some(final_text.to_string()),
+    )
+    .await;
+
+    assert!(requests.iter().any(|request| matches!(
+        request,
+        StreamApiRequest::EditMessage { text } if text == final_text
+    )));
+    assert!(requests.iter().any(|request| matches!(
+        request,
+        StreamApiRequest::SendMessage { text, .. } if text == final_text
+    )));
 }
 
 #[tokio::test]

--- a/crates/telegram/src/outbound/tests.rs
+++ b/crates/telegram/src/outbound/tests.rs
@@ -374,10 +374,10 @@ fn stream_min_initial_chars_uses_character_count() {
 }
 
 #[test]
-fn stream_progress_html_marks_text_as_progress() {
+fn stream_progress_html_omits_progress_heading() {
     let html = format_stream_progress_html("working", false);
 
-    assert!(html.contains("Progress update"));
+    assert!(!html.contains("Progress update"));
     assert!(html.contains("working"));
 }
 
@@ -456,8 +456,8 @@ fn stream_progress_tail_escapes_html_and_stays_under_telegram_limit() {
 fn stream_progress_cleanup_marker_points_to_final_answer() {
     let html = stream_progress_cleanup_html();
 
-    assert!(html.contains("Progress update complete"));
-    assert!(html.contains("final answer follows"));
+    assert!(!html.contains("Progress update"));
+    assert!(html.contains("Final answer follows"));
 }
 
 #[tokio::test]
@@ -527,8 +527,10 @@ async fn cleanup_progress_message_reports_failed_delete_and_failed_marker_edit()
     server.await.expect("server join");
 }
 
-#[tokio::test]
-async fn send_stream_edits_then_deletes_temporary_progress_message() {
+async fn run_stream_lifecycle(
+    notify_on_complete: bool,
+    events: Vec<(StreamEvent, Duration)>,
+) -> Vec<StreamApiRequest> {
     let recorded_requests = Arc::new(Mutex::new(Vec::<StreamApiRequest>::new()));
     let mock_api = MockTelegramStreamApi {
         requests: Arc::clone(&recorded_requests),
@@ -572,6 +574,7 @@ async fn send_stream_edits_then_deletes_temporary_progress_message() {
                 token: Secret::new("test-token".to_string()),
                 dm_policy: DmPolicy::Open,
                 edit_throttle_ms: 250,
+                stream_notify_on_complete: notify_on_complete,
                 stream_min_initial_chars: 3,
                 ..Default::default()
             },
@@ -583,7 +586,7 @@ async fn send_stream_edits_then_deletes_temporary_progress_message() {
         });
     }
 
-    let (tx, rx) = tokio::sync::mpsc::channel(8);
+    let (tx, rx) = tokio::sync::mpsc::channel(16);
     let outbound_for_stream = Arc::clone(&outbound);
     let stream_task = tokio::spawn(async move {
         outbound_for_stream
@@ -591,21 +594,12 @@ async fn send_stream_edits_then_deletes_temporary_progress_message() {
             .await
     });
 
-    tx.send(StreamEvent::Delta("hel".to_string()))
-        .await
-        .expect("send initial delta");
-    tokio::time::sleep(Duration::from_millis(25)).await;
-    if let Err(err) = tx.send(StreamEvent::Delta("lo".to_string())).await {
-        let stream_result = stream_task
-            .await
-            .expect("stream task joins after early close");
-        let requests = recorded_requests.lock().expect("requests lock").clone();
-        panic!(
-            "send second delta failed: {err:?}; stream_result={stream_result:?}; requests={requests:?}"
-        );
+    for (event, delay) in events {
+        tx.send(event).await.expect("send stream event");
+        if !delay.is_zero() {
+            tokio::time::sleep(delay).await;
+        }
     }
-    tokio::time::sleep(Duration::from_millis(600)).await;
-    tx.send(StreamEvent::Done).await.expect("send done");
     drop(tx);
 
     stream_task
@@ -613,37 +607,224 @@ async fn send_stream_edits_then_deletes_temporary_progress_message() {
         .expect("stream task joins")
         .expect("stream completes");
 
-    {
-        let requests = recorded_requests.lock().expect("requests lock");
-        assert_eq!(
-            requests
-                .iter()
-                .filter(|request| matches!(request, StreamApiRequest::SendMessage { .. }))
-                .count(),
-            1,
-            "stream worker should only send the temporary progress message"
-        );
-        assert!(matches!(
-            &requests[0],
-            StreamApiRequest::SendMessage {
-                text,
-                disable_notification: true,
-            } if text.contains("Progress update") && text.contains("hel")
-        ));
-        assert!(requests.iter().any(|request| matches!(
-            request,
-            StreamApiRequest::EditMessage { text }
-                if text.contains("Progress update") && text.contains("hello")
-        )));
-        assert!(
-            requests.iter().any(
-                |request| matches!(request, StreamApiRequest::DeleteMessage { message_id: 10 })
-            )
-        );
-    }
-
     let _ = shutdown_tx.send(());
     server.await.expect("server join");
+
+    recorded_requests.lock().expect("requests lock").clone()
+}
+
+#[tokio::test]
+async fn send_stream_reuses_progress_message_for_final_when_notify_disabled() {
+    let requests = run_stream_lifecycle(false, vec![
+        (
+            StreamEvent::ProgressDelta("hel".to_string()),
+            Duration::from_millis(25),
+        ),
+        (
+            StreamEvent::ProgressDelta("lo".to_string()),
+            Duration::from_millis(600),
+        ),
+        (
+            StreamEvent::Delta("**done**".to_string()),
+            Duration::from_millis(25),
+        ),
+        (StreamEvent::Done, Duration::ZERO),
+    ])
+    .await;
+
+    assert_eq!(
+        requests
+            .iter()
+            .filter(|request| matches!(request, StreamApiRequest::SendMessage { .. }))
+            .count(),
+        1,
+        "notify=false should reuse the progress message for the final stream"
+    );
+    assert!(matches!(
+        &requests[0],
+        StreamApiRequest::SendMessage {
+            text,
+            disable_notification: true,
+        } if !text.contains("Progress update") && text.contains("hel")
+    ));
+    assert!(
+        !requests
+            .iter()
+            .any(|request| matches!(request, StreamApiRequest::DeleteMessage { .. }))
+    );
+
+    let final_edit = requests
+        .iter()
+        .rev()
+        .find_map(|request| match request {
+            StreamApiRequest::EditMessage { text } if text.contains("done") => Some(text),
+            _ => None,
+        })
+        .expect("final edit message");
+    assert!(final_edit.contains("<b>done</b>"));
+    assert!(!final_edit.contains("**done**"));
+    assert!(!final_edit.contains("hello"));
+    assert!(!final_edit.contains("Progress update"));
+}
+
+#[tokio::test]
+async fn send_stream_sends_remaining_final_chunks_on_done() {
+    let long_final = format!("{}tail-marker", "word ".repeat(TELEGRAM_MAX_MESSAGE_LEN));
+    let requests = run_stream_lifecycle(false, vec![
+        (StreamEvent::Delta(long_final), Duration::from_millis(25)),
+        (StreamEvent::Done, Duration::ZERO),
+    ])
+    .await;
+
+    let sent_texts: Vec<&str> = requests
+        .iter()
+        .filter_map(|request| match request {
+            StreamApiRequest::SendMessage { text, .. } => Some(text.as_str()),
+            _ => None,
+        })
+        .collect();
+    assert!(
+        sent_texts.len() >= 2,
+        "long streamed finals must continue after the edited first message"
+    );
+    assert!(sent_texts.iter().any(|text| text.contains("tail-marker")));
+}
+
+#[tokio::test]
+async fn send_stream_reclassifies_live_draft_as_progress_then_reuses_for_final_when_notify_disabled()
+ {
+    let requests = run_stream_lifecycle(false, vec![
+        (
+            StreamEvent::Delta("**thinking**".to_string()),
+            Duration::from_millis(600),
+        ),
+        (
+            StreamEvent::ProgressDelta("**thinking**".to_string()),
+            Duration::from_millis(600),
+        ),
+        (
+            StreamEvent::Delta("**done**".to_string()),
+            Duration::from_millis(600),
+        ),
+        (StreamEvent::Done, Duration::ZERO),
+    ])
+    .await;
+
+    assert_eq!(
+        requests
+            .iter()
+            .filter(|request| matches!(request, StreamApiRequest::SendMessage { .. }))
+            .count(),
+        1,
+        "notify=false should keep draft, progress, and final in one message"
+    );
+    assert!(matches!(
+        &requests[0],
+        StreamApiRequest::SendMessage {
+            text,
+            disable_notification: true,
+        } if text.contains("<b>thinking</b>")
+    ));
+    assert!(
+        !requests
+            .iter()
+            .any(|request| matches!(request, StreamApiRequest::DeleteMessage { .. }))
+    );
+
+    let edit_texts: Vec<&str> = requests
+        .iter()
+        .filter_map(|request| match request {
+            StreamApiRequest::EditMessage { text } => Some(text.as_str()),
+            _ => None,
+        })
+        .collect();
+    assert!(
+        edit_texts
+            .iter()
+            .any(|text| text.contains("<b>thinking</b>") && !text.contains("**thinking**"))
+    );
+    let final_edit = edit_texts
+        .iter()
+        .rev()
+        .find(|text| text.contains("done"))
+        .expect("final edit message");
+    assert!(final_edit.contains("<b>done</b>"));
+    assert!(!final_edit.contains("**done**"));
+    assert!(!final_edit.contains("thinking"));
+}
+
+#[tokio::test]
+async fn send_stream_keeps_code_fence_rendered_when_live_draft_becomes_progress() {
+    let json = "JSON arguments:\n\n```json\n{\n  \"action\": \"add\"\n}\n```";
+    let requests = run_stream_lifecycle(false, vec![
+        (
+            StreamEvent::Delta(json.to_string()),
+            Duration::from_millis(600),
+        ),
+        (
+            StreamEvent::ProgressDelta(json.to_string()),
+            Duration::from_millis(600),
+        ),
+        (
+            StreamEvent::Delta("done".to_string()),
+            Duration::from_millis(600),
+        ),
+        (StreamEvent::Done, Duration::ZERO),
+    ])
+    .await;
+
+    let progress_edit = requests
+        .iter()
+        .filter_map(|request| match request {
+            StreamApiRequest::EditMessage { text } => Some(text.as_str()),
+            _ => None,
+        })
+        .find(|text| text.contains("action"))
+        .expect("progress edit containing JSON");
+
+    assert!(progress_edit.contains("<pre"));
+    assert!(progress_edit.contains("<code"));
+    assert!(!progress_edit.contains("```json"));
+}
+
+#[tokio::test]
+async fn send_stream_deletes_progress_and_sends_new_final_when_notify_enabled() {
+    let requests = run_stream_lifecycle(true, vec![
+        (
+            StreamEvent::ProgressDelta("hel".to_string()),
+            Duration::from_millis(25),
+        ),
+        (
+            StreamEvent::Delta("**done**".to_string()),
+            Duration::from_millis(25),
+        ),
+        (StreamEvent::Done, Duration::ZERO),
+    ])
+    .await;
+
+    let sends: Vec<_> = requests
+        .iter()
+        .filter_map(|request| match request {
+            StreamApiRequest::SendMessage {
+                text,
+                disable_notification,
+            } => Some((text, *disable_notification)),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(sends.len(), 2);
+    assert!(sends[0].1, "progress message should be silent");
+    assert!(!sends[0].0.contains("Progress update"));
+    assert!(sends[0].0.contains("hel"));
+    assert!(
+        requests
+            .iter()
+            .any(|request| matches!(request, StreamApiRequest::DeleteMessage { message_id: 10 }))
+    );
+    assert!(!sends[1].1, "notify=true final message should notify");
+    assert!(sends[1].0.contains("<b>done</b>"));
+    assert!(!sends[1].0.contains("**done**"));
+    assert!(!sends[1].0.contains("hel"));
 }
 
 #[tokio::test]

--- a/crates/telegram/src/outbound/tests.rs
+++ b/crates/telegram/src/outbound/tests.rs
@@ -24,6 +24,7 @@ use {
 
 use crate::{
     config::TelegramAccountConfig,
+    markdown::TELEGRAM_MAX_MESSAGE_LEN,
     otp::OtpState,
     state::{AccountState, AccountStateMap},
 };
@@ -363,20 +364,18 @@ fn is_message_not_modified_error_ignores_other_errors() {
 
 #[test]
 fn stream_min_initial_chars_uses_character_count() {
-    assert!(has_reached_stream_min_initial_chars("hello", 5));
     assert!(has_reached_stream_min_initial_chars(
-        "\u{1F642}\u{1F642}\u{1F642}",
-        3
+        "hello".chars().count(),
+        5
     ));
-    assert!(!has_reached_stream_min_initial_chars(
-        "\u{1F642}\u{1F642}\u{1F642}",
-        4
-    ));
+    let emoji_count = "\u{1F642}\u{1F642}\u{1F642}".chars().count();
+    assert!(has_reached_stream_min_initial_chars(emoji_count, 3));
+    assert!(!has_reached_stream_min_initial_chars(emoji_count, 4));
 }
 
 #[test]
 fn stream_progress_html_marks_text_as_progress() {
-    let html = format_stream_progress_html("working");
+    let html = format_stream_progress_html("working", false);
 
     assert!(html.contains("Progress update"));
     assert!(html.contains("working"));
@@ -384,7 +383,7 @@ fn stream_progress_html_marks_text_as_progress() {
 
 #[test]
 fn stream_progress_state_flushes_pending_text_after_throttle() {
-    let mut state = StreamProgressState::new(3);
+    let mut state = StreamProgressState::new(3, 3500);
     let now = Instant::now();
 
     state.push_delta("hel");
@@ -398,7 +397,7 @@ fn stream_progress_state_flushes_pending_text_after_throttle() {
 
 #[test]
 fn stream_progress_state_suppresses_flush_until_backoff_expires() {
-    let mut state = StreamProgressState::new(3);
+    let mut state = StreamProgressState::new(3, 3500);
     let now = Instant::now();
 
     state.push_delta("hel");
@@ -414,7 +413,7 @@ fn stream_progress_state_suppresses_flush_until_backoff_expires() {
 
 #[test]
 fn stream_progress_state_resets_throttle_when_rendered_html_is_unchanged() {
-    let mut state = StreamProgressState::new(3);
+    let mut state = StreamProgressState::new(3, 3500);
     let now = Instant::now();
 
     state.push_delta("hel");
@@ -426,6 +425,31 @@ fn stream_progress_state_resets_throttle_when_rendered_html_is_unchanged() {
 
     assert!(!state.should_flush_progress(now + Duration::from_secs(3), Duration::from_secs(2)));
     assert!(!state.should_flush_progress(now + Duration::from_secs(4), Duration::from_secs(2)));
+}
+
+#[test]
+fn stream_progress_state_keeps_recent_tail_when_progress_exceeds_limit() {
+    let mut state = StreamProgressState::new(1, 12);
+
+    state.push_delta("old-prefix ");
+    state.push_delta("fresh-tail");
+    let html = state.current_progress_html();
+
+    assert!(html.contains("Older progress hidden"));
+    assert!(html.contains("fresh-tail"));
+    assert!(!html.contains("old-prefix"));
+}
+
+#[test]
+fn stream_progress_tail_escapes_html_and_stays_under_telegram_limit() {
+    let mut state = StreamProgressState::new(1, TELEGRAM_MAX_MESSAGE_LEN);
+
+    state.push_delta(&"<".repeat(TELEGRAM_MAX_MESSAGE_LEN));
+    let html = state.current_progress_html();
+
+    assert!(html.contains("&lt;"));
+    assert!(!html.contains("<".repeat(10).as_str()));
+    assert!(html.len() <= TELEGRAM_MAX_MESSAGE_LEN);
 }
 
 #[test]

--- a/crates/telegram/src/outbound/tests.rs
+++ b/crates/telegram/src/outbound/tests.rs
@@ -92,6 +92,8 @@ enum StreamApiRequest {
 #[derive(Clone)]
 struct MockTelegramStreamApi {
     requests: Arc<Mutex<Vec<StreamApiRequest>>>,
+    fail_delete: bool,
+    fail_cleanup_edit: bool,
 }
 
 async fn send_message_handler(
@@ -136,13 +138,16 @@ async fn stream_lifecycle_handler(
     State(state): State<MockTelegramStreamApi>,
     uri: Uri,
     Json(body): Json<serde_json::Value>,
-) -> Json<serde_json::Value> {
+) -> (StatusCode, Json<serde_json::Value>) {
     let path = uri.path();
     if path.ends_with("/sendChatAction")
         || path.ends_with("/send_chat_action")
         || path.ends_with("/SendChatAction")
     {
-        return Json(serde_json::json!({ "ok": true, "result": true }));
+        return (
+            StatusCode::OK,
+            Json(serde_json::json!({ "ok": true, "result": true })),
+        );
     }
 
     if path.ends_with("/sendMessage")
@@ -164,64 +169,75 @@ async fn stream_lifecycle_handler(
                     .and_then(serde_json::Value::as_bool)
                     .unwrap_or(false),
             });
-        return Json(serde_json::json!(TelegramApiResponse {
-            ok: true,
-            result: TelegramMessageResult {
-                message_id: 10,
-                date: 0,
-                chat: TelegramChat {
-                    id: body
-                        .get("chat_id")
-                        .and_then(serde_json::Value::as_i64)
-                        .unwrap_or(42),
-                    chat_type: "private".to_string(),
+        return (
+            StatusCode::OK,
+            Json(serde_json::json!(TelegramApiResponse {
+                ok: true,
+                result: TelegramMessageResult {
+                    message_id: 10,
+                    date: 0,
+                    chat: TelegramChat {
+                        id: body
+                            .get("chat_id")
+                            .and_then(serde_json::Value::as_i64)
+                            .unwrap_or(42),
+                        chat_type: "private".to_string(),
+                    },
+                    text: body
+                        .get("text")
+                        .and_then(serde_json::Value::as_str)
+                        .unwrap_or_default()
+                        .to_string(),
                 },
-                text: body
-                    .get("text")
-                    .and_then(serde_json::Value::as_str)
-                    .unwrap_or_default()
-                    .to_string(),
-            },
-        }));
+            })),
+        );
     }
 
     if path.ends_with("/editMessageText")
         || path.ends_with("/edit_message_text")
         || path.ends_with("/EditMessageText")
     {
+        let text = body
+            .get("text")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or_default()
+            .to_string();
         state
             .requests
             .lock()
             .expect("lock stream requests")
-            .push(StreamApiRequest::EditMessage {
-                text: body
-                    .get("text")
-                    .and_then(serde_json::Value::as_str)
-                    .unwrap_or_default()
-                    .to_string(),
-            });
-        return Json(serde_json::json!(TelegramApiResponse {
-            ok: true,
-            result: TelegramMessageResult {
-                message_id: body
-                    .get("message_id")
-                    .and_then(serde_json::Value::as_i64)
-                    .unwrap_or(10),
-                date: 0,
-                chat: TelegramChat {
-                    id: body
-                        .get("chat_id")
+            .push(StreamApiRequest::EditMessage { text: text.clone() });
+        if state.fail_cleanup_edit && text == stream_progress_cleanup_html() {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({
+                    "ok": false,
+                    "error_code": 400,
+                    "description": "Bad Request: cleanup edit failed"
+                })),
+            );
+        }
+        return (
+            StatusCode::OK,
+            Json(serde_json::json!(TelegramApiResponse {
+                ok: true,
+                result: TelegramMessageResult {
+                    message_id: body
+                        .get("message_id")
                         .and_then(serde_json::Value::as_i64)
-                        .unwrap_or(42),
-                    chat_type: "private".to_string(),
+                        .unwrap_or(10),
+                    date: 0,
+                    chat: TelegramChat {
+                        id: body
+                            .get("chat_id")
+                            .and_then(serde_json::Value::as_i64)
+                            .unwrap_or(42),
+                        chat_type: "private".to_string(),
+                    },
+                    text,
                 },
-                text: body
-                    .get("text")
-                    .and_then(serde_json::Value::as_str)
-                    .unwrap_or_default()
-                    .to_string(),
-            },
-        }));
+            })),
+        );
     }
 
     if path.ends_with("/deleteMessage")
@@ -236,7 +252,20 @@ async fn stream_lifecycle_handler(
                     .unwrap_or_default(),
             },
         );
-        return Json(serde_json::json!({ "ok": true, "result": true }));
+        if state.fail_delete {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({
+                    "ok": false,
+                    "error_code": 400,
+                    "description": "Bad Request: delete failed"
+                })),
+            );
+        }
+        return (
+            StatusCode::OK,
+            Json(serde_json::json!({ "ok": true, "result": true })),
+        );
     }
 
     state
@@ -246,7 +275,10 @@ async fn stream_lifecycle_handler(
         .push(StreamApiRequest::Unknown {
             path: path.to_string(),
         });
-    Json(serde_json::json!({ "ok": true, "result": true }))
+    (
+        StatusCode::OK,
+        Json(serde_json::json!({ "ok": true, "result": true })),
+    )
 }
 
 #[tokio::test]
@@ -381,6 +413,22 @@ fn stream_progress_state_suppresses_flush_until_backoff_expires() {
 }
 
 #[test]
+fn stream_progress_state_resets_throttle_when_rendered_html_is_unchanged() {
+    let mut state = StreamProgressState::new(3);
+    let now = Instant::now();
+
+    state.push_delta("hel");
+    state.mark_progress_sent(now, "same");
+    state.push_delta("lo");
+    assert!(state.should_flush_progress(now + Duration::from_secs(2), Duration::from_secs(2)));
+
+    state.mark_progress_observed(now + Duration::from_secs(2), "same");
+
+    assert!(!state.should_flush_progress(now + Duration::from_secs(3), Duration::from_secs(2)));
+    assert!(!state.should_flush_progress(now + Duration::from_secs(4), Duration::from_secs(2)));
+}
+
+#[test]
 fn stream_progress_cleanup_marker_points_to_final_answer() {
     let html = stream_progress_cleanup_html();
 
@@ -397,10 +445,71 @@ async fn telegram_streaming_does_not_replace_final_delivery() {
 }
 
 #[tokio::test]
+async fn cleanup_progress_message_reports_failed_delete_and_failed_marker_edit() {
+    let recorded_requests = Arc::new(Mutex::new(Vec::<StreamApiRequest>::new()));
+    let mock_api = MockTelegramStreamApi {
+        requests: Arc::clone(&recorded_requests),
+        fail_delete: true,
+        fail_cleanup_edit: true,
+    };
+    let app = Router::new()
+        .route("/{*path}", post(stream_lifecycle_handler))
+        .with_state(mock_api);
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind test listener");
+    let addr = listener.local_addr().expect("local addr");
+    let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
+    let server = tokio::spawn(async move {
+        axum::serve(listener, app)
+            .with_graceful_shutdown(async {
+                let _ = shutdown_rx.await;
+            })
+            .await
+            .expect("serve mock telegram api");
+    });
+
+    let api_url = reqwest::Url::parse(&format!("http://{addr}/")).expect("parse api url");
+    let bot = teloxide::Bot::new("test-token").set_api_url(api_url);
+    let accounts: AccountStateMap = Arc::new(std::sync::RwLock::new(HashMap::new()));
+    let outbound = TelegramOutbound { accounts };
+
+    let cleaned_up = outbound
+        .cleanup_progress_message(
+            &bot,
+            "test-account",
+            "42",
+            teloxide::types::ChatId(42),
+            teloxide::types::MessageId(10),
+        )
+        .await;
+
+    assert!(!cleaned_up);
+    {
+        let requests = recorded_requests.lock().expect("requests lock");
+        assert!(
+            requests.iter().any(
+                |request| matches!(request, StreamApiRequest::DeleteMessage { message_id: 10 })
+            )
+        );
+        assert!(requests.iter().any(|request| matches!(
+            request,
+            StreamApiRequest::EditMessage { text } if text == stream_progress_cleanup_html()
+        )));
+    }
+
+    let _ = shutdown_tx.send(());
+    server.await.expect("server join");
+}
+
+#[tokio::test]
 async fn send_stream_edits_then_deletes_temporary_progress_message() {
     let recorded_requests = Arc::new(Mutex::new(Vec::<StreamApiRequest>::new()));
     let mock_api = MockTelegramStreamApi {
         requests: Arc::clone(&recorded_requests),
+        fail_delete: false,
+        fail_cleanup_edit: false,
     };
     let app = Router::new()
         .route("/{*path}", post(stream_lifecycle_handler))

--- a/crates/telegram/src/outbound/tests.rs
+++ b/crates/telegram/src/outbound/tests.rs
@@ -1,7 +1,15 @@
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 use {
-    axum::{Json, Router, extract::State, http::StatusCode, routing::post},
-    moltis_channels::{gating::DmPolicy, plugin::ChannelOutbound},
+    axum::{
+        Json, Router,
+        extract::State,
+        http::{StatusCode, Uri},
+        routing::post,
+    },
+    moltis_channels::{
+        gating::DmPolicy,
+        plugin::{ChannelOutbound, ChannelStreamOutbound, StreamEvent},
+    },
     secrecy::Secret,
     serde::{Deserialize, Serialize},
     std::{
@@ -10,7 +18,7 @@ use {
         time::Duration,
     },
     teloxide::{ApiError, RequestError},
-    tokio::sync::oneshot,
+    tokio::{sync::oneshot, time::Instant},
     tokio_util::sync::CancellationToken,
 };
 
@@ -24,7 +32,10 @@ use super::{
     TelegramOutbound,
     formatting::telegram_html_to_plain_text,
     retry::{is_message_not_modified_error, retry_after_duration},
-    stream::{has_reached_stream_min_initial_chars, should_send_stream_completion_notification},
+    stream::{
+        StreamProgressState, format_stream_progress_html, has_reached_stream_min_initial_chars,
+        stream_progress_cleanup_html,
+    },
 };
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
@@ -59,6 +70,28 @@ struct TelegramChat {
 #[derive(Clone)]
 struct MockTelegramApi {
     requests: Arc<Mutex<Vec<SendMessageRequest>>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum StreamApiRequest {
+    Unknown {
+        path: String,
+    },
+    SendMessage {
+        text: String,
+        disable_notification: bool,
+    },
+    EditMessage {
+        text: String,
+    },
+    DeleteMessage {
+        message_id: i64,
+    },
+}
+
+#[derive(Clone)]
+struct MockTelegramStreamApi {
+    requests: Arc<Mutex<Vec<StreamApiRequest>>>,
 }
 
 async fn send_message_handler(
@@ -97,6 +130,123 @@ async fn send_message_handler(
             },
         })),
     )
+}
+
+async fn stream_lifecycle_handler(
+    State(state): State<MockTelegramStreamApi>,
+    uri: Uri,
+    Json(body): Json<serde_json::Value>,
+) -> Json<serde_json::Value> {
+    let path = uri.path();
+    if path.ends_with("/sendChatAction")
+        || path.ends_with("/send_chat_action")
+        || path.ends_with("/SendChatAction")
+    {
+        return Json(serde_json::json!({ "ok": true, "result": true }));
+    }
+
+    if path.ends_with("/sendMessage")
+        || path.ends_with("/send_message")
+        || path.ends_with("/SendMessage")
+    {
+        state
+            .requests
+            .lock()
+            .expect("lock stream requests")
+            .push(StreamApiRequest::SendMessage {
+                text: body
+                    .get("text")
+                    .and_then(serde_json::Value::as_str)
+                    .unwrap_or_default()
+                    .to_string(),
+                disable_notification: body
+                    .get("disable_notification")
+                    .and_then(serde_json::Value::as_bool)
+                    .unwrap_or(false),
+            });
+        return Json(serde_json::json!(TelegramApiResponse {
+            ok: true,
+            result: TelegramMessageResult {
+                message_id: 10,
+                date: 0,
+                chat: TelegramChat {
+                    id: body
+                        .get("chat_id")
+                        .and_then(serde_json::Value::as_i64)
+                        .unwrap_or(42),
+                    chat_type: "private".to_string(),
+                },
+                text: body
+                    .get("text")
+                    .and_then(serde_json::Value::as_str)
+                    .unwrap_or_default()
+                    .to_string(),
+            },
+        }));
+    }
+
+    if path.ends_with("/editMessageText")
+        || path.ends_with("/edit_message_text")
+        || path.ends_with("/EditMessageText")
+    {
+        state
+            .requests
+            .lock()
+            .expect("lock stream requests")
+            .push(StreamApiRequest::EditMessage {
+                text: body
+                    .get("text")
+                    .and_then(serde_json::Value::as_str)
+                    .unwrap_or_default()
+                    .to_string(),
+            });
+        return Json(serde_json::json!(TelegramApiResponse {
+            ok: true,
+            result: TelegramMessageResult {
+                message_id: body
+                    .get("message_id")
+                    .and_then(serde_json::Value::as_i64)
+                    .unwrap_or(10),
+                date: 0,
+                chat: TelegramChat {
+                    id: body
+                        .get("chat_id")
+                        .and_then(serde_json::Value::as_i64)
+                        .unwrap_or(42),
+                    chat_type: "private".to_string(),
+                },
+                text: body
+                    .get("text")
+                    .and_then(serde_json::Value::as_str)
+                    .unwrap_or_default()
+                    .to_string(),
+            },
+        }));
+    }
+
+    if path.ends_with("/deleteMessage")
+        || path.ends_with("/delete_message")
+        || path.ends_with("/DeleteMessage")
+    {
+        state.requests.lock().expect("lock stream requests").push(
+            StreamApiRequest::DeleteMessage {
+                message_id: body
+                    .get("message_id")
+                    .and_then(serde_json::Value::as_i64)
+                    .unwrap_or_default(),
+            },
+        );
+        return Json(serde_json::json!({ "ok": true, "result": true }));
+    }
+
+    state
+        .requests
+        .lock()
+        .expect("lock stream requests")
+        .push(StreamApiRequest::Unknown {
+            path: path.to_string(),
+        });
+    Json(serde_json::json!({ "ok": true, "result": true }))
 }
 
 #[tokio::test]
@@ -193,17 +343,174 @@ fn stream_min_initial_chars_uses_character_count() {
 }
 
 #[test]
-fn stream_completion_notification_requires_opt_in() {
-    assert!(!should_send_stream_completion_notification(
-        false, true, false
-    ));
+fn stream_progress_html_marks_text_as_progress() {
+    let html = format_stream_progress_html("working");
+
+    assert!(html.contains("Progress update"));
+    assert!(html.contains("working"));
 }
 
 #[test]
-fn stream_completion_notification_skips_when_no_text() {
-    assert!(!should_send_stream_completion_notification(
-        true, false, false
-    ));
+fn stream_progress_state_flushes_pending_text_after_throttle() {
+    let mut state = StreamProgressState::new(3);
+    let now = Instant::now();
+
+    state.push_delta("hel");
+    assert!(state.should_send_initial_progress());
+    state.mark_progress_sent(now, "initial");
+    state.push_delta("lo");
+
+    assert!(!state.should_flush_progress(now, Duration::from_secs(2)));
+    assert!(state.should_flush_progress(now + Duration::from_secs(2), Duration::from_secs(2)));
+}
+
+#[test]
+fn stream_progress_state_suppresses_flush_until_backoff_expires() {
+    let mut state = StreamProgressState::new(3);
+    let now = Instant::now();
+
+    state.push_delta("hel");
+    state.mark_progress_sent(now, "initial");
+    state.push_delta("lo");
+    assert!(state.should_flush_progress(now + Duration::from_secs(2), Duration::from_secs(2)));
+
+    state.defer_progress_until(now + Duration::from_secs(10));
+
+    assert!(!state.should_flush_progress(now + Duration::from_secs(5), Duration::from_secs(2)));
+    assert!(state.should_flush_progress(now + Duration::from_secs(10), Duration::from_secs(2)));
+}
+
+#[test]
+fn stream_progress_cleanup_marker_points_to_final_answer() {
+    let html = stream_progress_cleanup_html();
+
+    assert!(html.contains("Progress update complete"));
+    assert!(html.contains("final answer follows"));
+}
+
+#[tokio::test]
+async fn telegram_streaming_does_not_replace_final_delivery() {
+    let accounts: AccountStateMap = Arc::new(std::sync::RwLock::new(HashMap::new()));
+    let outbound = TelegramOutbound { accounts };
+
+    assert!(!outbound.streams_final_replies("missing").await);
+}
+
+#[tokio::test]
+async fn send_stream_edits_then_deletes_temporary_progress_message() {
+    let recorded_requests = Arc::new(Mutex::new(Vec::<StreamApiRequest>::new()));
+    let mock_api = MockTelegramStreamApi {
+        requests: Arc::clone(&recorded_requests),
+    };
+    let app = Router::new()
+        .route("/{*path}", post(stream_lifecycle_handler))
+        .with_state(mock_api);
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind test listener");
+    let addr = listener.local_addr().expect("local addr");
+    let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
+    let server = tokio::spawn(async move {
+        axum::serve(listener, app)
+            .with_graceful_shutdown(async {
+                let _ = shutdown_rx.await;
+            })
+            .await
+            .expect("serve mock telegram api");
+    });
+
+    let api_url = reqwest::Url::parse(&format!("http://{addr}/")).expect("parse api url");
+    let bot = teloxide::Bot::new("test-token").set_api_url(api_url);
+
+    let accounts: AccountStateMap = Arc::new(std::sync::RwLock::new(HashMap::new()));
+    let outbound = Arc::new(TelegramOutbound {
+        accounts: Arc::clone(&accounts),
+    });
+    let account_id = "test-account";
+
+    {
+        let mut map = accounts.write().expect("accounts write lock");
+        map.insert(account_id.to_string(), AccountState {
+            bot: bot.clone(),
+            bot_username: Some("test_bot".to_string()),
+            account_id: account_id.to_string(),
+            config: TelegramAccountConfig {
+                token: Secret::new("test-token".to_string()),
+                dm_policy: DmPolicy::Open,
+                edit_throttle_ms: 250,
+                stream_min_initial_chars: 3,
+                ..Default::default()
+            },
+            outbound: Arc::clone(&outbound),
+            cancel: CancellationToken::new(),
+            message_log: None,
+            event_sink: None,
+            otp: Mutex::new(OtpState::new(300)),
+        });
+    }
+
+    let (tx, rx) = tokio::sync::mpsc::channel(8);
+    let outbound_for_stream = Arc::clone(&outbound);
+    let stream_task = tokio::spawn(async move {
+        outbound_for_stream
+            .send_stream(account_id, "42", None, rx)
+            .await
+    });
+
+    tx.send(StreamEvent::Delta("hel".to_string()))
+        .await
+        .expect("send initial delta");
+    tokio::time::sleep(Duration::from_millis(25)).await;
+    if let Err(err) = tx.send(StreamEvent::Delta("lo".to_string())).await {
+        let stream_result = stream_task
+            .await
+            .expect("stream task joins after early close");
+        let requests = recorded_requests.lock().expect("requests lock").clone();
+        panic!(
+            "send second delta failed: {err:?}; stream_result={stream_result:?}; requests={requests:?}"
+        );
+    }
+    tokio::time::sleep(Duration::from_millis(600)).await;
+    tx.send(StreamEvent::Done).await.expect("send done");
+    drop(tx);
+
+    stream_task
+        .await
+        .expect("stream task joins")
+        .expect("stream completes");
+
+    {
+        let requests = recorded_requests.lock().expect("requests lock");
+        assert_eq!(
+            requests
+                .iter()
+                .filter(|request| matches!(request, StreamApiRequest::SendMessage { .. }))
+                .count(),
+            1,
+            "stream worker should only send the temporary progress message"
+        );
+        assert!(matches!(
+            &requests[0],
+            StreamApiRequest::SendMessage {
+                text,
+                disable_notification: true,
+            } if text.contains("Progress update") && text.contains("hel")
+        ));
+        assert!(requests.iter().any(|request| matches!(
+            request,
+            StreamApiRequest::EditMessage { text }
+                if text.contains("Progress update") && text.contains("hello")
+        )));
+        assert!(
+            requests.iter().any(
+                |request| matches!(request, StreamApiRequest::DeleteMessage { message_id: 10 })
+            )
+        );
+    }
+
+    let _ = shutdown_tx.send(());
+    server.await.expect("server join");
 }
 
 #[tokio::test]
@@ -388,18 +695,4 @@ async fn send_document_to_topic_chat_does_not_panic() {
 
     let _ = shutdown_tx.send(());
     server.await.expect("server join");
-}
-
-#[test]
-fn stream_completion_notification_skips_when_already_notified_by_chunks() {
-    assert!(!should_send_stream_completion_notification(
-        true, true, true
-    ));
-}
-
-#[test]
-fn stream_completion_notification_enabled_when_needed() {
-    assert!(should_send_stream_completion_notification(
-        true, true, false
-    ));
 }

--- a/crates/whatsapp/src/outbound.rs
+++ b/crates/whatsapp/src/outbound.rs
@@ -284,7 +284,9 @@ impl ChannelStreamOutbound for WhatsAppOutbound {
         let mut text = String::new();
         while let Some(event) = stream.recv().await {
             match event {
-                StreamEvent::Delta(delta) => text.push_str(&delta),
+                StreamEvent::Delta(delta) | StreamEvent::ProgressDelta(delta) => {
+                    text.push_str(&delta)
+                },
                 StreamEvent::Done => break,
                 StreamEvent::Error(err) => {
                     debug!(account_id, chat_id = to, "WhatsApp stream error: {err}");

--- a/docs/src/telegram.md
+++ b/docs/src/telegram.md
@@ -85,6 +85,7 @@ offered = ["telegram"]
 | `edit_throttle_ms` | no | `300` | Minimum milliseconds between streaming edit updates |
 | `stream_notify_on_complete` | no | `false` | Send a completion notification after streaming finishes |
 | `stream_min_initial_chars` | no | `30` | Minimum characters before sending the first streamed message |
+| `stream_progress_max_chars` | no | `3500` | Maximum recent progress characters kept visible in the temporary streamed message |
 
 ```admonish important title="Allowlist values are strings"
 All allowlist entries must be **strings**, even for numeric Telegram user IDs.

--- a/docs/src/telegram.md
+++ b/docs/src/telegram.md
@@ -83,8 +83,8 @@ offered = ["telegram"]
 | `otp_cooldown_secs` | no | `300` | Cooldown in seconds after 3 failed OTP attempts |
 | `stream_mode` | no | `"edit_in_place"` | Streaming mode: `"edit_in_place"` or `"off"` |
 | `edit_throttle_ms` | no | `2000` | Minimum milliseconds between streaming edit updates |
-| `stream_notify_on_complete` | no | `false` | Send a completion notification after streaming finishes |
-| `stream_min_initial_chars` | no | `30` | Minimum characters before sending the first streamed message |
+| `stream_notify_on_complete` | no | `false` | Send the final answer as a notifying message instead of silently reusing the progress message |
+| `stream_min_initial_chars` | no | `30` | Minimum characters before sending the first temporary progress message |
 | `stream_progress_max_chars` | no | `3500` | Maximum recent progress characters kept visible in the temporary streamed message |
 
 ```admonish important title="Allowlist values are strings"
@@ -211,10 +211,18 @@ the web UI.
 
 ## Streaming
 
-By default (`stream_mode = "edit_in_place"`), the bot sends an initial message
-after `stream_min_initial_chars` characters (default: 30) and then edits it
-in place as tokens arrive, throttled to at most one edit every
-`edit_throttle_ms` milliseconds (default: 2000).
+By default (`stream_mode = "edit_in_place"`), Telegram shows temporary progress
+while a turn is running. The bot sends a silent progress message after
+`stream_min_initial_chars` characters (default: 30), edits that progress message
+at most once every `edit_throttle_ms` milliseconds (default: 2000), and keeps only
+the latest `stream_progress_max_chars` progress characters visible.
+
+When the final answer is ready, the progress message is cleaned up or reused and
+the final answer is delivered separately from intermediate progress. With
+`stream_notify_on_complete = false` (default), Moltis may silently reuse the
+existing progress message for the final answer. With `stream_notify_on_complete =
+true`, Moltis deletes the progress message where possible and sends the final
+answer as a new notifying message.
 
 ## Session Commands
 

--- a/docs/src/telegram.md
+++ b/docs/src/telegram.md
@@ -82,7 +82,7 @@ offered = ["telegram"]
 | `otp_self_approval` | no | `true` | Enable OTP self-approval for non-allowlisted DM users |
 | `otp_cooldown_secs` | no | `300` | Cooldown in seconds after 3 failed OTP attempts |
 | `stream_mode` | no | `"edit_in_place"` | Streaming mode: `"edit_in_place"` or `"off"` |
-| `edit_throttle_ms` | no | `300` | Minimum milliseconds between streaming edit updates |
+| `edit_throttle_ms` | no | `2000` | Minimum milliseconds between streaming edit updates |
 | `stream_notify_on_complete` | no | `false` | Send a completion notification after streaming finishes |
 | `stream_min_initial_chars` | no | `30` | Minimum characters before sending the first streamed message |
 | `stream_progress_max_chars` | no | `3500` | Maximum recent progress characters kept visible in the temporary streamed message |
@@ -113,7 +113,7 @@ model_provider = "anthropic"
 agent_id = "research"
 otp_self_approval = true
 stream_mode = "edit_in_place"
-edit_throttle_ms = 300
+edit_throttle_ms = 2000
 ```
 
 ### Per-User and Per-Channel Model and Agent Overrides
@@ -214,7 +214,7 @@ the web UI.
 By default (`stream_mode = "edit_in_place"`), the bot sends an initial message
 after `stream_min_initial_chars` characters (default: 30) and then edits it
 in place as tokens arrive, throttled to at most one edit every
-`edit_throttle_ms` milliseconds (default: 300).
+`edit_throttle_ms` milliseconds (default: 2000).
 
 ## Session Commands
 


### PR DESCRIPTION
Fixes #1097

## Summary

- Treat Telegram channel streaming as temporary progress updates, not as final-answer delivery.
- Send a silent Telegram progress message, edit it with throttled recent progress, then delete it when the stream finishes so the normal final reply is delivered separately.
- Keep only the newest progress tail in the temporary message; older progress is hidden instead of creating additional Telegram messages.
- Add `stream_progress_max_chars` to configure the visible progress tail length, defaulting to `3500`.
- Add channel-level `streams_final_replies` semantics so existing stream-final channels keep their old dedupe behavior while Telegram opts out.
- Back off progress edits after Telegram `RetryAfter` without blocking the stream worker.
- Handle review edge cases: failed cleanup fallback is reported, and unchanged rendered progress resets the throttle clock.

## Root cause

Telegram `edit_in_place` streaming accumulated every `TextDelta`, including tool/progress deltas, into the same message that was also treated as the final streamed reply. The chat dispatcher then suppressed normal final delivery for streamed targets, so Telegram users could receive an intermediate/tool-progress transcript instead of a clean final answer. High-frequency edits also made Telegram flood waits worse.

## Validation

- `cargo fmt --all --check`
- `cargo test -p moltis-telegram` (119 passed)
- `cargo test -p moltis-channels` (91 passed)
- `cargo test -p moltis-chat` (116 passed)
- `cargo test -p moltis-tools sandbox_write_requires_approval_before_bridge`
- `just build-web-assets`
- `cargo test --workspace`
- `cargo +nightly-2025-12-27 nextest run --workspace` (6063 passed, 126 skipped)

## Notes

- `just test` was attempted after installing `cargo-nextest`, but this environment cannot build its `--all-features` path because `local-llm-cuda` enables `llama-cpp-sys-2` with `GGML_CUDA=ON` and requires CUDA Toolkit.
