### PR TITLE
fix(gateway): don't force-enable matrix-sdk via the metrics feature

### DIFF
--- a/crates/gateway/Cargo.toml
+++ b/crates/gateway/Cargo.toml
@@ -179,7 +179,7 @@ metrics = [
   "dep:moltis-metrics",
   "moltis-chat/metrics",
   "moltis-discord?/metrics",
-  "moltis-matrix/metrics",
+  "moltis-matrix?/metrics",
   "moltis-metrics/sqlite",
   "moltis-msteams?/metrics",
   "moltis-nostr?/metrics",


### PR DESCRIPTION
## Summary

The gateway's `metrics` feature lists `moltis-matrix/metrics` **without** the weak `?` qualifier, so enabling `metrics` force-enables the optional `moltis-matrix` dependency — pulling the entire `matrix-sdk` into the build even when the Matrix channel is otherwise disabled.

Every other optional channel in the same list already uses the weak form:

```toml
metrics = [
  "dep:moltis-metrics",
  "moltis-chat/metrics",
  "moltis-discord?/metrics",
  "moltis-matrix/metrics",     # <-- the lone non-weak ref
  "moltis-metrics/sqlite",
  "moltis-msteams?/metrics",
  "moltis-nostr?/metrics",
  "moltis-signal?/metrics",
]
```

`moltis-matrix` is the only inconsistency. The fix makes it weak (`moltis-matrix?/metrics`): `metrics` now enables matrix's metrics *only when matrix is independently enabled*, instead of dragging it into matrix-free builds.

### Why this matters

A build that wants metrics but no Matrix (`--no-default-features --features "...,metrics"` without `matrix`) currently still compiles `matrix-sdk`. Besides the wasted build time, on the repo's pinned nightly `matrix-sdk 0.16` currently fails to compile (`error: queries overflow the depth limit`), so this unnecessary edge makes otherwise-valid matrix-free builds fail. No effect on the default feature set, which enables `matrix` anyway.

## Validation

### Completed (via `cargo tree`)
- `cargo tree -p moltis-gateway --no-default-features --features metrics -i matrix-sdk` → **"nothing to print"** (was previously pulling `matrix-sdk v0.16.0`).
- `cargo tree -p moltis-gateway -i matrix-sdk` (default features) → still resolves `matrix-sdk` — **no regression** for default builds.
- `cargo metadata` parses cleanly.

### Remaining (CI / maintainer)
- `just release-preflight` / full build matrix.

## Manual QA

Build the gateway with metrics but without Matrix and confirm `matrix-sdk` is absent from the compile set:
```
cargo build -p moltis-gateway --no-default-features --features metrics
```