### PR TITLE
Fix Docker sandbox filesystem tool fallback

### DIFF
--- a/crates/tools/src/fs/contract_tests.rs
+++ b/crates/tools/src/fs/contract_tests.rs
@@ -890,6 +890,232 @@ async fn sandbox_write_via_registry_sends_base64_to_bridge() {
 }
 
 #[tokio::test]
+async fn sandbox_write_home_path_via_registry_uses_bridge_not_host_parent_resolution() {
+    use {
+        crate::{
+            exec::ExecResult,
+            fs::sandbox_bridge::test_helpers::MockSandbox,
+            sandbox::{Sandbox, SandboxConfig, SandboxRouter},
+        },
+        base64::{Engine as _, engine::general_purpose::STANDARD as BASE64},
+        std::sync::Arc,
+    };
+
+    let mock = MockSandbox::new(vec![ExecResult {
+        stdout: String::new(),
+        stderr: String::new(),
+        exit_code: 0,
+    }]);
+    let backend: Arc<dyn Sandbox> = mock.clone();
+    let router = Arc::new(SandboxRouter::with_backend(
+        SandboxConfig::default(),
+        backend,
+    ));
+    router.set_override("sandboxed", true).await;
+
+    let mut registry = ToolRegistry::new();
+    register_fs_tools(&mut registry, FsToolsContext {
+        sandbox_router: Some(router),
+        ..FsToolsContext::default()
+    });
+
+    let write = registry.get("Write").unwrap();
+    let value = write
+        .execute(json!({
+            "file_path": "/home/sandbox/write_probe.txt",
+            "content": "sandbox home write",
+            "_session_key": "sandboxed",
+        }))
+        .await
+        .unwrap();
+
+    assert_eq!(value["bytes_written"], 18);
+    let cmd = mock.last_command().unwrap();
+    assert!(cmd.contains("/home/sandbox/write_probe.txt"));
+    assert!(cmd.contains(&BASE64.encode(b"sandbox home write")));
+}
+
+#[tokio::test]
+async fn sandbox_read_and_write_workspace_paths_via_registry_use_bridge() {
+    use {
+        crate::{
+            exec::ExecResult,
+            fs::sandbox_bridge::test_helpers::MockSandbox,
+            sandbox::{Sandbox, SandboxConfig, SandboxRouter},
+        },
+        base64::{Engine as _, engine::general_purpose::STANDARD as BASE64},
+        std::sync::Arc,
+    };
+
+    let workspace_file = moltis_config::data_dir().join("notes/workspace_probe.txt");
+    let workspace_file = workspace_file.display().to_string();
+    let mock = MockSandbox::new(vec![
+        ExecResult {
+            stdout: BASE64.encode(b"workspace read"),
+            stderr: String::new(),
+            exit_code: 0,
+        },
+        ExecResult {
+            stdout: String::new(),
+            stderr: String::new(),
+            exit_code: 0,
+        },
+    ]);
+    let backend: Arc<dyn Sandbox> = mock.clone();
+    let router = Arc::new(SandboxRouter::with_backend(
+        SandboxConfig::default(),
+        backend,
+    ));
+    router.set_override("sandboxed", true).await;
+
+    let mut registry = ToolRegistry::new();
+    register_fs_tools(&mut registry, FsToolsContext {
+        sandbox_router: Some(router),
+        ..FsToolsContext::default()
+    });
+
+    let read = registry.get("Read").unwrap();
+    let value = read
+        .execute(json!({
+            "file_path": workspace_file,
+            "_session_key": "sandboxed",
+        }))
+        .await
+        .unwrap();
+    assert!(
+        value["content"]
+            .as_str()
+            .unwrap()
+            .contains("workspace read")
+    );
+
+    let write = registry.get("Write").unwrap();
+    let value = write
+        .execute(json!({
+            "file_path": workspace_file,
+            "content": "workspace write",
+            "_session_key": "sandboxed",
+        }))
+        .await
+        .unwrap();
+
+    assert_eq!(value["bytes_written"], 15);
+    let cmd = mock.last_command().unwrap();
+    assert!(cmd.contains("notes/workspace_probe.txt"));
+    assert!(cmd.contains(&BASE64.encode(b"workspace write")));
+}
+
+#[tokio::test]
+async fn sandbox_edit_home_path_via_registry_reads_and_writes_through_bridge() {
+    use {
+        crate::{
+            exec::ExecResult,
+            fs::sandbox_bridge::test_helpers::MockSandbox,
+            sandbox::{Sandbox, SandboxConfig, SandboxRouter},
+        },
+        base64::{Engine as _, engine::general_purpose::STANDARD as BASE64},
+        std::sync::Arc,
+    };
+
+    let mock = MockSandbox::new(vec![
+        ExecResult {
+            stdout: BASE64.encode(b"before\n"),
+            stderr: String::new(),
+            exit_code: 0,
+        },
+        ExecResult {
+            stdout: String::new(),
+            stderr: String::new(),
+            exit_code: 0,
+        },
+    ]);
+    let backend: Arc<dyn Sandbox> = mock.clone();
+    let router = Arc::new(SandboxRouter::with_backend(
+        SandboxConfig::default(),
+        backend,
+    ));
+    router.set_override("sandboxed", true).await;
+
+    let mut registry = ToolRegistry::new();
+    register_fs_tools(&mut registry, FsToolsContext {
+        sandbox_router: Some(router),
+        ..FsToolsContext::default()
+    });
+
+    let edit = registry.get("Edit").unwrap();
+    let value = edit
+        .execute(json!({
+            "file_path": "/home/sandbox/edit_probe.txt",
+            "old_string": "before",
+            "new_string": "after",
+            "_session_key": "sandboxed",
+        }))
+        .await
+        .unwrap();
+
+    assert_eq!(value["replacements"], 1);
+    let cmd = mock.last_command().unwrap();
+    assert!(cmd.contains("/home/sandbox/edit_probe.txt"));
+    assert!(cmd.contains(&BASE64.encode(b"after\n")));
+}
+
+#[tokio::test]
+async fn sandbox_multi_edit_home_path_via_registry_reads_and_writes_through_bridge() {
+    use {
+        crate::{
+            exec::ExecResult,
+            fs::sandbox_bridge::test_helpers::MockSandbox,
+            sandbox::{Sandbox, SandboxConfig, SandboxRouter},
+        },
+        base64::{Engine as _, engine::general_purpose::STANDARD as BASE64},
+        std::sync::Arc,
+    };
+
+    let mock = MockSandbox::new(vec![
+        ExecResult {
+            stdout: BASE64.encode(b"alpha beta\n"),
+            stderr: String::new(),
+            exit_code: 0,
+        },
+        ExecResult {
+            stdout: String::new(),
+            stderr: String::new(),
+            exit_code: 0,
+        },
+    ]);
+    let backend: Arc<dyn Sandbox> = mock.clone();
+    let router = Arc::new(SandboxRouter::with_backend(
+        SandboxConfig::default(),
+        backend,
+    ));
+    router.set_override("sandboxed", true).await;
+
+    let mut registry = ToolRegistry::new();
+    register_fs_tools(&mut registry, FsToolsContext {
+        sandbox_router: Some(router),
+        ..FsToolsContext::default()
+    });
+
+    let multi_edit = registry.get("MultiEdit").unwrap();
+    let value = multi_edit
+        .execute(json!({
+            "file_path": "/home/sandbox/multi_probe.txt",
+            "edits": [
+                { "old_string": "alpha", "new_string": "ALPHA" },
+                { "old_string": "beta", "new_string": "BETA" }
+            ],
+            "_session_key": "sandboxed",
+        }))
+        .await
+        .unwrap();
+
+    assert_eq!(value["edits_applied"], 2);
+    let cmd = mock.last_command().unwrap();
+    assert!(cmd.contains("/home/sandbox/multi_probe.txt"));
+    assert!(cmd.contains(&BASE64.encode(b"ALPHA BETA\n")));
+}
+
+#[tokio::test]
 async fn sandbox_write_serializes_same_file_mutations_via_registry() {
     let probe = ConcurrentExecProbeSandbox::new();
     let backend: Arc<dyn Sandbox> = probe.clone();

--- a/crates/tools/src/fs/edit.rs
+++ b/crates/tools/src/fs/edit.rs
@@ -476,7 +476,9 @@ impl AgentTool for EditTool {
          `old_string` is not unique in the file unless `replace_all=true`. \
          This uniqueness requirement prevents the most common class of \
          edit mistakes. Supply enough context in `old_string` to make the \
-         match unique."
+         match unique. In sandboxed sessions, use absolute workspace/data paths \
+         or `/home/sandbox/...` paths; both are read and written through the \
+         sandbox when needed."
     }
 
     fn parameters_schema(&self) -> Value {

--- a/crates/tools/src/fs/multi_edit.rs
+++ b/crates/tools/src/fs/multi_edit.rs
@@ -316,7 +316,9 @@ impl AgentTool for MultiEditTool {
         "Apply multiple sequential edits to a single file as one atomic \
          operation. Each edit sees the output of previous edits. Either all \
          edits succeed or none are applied (full rollback on any failure). \
-         Each edit follows the same uniqueness rules as `Edit`."
+         Each edit follows the same uniqueness rules as `Edit`. In sandboxed \
+         sessions, use absolute workspace/data paths or `/home/sandbox/...` \
+         paths; both are read and written through the sandbox when needed."
     }
 
     fn parameters_schema(&self) -> Value {

--- a/crates/tools/src/fs/read/tool.rs
+++ b/crates/tools/src/fs/read/tool.rs
@@ -528,7 +528,9 @@ impl AgentTool for ReadTool {
          Supports `offset` (1-indexed line to start at) and `limit` (max lines \
          to return) for paginating large files. Returns structured JSON with \
          the file's content, total line count, and truncation flag. Binary \
-         files return a typed marker instead of garbage."
+         files return a typed marker instead of garbage. In sandboxed sessions, \
+         use absolute workspace/data paths or `/home/sandbox/...` paths; both \
+         are routed through the sandbox when needed."
     }
 
     fn parameters_schema(&self) -> Value {

--- a/crates/tools/src/fs/write.rs
+++ b/crates/tools/src/fs/write.rs
@@ -248,7 +248,9 @@ impl AgentTool for WriteTool {
     fn description(&self) -> &str {
         "Atomically write a file to the local filesystem. Parent directories \
          must already exist. Refuses to follow symlinks. The entire file is \
-         replaced — use `Edit` for surgical changes."
+         replaced — use `Edit` for surgical changes. In sandboxed sessions, \
+         use absolute workspace/data paths or `/home/sandbox/...` paths; parent \
+         directories must already exist in the target namespace."
     }
 
     fn parameters_schema(&self) -> Value {

--- a/crates/tools/src/sandbox/docker.rs
+++ b/crates/tools/src/sandbox/docker.rs
@@ -88,6 +88,18 @@ impl DockerSandbox {
         }
     }
 
+    #[cfg(test)]
+    pub(crate) fn with_cli(config: SandboxConfig, cli: &'static str) -> Self {
+        Self {
+            config,
+            kind: BackendKind::Docker,
+            cli,
+            backend_label: "docker",
+            provisioned: Mutex::new(HashSet::new()),
+            startup_gates: Mutex::new(HashMap::new()),
+        }
+    }
+
     fn image(&self) -> &str {
         self.config
             .image
@@ -758,7 +770,10 @@ impl Sandbox for DockerSandbox {
             max_bytes,
         )
         .await?;
-        if !matches!(host_result, SandboxReadResult::NotFound) {
+        if matches!(
+            host_result,
+            SandboxReadResult::Ok(_) | SandboxReadResult::TooLarge(_)
+        ) {
             return Ok(host_result);
         }
 
@@ -780,13 +795,24 @@ impl Sandbox for DockerSandbox {
         content: &[u8],
     ) -> Result<Option<serde_json::Value>> {
         if let Some(host_path) = self.mounted_host_path(id, file_path) {
-            return native_host_write_file(
+            let host_result = native_host_write_file(
                 host_path
                     .to_str()
                     .ok_or_else(|| Error::message("mounted host path contains invalid UTF-8"))?,
                 content,
             )
             .await;
+            match host_result {
+                Ok(payload) => return Ok(payload),
+                Err(error) => {
+                    debug!(
+                        guest_path = file_path,
+                        host_path = %host_path.display(),
+                        %error,
+                        "mounted host write failed; falling back to container write"
+                    );
+                },
+            }
         }
 
         let container_name = self.container_name(id);
@@ -795,13 +821,25 @@ impl Sandbox for DockerSandbox {
 
     async fn list_files(&self, id: &SandboxId, root: &str) -> Result<SandboxListFilesResult> {
         if let Some(host_path) = self.mounted_host_path(id, root) {
-            let host_files = native_host_list_files(
+            let host_result = native_host_list_files(
                 host_path
                     .to_str()
                     .ok_or_else(|| Error::message("mounted host path contains invalid UTF-8"))?,
             )
-            .await?;
-            return remap_host_list_result_to_guest(root, &host_path, host_files);
+            .await;
+            match host_result {
+                Ok(host_files) => {
+                    return remap_host_list_result_to_guest(root, &host_path, host_files);
+                },
+                Err(error) => {
+                    debug!(
+                        guest_path = root,
+                        host_path = %host_path.display(),
+                        %error,
+                        "mounted host list failed; falling back to container list"
+                    );
+                },
+            }
         }
 
         let container_name = self.container_name(id);

--- a/crates/tools/src/sandbox/docker.rs
+++ b/crates/tools/src/sandbox/docker.rs
@@ -763,13 +763,10 @@ impl Sandbox for DockerSandbox {
             return oci_container_read_file(self.cli, &container_name, file_path, max_bytes).await;
         };
 
-        let host_result = native_host_read_file(
-            host_path
-                .to_str()
-                .ok_or_else(|| Error::message("mounted host path contains invalid UTF-8"))?,
-            max_bytes,
-        )
-        .await;
+        let host_result = match host_path.to_str() {
+            Some(host_path) => native_host_read_file(host_path, max_bytes).await,
+            None => Err(Error::message("mounted host path contains invalid UTF-8")),
+        };
         match host_result {
             Ok(result @ (SandboxReadResult::Ok(_) | SandboxReadResult::TooLarge(_))) => {
                 return Ok(result);
@@ -803,13 +800,10 @@ impl Sandbox for DockerSandbox {
         content: &[u8],
     ) -> Result<Option<serde_json::Value>> {
         if let Some(host_path) = self.mounted_host_path(id, file_path) {
-            let host_result = native_host_write_file(
-                host_path
-                    .to_str()
-                    .ok_or_else(|| Error::message("mounted host path contains invalid UTF-8"))?,
-                content,
-            )
-            .await;
+            let host_result = match host_path.to_str() {
+                Some(host_path) => native_host_write_file(host_path, content).await,
+                None => Err(Error::message("mounted host path contains invalid UTF-8")),
+            };
             match host_result {
                 Ok(payload) => return Ok(payload),
                 Err(error) => {
@@ -829,12 +823,15 @@ impl Sandbox for DockerSandbox {
 
     async fn list_files(&self, id: &SandboxId, root: &str) -> Result<SandboxListFilesResult> {
         if let Some(host_path) = self.mounted_host_path(id, root) {
-            let host_result = native_host_list_files(
-                host_path
-                    .to_str()
-                    .ok_or_else(|| Error::message("mounted host path contains invalid UTF-8"))?,
-            )
-            .await;
+            let host_result = match host_path.to_str() {
+                Some(host_path) => match tokio::fs::symlink_metadata(host_path).await {
+                    Ok(_) => native_host_list_files(host_path).await,
+                    Err(error) => Err(Error::message(format!(
+                        "failed to inspect mounted host path: {error}"
+                    ))),
+                },
+                None => Err(Error::message("mounted host path contains invalid UTF-8")),
+            };
             match host_result {
                 Ok(host_files) => {
                     return remap_host_list_result_to_guest(root, &host_path, host_files);

--- a/crates/tools/src/sandbox/docker.rs
+++ b/crates/tools/src/sandbox/docker.rs
@@ -769,20 +769,28 @@ impl Sandbox for DockerSandbox {
                 .ok_or_else(|| Error::message("mounted host path contains invalid UTF-8"))?,
             max_bytes,
         )
-        .await?;
-        if matches!(
-            host_result,
-            SandboxReadResult::Ok(_) | SandboxReadResult::TooLarge(_)
-        ) {
-            return Ok(host_result);
+        .await;
+        match host_result {
+            Ok(result @ (SandboxReadResult::Ok(_) | SandboxReadResult::TooLarge(_))) => {
+                return Ok(result);
+            },
+            Ok(result) => {
+                debug!(
+                    guest_path = file_path,
+                    host_path = %host_path.display(),
+                    ?result,
+                    "mounted host read failed; falling back to container read"
+                );
+            },
+            Err(error) => {
+                debug!(
+                    guest_path = file_path,
+                    host_path = %host_path.display(),
+                    %error,
+                    "mounted host read failed; falling back to container read"
+                );
+            },
         }
-
-        debug!(
-            guest_path = file_path,
-            host_path = %host_path.display(),
-            result = ?host_result,
-            "mounted host read failed; falling back to container read"
-        );
 
         let container_name = self.container_name(id);
         oci_container_read_file(self.cli, &container_name, file_path, max_bytes).await

--- a/crates/tools/src/sandbox/docker.rs
+++ b/crates/tools/src/sandbox/docker.rs
@@ -32,8 +32,9 @@ use {
         exec::{ExecOpts, ExecResult},
         sandbox::file_system::{
             SandboxListFilesResult, SandboxReadResult, native_host_list_files,
-            native_host_read_file, native_host_write_file, oci_container_list_files,
-            oci_container_read_file, oci_container_write_file, remap_host_list_result_to_guest,
+            native_host_list_files_strict, native_host_read_file, native_host_write_file,
+            oci_container_list_files, oci_container_read_file, oci_container_write_file,
+            remap_host_list_result_to_guest,
         },
     },
 };
@@ -824,12 +825,7 @@ impl Sandbox for DockerSandbox {
     async fn list_files(&self, id: &SandboxId, root: &str) -> Result<SandboxListFilesResult> {
         if let Some(host_path) = self.mounted_host_path(id, root) {
             let host_result = match host_path.to_str() {
-                Some(host_path) => match tokio::fs::symlink_metadata(host_path).await {
-                    Ok(_) => native_host_list_files(host_path).await,
-                    Err(error) => Err(Error::message(format!(
-                        "failed to inspect mounted host path: {error}"
-                    ))),
-                },
+                Some(host_path) => native_host_list_files_strict(host_path).await,
                 None => Err(Error::message("mounted host path contains invalid UTF-8")),
             };
             match host_result {

--- a/crates/tools/src/sandbox/file_system.rs
+++ b/crates/tools/src/sandbox/file_system.rs
@@ -557,6 +557,17 @@ fn classify_container_copy_error(stderr: &str) -> Option<ContainerCopyErrorKind>
     None
 }
 
+fn container_copy_failure_detail(stderr: &str, exit_code: Option<i32>) -> String {
+    let detail = stderr.trim();
+    if !detail.is_empty() {
+        return detail.to_string();
+    }
+    match exit_code {
+        Some(code) => format!("copy command exited with code {code} and no stderr"),
+        None => "copy command exited without a status code or stderr".to_string(),
+    }
+}
+
 async fn oci_exec_shell(
     cli: &str,
     container_name: &str,
@@ -1084,7 +1095,7 @@ pub async fn oci_container_read_file(
 
                 Err(Error::message(format!(
                     "{cli} cp failed for '{file_path}': {}",
-                    stderr.trim()
+                    container_copy_failure_detail(stderr.trim(), status.code())
                 )))
             })
             .await
@@ -1148,7 +1159,8 @@ pub async fn oci_container_write_file(
     }
 
     Err(Error::message(format!(
-        "{cli} cp failed for '{file_path}': {detail}"
+        "{cli} cp failed for '{file_path}': {}",
+        container_copy_failure_detail(detail, output.status.code())
     )))
 }
 
@@ -1421,5 +1433,17 @@ mod tests {
         .unwrap();
 
         assert!(matches!(result, SandboxReadResult::NotFound));
+    }
+
+    #[test]
+    fn oci_copy_failure_detail_is_not_empty_when_stderr_is_empty() {
+        assert_eq!(
+            container_copy_failure_detail("", Some(1)),
+            "copy command exited with code 1 and no stderr"
+        );
+        assert_eq!(
+            container_copy_failure_detail("explicit failure", Some(1)),
+            "explicit failure"
+        );
     }
 }

--- a/crates/tools/src/sandbox/file_system.rs
+++ b/crates/tools/src/sandbox/file_system.rs
@@ -902,11 +902,37 @@ pub async fn native_host_write_file(file_path: &str, content: &[u8]) -> Result<O
 /// Native host-backed file listing implementation for sandbox backends whose
 /// paths are just host paths.
 pub async fn native_host_list_files(root: &str) -> Result<SandboxListFilesResult> {
+    native_host_list_files_with_behavior(root, MissingRootBehavior::ReturnEmpty).await
+}
+
+pub(crate) async fn native_host_list_files_strict(root: &str) -> Result<SandboxListFilesResult> {
+    native_host_list_files_with_behavior(root, MissingRootBehavior::ReturnError).await
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum MissingRootBehavior {
+    ReturnEmpty,
+    ReturnError,
+}
+
+async fn native_host_list_files_with_behavior(
+    root: &str,
+    missing_root_behavior: MissingRootBehavior,
+) -> Result<SandboxListFilesResult> {
     let root = PathBuf::from(root);
     tokio::task::spawn_blocking(move || -> Result<SandboxListFilesResult> {
         match std::fs::symlink_metadata(&root) {
-            Ok(metadata) if metadata.file_type().is_symlink() => {
+            Ok(metadata)
+                if metadata.file_type().is_symlink()
+                    && missing_root_behavior == MissingRootBehavior::ReturnEmpty =>
+            {
                 return Ok(SandboxListFilesResult::complete(Vec::new()));
+            },
+            Ok(metadata) if metadata.file_type().is_symlink() => {
+                return Err(Error::message(format!(
+                    "sandbox list_files '{}' failed: root is a symlink",
+                    root.display()
+                )));
             },
             Ok(metadata) if metadata.is_file() => {
                 return Ok(SandboxListFilesResult::complete(vec![
@@ -914,7 +940,10 @@ pub async fn native_host_list_files(root: &str) -> Result<SandboxListFilesResult
                 ]));
             },
             Ok(_) => {},
-            Err(error) if error.kind() == io::ErrorKind::NotFound => {
+            Err(error)
+                if error.kind() == io::ErrorKind::NotFound
+                    && missing_root_behavior == MissingRootBehavior::ReturnEmpty =>
+            {
                 return Ok(SandboxListFilesResult::complete(Vec::new()));
             },
             Err(error) => {
@@ -925,6 +954,7 @@ pub async fn native_host_list_files(root: &str) -> Result<SandboxListFilesResult
             },
         }
 
+        let root_path = root.clone();
         let mut stack = vec![root];
         let mut files = Vec::new();
 
@@ -932,7 +962,10 @@ pub async fn native_host_list_files(root: &str) -> Result<SandboxListFilesResult
             let entries = match std::fs::read_dir(&dir) {
                 Ok(entries) => entries,
                 Err(error) => {
-                    if error.kind() == io::ErrorKind::NotFound {
+                    if error.kind() == io::ErrorKind::NotFound
+                        && (dir != root_path
+                            || missing_root_behavior == MissingRootBehavior::ReturnEmpty)
+                    {
                         continue;
                     }
                     return Err(Error::message(format!(

--- a/crates/tools/src/sandbox/tests/core.rs
+++ b/crates/tools/src/sandbox/tests/core.rs
@@ -610,6 +610,54 @@ async fn test_docker_write_file_uses_mounted_workspace_path() {
     );
 }
 
+#[cfg(unix)]
+#[tokio::test]
+async fn test_docker_write_file_falls_back_to_container_copy_when_host_mount_is_inaccessible() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let fake_cli = temp_dir.path().join("fake-docker");
+    std::fs::write(
+        &fake_cli,
+        "#!/bin/sh\n\
+         if [ \"$1\" = \"exec\" ]; then printf 'missing-file\\n'; exit 0; fi\n\
+         if [ \"$1\" = \"cp\" ]; then cat >/dev/null; exit 0; fi\n\
+         exit 2\n",
+    )
+    .unwrap();
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+        let mut permissions = std::fs::metadata(&fake_cli).unwrap().permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&fake_cli, permissions).unwrap();
+    }
+
+    let cli: &'static str = Box::leak(fake_cli.display().to_string().into_boxed_str());
+    let host_data_dir = temp_dir.path().join("host-only-data");
+    let docker = DockerSandbox::with_cli(
+        SandboxConfig {
+            workspace_mount: WorkspaceMount::Rw,
+            host_data_dir: Some(host_data_dir),
+            ..Default::default()
+        },
+        cli,
+    );
+    let id = SandboxId {
+        scope: SandboxScope::Session,
+        key: "test-docker-write-fallback".into(),
+    };
+    let guest_file = moltis_config::data_dir().join("notes/todo.txt");
+
+    let result = docker
+        .write_file(
+            &id,
+            &guest_file.display().to_string(),
+            b"docker fallback write",
+        )
+        .await
+        .unwrap();
+
+    assert!(result.is_none());
+}
+
 #[tokio::test]
 async fn test_docker_write_file_uses_mounted_home_path() {
     let temp_dir = tempfile::tempdir().unwrap();

--- a/crates/tools/src/sandbox/tests/core.rs
+++ b/crates/tools/src/sandbox/tests/core.rs
@@ -717,6 +717,54 @@ async fn test_docker_list_files_remaps_mounted_workspace_paths() {
     assert!(!files.truncated);
 }
 
+#[cfg(unix)]
+#[tokio::test]
+async fn test_docker_list_files_falls_back_when_host_mount_is_inaccessible() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let fake_cli = temp_dir.path().join("fake-docker");
+    std::fs::write(
+        &fake_cli,
+        "#!/bin/sh\n\
+         if [ \"$1\" != \"exec\" ]; then exit 2; fi\n\
+         case \"$*\" in\n\
+           *\"find \"*) printf '/container/listed.txt\\n' ;;\n\
+           *) printf 'dir\\n' ;;\n\
+         esac\n",
+    )
+    .unwrap();
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+        let mut permissions = std::fs::metadata(&fake_cli).unwrap().permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&fake_cli, permissions).unwrap();
+    }
+
+    let host_data_dir = temp_dir.path().join("host-only-data");
+    std::fs::write(&host_data_dir, "not a directory").unwrap();
+    let cli: &'static str = Box::leak(fake_cli.display().to_string().into_boxed_str());
+    let docker = DockerSandbox::with_cli(
+        SandboxConfig {
+            workspace_mount: WorkspaceMount::Rw,
+            host_data_dir: Some(host_data_dir),
+            ..Default::default()
+        },
+        cli,
+    );
+    let id = SandboxId {
+        scope: SandboxScope::Session,
+        key: "test-docker-list-fallback".into(),
+    };
+    let guest_root = moltis_config::data_dir().join("notes");
+
+    let files = docker
+        .list_files(&id, &guest_root.display().to_string())
+        .await
+        .unwrap();
+
+    assert_eq!(files.files, vec!["/container/listed.txt"]);
+    assert!(!files.truncated);
+}
+
 #[tokio::test]
 async fn test_provisioning_guard_skips_second_call() {
     let docker = DockerSandbox::new(SandboxConfig::default());

--- a/crates/tools/src/sandbox/tests/core.rs
+++ b/crates/tools/src/sandbox/tests/core.rs
@@ -739,15 +739,8 @@ async fn test_docker_list_files_falls_back_when_host_mount_is_inaccessible() {
         std::fs::set_permissions(&fake_cli, permissions).unwrap();
     }
 
-    let host_data_dir = temp_dir.path().join("host-only-data");
-    std::fs::write(&host_data_dir, "not a directory").unwrap();
-    let inaccessible_host_root = host_data_dir.join("notes");
-    assert!(
-        file_system::native_host_list_files(&inaccessible_host_root.display().to_string())
-            .await
-            .is_err(),
-        "a path below a regular file must fail instead of returning an empty host listing"
-    );
+    let host_data_dir = temp_dir.path().join("missing-host-data");
+    assert!(!host_data_dir.exists());
     let cli: &'static str = Box::leak(fake_cli.display().to_string().into_boxed_str());
     let docker = DockerSandbox::with_cli(
         SandboxConfig {

--- a/crates/tools/src/sandbox/tests/core.rs
+++ b/crates/tools/src/sandbox/tests/core.rs
@@ -741,6 +741,13 @@ async fn test_docker_list_files_falls_back_when_host_mount_is_inaccessible() {
 
     let host_data_dir = temp_dir.path().join("host-only-data");
     std::fs::write(&host_data_dir, "not a directory").unwrap();
+    let inaccessible_host_root = host_data_dir.join("notes");
+    assert!(
+        file_system::native_host_list_files(&inaccessible_host_root.display().to_string())
+            .await
+            .is_err(),
+        "a path below a regular file must fail instead of returning an empty host listing"
+    );
     let cli: &'static str = Box::leak(fake_cli.display().to_string().into_boxed_str());
     let docker = DockerSandbox::with_cli(
         SandboxConfig {

--- a/crates/tools/src/sandbox/tests/core.rs
+++ b/crates/tools/src/sandbox/tests/core.rs
@@ -745,7 +745,7 @@ async fn test_docker_list_files_falls_back_when_host_mount_is_inaccessible() {
     let docker = DockerSandbox::with_cli(
         SandboxConfig {
             workspace_mount: WorkspaceMount::Rw,
-            host_data_dir: Some(host_data_dir),
+            host_data_dir: Some(host_data_dir.clone()),
             ..Default::default()
         },
         cli,
@@ -755,6 +755,21 @@ async fn test_docker_list_files_falls_back_when_host_mount_is_inaccessible() {
         key: "test-docker-list-fallback".into(),
     };
     let guest_root = moltis_config::data_dir().join("notes");
+
+    let files = docker
+        .list_files(&id, &guest_root.display().to_string())
+        .await
+        .unwrap();
+
+    assert_eq!(files.files, vec!["/container/listed.txt"]);
+    assert!(!files.truncated);
+
+    std::fs::create_dir_all(&host_data_dir).unwrap();
+    std::os::unix::fs::symlink(
+        temp_dir.path().join("missing-target"),
+        host_data_dir.join("notes"),
+    )
+    .unwrap();
 
     let files = docker
         .list_files(&id, &guest_root.display().to_string())


### PR DESCRIPTION
## Summary
- Add regression coverage for sandboxed Read/Write/Edit/MultiEdit on /home/sandbox and workspace/data paths
- Fall back from translated Docker host paths to container operations when the gateway process cannot access the host mount
- Preserve direct-host missing-list semantics while making Docker listing strict for missing, symlinked, and concurrently removed translated roots
- Improve empty docker/OCI copy failure diagnostics and clarify sandbox path guidance in fs tool descriptions
- Closes #1096

## Validation
### Completed
- [x] `cargo test -p moltis-tools fs::contract_tests::sandbox_`
- [x] `cargo test -p moltis-tools sandbox::tests::core::test_docker_`
- [x] `cargo test -p moltis-tools sandbox::file_system::tests::`
- [x] `cargo test -p moltis-tools` (1,064 passed)
- [x] `cargo clippy -p moltis-tools --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `./scripts/check-file-size.sh`
- [x] `./scripts/local-validate.sh 1105`: build, lint, full tests, macOS app, iOS app, formatting, Biome, TypeScript, i18n, lockfile, file size, install names/docs, web assets, and zizmor passed

### Remaining
- [ ] `./scripts/local-validate.sh 1105`: `local/e2e` reported 411 passed, 7 skipped, and 2 unrelated failures: OAuth disconnect UI state did not refresh, and the Daytona live API returned HTTP 401

## Manual QA
- Docker-in-Docker behavior is covered with fake OCI CLI regression tests for missing and dangling translated host roots and container fallback.