### PR TITLE
Add Requesty as an OpenAI-compatible provider

### DIFF
--- a/crates/cli/src/doctor_commands.rs
+++ b/crates/cli/src/doctor_commands.rs
@@ -120,6 +120,7 @@ const PROVIDER_ENV_MAP: &[(&str, &str, bool)] = &[
     ("deepseek", "DEEPSEEK_API_KEY", false),
     ("mistral", "MISTRAL_API_KEY", false),
     ("openrouter", "OPENROUTER_API_KEY", false),
+    ("requesty", "REQUESTY_API_KEY", false),
     ("cerebras", "CEREBRAS_API_KEY", false),
     ("minimax", "MINIMAX_API_KEY", false),
     ("moonshot", "MOONSHOT_API_KEY", false),

--- a/crates/config/src/schema/providers.rs
+++ b/crates/config/src/schema/providers.rs
@@ -37,6 +37,7 @@ pub const KNOWN_PROVIDER_NAMES: &[&str] = &[
     "nearai",
     "ollama",
     "openrouter",
+    "requesty",
     "venice",
     "zai",
     "zai-code",

--- a/crates/config/src/template.rs
+++ b/crates/config/src/template.rs
@@ -136,7 +136,7 @@ port = {port}                           # Port number (auto-generated for this i
 # show_legacy_models = true         # Show models older than 1 year in the chat model selector (they always appear in Settings)
 # All available providers (canonical list in schema/providers.rs):
 #   "anthropic", "openai", "gemini", "groq", "xai", "deepinfra",
-#   "deepseek", "fireworks", "mistral", "openrouter", "cerebras", "minimax",
+#   "deepseek", "fireworks", "mistral", "openrouter", "requesty", "cerebras", "minimax",
 #   "moonshot", "zai", "zai-code", "venice", "nearai", "alibaba-coding",
 #   "ollama", "lmstudio", "local-llm", "openai-codex",
 #   "github-copilot", "kimi-code"
@@ -219,6 +219,13 @@ port = {port}                           # Port number (auto-generated for this i
 # api_key = "..."                             # Or set OPENROUTER_API_KEY env var
 # models = ["anthropic/claude-3.5-sonnet"]    # Any model IDs on OpenRouter
 # base_url = "https://openrouter.ai/api/v1"
+
+# ── Requesty (multi-provider router) ──────────────────────────
+# [providers.requesty]
+# enabled = true
+# api_key = "..."                             # Or set REQUESTY_API_KEY env var
+# models = ["anthropic/claude-sonnet-4-5"]    # Any model IDs on Requesty
+# base_url = "https://router.requesty.ai/v1"
 
 # ── Moonshot (Kimi) ─────────────────────────────────────────
 # [providers.moonshot]

--- a/crates/provider-setup/src/known_providers.rs
+++ b/crates/provider-setup/src/known_providers.rs
@@ -168,6 +168,16 @@ pub fn known_providers() -> Vec<KnownProvider> {
             local_only: false,
         },
         KnownProvider {
+            name: "requesty",
+            display_name: "Requesty",
+            auth_type: AuthType::ApiKey,
+            env_key: Some("REQUESTY_API_KEY"),
+            default_base_url: Some("https://router.requesty.ai/v1"),
+            requires_model: false,
+            key_optional: false,
+            local_only: false,
+        },
+        KnownProvider {
             name: "cerebras",
             display_name: "Cerebras",
             auth_type: AuthType::ApiKey,

--- a/crates/providers/src/model_catalogs.rs
+++ b/crates/providers/src/model_catalogs.rs
@@ -203,6 +203,18 @@ pub(crate) const OPENAI_COMPAT_PROVIDERS: &[OpenAiCompatDef] = &[
         ..OpenAiCompatDef::DEFAULT
     },
     OpenAiCompatDef {
+        config_name: "requesty",
+        env_key: "REQUESTY_API_KEY",
+        env_base_url_key: "REQUESTY_BASE_URL",
+        default_base_url: "https://router.requesty.ai/v1",
+        capabilities: OpenAiProviderCapabilities {
+            default_strict_tools: false,
+            cache_control_policy: CacheControlPolicy::OpenRouterAnthropic,
+            ..OpenAiProviderCapabilities::DEFAULT
+        },
+        ..OpenAiCompatDef::DEFAULT
+    },
+    OpenAiCompatDef {
         config_name: "cerebras",
         env_key: "CEREBRAS_API_KEY",
         env_base_url_key: "CEREBRAS_BASE_URL",

--- a/crates/providers/tests/requesty_integration.rs
+++ b/crates/providers/tests/requesty_integration.rs
@@ -1,0 +1,317 @@
+//! Live integration tests for the Requesty provider.
+//!
+//! Requires `REQUESTY_API_KEY`. Run with:
+//!   cargo test --test requesty_integration -- --ignored
+//!
+//! Requesty is a model router — it proxies requests to upstream providers.
+//! We test with a cheap, reliable model to validate the integration path.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use {
+    futures::StreamExt,
+    moltis_agents::model::{ChatMessage, LlmProvider, StreamEvent, ToolCall},
+    moltis_providers::{openai::OpenAiProvider, openai_compat::to_openai_tools},
+    secrecy::{ExposeSecret, Secret},
+};
+
+const BASE_URL: &str = "https://router.requesty.ai/v1";
+/// Use a cheap model for testing. Requesty has no static catalog — models
+/// are discovered via API.
+const TEST_MODEL: &str = "openai/gpt-4o-mini";
+
+fn api_key() -> Secret<String> {
+    Secret::new(
+        std::env::var("REQUESTY_API_KEY")
+            .expect("REQUESTY_API_KEY must be set for integration tests"),
+    )
+}
+
+fn make_provider(model: &str) -> OpenAiProvider {
+    OpenAiProvider::new_with_name(
+        api_key(),
+        model.to_string(),
+        BASE_URL.to_string(),
+        "requesty".to_string(),
+    )
+}
+
+fn weather_tool() -> serde_json::Value {
+    serde_json::json!({
+        "name": "get_weather",
+        "description": "Get current weather for a location. You MUST call this tool when asked about weather.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "location": { "type": "string", "description": "City name" }
+            },
+            "required": ["location"]
+        }
+    })
+}
+
+// ── System prompt ────────────────────────────────────────────────────────────
+
+#[tokio::test]
+#[ignore]
+async fn system_prompt_is_received_non_streaming() {
+    let p = make_provider(TEST_MODEL);
+    let keyword = "PERSIMMON";
+    let messages = vec![
+        ChatMessage::system(format!(
+            "You MUST include the exact word \"{keyword}\" in every response, no matter what."
+        )),
+        ChatMessage::user("What is 2+2?"),
+    ];
+    let response = p.complete(&messages, &[]).await.expect("should succeed");
+    let text = response.text.expect("must have text");
+    assert!(
+        text.to_lowercase().contains(&keyword.to_lowercase()),
+        "system prompt not received: {text:?}"
+    );
+}
+
+#[tokio::test]
+#[ignore]
+async fn system_prompt_is_received_streaming() {
+    let p = make_provider(TEST_MODEL);
+    let keyword = "GUAVA";
+    let messages = vec![
+        ChatMessage::system(format!(
+            "You MUST include the exact word \"{keyword}\" in every response, no matter what."
+        )),
+        ChatMessage::user("What is 3+3?"),
+    ];
+    let mut stream = p.stream_with_tools(messages, vec![]);
+    let mut full_text = String::new();
+    let mut saw_done = false;
+    while let Some(event) = stream.next().await {
+        match event {
+            StreamEvent::Delta(chunk) => full_text.push_str(&chunk),
+            StreamEvent::Done(_) => {
+                saw_done = true;
+                break;
+            },
+            StreamEvent::Error(err) => panic!("stream error: {err}"),
+            _ => {},
+        }
+    }
+    assert!(saw_done, "stream must emit Done");
+    assert!(
+        full_text.to_lowercase().contains(&keyword.to_lowercase()),
+        "system prompt not received: {full_text:?}"
+    );
+}
+
+// ── Tool calling ─────────────────────────────────────────────────────────────
+
+#[tokio::test]
+#[ignore]
+async fn tool_call_round_trip_non_streaming() {
+    let p = make_provider(TEST_MODEL);
+    let response = p
+        .complete(
+            &[ChatMessage::user(
+                "What's the weather in Tokyo? Use the get_weather tool.",
+            )],
+            &[weather_tool()],
+        )
+        .await
+        .expect("should succeed");
+    assert!(
+        !response.tool_calls.is_empty(),
+        "should call tool, got text: {:?}",
+        response.text
+    );
+    assert_eq!(response.tool_calls[0].name, "get_weather");
+}
+
+#[tokio::test]
+#[ignore]
+async fn tool_call_round_trip_streaming() {
+    let p = make_provider(TEST_MODEL);
+    let mut stream = p.stream_with_tools(
+        vec![ChatMessage::user(
+            "What's the weather in Paris? Use the get_weather tool.",
+        )],
+        vec![weather_tool()],
+    );
+    let mut saw_tool = false;
+    let mut saw_done = false;
+    let mut tool_name = String::new();
+    while let Some(event) = stream.next().await {
+        match event {
+            StreamEvent::ToolCallStart { name, .. } => {
+                saw_tool = true;
+                tool_name = name;
+            },
+            StreamEvent::Done(_) => {
+                saw_done = true;
+                break;
+            },
+            StreamEvent::Error(err) => panic!("stream error: {err}"),
+            _ => {},
+        }
+    }
+    assert!(saw_done, "must emit Done");
+    assert!(saw_tool, "should include tool call");
+    assert_eq!(tool_name, "get_weather");
+}
+
+#[tokio::test]
+#[ignore]
+async fn multi_turn_tool_use() {
+    let p = make_provider(TEST_MODEL);
+    let tools = vec![weather_tool()];
+    let r = p
+        .complete(
+            &[ChatMessage::user("Weather in London? Use get_weather.")],
+            &tools,
+        )
+        .await
+        .expect("first turn");
+    assert!(!r.tool_calls.is_empty(), "should call tool");
+    let tc = &r.tool_calls[0];
+    let r2 = p
+        .complete(
+            &[
+                ChatMessage::user("Weather in London? Use get_weather."),
+                ChatMessage::assistant_with_tools(r.text.clone(), vec![ToolCall {
+                    id: tc.id.clone(),
+                    name: tc.name.clone(),
+                    arguments: tc.arguments.clone(),
+                    argument_diagnostic: tc.argument_diagnostic.clone(),
+                    metadata: tc.metadata.clone(),
+                }]),
+                ChatMessage::tool(&tc.id, r#"{"temperature": 15, "condition": "cloudy"}"#),
+            ],
+            &tools,
+        )
+        .await
+        .expect("second turn");
+    assert!(r2.text.is_some(), "should have text after tool result");
+}
+
+#[tokio::test]
+#[ignore]
+async fn google_ai_studio_accepts_non_strict_union_typed_tool_schema() {
+    let key = api_key();
+    let client = reqwest::Client::new();
+    let tools = to_openai_tools(
+        &[serde_json::json!({
+            "name": "cron",
+            "description": "Manage cron jobs.",
+            "parameters": {
+                "type": "object",
+                "required": ["action", "job"],
+                "properties": {
+                    "action": { "type": "string" },
+                    "job": {
+                        "type": ["object", "string"],
+                        "properties": {
+                            "name": { "type": "string" },
+                            "schedule": {
+                                "type": ["object", "string", "integer"],
+                                "properties": {
+                                    "kind": { "type": "string" }
+                                },
+                                "required": ["kind"]
+                            }
+                        },
+                        "required": ["name", "schedule"]
+                    }
+                }
+            }
+        })],
+        false,
+    );
+    let body = serde_json::json!({
+        "model": "google/gemini-3-flash-preview",
+        "messages": [{ "role": "user", "content": "hi" }],
+        "stream": false,
+        "provider": {
+            "ignore": ["google-vertex"]
+        },
+        "tools": tools
+    });
+
+    let resp = client
+        .post(format!("{BASE_URL}/chat/completions"))
+        .header("Authorization", format!("Bearer {}", key.expose_secret()))
+        .json(&body)
+        .send()
+        .await
+        .expect("HTTP request should complete");
+    let status = resp.status();
+    let text = resp.text().await.expect("response body should be readable");
+    assert!(
+        status.is_success(),
+        "Requesty Google AI Studio should accept normalized union-typed tool schema, got {status}: {text}"
+    );
+}
+
+// ── Probe & streaming ────────────────────────────────────────────────────────
+
+#[tokio::test]
+#[ignore]
+async fn probe_succeeds() {
+    make_provider(TEST_MODEL)
+        .probe()
+        .await
+        .expect("probe should succeed");
+}
+
+#[tokio::test]
+#[ignore]
+async fn stream_emits_delta_and_done() {
+    let p = make_provider(TEST_MODEL);
+    let mut stream = p.stream(vec![ChatMessage::user("Say hello in one word.")]);
+    let mut saw_delta = false;
+    let mut saw_done = false;
+    while let Some(event) = stream.next().await {
+        match event {
+            StreamEvent::Delta(_) => saw_delta = true,
+            StreamEvent::Done(_) => {
+                saw_done = true;
+                break;
+            },
+            StreamEvent::Error(err) => panic!("stream error: {err}"),
+            _ => {},
+        }
+    }
+    assert!(saw_delta && saw_done);
+}
+
+// ── Model catalog ────────────────────────────────────────────────────────────
+
+/// Requesty has no static catalog — all models come from discovery.
+/// This test validates the /models endpoint works and reports available models.
+#[tokio::test]
+#[ignore]
+async fn detect_models_via_api() {
+    let key = api_key();
+    let client = reqwest::Client::new();
+    let resp = client
+        .get(format!("{BASE_URL}/models"))
+        .header("Authorization", format!("Bearer {}", key.expose_secret()))
+        .send()
+        .await
+        .expect("HTTP request should succeed");
+    assert!(
+        resp.status().is_success(),
+        "Requesty /models should return 200, got {}",
+        resp.status()
+    );
+    let body: serde_json::Value = resp.json().await.expect("valid JSON");
+    let models = body.get("data").and_then(|d| d.as_array()).expect("data");
+    eprintln!(
+        "\n=== Requesty /models API: {} models available ===\n",
+        models.len()
+    );
+    // Just verify we got a reasonable number of models
+    assert!(
+        models.len() > 10,
+        "Requesty should have many models, got {}",
+        models.len()
+    );
+}

--- a/crates/web/ui/src/onboarding/steps/ProviderStep.tsx
+++ b/crates/web/ui/src/onboarding/steps/ProviderStep.tsx
@@ -34,6 +34,7 @@ const OPENAI_COMPATIBLE = [
 	"openai",
 	"mistral",
 	"openrouter",
+	"requesty",
 	"cerebras",
 	"minimax",
 	"moonshot",

--- a/crates/web/ui/src/provider-key-help.ts
+++ b/crates/web/ui/src/provider-key-help.ts
@@ -51,6 +51,10 @@ const KEY_SOURCE_BY_PROVIDER: Record<string, KeySource> = {
 		url: "https://openrouter.ai/settings/keys",
 		label: "OpenRouter Settings",
 	},
+	requesty: {
+		url: "https://app.requesty.ai/api-keys",
+		label: "Requesty API Keys",
+	},
 	cerebras: {
 		url: "https://cloud.cerebras.ai/",
 		label: "Cerebras Cloud",

--- a/crates/web/ui/src/providers/shared.ts
+++ b/crates/web/ui/src/providers/shared.ts
@@ -38,6 +38,7 @@ export const OPENAI_COMPATIBLE_PROVIDERS: string[] = [
 	"openai",
 	"mistral",
 	"openrouter",
+	"requesty",
 	"cerebras",
 	"minimax",
 	"moonshot",


### PR DESCRIPTION
Adds Requesty as a table-driven OpenAI-compatible provider, mirroring the existing `openrouter` wiring as closely as possible.

Requesty (https://requesty.ai) is an OpenAI-compatible LLM router. Base URL `https://router.requesty.ai/v1`, auth via `Authorization: Bearer $REQUESTY_API_KEY`, `provider/model` naming, and a live `GET /v1/models` endpoint, the same shape moltis already consumes for OpenRouter.

Changes:
- `crates/providers/src/model_catalogs.rs`: new `OpenAiCompatDef` entry for `requesty` (env `REQUESTY_API_KEY` / `REQUESTY_BASE_URL`, default base URL `https://router.requesty.ai/v1`), mirroring the OpenRouter entry, including the OpenRouter-style Anthropic cache-control policy, since Requesty proxies Anthropic models the same way. Models are discovered live via `/v1/models` (no hardcoded catalog), like OpenRouter.
- `crates/config/src/schema/providers.rs`: `requesty` added to `KNOWN_PROVIDERS`.
- `crates/provider-setup/src/known_providers.rs`: setup entry (name + default base URL).
- `crates/cli/src/doctor_commands.rs`: `requesty` / `REQUESTY_API_KEY` in the doctor env check.
- `crates/config/src/template.rs`: commented `[providers.requesty]` example in the default config template.
- `crates/web/ui/`: onboarding provider list, key-help link (`https://app.requesty.ai/api-keys`), and shared providers list.
- `crates/providers/tests/requesty_integration.rs`: mirror of `openrouter_integration.rs` (network-gated / `#[ignore]`d exactly like the OpenRouter test, so it does not run live in CI).

Verification:
- `cargo build -p moltis-config -p moltis-provider-setup` passes; `cargo test -p moltis-config -p moltis-provider-setup` → 100 passed.
- `cargo test -p moltis-providers --test requesty_integration` compiles and runs (9 ignored, network-gated).
- The full `cargo build` fails only on the pre-existing `moltis-web` build script requiring prebuilt frontend assets (`css/style.css`, `dist/`, `sw.js` via `just build-web-assets`), unrelated to this change.

I work at Requesty. This mirrors the existing OpenRouter provider as closely as possible. Happy to adjust or close it if it's not a fit.
