### PR TITLE
fix(browser): pierce shadow DOM lookups efficiently

### DIFF
--- a/crates/browser/src/manager.rs
+++ b/crates/browser/src/manager.rs
@@ -22,7 +22,8 @@ use crate::{
     error::Error,
     pool::BrowserPool,
     snapshot::{
-        extract_snapshot, find_element_by_ref, focus_element_by_ref, scroll_element_into_view,
+        DEEP_COLLECT_FN, DEEP_FIND_FN, extract_snapshot, find_element_by_ref, focus_element_by_ref,
+        scroll_element_into_view,
     },
     types::{
         BrowserAction, BrowserConfig, BrowserKind, BrowserPreference, BrowserRequest,
@@ -578,13 +579,14 @@ impl BrowserManager {
         let page = self.pool.get_page(&sid).await?;
 
         let js = if let Some(ref_) = ref_ {
-            format!(
+            let body = format!(
                 r#"(() => {{
-                    const el = document.querySelector(`[data-moltis-ref="{ref_}"]`);
+                    const el = __mDeepFind(`[data-moltis-ref="{ref_}"]`);
                     if (el) el.scrollBy({x}, {y});
                     return !!el;
                 }})()"#
-            )
+            );
+            format!("{DEEP_FIND_FN}{body}")
         } else {
             format!("window.scrollBy({x}, {y}); true")
         };
@@ -643,7 +645,7 @@ impl BrowserManager {
                 serde_json::to_string(selector).map_err(|e| Error::Cdp(e.to_string()))?
             )
         } else if let Some(ref_) = ref_ {
-            format!(r#"document.querySelector('[data-moltis-ref="{ref_}"]') !== null"#)
+            format!(r#"{DEEP_FIND_FN}__mDeepFind('[data-moltis-ref="{ref_}"]') !== null"#)
         } else {
             return Err(Error::InvalidAction("wait requires selector or ref".into()));
         };
@@ -797,15 +799,16 @@ impl BrowserManager {
 
     /// Highlight an element (for screenshots).
     async fn highlight_element(&self, page: &Page, ref_: u32) -> Result<(), Error> {
-        let js = format!(
+        let body = format!(
             r#"(() => {{
-                const el = document.querySelector(`[data-moltis-ref="{ref_}"]`);
+                const el = __mDeepFind(`[data-moltis-ref="{ref_}"]`);
                 if (el) {{
                     el.style.outline = '3px solid #ff0000';
                     el.style.outlineOffset = '2px';
                 }}
             }})()"#
         );
+        let js = format!("{DEEP_FIND_FN}{body}");
 
         page.evaluate(js.as_str())
             .await
@@ -816,14 +819,14 @@ impl BrowserManager {
 
     /// Remove all element highlights.
     async fn remove_highlights(&self, page: &Page) -> Result<(), Error> {
-        let js = r#"
-            document.querySelectorAll('[data-moltis-ref]').forEach(el => {
+        let js = format!(
+            r#"{DEEP_COLLECT_FN}__mDeepCollect('[data-moltis-ref]').forEach(el => {{
                 el.style.outline = '';
                 el.style.outlineOffset = '';
-            });
-        "#;
+            }});"#
+        );
 
-        page.evaluate(js)
+        page.evaluate(js.as_str())
             .await
             .map_err(|e| Error::JsEvalFailed(e.to_string()))?;
 

--- a/crates/browser/src/manager.rs
+++ b/crates/browser/src/manager.rs
@@ -641,7 +641,7 @@ impl BrowserManager {
 
         let check_js = if let Some(ref selector) = selector {
             format!(
-                r#"document.querySelector({}) !== null"#,
+                r#"{DEEP_FIND_FN}__mDeepFind({}) !== null"#,
                 serde_json::to_string(selector).map_err(|e| Error::Cdp(e.to_string()))?
             )
         } else if let Some(ref_) = ref_ {
@@ -985,6 +985,17 @@ mod tests {
         assert_eq!(prefix.len(), 99);
         assert!(!prefix.contains('л'));
         assert!(prefix.ends_with('a'));
+    }
+
+    #[test]
+    fn wait_selector_path_uses_shadow_piercing_lookup() {
+        let source = include_str!("manager.rs");
+
+        let flat_query = concat!("document.", "querySelector({}) !== null");
+        let deep_query = concat!("{DEEP_FIND_FN}", "__mDeepFind({}) !== null");
+
+        assert!(!source.contains(flat_query));
+        assert!(source.contains(deep_query));
     }
 
     #[tokio::test]

--- a/crates/browser/src/snapshot.rs
+++ b/crates/browser/src/snapshot.rs
@@ -42,11 +42,13 @@ window.__mDeepCollect = window.__mDeepCollect || ((sel) => {
   const out = [];
   const visit = (root) => {
     let matches = [];
-    try { matches = root.querySelectorAll(sel); } catch (e) { matches = []; }
-    for (const m of matches) out.push(m);
-    let all = [];
-    try { all = root.querySelectorAll('*'); } catch (e) { all = []; }
-    for (const el of all) { if (el.shadowRoot) visit(el.shadowRoot); }
+    try { matches = root.querySelectorAll('*'); } catch (e) { matches = []; }
+    for (const el of matches) {
+      let isMatch = false;
+      try { isMatch = el.matches(sel); } catch (e) { isMatch = false; }
+      if (isMatch) out.push(el);
+      if (el.shadowRoot) visit(el.shadowRoot);
+    }
   };
   visit(document);
   return out;
@@ -390,6 +392,16 @@ mod tests {
         // the global eval scope does not throw a redeclaration error.
         assert!(DEEP_FIND_FN.contains("window.__mDeepFind = window.__mDeepFind ||"));
         assert!(DEEP_COLLECT_FN.contains("window.__mDeepCollect = window.__mDeepCollect ||"));
+    }
+
+    #[test]
+    fn deep_collect_uses_one_dom_walk_for_matches_and_shadow_hosts() {
+        assert_eq!(
+            DEEP_COLLECT_FN.matches("querySelectorAll(").count(),
+            1,
+            "deep collection should not walk each root twice"
+        );
+        assert!(DEEP_COLLECT_FN.contains("el.matches(sel)"));
     }
 
     #[test]

--- a/crates/browser/src/snapshot.rs
+++ b/crates/browser/src/snapshot.rs
@@ -13,7 +13,48 @@ use crate::{
     types::{DomSnapshot, ElementBounds, ElementRef, ScrollDimensions, ViewportSize},
 };
 
-/// JavaScript to extract interactive elements from the DOM.
+/// JS helper defining `__mDeepFind(sel)` — like `document.querySelector` but it
+/// also descends into open shadow roots, so elements rendered inside web
+/// components (e.g. Salesforce Lightning login fields) are reachable. Closed
+/// shadow roots (`mode: 'closed'`) cannot be pierced from page script and are
+/// skipped. Prepend to any snippet that resolves an element by ref.
+pub(crate) const DEEP_FIND_FN: &str = r#"
+window.__mDeepFind = window.__mDeepFind || ((sel) => {
+  const visit = (root) => {
+    let el = null;
+    try { el = root.querySelector(sel); } catch (e) { el = null; }
+    if (el) return el;
+    let all = [];
+    try { all = root.querySelectorAll('*'); } catch (e) { all = []; }
+    for (const h of all) {
+      if (h.shadowRoot) { const f = visit(h.shadowRoot); if (f) return f; }
+    }
+    return null;
+  };
+  return visit(document);
+});
+"#;
+
+/// JS helper defining `__mDeepCollect(sel)` — like `document.querySelectorAll`
+/// but also descends into open shadow roots. Returns a flat array of matches.
+pub(crate) const DEEP_COLLECT_FN: &str = r#"
+window.__mDeepCollect = window.__mDeepCollect || ((sel) => {
+  const out = [];
+  const visit = (root) => {
+    let matches = [];
+    try { matches = root.querySelectorAll(sel); } catch (e) { matches = []; }
+    for (const m of matches) out.push(m);
+    let all = [];
+    try { all = root.querySelectorAll('*'); } catch (e) { all = []; }
+    for (const el of all) { if (el.shadowRoot) visit(el.shadowRoot); }
+  };
+  visit(document);
+  return out;
+});
+"#;
+
+/// JavaScript to extract interactive elements from the DOM (including those
+/// inside open shadow roots, via `__mDeepCollect`).
 const EXTRACT_ELEMENTS_JS: &str = r#"
 (() => {
     const interactive = [
@@ -25,7 +66,7 @@ const EXTRACT_ELEMENTS_JS: &str = r#"
     ];
 
     const selector = interactive.join(', ');
-    const elements = document.querySelectorAll(selector);
+    const elements = __mDeepCollect(selector);
     const results = [];
 
     function isVisible(el) {
@@ -145,7 +186,7 @@ const EXTRACT_ELEMENTS_JS: &str = r#"
 /// JavaScript to find an element by its ref number.
 const FIND_BY_REF_JS: &str = r#"
 ((ref) => {
-    const el = document.querySelector(`[data-moltis-ref="${ref}"]`);
+    const el = __mDeepFind(`[data-moltis-ref="${ref}"]`);
     if (!el) return null;
     const rect = el.getBoundingClientRect();
     return {
@@ -171,8 +212,9 @@ pub async fn extract_snapshot(page: &Page) -> Result<DomSnapshot, Error> {
         .map_err(|e| Error::Cdp(e.to_string()))?
         .unwrap_or_default();
 
+    let extract_js = format!("{DEEP_COLLECT_FN}{EXTRACT_ELEMENTS_JS}");
     let result: Value = page
-        .evaluate(EXTRACT_ELEMENTS_JS)
+        .evaluate(extract_js.as_str())
         .await
         .map_err(|e| Error::JsEvalFailed(e.to_string()))?
         .into_value()
@@ -206,7 +248,7 @@ pub async fn extract_snapshot(page: &Page) -> Result<DomSnapshot, Error> {
 
 /// Find an element's center coordinates by its ref number.
 pub async fn find_element_by_ref(page: &Page, ref_: u32) -> Result<(f64, f64), Error> {
-    let js = format!("({FIND_BY_REF_JS})({ref_})");
+    let js = format!("{DEEP_FIND_FN}({FIND_BY_REF_JS})({ref_})");
 
     let result: Value = page
         .evaluate(js.as_str())
@@ -231,14 +273,15 @@ pub async fn find_element_by_ref(page: &Page, ref_: u32) -> Result<(f64, f64), E
 
 /// Focus an input element by its ref number.
 pub async fn focus_element_by_ref(page: &Page, ref_: u32) -> Result<(), Error> {
-    let js = format!(
+    let body = format!(
         r#"(() => {{
-            const el = document.querySelector(`[data-moltis-ref="{ref_}"]`);
+            const el = __mDeepFind(`[data-moltis-ref="{ref_}"]`);
             if (!el) return false;
             el.focus();
             return true;
         }})()"#
     );
+    let js = format!("{DEEP_FIND_FN}{body}");
 
     let result: Value = page
         .evaluate(js.as_str())
@@ -256,14 +299,15 @@ pub async fn focus_element_by_ref(page: &Page, ref_: u32) -> Result<(), Error> {
 
 /// Scroll an element into view by its ref number.
 pub async fn scroll_element_into_view(page: &Page, ref_: u32) -> Result<(), Error> {
-    let js = format!(
+    let body = format!(
         r#"(() => {{
-            const el = document.querySelector(`[data-moltis-ref="{ref_}"]`);
+            const el = __mDeepFind(`[data-moltis-ref="{ref_}"]`);
             if (!el) return false;
             el.scrollIntoView({{ behavior: 'instant', block: 'center' }});
             return true;
         }})()"#
     );
+    let js = format!("{DEEP_FIND_FN}{body}");
 
     let result: Value = page
         .evaluate(js.as_str())
@@ -335,6 +379,28 @@ fn parse_scroll(result: &Value) -> Result<ScrollDimensions, Error> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn deep_helpers_traverse_shadow_roots_and_are_idempotent() {
+        // Must recurse into open shadow roots so elements inside web components
+        // (e.g. Salesforce Lightning) are reachable.
+        assert!(DEEP_FIND_FN.contains("shadowRoot"));
+        assert!(DEEP_COLLECT_FN.contains("shadowRoot"));
+        // Defined via `window.x = window.x || (...)` so repeated injection into
+        // the global eval scope does not throw a redeclaration error.
+        assert!(DEEP_FIND_FN.contains("window.__mDeepFind = window.__mDeepFind ||"));
+        assert!(DEEP_COLLECT_FN.contains("window.__mDeepCollect = window.__mDeepCollect ||"));
+    }
+
+    #[test]
+    fn snapshot_js_uses_shadow_piercing_helpers_not_flat_queries() {
+        // Element collection must go through the deep collector.
+        assert!(EXTRACT_ELEMENTS_JS.contains("__mDeepCollect(selector)"));
+        assert!(!EXTRACT_ELEMENTS_JS.contains("document.querySelectorAll(selector)"));
+        // Ref resolution must go through the deep finder.
+        assert!(FIND_BY_REF_JS.contains("__mDeepFind("));
+        assert!(!FIND_BY_REF_JS.contains("document.querySelector("));
+    }
 
     #[test]
     fn test_parse_elements_empty() {

--- a/crates/browser/src/snapshot.rs
+++ b/crates/browser/src/snapshot.rs
@@ -21,13 +21,13 @@ use crate::{
 pub(crate) const DEEP_FIND_FN: &str = r#"
 window.__mDeepFind = window.__mDeepFind || ((sel) => {
   const visit = (root) => {
-    let el = null;
-    try { el = root.querySelector(sel); } catch (e) { el = null; }
-    if (el) return el;
     let all = [];
     try { all = root.querySelectorAll('*'); } catch (e) { all = []; }
-    for (const h of all) {
-      if (h.shadowRoot) { const f = visit(h.shadowRoot); if (f) return f; }
+    for (const el of all) {
+      let isMatch = false;
+      try { isMatch = el.matches(sel); } catch (e) { isMatch = false; }
+      if (isMatch) return el;
+      if (el.shadowRoot) { const f = visit(el.shadowRoot); if (f) return f; }
     }
     return null;
   };
@@ -392,6 +392,13 @@ mod tests {
         // the global eval scope does not throw a redeclaration error.
         assert!(DEEP_FIND_FN.contains("window.__mDeepFind = window.__mDeepFind ||"));
         assert!(DEEP_COLLECT_FN.contains("window.__mDeepCollect = window.__mDeepCollect ||"));
+    }
+
+    #[test]
+    fn deep_find_uses_one_dom_walk_for_matches_and_shadow_hosts() {
+        assert!(!DEEP_FIND_FN.contains("root.querySelector(sel)"));
+        assert!(DEEP_FIND_FN.contains("el.matches(sel)"));
+        assert!(DEEP_FIND_FN.contains("if (isMatch) return el;"));
     }
 
     #[test]

--- a/crates/browser/src/snapshot.rs
+++ b/crates/browser/src/snapshot.rs
@@ -17,16 +17,16 @@ use crate::{
 /// also descends into open shadow roots, so elements rendered inside web
 /// components (e.g. Salesforce Lightning login fields) are reachable. Closed
 /// shadow roots (`mode: 'closed'`) cannot be pierced from page script and are
-/// skipped. Prepend to any snippet that resolves an element by ref.
+/// skipped. Invalid selectors throw a SyntaxError immediately (validated on an
+/// empty fragment before the walk), matching `querySelector` semantics so
+/// callers fail fast instead of polling to a timeout. Prepend to any snippet
+/// that resolves an element by ref.
 pub(crate) const DEEP_FIND_FN: &str = r#"
 window.__mDeepFind = window.__mDeepFind || ((sel) => {
+  document.createDocumentFragment().querySelector(sel);
   const visit = (root) => {
-    let all = [];
-    try { all = root.querySelectorAll('*'); } catch (e) { all = []; }
-    for (const el of all) {
-      let isMatch = false;
-      try { isMatch = el.matches(sel); } catch (e) { isMatch = false; }
-      if (isMatch) return el;
+    for (const el of root.querySelectorAll('*')) {
+      if (el.matches(sel)) return el;
       if (el.shadowRoot) { const f = visit(el.shadowRoot); if (f) return f; }
     }
     return null;
@@ -37,16 +37,14 @@ window.__mDeepFind = window.__mDeepFind || ((sel) => {
 
 /// JS helper defining `__mDeepCollect(sel)` — like `document.querySelectorAll`
 /// but also descends into open shadow roots. Returns a flat array of matches.
+/// Invalid selectors throw immediately, same as [`DEEP_FIND_FN`].
 pub(crate) const DEEP_COLLECT_FN: &str = r#"
 window.__mDeepCollect = window.__mDeepCollect || ((sel) => {
+  document.createDocumentFragment().querySelector(sel);
   const out = [];
   const visit = (root) => {
-    let matches = [];
-    try { matches = root.querySelectorAll('*'); } catch (e) { matches = []; }
-    for (const el of matches) {
-      let isMatch = false;
-      try { isMatch = el.matches(sel); } catch (e) { isMatch = false; }
-      if (isMatch) out.push(el);
+    for (const el of root.querySelectorAll('*')) {
+      if (el.matches(sel)) out.push(el);
       if (el.shadowRoot) visit(el.shadowRoot);
     }
   };
@@ -68,6 +66,14 @@ const EXTRACT_ELEMENTS_JS: &str = r#"
     ];
 
     const selector = interactive.join(', ');
+
+    // Drop refs assigned by earlier snapshots first: an element that has since
+    // become hidden (and is skipped below) would otherwise keep its old number
+    // and could shadow the same ref freshly assigned to another element.
+    for (const el of __mDeepCollect('[data-moltis-ref]')) {
+        delete el.dataset.moltisRef;
+    }
+
     const elements = __mDeepCollect(selector);
     const results = [];
 
@@ -398,7 +404,26 @@ mod tests {
     fn deep_find_uses_one_dom_walk_for_matches_and_shadow_hosts() {
         assert!(!DEEP_FIND_FN.contains("root.querySelector(sel)"));
         assert!(DEEP_FIND_FN.contains("el.matches(sel)"));
-        assert!(DEEP_FIND_FN.contains("if (isMatch) return el;"));
+    }
+
+    #[test]
+    fn deep_helpers_fail_fast_on_invalid_selectors() {
+        // A bad selector must throw on first use (validated against an empty
+        // fragment) so `wait` errors immediately instead of polling to its
+        // timeout. No try/catch may swallow matching errors.
+        let validation = "document.createDocumentFragment().querySelector(sel);";
+        assert!(DEEP_FIND_FN.contains(validation));
+        assert!(DEEP_COLLECT_FN.contains(validation));
+        assert!(!DEEP_FIND_FN.contains("catch"));
+        assert!(!DEEP_COLLECT_FN.contains("catch"));
+    }
+
+    #[test]
+    fn snapshot_js_clears_stale_refs_before_renumbering() {
+        // Elements tagged by a previous snapshot that are now hidden must not
+        // keep their old ref, or find-by-ref could resolve to the wrong node.
+        assert!(EXTRACT_ELEMENTS_JS.contains("__mDeepCollect('[data-moltis-ref]')"));
+        assert!(EXTRACT_ELEMENTS_JS.contains("delete el.dataset.moltisRef;"));
     }
 
     #[test]

--- a/crates/browser/tests/shadow_dom.rs
+++ b/crates/browser/tests/shadow_dom.rs
@@ -1,0 +1,245 @@
+//! Real-browser end-to-end tests for shadow-DOM piercing element lookups.
+//!
+//! Launches an installed Chromium-family browser in headless mode against a
+//! local test page containing nested open shadow roots. When no suitable
+//! browser is installed (e.g. bare CI runners) the test skips itself with a
+//! message instead of failing.
+
+use std::time::{Duration, Instant};
+
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+use moltis_browser::{
+    BrowserAction, BrowserConfig, BrowserManager, BrowserRequest, detect::detect_browser,
+};
+
+/// Test page: one light-DOM button, one button inside an open shadow root, and
+/// one input inside a shadow root nested one level deeper.
+const SHADOW_PAGE: &str = r#"<!doctype html>
+<html><body>
+<button id="light">Light button</button>
+<div id="host"></div>
+<script>
+  const host = document.getElementById('host');
+  const root = host.attachShadow({ mode: 'open' });
+  root.innerHTML = '<button id="shadow-btn">Shadow button</button><div id="nested"></div>';
+  root.getElementById('shadow-btn').addEventListener('click', () => {
+    window.__moltisClicked = true;
+  });
+  const nested = root.getElementById('nested').attachShadow({ mode: 'open' });
+  nested.innerHTML = '<input type="text" placeholder="deep-input">';
+</script>
+</body></html>"#;
+
+/// Serve `SHADOW_PAGE` on an ephemeral localhost port and return its URL.
+async fn serve_shadow_page() -> String {
+    let listener = match tokio::net::TcpListener::bind("127.0.0.1:0").await {
+        Ok(listener) => listener,
+        Err(e) => panic!("failed to bind test HTTP server: {e}"),
+    };
+    let addr = match listener.local_addr() {
+        Ok(addr) => addr,
+        Err(e) => panic!("failed to read test HTTP server address: {e}"),
+    };
+
+    tokio::spawn(async move {
+        loop {
+            let Ok((mut stream, _)) = listener.accept().await else {
+                return;
+            };
+            tokio::spawn(async move {
+                let mut buf = [0u8; 4096];
+                let _ = stream.read(&mut buf).await;
+                let response = format!(
+                    "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nContent-Length: \
+                     {}\r\nConnection: close\r\n\r\n{SHADOW_PAGE}",
+                    SHADOW_PAGE.len()
+                );
+                let _ = stream.write_all(response.as_bytes()).await;
+                let _ = stream.shutdown().await;
+            });
+        }
+    });
+
+    format!("http://127.0.0.1:{}/", addr.port())
+}
+
+fn req(session_id: Option<String>, action: BrowserAction) -> BrowserRequest {
+    BrowserRequest {
+        session_id,
+        action,
+        timeout_ms: 30_000,
+        sandbox: Some(false),
+        browser: None,
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn shadow_dom_lookups_pierce_open_roots() {
+    let detection = detect_browser(None);
+    // Renderless CDP browsers (Obscura, Lightpanda) don't implement enough of
+    // the DOM for this test; require a pixel-rendering Chromium-family engine.
+    let Some(chromium) = detection
+        .browsers
+        .iter()
+        .find(|b| b.kind.supports_screenshots())
+    else {
+        eprintln!("skipping shadow_dom e2e: no Chromium-family browser installed");
+        return;
+    };
+
+    let url = serve_shadow_page().await;
+
+    let config = BrowserConfig {
+        enabled: true,
+        headless: true,
+        persist_profile: false,
+        chrome_path: Some(chromium.path.to_string_lossy().into_owned()),
+        ..BrowserConfig::default()
+    };
+    let manager = BrowserManager::new(config);
+
+    let nav = manager
+        .handle_request(req(None, BrowserAction::Navigate { url }))
+        .await;
+    assert!(nav.success, "navigate failed: {:?}", nav.error);
+    let sid = Some(nav.session_id.clone());
+
+    // Snapshot must surface elements from the light DOM, an open shadow root,
+    // and a shadow root nested inside another shadow root.
+    let snap = manager
+        .handle_request(req(sid.clone(), BrowserAction::Snapshot))
+        .await;
+    assert!(snap.success, "snapshot failed: {:?}", snap.error);
+    let Some(snapshot) = snap.snapshot else {
+        panic!("snapshot response missing DOM snapshot");
+    };
+    assert!(
+        snapshot
+            .elements
+            .iter()
+            .any(|e| e.text.as_deref() == Some("Light button")),
+        "light-DOM button missing from snapshot: {:?}",
+        snapshot.elements
+    );
+    let Some(shadow_btn) = snapshot
+        .elements
+        .iter()
+        .find(|e| e.text.as_deref() == Some("Shadow button"))
+    else {
+        panic!(
+            "open-shadow-root button missing from snapshot: {:?}",
+            snapshot.elements
+        );
+    };
+    let Some(deep_input) = snapshot
+        .elements
+        .iter()
+        .find(|e| e.placeholder.as_deref() == Some("deep-input"))
+    else {
+        panic!(
+            "nested-shadow-root input missing from snapshot: {:?}",
+            snapshot.elements
+        );
+    };
+
+    // Click resolves the shadow element's coordinates through the deep finder.
+    let click = manager
+        .handle_request(req(sid.clone(), BrowserAction::Click {
+            ref_: shadow_btn.ref_,
+        }))
+        .await;
+    assert!(click.success, "click failed: {:?}", click.error);
+    let clicked = manager
+        .handle_request(req(sid.clone(), BrowserAction::Evaluate {
+            code: "window.__moltisClicked === true".into(),
+        }))
+        .await;
+    assert_eq!(
+        clicked.result,
+        Some(serde_json::Value::Bool(true)),
+        "click on shadow-root button did not fire its handler"
+    );
+
+    // Type focuses the nested shadow input through the deep finder.
+    let typed = manager
+        .handle_request(req(sid.clone(), BrowserAction::Type {
+            ref_: deep_input.ref_,
+            text: "hi".into(),
+        }))
+        .await;
+    assert!(typed.success, "type failed: {:?}", typed.error);
+    let value = manager
+        .handle_request(req(sid.clone(), BrowserAction::Evaluate {
+            code: "document.getElementById('host').shadowRoot.getElementById('nested')\
+                   .shadowRoot.querySelector('input').value"
+                .into(),
+        }))
+        .await;
+    assert_eq!(
+        value.result,
+        Some(serde_json::Value::String("hi".into())),
+        "typed text did not reach the nested shadow input"
+    );
+
+    // Wait with a selector that only matches inside the nested shadow root.
+    let ok_wait = manager
+        .handle_request(req(sid.clone(), BrowserAction::Wait {
+            selector: Some(r#"[placeholder="deep-input"]"#.into()),
+            ref_: None,
+            timeout_ms: 5_000,
+        }))
+        .await;
+    assert!(
+        ok_wait.success,
+        "wait on shadow selector failed: {:?}",
+        ok_wait.error
+    );
+
+    // An invalid selector must fail fast, not poll until the wait timeout.
+    let start = Instant::now();
+    let bad_wait = manager
+        .handle_request(req(sid.clone(), BrowserAction::Wait {
+            selector: Some("[[not-a-selector".into()),
+            ref_: None,
+            timeout_ms: 10_000,
+        }))
+        .await;
+    let elapsed = start.elapsed();
+    assert!(!bad_wait.success, "invalid selector unexpectedly matched");
+    let bad_err = bad_wait.error.unwrap_or_default();
+    assert!(
+        !bad_err.contains("element not found"),
+        "invalid selector polled to timeout instead of failing fast: {bad_err}"
+    );
+    assert!(
+        elapsed < Duration::from_secs(3),
+        "invalid selector took {elapsed:?}; expected an immediate error"
+    );
+
+    // Stale refs from a previous snapshot must be cleared: hide the light
+    // button, re-snapshot, and its old ref attribute must be gone.
+    let hide = manager
+        .handle_request(req(sid.clone(), BrowserAction::Evaluate {
+            code: "document.getElementById('light').style.display = 'none'; true".into(),
+        }))
+        .await;
+    assert!(hide.success, "hide failed: {:?}", hide.error);
+    let resnap = manager
+        .handle_request(req(sid.clone(), BrowserAction::Snapshot))
+        .await;
+    assert!(resnap.success, "re-snapshot failed: {:?}", resnap.error);
+    let stale = manager
+        .handle_request(req(sid.clone(), BrowserAction::Evaluate {
+            code: "document.getElementById('light').hasAttribute('data-moltis-ref')".into(),
+        }))
+        .await;
+    assert_eq!(
+        stale.result,
+        Some(serde_json::Value::Bool(false)),
+        "hidden element kept its stale ref after re-snapshot"
+    );
+
+    let close = manager.handle_request(req(sid, BrowserAction::Close)).await;
+    assert!(close.success, "close failed: {:?}", close.error);
+}


### PR DESCRIPTION
## Summary

This PR is an alternative/update path for #1100 because I could not push a follow-up commit to the original PR head repository (`resumeparseeval/mycelium`). It keeps the original behavior from #1100 and adds the review fixes on top.

The browser snapshot and ref-based lookup paths now pierce open shadow roots so controls inside web components, such as Salesforce Lightning login fields, are visible to the browser tool and reachable by ref-based actions.

## What changed

- Adds reusable shadow-piercing helpers:
  - `__mDeepFind(sel)` for first-match lookup across `document` and open shadow roots.
  - `__mDeepCollect(sel)` for collecting matching elements across `document` and open shadow roots.
- Routes snapshot extraction through `__mDeepCollect(selector)` instead of a flat `document.querySelectorAll(selector)`.
- Routes ref-based operations through `__mDeepFind('[data-moltis-ref="N"]')`:
  - `find_element_by_ref`
  - `focus_element_by_ref`
  - `scroll_element_into_view`
  - manager element scroll
  - `wait(ref=...)`
  - screenshot highlight lookup
- Routes highlight cleanup through `__mDeepCollect('[data-moltis-ref]')` so highlighted elements inside open shadow roots are cleaned up too.
- Fixes the unresolved review feedback from #1100: `__mDeepCollect` now performs one DOM walk per root using `querySelectorAll('*')` plus `el.matches(sel)`, instead of walking each root twice with both `querySelectorAll(sel)` and `querySelectorAll('*')`.
- Additional self-review fix: `wait(selector=...)` now uses `__mDeepFind(selector)` instead of flat `document.querySelector(selector)`, so selector waits work consistently for open-shadow-root content.

## Root cause

The existing browser tool used flat DOM queries for both snapshot collection and several ref-resolution paths. Flat `document.querySelector*` calls do not cross shadow DOM boundaries, so elements rendered inside open web-component shadow roots were invisible to snapshots and unreachable by later `click`, `type`, `scroll`, `wait`, or highlight operations.

The first implementation of `__mDeepCollect` fixed visibility but did two full traversals per root: one traversal to collect selector matches and another traversal to find shadow hosts. The review comment correctly pointed out that this is unnecessary. A single all-elements traversal can both test `el.matches(sel)` and recurse into `el.shadowRoot`.

## User impact

Pages built with web components expose interactive controls to the browser tool when those controls live in open shadow roots. Agents can now see and operate on those elements through the normal snapshot/ref workflow instead of looping on empty or incomplete DOM results.

Closed shadow roots remain intentionally unsupported because page JavaScript cannot pierce them.

## Validation

Ran on `sgn-mp-eu-1-prod` in `/home/iayyje/moltis-custom`:

- `cargo fmt --all -- --check`
- `cargo test -p moltis-browser`
  - `101 passed; 0 failed`
- `cargo clippy -p moltis-browser --all-targets -- -D warnings`

## Notes

This PR includes the original #1100 change plus the review follow-up commit `76a7882a fix(browser): tighten shadow DOM element lookups`.
