### PR TITLE
fix(browser): pierce open shadow roots in snapshot and ref lookups

### DIFF
--- a/crates/browser/src/manager.rs
+++ b/crates/browser/src/manager.rs
@@ -22,7 +22,8 @@ use crate::{
     error::Error,
     pool::BrowserPool,
     snapshot::{
-        extract_snapshot, find_element_by_ref, focus_element_by_ref, scroll_element_into_view,
+        DEEP_COLLECT_FN, DEEP_FIND_FN, extract_snapshot, find_element_by_ref, focus_element_by_ref,
+        scroll_element_into_view,
     },
     types::{
         BrowserAction, BrowserConfig, BrowserKind, BrowserPreference, BrowserRequest,
@@ -578,13 +579,14 @@ impl BrowserManager {
         let page = self.pool.get_page(&sid).await?;
 
         let js = if let Some(ref_) = ref_ {
-            format!(
+            let body = format!(
                 r#"(() => {{
-                    const el = document.querySelector(`[data-moltis-ref="{ref_}"]`);
+                    const el = __mDeepFind(`[data-moltis-ref="{ref_}"]`);
                     if (el) el.scrollBy({x}, {y});
                     return !!el;
                 }})()"#
-            )
+            );
+            format!("{DEEP_FIND_FN}{body}")
         } else {
             format!("window.scrollBy({x}, {y}); true")
         };
@@ -643,7 +645,7 @@ impl BrowserManager {
                 serde_json::to_string(selector).map_err(|e| Error::Cdp(e.to_string()))?
             )
         } else if let Some(ref_) = ref_ {
-            format!(r#"document.querySelector('[data-moltis-ref="{ref_}"]') !== null"#)
+            format!(r#"{DEEP_FIND_FN}__mDeepFind('[data-moltis-ref="{ref_}"]') !== null"#)
         } else {
             return Err(Error::InvalidAction("wait requires selector or ref".into()));
         };
@@ -797,15 +799,16 @@ impl BrowserManager {
 
     /// Highlight an element (for screenshots).
     async fn highlight_element(&self, page: &Page, ref_: u32) -> Result<(), Error> {
-        let js = format!(
+        let body = format!(
             r#"(() => {{
-                const el = document.querySelector(`[data-moltis-ref="{ref_}"]`);
+                const el = __mDeepFind(`[data-moltis-ref="{ref_}"]`);
                 if (el) {{
                     el.style.outline = '3px solid #ff0000';
                     el.style.outlineOffset = '2px';
                 }}
             }})()"#
         );
+        let js = format!("{DEEP_FIND_FN}{body}");
 
         page.evaluate(js.as_str())
             .await
@@ -816,14 +819,14 @@ impl BrowserManager {
 
     /// Remove all element highlights.
     async fn remove_highlights(&self, page: &Page) -> Result<(), Error> {
-        let js = r#"
-            document.querySelectorAll('[data-moltis-ref]').forEach(el => {
+        let js = format!(
+            r#"{DEEP_COLLECT_FN}__mDeepCollect('[data-moltis-ref]').forEach(el => {{
                 el.style.outline = '';
                 el.style.outlineOffset = '';
-            });
-        "#;
+            }});"#
+        );
 
-        page.evaluate(js)
+        page.evaluate(js.as_str())
             .await
             .map_err(|e| Error::JsEvalFailed(e.to_string()))?;
 

--- a/crates/browser/src/snapshot.rs
+++ b/crates/browser/src/snapshot.rs
@@ -13,7 +13,48 @@ use crate::{
     types::{DomSnapshot, ElementBounds, ElementRef, ScrollDimensions, ViewportSize},
 };
 
-/// JavaScript to extract interactive elements from the DOM.
+/// JS helper defining `__mDeepFind(sel)` — like `document.querySelector` but it
+/// also descends into open shadow roots, so elements rendered inside web
+/// components (e.g. Salesforce Lightning login fields) are reachable. Closed
+/// shadow roots (`mode: 'closed'`) cannot be pierced from page script and are
+/// skipped. Prepend to any snippet that resolves an element by ref.
+pub(crate) const DEEP_FIND_FN: &str = r#"
+window.__mDeepFind = window.__mDeepFind || ((sel) => {
+  const visit = (root) => {
+    let el = null;
+    try { el = root.querySelector(sel); } catch (e) { el = null; }
+    if (el) return el;
+    let all = [];
+    try { all = root.querySelectorAll('*'); } catch (e) { all = []; }
+    for (const h of all) {
+      if (h.shadowRoot) { const f = visit(h.shadowRoot); if (f) return f; }
+    }
+    return null;
+  };
+  return visit(document);
+});
+"#;
+
+/// JS helper defining `__mDeepCollect(sel)` — like `document.querySelectorAll`
+/// but also descends into open shadow roots. Returns a flat array of matches.
+pub(crate) const DEEP_COLLECT_FN: &str = r#"
+window.__mDeepCollect = window.__mDeepCollect || ((sel) => {
+  const out = [];
+  const visit = (root) => {
+    let matches = [];
+    try { matches = root.querySelectorAll(sel); } catch (e) { matches = []; }
+    for (const m of matches) out.push(m);
+    let all = [];
+    try { all = root.querySelectorAll('*'); } catch (e) { all = []; }
+    for (const el of all) { if (el.shadowRoot) visit(el.shadowRoot); }
+  };
+  visit(document);
+  return out;
+});
+"#;
+
+/// JavaScript to extract interactive elements from the DOM (including those
+/// inside open shadow roots, via `__mDeepCollect`).
 const EXTRACT_ELEMENTS_JS: &str = r#"
 (() => {
     const interactive = [
@@ -25,7 +66,7 @@ const EXTRACT_ELEMENTS_JS: &str = r#"
     ];
 
     const selector = interactive.join(', ');
-    const elements = document.querySelectorAll(selector);
+    const elements = __mDeepCollect(selector);
     const results = [];
 
     function isVisible(el) {
@@ -145,7 +186,7 @@ const EXTRACT_ELEMENTS_JS: &str = r#"
 /// JavaScript to find an element by its ref number.
 const FIND_BY_REF_JS: &str = r#"
 ((ref) => {
-    const el = document.querySelector(`[data-moltis-ref="${ref}"]`);
+    const el = __mDeepFind(`[data-moltis-ref="${ref}"]`);
     if (!el) return null;
     const rect = el.getBoundingClientRect();
     return {
@@ -171,8 +212,9 @@ pub async fn extract_snapshot(page: &Page) -> Result<DomSnapshot, Error> {
         .map_err(|e| Error::Cdp(e.to_string()))?
         .unwrap_or_default();
 
+    let extract_js = format!("{DEEP_COLLECT_FN}{EXTRACT_ELEMENTS_JS}");
     let result: Value = page
-        .evaluate(EXTRACT_ELEMENTS_JS)
+        .evaluate(extract_js.as_str())
         .await
         .map_err(|e| Error::JsEvalFailed(e.to_string()))?
         .into_value()
@@ -206,7 +248,7 @@ pub async fn extract_snapshot(page: &Page) -> Result<DomSnapshot, Error> {
 
 /// Find an element's center coordinates by its ref number.
 pub async fn find_element_by_ref(page: &Page, ref_: u32) -> Result<(f64, f64), Error> {
-    let js = format!("({FIND_BY_REF_JS})({ref_})");
+    let js = format!("{DEEP_FIND_FN}({FIND_BY_REF_JS})({ref_})");
 
     let result: Value = page
         .evaluate(js.as_str())
@@ -231,14 +273,15 @@ pub async fn find_element_by_ref(page: &Page, ref_: u32) -> Result<(f64, f64), E
 
 /// Focus an input element by its ref number.
 pub async fn focus_element_by_ref(page: &Page, ref_: u32) -> Result<(), Error> {
-    let js = format!(
+    let body = format!(
         r#"(() => {{
-            const el = document.querySelector(`[data-moltis-ref="{ref_}"]`);
+            const el = __mDeepFind(`[data-moltis-ref="{ref_}"]`);
             if (!el) return false;
             el.focus();
             return true;
         }})()"#
     );
+    let js = format!("{DEEP_FIND_FN}{body}");
 
     let result: Value = page
         .evaluate(js.as_str())
@@ -256,14 +299,15 @@ pub async fn focus_element_by_ref(page: &Page, ref_: u32) -> Result<(), Error> {
 
 /// Scroll an element into view by its ref number.
 pub async fn scroll_element_into_view(page: &Page, ref_: u32) -> Result<(), Error> {
-    let js = format!(
+    let body = format!(
         r#"(() => {{
-            const el = document.querySelector(`[data-moltis-ref="{ref_}"]`);
+            const el = __mDeepFind(`[data-moltis-ref="{ref_}"]`);
             if (!el) return false;
             el.scrollIntoView({{ behavior: 'instant', block: 'center' }});
             return true;
         }})()"#
     );
+    let js = format!("{DEEP_FIND_FN}{body}");
 
     let result: Value = page
         .evaluate(js.as_str())
@@ -335,6 +379,28 @@ fn parse_scroll(result: &Value) -> Result<ScrollDimensions, Error> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn deep_helpers_traverse_shadow_roots_and_are_idempotent() {
+        // Must recurse into open shadow roots so elements inside web components
+        // (e.g. Salesforce Lightning) are reachable.
+        assert!(DEEP_FIND_FN.contains("shadowRoot"));
+        assert!(DEEP_COLLECT_FN.contains("shadowRoot"));
+        // Defined via `window.x = window.x || (...)` so repeated injection into
+        // the global eval scope does not throw a redeclaration error.
+        assert!(DEEP_FIND_FN.contains("window.__mDeepFind = window.__mDeepFind ||"));
+        assert!(DEEP_COLLECT_FN.contains("window.__mDeepCollect = window.__mDeepCollect ||"));
+    }
+
+    #[test]
+    fn snapshot_js_uses_shadow_piercing_helpers_not_flat_queries() {
+        // Element collection must go through the deep collector.
+        assert!(EXTRACT_ELEMENTS_JS.contains("__mDeepCollect(selector)"));
+        assert!(!EXTRACT_ELEMENTS_JS.contains("document.querySelectorAll(selector)"));
+        // Ref resolution must go through the deep finder.
+        assert!(FIND_BY_REF_JS.contains("__mDeepFind("));
+        assert!(!FIND_BY_REF_JS.contains("document.querySelector("));
+    }
 
     #[test]
     fn test_parse_elements_empty() {


### PR DESCRIPTION
## Summary

The browser tool found interactive elements with a flat `document.querySelectorAll`
(snapshot collection) and resolved refs with `document.querySelector('[data-moltis-ref="N"]')`.
Neither crosses **shadow-DOM** boundaries, so elements rendered inside web components —
e.g. **Salesforce Lightning** login fields — were invisible to `snapshot` and unreachable
by `click`/`type`/`scroll`/`wait`/highlight. Against such pages the agent could never see
or fill the controls and would loop on empty DOM queries.

### Fix
Two shadow-piercing JS helpers that recurse into **open** shadow roots, with every element
lookup routed through them:
- `__mDeepFind(sel)` — `querySelector` that descends into `element.shadowRoot`
- `__mDeepCollect(sel)` — `querySelectorAll` that descends into `element.shadowRoot`

Applied to:
- `snapshot.rs`: element collection, `find_element_by_ref` (click), `focus_element_by_ref` (type), `scroll_element_into_view`
- `manager.rs`: `scroll`, `wait` (ref branch), `highlight_element`, `remove_highlights`

Helpers are defined idempotently (`window.x = window.x || (...)`) so repeated injection into
the global eval scope doesn't throw a redeclaration error — notably `wait()` re-evaluates its
check on every poll.

**Caveat:** closed shadow roots (`mode: 'closed'`) cannot be pierced from page script and are
skipped (documented in the helper).

- `crates/browser/src/snapshot.rs`
- `crates/browser/src/manager.rs`

## Validation
### Completed
- `cargo test -p moltis-browser snapshot` — 4 pass, incl. 2 new regression tests
  (`deep_helpers_traverse_shadow_roots_and_are_idempotent`,
  `snapshot_js_uses_shadow_piercing_helpers_not_flat_queries`).
- `cargo check -p moltis-browser` — clean.
- Both changed files are clean under the pinned nightly rustfmt.

### Remaining (CI / maintainer)
- `cargo fmt --all -- --check`
- `just lint`
- `just test`

## Manual QA
Reproduced against PG&E's `myaccount.pge.com` (Salesforce Lightning) with a local model
driving the browser tool. Before: `snapshot` returned no login fields and the agent looped
on `querySelectorAll('input')` (shadow DOM). After: `snapshot` returns the username/password
textboxes and they're addressable by ref.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
