### PR TITLE
fix(mcp): use direct fetch for resource_metadata URL from WWW-Authenticate

### DIFF
--- a/crates/mcp/src/auth.rs
+++ b/crates/mcp/src/auth.rs
@@ -23,8 +23,8 @@ use crate::{
 
 use moltis_oauth::{
     OAuthConfig, OAuthFlow, OAuthTokens, RegistrationStore, StoredRegistration, TokenStore,
-    fetch_as_metadata, fetch_resource_metadata, normalize_loopback_redirect,
-    parse_www_authenticate, register_client,
+    fetch_as_metadata, fetch_resource_metadata, fetch_resource_metadata_direct,
+    normalize_loopback_redirect, parse_www_authenticate, register_client,
 };
 
 // ── Auth state ─────────────────────────────────────────────────────────────
@@ -410,7 +410,11 @@ impl McpOAuthProvider {
                 debug!(url = %meta_url, "using resource_metadata URL from WWW-Authenticate");
                 let meta_url = Url::parse(&meta_url)
                     .context("invalid resource_metadata URL in WWW-Authenticate header")?;
-                fetch_resource_metadata(&self.http_client, &meta_url).await
+                // The resource_metadata URL from WWW-Authenticate is already the
+                // complete metadata endpoint — do NOT pass through
+                // fetch_resource_metadata() which would append another
+                // /.well-known/oauth-protected-resource suffix.
+                fetch_resource_metadata_direct(&self.http_client, &meta_url).await
             } else {
                 let result = fetch_resource_metadata(&self.http_client, &server_url).await;
                 if result.is_err() && has_path {
@@ -1136,6 +1140,89 @@ mod tests {
             .map(|(_, v)| v.into_owned())
             .expect("auth URL must have redirect_uri");
         assert_eq!(encoded_redirect, http_redirect);
+
+        resource_meta.assert_async().await;
+        as_meta.assert_async().await;
+        register.assert_async().await;
+    }
+
+    /// RFC 9728 origin-based discovery: the `WWW-Authenticate` header carries
+    /// a `resource_metadata` URL that is the **full metadata endpoint**, not
+    /// the resource's base URL. `discover_and_register` must fetch that URL
+    /// directly instead of appending `/.well-known/oauth-protected-resource`.
+    #[tokio::test]
+    async fn discovery_uses_www_authenticate_resource_metadata_directly() {
+        let mut server = mockito::Server::new_async().await;
+        let base = server.url();
+
+        // Origin-based layout: /.well-known/oauth-protected-resource/mcp
+        // (as opposed to path-aware: /mcp/.well-known/oauth-protected-resource).
+        let resource_meta = server
+            .mock("GET", "/.well-known/oauth-protected-resource/mcp")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                serde_json::json!({
+                    "resource": format!("{base}/mcp"),
+                    "authorization_servers": [base.clone()],
+                })
+                .to_string(),
+            )
+            .create_async()
+            .await;
+
+        let as_meta = server
+            .mock("GET", "/.well-known/oauth-authorization-server")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                serde_json::json!({
+                    "issuer": base.clone(),
+                    "authorization_endpoint": format!("{base}/authorize"),
+                    "token_endpoint": format!("{base}/token"),
+                    "registration_endpoint": format!("{base}/register"),
+                })
+                .to_string(),
+            )
+            .create_async()
+            .await;
+
+        let redirect_uri = "http://127.0.0.1:6666/auth/callback";
+        let register = server
+            .mock("POST", "/register")
+            .with_status(201)
+            .with_header("content-type", "application/json")
+            .with_body(
+                serde_json::json!({
+                    "client_id": "notion-client",
+                    "redirect_uris": [redirect_uri],
+                })
+                .to_string(),
+            )
+            .create_async()
+            .await;
+
+        let dir = tempfile::tempdir().unwrap();
+        let provider = McpOAuthProvider::with_stores(
+            "notion",
+            &format!("{base}/mcp"),
+            TokenStore::with_path(dir.path().join("tokens.json")),
+            RegistrationStore::with_path(dir.path().join("registrations.json")),
+        );
+
+        // Simulate the WWW-Authenticate header that Notion sends.
+        let www_authenticate = format!(
+            r#"Bearer realm="OAuth", resource_metadata="{base}/.well-known/oauth-protected-resource/mcp", error="invalid_token""#
+        );
+
+        let (_client_id, _client_secret, _auth_url, _token_url, _scopes, resource) = provider
+            .discover_and_register(Some(&www_authenticate), redirect_uri)
+            .await
+            .unwrap();
+
+        // The resource must come from the metadata JSON (the MCP server URL),
+        // not from the .well-known URL or the origin.
+        assert_eq!(resource, format!("{base}/mcp"));
 
         resource_meta.assert_async().await;
         as_meta.assert_async().await;

--- a/crates/oauth/src/discovery.rs
+++ b/crates/oauth/src/discovery.rs
@@ -41,11 +41,32 @@ pub async fn fetch_resource_metadata(
     resource_url: &Url,
 ) -> Result<ProtectedResourceMetadata> {
     let well_known = build_well_known_url(resource_url, "oauth-protected-resource")?;
+    fetch_resource_metadata_from_url(client, &well_known).await
+}
 
-    debug!(url = %well_known, "fetching protected resource metadata");
+/// Fetch protected resource metadata from an already-known URL.
+///
+/// Unlike [`fetch_resource_metadata`], this does NOT append
+/// `/.well-known/oauth-protected-resource`.  Use this when the URL was
+/// already extracted from a `WWW-Authenticate: Bearer resource_metadata=…`
+/// header (RFC 9728 §5.1), which is the complete metadata endpoint.
+pub async fn fetch_resource_metadata_direct(
+    client: &Client,
+    metadata_url: &Url,
+) -> Result<ProtectedResourceMetadata> {
+    fetch_resource_metadata_from_url(client, metadata_url).await
+}
+
+/// Shared implementation: fetch and parse protected resource metadata from
+/// the given URL.
+async fn fetch_resource_metadata_from_url(
+    client: &Client,
+    url: &Url,
+) -> Result<ProtectedResourceMetadata> {
+    debug!(url = %url, "fetching protected resource metadata");
 
     let resp = client
-        .get(well_known.as_str())
+        .get(url.as_str())
         .header("Accept", "application/json")
         .send()
         .await
@@ -531,5 +552,58 @@ mod tests {
         let url = Url::parse("http://127.0.0.1:1").unwrap();
         let result = fetch_resource_metadata(&client, &url).await;
         assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn fetch_resource_metadata_direct_success() {
+        let mut server = mockito::Server::new_async().await;
+        // The resource_metadata URL from WWW-Authenticate is already the
+        // complete endpoint (RFC 9728 origin-based layout).
+        // fetch_resource_metadata_direct must use it as-is without appending
+        // /.well-known/oauth-protected-resource.
+        let mock = server
+            .mock("GET", "/.well-known/oauth-protected-resource/mcp")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                serde_json::json!({
+                    "resource": format!("{}/mcp", server.url()),
+                    "authorization_servers": ["https://auth.example.com"]
+                })
+                .to_string(),
+            )
+            .create_async()
+            .await;
+
+        let client = Client::new();
+        let url = Url::parse(&format!(
+            "{}/.well-known/oauth-protected-resource/mcp",
+            server.url()
+        ))
+        .unwrap();
+        let meta = fetch_resource_metadata_direct(&client, &url)
+            .await
+            .unwrap();
+
+        assert_eq!(meta.resource, format!("{}/mcp", server.url()));
+        assert_eq!(meta.authorization_servers, vec!["https://auth.example.com"]);
+        mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn fetch_resource_metadata_direct_not_found() {
+        let mut server = mockito::Server::new_async().await;
+        let _mock = server
+            .mock("GET", "/some/metadata/path")
+            .with_status(404)
+            .with_body("not found")
+            .create_async()
+            .await;
+
+        let client = Client::new();
+        let url = Url::parse(&format!("{}/some/metadata/path", server.url())).unwrap();
+        let result = fetch_resource_metadata_direct(&client, &url).await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("404"));
     }
 }

--- a/crates/oauth/src/lib.rs
+++ b/crates/oauth/src/lib.rs
@@ -20,7 +20,8 @@ pub use {
     device_flow::DeviceCodeResponse,
     discovery::{
         AuthorizationServerMetadata, ClientRegistrationResponse, ProtectedResourceMetadata,
-        fetch_as_metadata, fetch_resource_metadata, parse_www_authenticate, register_client,
+        fetch_as_metadata, fetch_resource_metadata, fetch_resource_metadata_direct,
+        parse_www_authenticate, register_client,
     },
     flow::OAuthFlow,
     kimi::kimi_headers,


### PR DESCRIPTION
## Summary

Fixes #1119 — MCP OAuth fails with `invalid_target` for servers that include `resource_metadata` in their `WWW-Authenticate` header (Notion, Linear).

### Problem

`discover_and_register()` passes the `resource_metadata` URL from `WWW-Authenticate` to `fetch_resource_metadata()`, which appends `/.well-known/oauth-protected-resource` — but the URL is already the complete metadata endpoint per RFC 9728 §5.1. This produces a broken double-suffix URL, the fetch fails silently, and the fallback path uses the wrong resource identifier (origin instead of the MCP server URL), causing the authorization server to reject with `invalid_target`.

### Changes

| File | Change |
|------|--------|
| `crates/oauth/src/discovery.rs` | Add `fetch_resource_metadata_direct()` — fetches from an already-complete metadata URL without appending `.well-known` suffix |
| `crates/oauth/src/lib.rs` | Export the new function |
| `crates/mcp/src/auth.rs` | Use `fetch_resource_metadata_direct` in `discover_and_register()` when URL comes from `WWW-Authenticate` header |

### Tests added

- `fetch_resource_metadata_direct_success` — Notion-style metadata at custom path
- `fetch_resource_metadata_direct_not_found` — error handling
- `discovery_uses_www_authenticate_resource_metadata_directly` — end-to-end discovery with `WWW-Authenticate` header returning correct resource

## Validation

### Completed
- [x] Verified Notion and Linear both send complete `resource_metadata` URLs in `WWW-Authenticate`
- [x] Verified the direct URL returns correct `resource` field
- [x] Confirmed servers without `resource_metadata` (Attio) are unaffected (fallback path unchanged)
- [x] Added unit tests for new function and integration test for the full discovery flow

### Remaining
- [ ] `cargo test -p moltis-oauth -p moltis-mcp`
- [ ] `cargo fmt --all -- --check`
- [ ] `just lint`

## Manual QA

1. Start Moltis gateway
2. Add Notion MCP server (`https://mcp.notion.com/mcp`, Streamable HTTP)
3. Verify browser opens Notion consent screen (not `invalid_target` error)
4. Complete OAuth flow and verify MCP tools appear
