### PR TITLE
fix(agents): coerce stringified scalar tool args before validation

### DIFF
--- a/crates/agents/src/runner/non_streaming.rs
+++ b/crates/agents/src/runner/non_streaming.rs
@@ -12,7 +12,7 @@ use moltis_common::hooks::{HookAction, HookPayload, HookRegistry};
 use crate::{
     model::{AgentToolControls, ChatMessage, LlmProvider, ToolCall, ToolChoice, UserContent},
     response_sanitizer::recover_tool_calls_from_content,
-    tool_arg_validator::validate_tool_args,
+    tool_arg_validator::{coerce_scalar_args, validate_tool_args},
     tool_loop_detector::ToolCallFingerprint,
     tool_parsing::{
         looks_like_failed_tool_call, new_synthetic_tool_call_id, parse_tool_calls_from_text,
@@ -587,6 +587,7 @@ pub async fn run_agent_loop_with_context_and_limits(
                     Some(reason)
                 } else if let Some(ref t) = tool {
                     let schema = t.parameters_schema();
+                    coerce_scalar_args(&schema, &mut args);
                     match validate_tool_args(&schema, &args) {
                         Ok(()) => None,
                         Err(e) => {
@@ -654,6 +655,7 @@ pub async fn run_agent_loop_with_context_and_limits(
                                 args = v;
                                 if let Some(ref tool) = tool {
                                     let schema = tool.parameters_schema();
+                                    coerce_scalar_args(&schema, &mut args);
                                     if let Err(e) = validate_tool_args(&schema, &args) {
                                         let err_str = e.to_llm_error_message(&tc_name);
                                         warn!(

--- a/crates/agents/src/runner/streaming.rs
+++ b/crates/agents/src/runner/streaming.rs
@@ -20,7 +20,7 @@ use crate::{
         UserContent, decode_tool_call_arguments_from_str, push_capped_provider_raw_event,
     },
     response_sanitizer::{clean_response, recover_tool_calls_from_content},
-    tool_arg_validator::validate_tool_args,
+    tool_arg_validator::{coerce_scalar_args, validate_tool_args},
     tool_loop_detector::ToolCallFingerprint,
     tool_parsing::{
         looks_like_failed_tool_call, new_synthetic_tool_call_id, parse_tool_calls_from_text,
@@ -731,6 +731,7 @@ pub async fn run_agent_loop_streaming_with_limits(
                     Some(reason)
                 } else if let Some(ref t) = tool {
                     let schema = t.parameters_schema();
+                    coerce_scalar_args(&schema, &mut args);
                     match validate_tool_args(&schema, &args) {
                         Ok(()) => None,
                         Err(e) => {
@@ -795,6 +796,7 @@ pub async fn run_agent_loop_streaming_with_limits(
                                 args = v;
                                 if let Some(ref tool) = tool {
                                     let schema = tool.parameters_schema();
+                                    coerce_scalar_args(&schema, &mut args);
                                     if let Err(e) = validate_tool_args(&schema, &args) {
                                         let err_str = e.to_llm_error_message(&tc_name);
                                         warn!(

--- a/crates/agents/src/tool_arg_validator.rs
+++ b/crates/agents/src/tool_arg_validator.rs
@@ -264,6 +264,113 @@ fn value_type_name(value: &Value) -> &'static str {
     }
 }
 
+/// Coerce stringified scalar arguments into the scalar type the schema declares.
+///
+/// Smaller models frequently emit scalars as JSON strings — e.g.
+/// `{"full_page": "true"}` or `{"timeout_ms": "5000"}`. Both this validator and
+/// the target tool's serde deserialization would otherwise reject them
+/// (`expected boolean, got string` / `invalid type: string`), failing the whole
+/// call over a purely cosmetic type slip.
+///
+/// For each top-level field whose schema declares a `boolean`, `integer`, or
+/// `number` type (and does **not** also permit `string`), a string value that
+/// parses unambiguously to that scalar is rewritten in place. Anything that does
+/// not parse cleanly is left untouched for [`validate_tool_args`] to flag.
+///
+/// This mirrors the existing leniency in `type_matches_single` that accepts
+/// integer-valued floats for `integer`: the goal is to avoid spurious
+/// rejections that drive reflex-retry churn, not to mask genuine mistakes.
+/// Coercion is deliberately limited to top-level scalars, matching the
+/// validator's own scope. Call it immediately before [`validate_tool_args`] so
+/// the coerced object is both validated and dispatched.
+pub fn coerce_scalar_args(schema: &Value, args: &mut Value) {
+    let Some(props) = schema
+        .as_object()
+        .and_then(|obj| obj.get("properties"))
+        .and_then(Value::as_object)
+    else {
+        return;
+    };
+    let Some(args_obj) = args.as_object_mut() else {
+        return;
+    };
+
+    // Snapshot which fields to rewrite first: `props` borrows `schema`, but the
+    // rewrite needs a mutable borrow of `args_obj`, so the two cannot overlap.
+    let mut rewrites: Vec<(String, Value)> = Vec::new();
+    for (field, prop_schema) in props {
+        let Some(Value::String(raw)) = args_obj.get(field) else {
+            continue; // only string inputs are candidates for coercion
+        };
+        let Some(expected) = prop_schema.as_object().and_then(|obj| obj.get("type")) else {
+            continue; // no declared type → nothing to coerce toward
+        };
+        let allowed = type_labels(expected);
+        // If a string is itself valid for this field, the model may genuinely
+        // have meant a string — leave it untouched.
+        if allowed.contains(&"string") {
+            continue;
+        }
+        if let Some(coerced) = coerce_string_scalar(raw, &allowed) {
+            rewrites.push((field.clone(), coerced));
+        }
+    }
+
+    for (field, coerced) in rewrites {
+        args_obj.insert(field, coerced);
+    }
+}
+
+/// Collect the declared JSON Schema `type` labels, handling both the scalar
+/// (`"boolean"`) and union (`["integer", "null"]`) forms.
+fn type_labels(expected: &Value) -> Vec<&str> {
+    match expected {
+        Value::String(single) => vec![single.as_str()],
+        Value::Array(types) => types.iter().filter_map(Value::as_str).collect(),
+        _ => Vec::new(),
+    }
+}
+
+/// Parse `raw` into the first scalar type in `allowed` it unambiguously matches.
+///
+/// Returns `None` when nothing parses cleanly, leaving the original string for
+/// the validator to reject.
+fn coerce_string_scalar(raw: &str, allowed: &[&str]) -> Option<Value> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    for label in allowed {
+        match *label {
+            "boolean" => {
+                if trimmed.eq_ignore_ascii_case("true") {
+                    return Some(Value::Bool(true));
+                }
+                if trimmed.eq_ignore_ascii_case("false") {
+                    return Some(Value::Bool(false));
+                }
+            },
+            "integer" => {
+                if let Ok(signed) = trimmed.parse::<i64>() {
+                    return Some(Value::Number(signed.into()));
+                }
+                if let Ok(unsigned) = trimmed.parse::<u64>() {
+                    return Some(Value::Number(unsigned.into()));
+                }
+            },
+            "number" => {
+                if let Ok(float) = trimmed.parse::<f64>()
+                    && let Some(number) = serde_json::Number::from_f64(float)
+                {
+                    return Some(Value::Number(number));
+                }
+            },
+            _ => {},
+        }
+    }
+    None
+}
+
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod tests {
@@ -528,5 +635,119 @@ mod tests {
         let s = err.short_summary();
         assert!(s.contains("missing=a"));
         assert!(s.contains("type_mismatch=b:integer!=string"));
+    }
+
+    /// The browser-tool failure class that motivated this change: a small model
+    /// sends `full_page` as the string `"true"` and an integer field as a
+    /// numeric string. After coercion the call validates cleanly.
+    #[test]
+    fn coerces_browser_style_stringified_scalars() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "full_page": { "type": "boolean" },
+                "timeout_ms": { "type": "integer" },
+                "url": { "type": "string" }
+            }
+        });
+        let mut args = json!({
+            "full_page": "true",
+            "timeout_ms": "5000",
+            "url": "https://example.com"
+        });
+        // Pre-coercion these would be rejected by the validator.
+        assert!(validate_tool_args(&schema, &args).is_err());
+
+        coerce_scalar_args(&schema, &mut args);
+
+        assert_eq!(args["full_page"], json!(true));
+        assert_eq!(args["timeout_ms"], json!(5000));
+        // Genuine strings are untouched.
+        assert_eq!(args["url"], json!("https://example.com"));
+        assert!(validate_tool_args(&schema, &args).is_ok());
+    }
+
+    #[test]
+    fn coerces_false_and_negative_and_float() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "flag": { "type": "boolean" },
+                "offset": { "type": "integer" },
+                "ratio": { "type": "number" }
+            }
+        });
+        let mut args = json!({"flag": "False", "offset": "-12", "ratio": "0.5"});
+        coerce_scalar_args(&schema, &mut args);
+        assert_eq!(args["flag"], json!(false));
+        assert_eq!(args["offset"], json!(-12));
+        assert_eq!(args["ratio"], json!(0.5));
+    }
+
+    /// When a field's schema also permits `string`, the model may have meant a
+    /// string — never coerce it.
+    #[test]
+    fn leaves_string_union_fields_alone() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "schedule": { "type": ["integer", "string"] }
+            }
+        });
+        let mut args = json!({"schedule": "5"});
+        coerce_scalar_args(&schema, &mut args);
+        assert_eq!(
+            args["schedule"],
+            json!("5"),
+            "string-typed union must stay a string"
+        );
+    }
+
+    /// Unparseable strings are left for the validator to reject, not mangled.
+    #[test]
+    fn leaves_unparseable_strings_for_the_validator() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "count": { "type": "integer" },
+                "flag": { "type": "boolean" }
+            }
+        });
+        let mut args = json!({"count": "not-a-number", "flag": "maybe"});
+        coerce_scalar_args(&schema, &mut args);
+        assert_eq!(args["count"], json!("not-a-number"));
+        assert_eq!(args["flag"], json!("maybe"));
+        assert!(validate_tool_args(&schema, &args).is_err());
+    }
+
+    /// A nullable union (`["integer", "null"]`) with no `string` still coerces.
+    #[test]
+    fn coerces_into_nullable_numeric_union() {
+        let schema = json!({
+            "type": "object",
+            "properties": { "ref_": { "type": ["integer", "null"] } }
+        });
+        let mut args = json!({"ref_": "14"});
+        coerce_scalar_args(&schema, &mut args);
+        assert_eq!(args["ref_"], json!(14));
+    }
+
+    /// Non-object args and schemas without `properties` are no-ops.
+    #[test]
+    fn coercion_is_a_noop_for_unstructured_inputs() {
+        let mut scalar = json!("plain");
+        coerce_scalar_args(
+            &json!({"properties": {"x": {"type": "integer"}}}),
+            &mut scalar,
+        );
+        assert_eq!(scalar, json!("plain"));
+
+        let mut args = json!({"x": "5"});
+        coerce_scalar_args(&json!({}), &mut args);
+        assert_eq!(
+            args["x"],
+            json!("5"),
+            "no properties → nothing to coerce toward"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Smaller models — notably local ones such as Gemma 4 and oMLX — frequently emit scalar tool arguments as JSON **strings** rather than bare scalars:

```json
{"action": "screenshot", "full_page": "true"}
{"action": "navigate", "url": "...", "timeout_ms": "5000"}
```

The pre-dispatch validator (`validate_tool_args`) rejects these as type mismatches **before the tool runs** (`type_mismatch=full_page:boolean!=string`), and the tool's own serde deserialization would reject them too. The entire tool call fails over a purely cosmetic type slip, and the model surfaces a "technical snag" to the user.

This is the string-typed sibling of the explicit-`null` failure class fixed for the browser tool in #1098. Unlike that one, it is **not** browser-specific — it affects every tool's schema, and it is caught in the shared validator, so the fix belongs there.

Observed in the wild (browser tool, local models): `full_page:boolean!=string`, plus stringified `integer` fields (`ref_`, `x`, `y`, `timeout_ms`).

### Fix

Add `coerce_scalar_args(schema, &mut args)`, called immediately before `validate_tool_args` at all four runner dispatch sites (streaming + non-streaming, both the initial and the post-`BeforeToolCall`-hook validation paths).

For each **top-level** field whose schema declares `boolean` / `integer` / `number` and does **not** also permit `string`:
- a string that parses unambiguously to that scalar is rewritten in place (`"true"` → `true`, `"5000"` → `5000`, `"0.5"` → `0.5`; booleans are ASCII-case-insensitive to absorb Python-style `"True"`);
- anything that does not parse cleanly is left untouched for the validator to reject.

Because the coerced object is the same one that gets dispatched to `execute`, the fix flows all the way through. Fields whose schema also allows `string` are never touched — if a string is valid there, the model may have meant a string.

This mirrors the validator's existing leniency that accepts integer-valued floats for `integer`: the goal is to avoid spurious rejections that drive reflex-retry churn (issue #658) without masking genuine model mistakes.

Out of scope (left for the validator to reject, since they are genuinely ambiguous): non-scalar mismatches such as an array sent for an `integer` field, or an object sent for a `string` field.

### Relationship to #1098

Independent and complementary. #1098 strips explicit `null` optionals in `crates/tools/src/browser.rs`; this coerces stringified scalars in `crates/agents/src/tool_arg_validator.rs`. Disjoint files, no ordering dependency — together they cover both shapes of small-model tool-arg sloppiness. Based on `main`, so it can merge in any order relative to #1098.

## Validation

### Completed
- `cargo test -p moltis-agents tool_arg_validator` — 23 pass, including 6 new `coerce_scalar_args` tests (browser-style coercion, false/negative/float, string-union left alone, unparseable left for validator, nullable numeric union, no-op on unstructured input).
- `cargo clippy -p moltis-agents --all-targets` (pinned nightly) — clean.
- `cargo fmt` (pinned nightly) — changed files clean.

### Remaining (CI / maintainer)
- `just release-preflight` (full workspace clippy + fmt gate).
- `just test` (full OS-aware suite).

## Manual QA

1. Configure a small local model (e.g. Gemma 4 via the GPU offload provider) that emits `full_page` as `"true"`.
2. Ask it to take a full-page screenshot of any page via the browser tool.
3. Before: call rejected with `type_mismatch=full_page:boolean!=string`; model replies with a "technical snag".
4. After: `"true"` is coerced to `true`, the call validates and executes, and the screenshot is taken.