### PR TITLE
hotfix(telegram): stream final replies without completion notify

### DIFF
--- a/crates/chat/src/agent_loop.rs
+++ b/crates/chat/src/agent_loop.rs
@@ -590,3 +590,123 @@ pub(crate) async fn compact_session(
 
     Ok(outcome)
 }
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use async_trait::async_trait;
+
+    use super::*;
+
+    struct RecordingStreamOutbound {
+        streams_final_replies: bool,
+        receives_progress_deltas: bool,
+        events: Arc<Mutex<Vec<moltis_channels::StreamEvent>>>,
+    }
+
+    #[async_trait]
+    impl moltis_channels::ChannelStreamOutbound for RecordingStreamOutbound {
+        async fn send_stream(
+            &self,
+            _account_id: &str,
+            _to: &str,
+            _reply_to: Option<&str>,
+            mut stream: moltis_channels::StreamReceiver,
+        ) -> moltis_channels::Result<()> {
+            while let Some(event) = stream.recv().await {
+                self.events.lock().await.push(event.clone());
+                if matches!(
+                    event,
+                    moltis_channels::StreamEvent::Done | moltis_channels::StreamEvent::Error(_)
+                ) {
+                    break;
+                }
+            }
+            Ok(())
+        }
+
+        async fn is_stream_enabled(&self, _account_id: &str) -> bool {
+            true
+        }
+
+        async fn streams_final_replies(&self, _account_id: &str) -> bool {
+            self.streams_final_replies
+        }
+
+        async fn receives_progress_deltas(&self, _account_id: &str) -> bool {
+            self.receives_progress_deltas
+        }
+    }
+
+    fn channel_target() -> moltis_channels::ChannelReplyTarget {
+        moltis_channels::ChannelReplyTarget {
+            channel_type: moltis_channels::ChannelType::Telegram,
+            account_id: "bot".into(),
+            chat_id: "chat".into(),
+            message_id: Some("msg".into()),
+            thread_id: None,
+        }
+    }
+
+    fn dispatcher_with(outbound: Arc<RecordingStreamOutbound>) -> ChannelStreamDispatcher {
+        ChannelStreamDispatcher {
+            outbound,
+            targets: vec![channel_target()],
+            workers: Vec::new(),
+            tasks: Vec::new(),
+            completed: Arc::new(Mutex::new(HashSet::new())),
+            started: false,
+            sent_final_delta: false,
+        }
+    }
+
+    fn event_kinds(events: &[moltis_channels::StreamEvent]) -> Vec<&'static str> {
+        events
+            .iter()
+            .map(|event| match event {
+                moltis_channels::StreamEvent::Delta(_) => "delta",
+                moltis_channels::StreamEvent::ProgressDelta(_) => "progress",
+                moltis_channels::StreamEvent::Done => "done",
+                moltis_channels::StreamEvent::Error(_) => "error",
+            })
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn streams_without_final_delivery_do_not_complete_targets() {
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let outbound = Arc::new(RecordingStreamOutbound {
+            streams_final_replies: false,
+            receives_progress_deltas: true,
+            events: Arc::clone(&events),
+        });
+        let mut dispatcher = dispatcher_with(outbound);
+
+        dispatcher.send_progress_delta("progress").await;
+        dispatcher.send_delta("final").await;
+        dispatcher.finish().await;
+
+        let events = events.lock().await;
+        assert_eq!(event_kinds(&events), vec!["progress", "delta", "done"]);
+        assert!(dispatcher.completed_target_keys().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn final_stream_workers_receive_progress_and_final_deltas_and_complete_targets() {
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let outbound = Arc::new(RecordingStreamOutbound {
+            streams_final_replies: true,
+            receives_progress_deltas: true,
+            events: Arc::clone(&events),
+        });
+        let mut dispatcher = dispatcher_with(outbound);
+
+        dispatcher.send_progress_delta("progress").await;
+        dispatcher.send_delta("final").await;
+        dispatcher.finish().await;
+
+        let events = events.lock().await;
+        assert_eq!(event_kinds(&events), vec!["progress", "delta", "done"]);
+        assert_eq!(dispatcher.completed_target_keys().await.len(), 1);
+    }
+}

--- a/crates/telegram/src/outbound/stream.rs
+++ b/crates/telegram/src/outbound/stream.rs
@@ -925,8 +925,8 @@ impl ChannelStreamOutbound for TelegramOutbound {
             .is_some_and(|s| s.config.stream_mode != StreamMode::Off)
     }
 
-    async fn streams_final_replies(&self, _account_id: &str) -> bool {
-        false
+    async fn streams_final_replies(&self, account_id: &str) -> bool {
+        self.is_stream_enabled(account_id).await
     }
 
     async fn receives_progress_deltas(&self, account_id: &str) -> bool {

--- a/crates/telegram/src/outbound/tests.rs
+++ b/crates/telegram/src/outbound/tests.rs
@@ -464,7 +464,7 @@ fn stream_progress_cleanup_marker_points_to_final_answer() {
 }
 
 #[tokio::test]
-async fn telegram_streaming_does_not_replace_final_delivery() {
+async fn telegram_streaming_delivers_progress_and_final_streams_without_notify() {
     let accounts: AccountStateMap = Arc::new(std::sync::RwLock::new(HashMap::new()));
     let outbound = Arc::new(TelegramOutbound {
         accounts: Arc::clone(&accounts),
@@ -478,6 +478,7 @@ async fn telegram_streaming_does_not_replace_final_delivery() {
             bot_username: Some("test_bot".to_string()),
             account_id: account_id.to_string(),
             config: TelegramAccountConfig {
+                stream_notify_on_complete: false,
                 token: Secret::new("test-token".to_string()),
                 dm_policy: DmPolicy::Open,
                 ..Default::default()
@@ -491,7 +492,8 @@ async fn telegram_streaming_does_not_replace_final_delivery() {
     }
 
     assert!(outbound.is_stream_enabled(account_id).await);
-    assert!(!outbound.streams_final_replies(account_id).await);
+    assert!(outbound.receives_progress_deltas(account_id).await);
+    assert!(outbound.streams_final_replies(account_id).await);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

Hotfix for Telegram edit-in-place streaming after [#1099](https://github.com/moltis-org/moltis/pull/1099).

When Telegram streaming was enabled but completion notifications were disabled, the final answer was not treated as a streamed final reply. This restores the expected behavior: Telegram can keep editing/streaming the final reply while `stream_notify_on_complete = false` only suppresses the completion notification.

## What was observed

In live Telegram testing with anonymized session details:

- `stream_mode = edit_in_place`
- `stream_notify_on_complete = false`
- final response arrived as a non-streamed whole response instead of being edited/streamed
- completion notification was correctly suppressed
- when the answer exceeded Telegram chunk limits, only the first chunk streamed and later chunks were sent at completion, which matched existing chunking behavior and was not part of this fix

## Root Cause

The channel streaming layer distinguishes between:

- streams that only consume progress deltas
- streams that also deliver the final reply text

After #1099, Telegram still reported `streams_final_replies = false` even when edit-in-place streaming was enabled. That made the chat layer treat Telegram as a progress-only stream for final delivery bookkeeping.

The fix changes Telegram's `streams_final_replies` implementation to follow `is_stream_enabled(...)`, so a Telegram account with streaming enabled is marked as a final-reply stream regardless of whether completion notifications are enabled.

## Code Investigation

Relevant paths checked:

- `crates/telegram/src/outbound/stream.rs`
  - `stream_notify_on_complete` controls whether Telegram gets a separate completion notification/final send behavior.
  - It should not disable final reply streaming.
  - `streams_final_replies` now returns the effective stream-enabled state.
- `crates/chat/src/agent_loop.rs`
  - dispatcher tests document that final-stream workers receive progress, final delta, and completion
  - current main still broadcasts final deltas to active stream workers, while `streams_final_replies` controls whether the target is considered completed for normal final delivery
- `crates/telegram/src/outbound/tests.rs`
  - notify-off Telegram config now asserts that streaming remains enabled for progress and final replies

## Validation

Passed:

```text
just format-check
bash ./scripts/check-changelog-guard.sh origin/main HEAD
cargo test -p moltis-telegram --lib notify -- --nocapture
cargo test -p moltis-chat --lib agent_loop::tests -- --nocapture
cargo clippy -p moltis-telegram -p moltis-chat --lib -- -D warnings
```

Also manually validated the deployed hotfix with Telegram settings `stream=on, notify=off`: the final answer streamed/edited in Telegram and no completion notification was emitted.