### PR TITLE
fix: drop VOLUME declarations that shadow the home bind mount

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -116,12 +116,13 @@ COPY --from=builder /build/target/wasm32-wasip2/release/moltis_wasm_calc.wasm /u
 COPY --from=builder /build/target/wasm32-wasip2/release/moltis_wasm_web_fetch.wasm /usr/share/moltis/wasm/
 COPY --from=builder /build/target/wasm32-wasip2/release/moltis_wasm_web_search.wasm /usr/share/moltis/wasm/
 
-# Create config and data directories
+# Create config and data directories.
+# Persistent state lives under these paths; mount a volume or bind mount at
+# runtime (see deployment compose). Intentionally NOT declared as VOLUME -- an
+# anonymous VOLUME on a nested path shadows a parent bind mount and seeds stub
+# data over real data, which silently sends the app through onboarding again.
 RUN mkdir -p /home/moltis/.config/moltis /home/moltis/.moltis /home/moltis/.npm && \
     chown -R moltis:moltis /home/moltis/.config /home/moltis/.moltis /home/moltis/.npm
-
-# Volume mount points for persistence and container runtime
-VOLUME ["/home/moltis/.config/moltis", "/home/moltis/.moltis", "/home/moltis/.npm", "/var/run/docker.sock"]
 
 USER moltis
 WORKDIR /home/moltis


### PR DESCRIPTION
The Dockerfile declared:

    VOLUME ["/home/moltis/.config/moltis", "/home/moltis/.moltis", \
            "/home/moltis/.npm", "/var/run/docker.sock"]

Pathological case
-----------------
Deployments bind mount the whole home directory (e.g. `./moltis-home:/home/moltis`). A VOLUME declared on a *nested* path is not covered by a parent bind mount: the container runtime attaches an anonymous volume at each declared subpath, which shadows the corresponding subtree of the bind mount. The image ships those dirs empty (only `mkdir`, no COPY), so on first boot moltis finds an empty data dir, seeds its default scaffolding, and writes a fresh empty `moltis.db` into the anonymous volume. The operator's real, populated `.moltis` (credentials, sessions, checkpoints, logs) sits untouched but invisible behind the anonymous volume.

The user-visible symptom is severe and misleading: the app forces onboarding again because `setup_required` is computed live from credential rows in `moltis.db`, and the shadowing anonymous volume has an empty one. The real data is fine; it is just not the file the process opened. The shadowing also cannot be undone by a downstream/wrapper image -- there is no UNVOLUME -- so it has to be fixed at the base image.

Illusion of beneficial cases
----------------------------
The only thing VOLUME buys here is an auto-created anonymous volume when the operator mounts nothing, which would seem to provide persistence by default and avoid the overlay copy-up write penalty. Both benefits are hollow for this image:
- The "persistence safety net" is a mirage. Anonymous volumes survive a restart but not `rm` / `--force-recreate`, and they orphan silently. It does not protect data; it only hides where the data went.
- Failing obviously (data in the ephemeral layer, gone on recreate) is better operator feedback than silently accumulating orphaned anonymous volumes.

Mount points are the operator's responsibility; the dirs are still created and chowned so an explicit mount lands with correct ownership. A comment documents the intent without the side effects.