### PR TITLE
fix(whatsapp): deliver replies to @lid chats via PN JID rewrite

### DIFF
--- a/crates/whatsapp/src/outbound.rs
+++ b/crates/whatsapp/src/outbound.rs
@@ -1,12 +1,12 @@
 use {
     async_trait::async_trait,
     base64::Engine,
-    tracing::{debug, info},
+    tracing::{debug, info, warn},
 };
 
 use {
     wacore::download::MediaType,
-    wacore_binary::jid::Jid,
+    wacore_binary::jid::{HIDDEN_USER_SERVER, Jid},
     waproto::whatsapp as wa,
     whatsapp_rust::{ChatStateType, upload::UploadResponse},
 };
@@ -28,6 +28,42 @@ fn resolve_jid(to: &str) -> ChannelResult<Jid> {
             .map_err(|e| moltis_channels::Error::invalid_input(format!("invalid JID: {e:?}")))
     } else {
         Ok(Jid::pn(to))
+    }
+}
+
+/// Whether a destination JID is keyed by LID and must be re-addressed to its
+/// phone number before sending.
+fn needs_lid_resolution(jid: &Jid) -> bool {
+    jid.server == HIDDEN_USER_SERVER
+}
+
+/// Rewrite a `@lid` destination to its phone-number JID when a mapping exists.
+///
+/// Stanzas addressed to `@lid` chats are accepted by the server but never
+/// delivered (no `Delivered` receipt), while the same message sent to the
+/// mapped PN JID arrives normally. Inbound chats from privacy-enabled senders
+/// are keyed by LID, so replies must be re-addressed before sending. When no
+/// mapping is known the JID is returned unchanged so behaviour matches the
+/// pre-fix path.
+async fn to_deliverable_jid(client: &whatsapp_rust::client::Client, jid: Jid) -> Jid {
+    if !needs_lid_resolution(&jid) {
+        return jid;
+    }
+    match client.get_phone_number_from_lid(&jid.user).await {
+        Some(pn) => {
+            debug!(lid = %jid, pn = %pn, "rewriting LID destination to PN JID");
+            Jid::pn(pn)
+        },
+        None => {
+            // No mapping known: the message goes to the `@lid` JID, which the
+            // server is likely to drop without a `Delivered` receipt. Warn so
+            // the undelivered reply is visible without enabling debug logging.
+            warn!(
+                lid = %jid,
+                "no PN mapping for LID destination; reply may not be delivered"
+            );
+            jid
+        },
     }
 }
 
@@ -161,7 +197,7 @@ impl ChannelOutbound for WhatsAppOutbound {
         _reply_to: Option<&str>,
     ) -> ChannelResult<()> {
         let client = self.get_client(account_id)?;
-        let jid = resolve_jid(to)?;
+        let jid = to_deliverable_jid(&client, resolve_jid(to)?).await;
 
         debug!(
             account_id,
@@ -234,7 +270,7 @@ impl ChannelOutbound for WhatsAppOutbound {
         );
 
         let client = self.get_client(account_id)?;
-        let jid = resolve_jid(to)?;
+        let jid = to_deliverable_jid(&client, resolve_jid(to)?).await;
 
         let upload = client.upload(bytes, media_type).await.map_err(|e| {
             moltis_channels::Error::unavailable(format!("whatsapp media upload: {e}"))
@@ -260,7 +296,7 @@ impl ChannelOutbound for WhatsAppOutbound {
 
     async fn send_typing(&self, account_id: &str, to: &str) -> ChannelResult<()> {
         let client = self.get_client(account_id)?;
-        let jid = resolve_jid(to)?;
+        let jid = to_deliverable_jid(&client, resolve_jid(to)?).await;
         client
             .chatstate()
             .send(&jid, ChatStateType::Composing)
@@ -311,6 +347,37 @@ impl ChannelStreamOutbound for WhatsAppOutbound {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn needs_lid_resolution_true_for_lid_jid() {
+        let jid: Jid = "111111111111111@lid"
+            .parse()
+            .unwrap_or_else(|e| panic!("parse lid jid: {e:?}"));
+        assert!(needs_lid_resolution(&jid));
+    }
+
+    #[test]
+    fn needs_lid_resolution_false_for_phone_number_jid() {
+        let jid: Jid = "15551234567@s.whatsapp.net"
+            .parse()
+            .unwrap_or_else(|e| panic!("parse pn jid: {e:?}"));
+        assert!(!needs_lid_resolution(&jid));
+    }
+
+    #[test]
+    fn needs_lid_resolution_false_for_group_jid() {
+        let jid: Jid = "120363456789@g.us"
+            .parse()
+            .unwrap_or_else(|e| panic!("parse group jid: {e:?}"));
+        assert!(!needs_lid_resolution(&jid));
+    }
+
+    #[test]
+    fn needs_lid_resolution_false_for_bare_phone_number() {
+        // `resolve_jid` turns bare numbers into PN JIDs, which must not be rewritten.
+        let jid = resolve_jid("15551234567").unwrap_or_else(|e| panic!("resolve: {e:?}"));
+        assert!(!needs_lid_resolution(&jid));
+    }
 
     #[test]
     fn decode_data_url_valid() {


### PR DESCRIPTION
Summary

  Replies sent to a privacy-enabled sender's @lid chat were silently dropped on WhatsApp. The
  gateway ran the agent, produced a reply (visible in the web UI), and called the outbound
  sender — but the message never reached the user and no Delivered receipt ever came back.
  Sending the same text to the sender's phone-number JID (@s.whatsapp.net) delivered fine.

  Root cause: inbound chats from senders who have number-privacy enabled are keyed by LID
  (<id>@lid). The bundled whatsapp-rust 0.5 does not auto-resolve a @lid destination to its
  phone number before sending (LID/PN address unification landed upstream in 0.6). The
  WhatsApp server accepts the stanza addressed to @lid but drops it.

  Fix: before each outbound send (text, media, typing), resolve a @lid destination to its PN
  JID via the existing Client::get_phone_number_from_lid mapping (already populated by the
  library). When no mapping is known the JID is left unchanged, so the behaviour matches the
  previous path. The @lid check uses the HIDDEN_USER_SERVER constant instead of a string
  literal.

  The change is isolated to crates/whatsapp/src/outbound.rs (+65/-4).

  Validation

  Completed (locally, pinned nightly nightly-2025-12-27)

  - cargo +nightly-2025-12-27 fmt --all -- --check — pass
  - cargo +nightly-2025-12-27 clippy -p moltis-whatsapp --all-targets -- -D warnings — pass
  - cargo +nightly-2025-12-27 test -p moltis-whatsapp — 95 passed, 0 failed (includes 4 new
  unit tests for needs_lid_resolution)

  Remaining (left to CI)

  - just test (full nextest --workspace)
  - just release-preflight (full-workspace clippy)
  - UI e2e — N/A, no web UI changes

  Manual QA

  Reproduced and verified end-to-end on a live self-hosted gateway (ZimaBoard / Docker) paired
  to a real WhatsApp number, with the sender's number-privacy enabled so the chat is keyed by
  @lid.

  - Before: messaging the bot produced a reply in the UI but nothing on WhatsApp; logs showed
  the send "succeed" with no Delivered receipt. A diagnostic send_message to the same person's
  classic @s.whatsapp.net JID did arrive — confirming transport works and only @lid
  addressing was broken.
  - After (patched image): messaging the bot delivers the reply on WhatsApp. Logs:
  DEBUG moltis_whatsapp::outbound: rewriting LID destination to PN JID lid=<redacted>@lid
  pn=<redacted>
  DEBUG whatsapp_rust::receipt: Received receipt type 'Delivered' for message <id>
  - The Delivered receipt (never present before) confirms the fix.

  Notes for maintainers

  - This is a targeted fix at the moltis layer. The deeper fix is bumping whatsapp-rust 0.5 →
  0.6, which brings unified LID/PN addressing; that is a larger change with breakage risk, so
  this PR keeps the surface minimal. Happy to follow up on the bump if preferred.
  - No new dependencies; uses an existing public method (get_phone_number_from_lid) and an
  existing constant (HIDDEN_USER_SERVER).