### PR TITLE
feat(whatsapp): bump whatsapp-rust 0.5 -> 0.6 with LID-native addressing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,7 +16,7 @@ checksum = "f279fc8b1f1a64138f0f4b9cda9be488ae35bc2f8556c7ffe60730f1c07d005a"
 dependencies = [
  "base64 0.21.7",
  "erased-serde",
- "http 1.4.0",
+ "http 1.4.2",
  "http-body-util",
  "hyper",
  "hyper-rustls 0.26.0",
@@ -91,11 +91,11 @@ dependencies = [
 
 [[package]]
 name = "aes"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66bd29a732b644c0431c6140f370d097879203d79b80c94a6747ba0872adaef8"
+checksum = "f1fc76eaeac4c9164506c466d4ffdd8ec9d0c5bf57ee97177c4d8eceb3a0e138"
 dependencies = [
- "cipher 0.5.1",
+ "cipher 0.5.2",
  "cpubits",
  "cpufeatures 0.3.0",
 ]
@@ -109,7 +109,7 @@ dependencies = [
  "aead",
  "aes 0.8.4",
  "cipher 0.4.4",
- "ctr",
+ "ctr 0.9.2",
  "ghash 0.5.1",
  "subtle",
 ]
@@ -120,7 +120,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10b6f24a1f796bc46415a1d0d18dc0a8203ccba088acf5def3291c4f61225522"
 dependencies = [
- "aes 0.9.0",
+ "aes 0.9.1",
  "byteorder",
 ]
 
@@ -235,7 +235,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -246,7 +246,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -517,7 +517,7 @@ dependencies = [
  "fnv",
  "futures-util",
  "handlebars",
- "http 1.4.0",
+ "http 1.4.2",
  "indexmap 2.14.0",
  "mime",
  "multer",
@@ -867,7 +867,7 @@ dependencies = [
  "bytes",
  "form_urlencoded",
  "futures-util",
- "http 1.4.0",
+ "http 1.4.2",
  "http-body",
  "http-body-util",
  "hyper",
@@ -882,7 +882,7 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
- "sha1",
+ "sha1 0.10.6",
  "sync_wrapper",
  "tokio",
  "tokio-tungstenite 0.29.0",
@@ -901,7 +901,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
- "http 1.4.0",
+ "http 1.4.2",
  "http-body",
  "http-body-util",
  "mime",
@@ -920,7 +920,7 @@ checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.4.0",
+ "http 1.4.2",
  "http-body",
  "http-body-util",
  "mime",
@@ -942,7 +942,7 @@ dependencies = [
  "bytes",
  "cookie",
  "futures-util",
- "http 1.4.0",
+ "http 1.4.2",
  "http-body",
  "http-body-util",
  "mime",
@@ -1063,7 +1063,7 @@ dependencies = [
  "bitflags 2.11.1",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.10.5",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -1206,6 +1206,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-padding"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "710f1dd022ef4e93f8a438b4ba958de7f64308434fa6a87104481645cc30068b"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "block2"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1289,9 +1298,9 @@ checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 dependencies = [
  "serde",
 ]
@@ -1427,6 +1436,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
 dependencies = [
  "cipher 0.4.4",
+]
+
+[[package]]
+name = "cbc"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce2dc9ee5f88d11e0beb842c88b33c8a5cf0d1329c4b19494af42b07dbfe8896"
+dependencies = [
+ "cipher 0.5.2",
 ]
 
 [[package]]
@@ -1619,11 +1637,12 @@ dependencies = [
 
 [[package]]
 name = "cipher"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e34d8227fe1ba289043aeb13792056ff80fd6de1a9f49137a5f499de8e8c78ea"
+checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
 dependencies = [
- "crypto-common 0.2.1",
+ "block-buffer 0.12.0",
+ "crypto-common 0.2.2",
  "inout 0.2.2",
 ]
 
@@ -1796,7 +1815,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1805,7 +1824,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1827,6 +1846,21 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "compact_str"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dfdd1c2274d9aa354115b09dc9a901d6c5576818cdf70d14cae2bdb47df00ab"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "serde",
+ "static_assertions",
 ]
 
 [[package]]
@@ -1914,24 +1948,6 @@ dependencies = [
  "percent-encoding",
  "time",
  "version_check",
-]
-
-[[package]]
-name = "cookie_store"
-version = "0.22.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15b2c103cf610ec6cae3da84a766285b42fd16aad564758459e6ecf128c75206"
-dependencies = [
- "cookie",
- "document-features",
- "idna",
- "indexmap 2.14.0",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "time",
- "url",
 ]
 
 [[package]]
@@ -2255,9 +2271,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
  "hybrid-array",
 ]
@@ -2275,6 +2291,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
 dependencies = [
  "cipher 0.4.4",
+]
+
+[[package]]
+name = "ctr"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baaca1c4b237092596f64d571e9db6ce4109c4ef9742e27590f1709594461f21"
+dependencies = [
+ "cipher 0.5.2",
 ]
 
 [[package]]
@@ -2338,9 +2363,24 @@ dependencies = [
  "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
  "digest 0.10.7",
- "fiat-crypto",
+ "fiat-crypto 0.2.9",
  "rustc_version",
  "serde",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "5.0.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c906a87e53a36ff795d72e06e8162a83c5436e3ea89e942a9cb9fc083f0a384f"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "curve25519-dalek-derive",
+ "fiat-crypto 0.3.0",
+ "rustc_version",
  "subtle",
  "zeroize",
 ]
@@ -2723,7 +2763,7 @@ checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
 dependencies = [
  "block-buffer 0.12.0",
  "const-oid 0.10.2",
- "crypto-common 0.2.1",
+ "crypto-common 0.2.2",
  "ctutils",
 ]
 
@@ -2774,7 +2814,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2802,9 +2842,9 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2827,15 +2867,6 @@ name = "doc-comment"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "780955b8b195a21ab8e4ac6b60dd1dbdcec1dc6c51c0617964b08c81785e12c9"
-
-[[package]]
-name = "document-features"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
-dependencies = [
- "litrs",
-]
 
 [[package]]
 name = "domain"
@@ -2935,7 +2966,7 @@ dependencies = [
  "base64 0.21.7",
  "byteorder",
  "hex",
- "hkdf",
+ "hkdf 0.12.4",
  "lazy_static",
  "once_cell",
  "openssl",
@@ -2971,7 +3002,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
 dependencies = [
- "curve25519-dalek",
+ "curve25519-dalek 4.1.3",
  "ed25519",
  "rand_core 0.6.4",
  "serde",
@@ -3001,7 +3032,7 @@ dependencies = [
  "ff",
  "generic-array",
  "group",
- "hkdf",
+ "hkdf 0.12.4",
  "pem-rfc7468",
  "pkcs8 0.10.2",
  "rand_core 0.6.4",
@@ -3076,29 +3107,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "env_filter"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
-dependencies = [
- "log",
-]
-
-[[package]]
 name = "env_home"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7f84e12ccf0a7ddc17a6c41c93326024c42920d7ee630d04950e6926645c0fe"
-
-[[package]]
-name = "env_logger"
-version = "0.11.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0621c04f2196ac3f488dd583365b9c09be011a4ab8b9f37248ffcc8f6198b56a"
-dependencies = [
- "env_filter",
- "log",
-]
 
 [[package]]
 name = "equivalent"
@@ -3132,7 +3144,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3317,6 +3329,12 @@ name = "fiat-crypto"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
+name = "fiat-crypto"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64cd1e32ddd350061ae6edb1b082d7c54915b5c672c389143b9a63403a109f24"
 
 [[package]]
 name = "file-id"
@@ -3739,11 +3757,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.1",
  "wasip2",
  "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -4812,7 +4832,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.4.0",
+ "http 1.4.2",
  "indexmap 2.14.0",
  "slab",
  "tokio",
@@ -4911,6 +4931,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
+name = "hashify"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd1246c0e5493286aeb2dde35b1f4eb9c4ce00e628641210a5e553fc001a1f26"
+dependencies = [
+ "indexmap 2.14.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "hashlink"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4928,10 +4960,10 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "headers-core",
- "http 1.4.0",
+ "http 1.4.2",
  "httpdate",
  "mime",
- "sha1",
+ "sha1 0.10.6",
 ]
 
 [[package]]
@@ -4940,7 +4972,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
 dependencies = [
- "http 1.4.0",
+ "http 1.4.2",
 ]
 
 [[package]]
@@ -5007,6 +5039,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
 dependencies = [
  "hmac 0.12.1",
+]
+
+[[package]]
+name = "hkdf"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4aaa26c720c68b866f2c96ef5c1264b3e6f473fe5d4ce61cd44bbe913e553018"
+dependencies = [
+ "hmac 0.13.0",
 ]
 
 [[package]]
@@ -5128,9 +5169,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.0"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
 dependencies = [
  "bytes",
  "itoa",
@@ -5152,7 +5193,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.4.0",
+ "http 1.4.2",
 ]
 
 [[package]]
@@ -5163,7 +5204,7 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.4.0",
+ "http 1.4.2",
  "http-body",
  "pin-project-lite",
 ]
@@ -5206,7 +5247,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "h2",
- "http 1.4.0",
+ "http 1.4.2",
  "http-body",
  "httparse",
  "httpdate",
@@ -5226,7 +5267,7 @@ dependencies = [
  "bytes",
  "futures-util",
  "headers",
- "http 1.4.0",
+ "http 1.4.2",
  "hyper",
  "hyper-rustls 0.27.9",
  "hyper-util",
@@ -5244,7 +5285,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0bea761b46ae2b24eb4aef630d8d1c398157b6fc29e6350ecf090a0b70c952c"
 dependencies = [
  "futures-util",
- "http 1.4.0",
+ "http 1.4.2",
  "hyper",
  "hyper-util",
  "rustls 0.22.4",
@@ -5261,7 +5302,7 @@ version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
- "http 1.4.0",
+ "http 1.4.2",
  "hyper",
  "hyper-util",
  "log",
@@ -5270,7 +5311,7 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.26.4",
  "tower-service",
- "webpki-roots 1.0.7",
+ "webpki-roots 1.0.8",
 ]
 
 [[package]]
@@ -5299,7 +5340,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.4.0",
+ "http 1.4.2",
  "http-body",
  "hyper",
  "ipnet",
@@ -5326,7 +5367,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -5667,7 +5708,7 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
- "block-padding",
+ "block-padding 0.3.3",
  "generic-array",
 ]
 
@@ -5677,6 +5718,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
 dependencies = [
+ "block-padding 0.4.2",
  "hybrid-array",
 ]
 
@@ -5805,15 +5847,6 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
@@ -5859,7 +5892,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6186,7 +6219,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9992f07580da9541219ae9b94ac67de3b832953a8ca63855b4be5f44c5076ba8"
 dependencies = [
  "domain",
- "http 1.4.0",
+ "http 1.4.2",
  "http-body-util",
  "hyper",
  "log",
@@ -6276,12 +6309,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
-name = "litrs"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
-
-[[package]]
 name = "llama-cpp-2"
 version = "0.1.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6338,7 +6365,7 @@ checksum = "c7184fdea2bc3cd272a1acec4030c321a8f9875e877b3f92a53f2f6033fdc289"
 dependencies = [
  "aes 0.8.4",
  "bitflags 2.11.1",
- "cbc",
+ "cbc 0.1.2",
  "ecb",
  "encoding_rs",
  "flate2",
@@ -6538,7 +6565,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "gloo-timers",
- "http 1.4.0",
+ "http 1.4.2",
  "imbl",
  "indexmap 2.14.0",
  "itertools 0.14.0",
@@ -6637,11 +6664,11 @@ dependencies = [
  "bs58",
  "byteorder",
  "cfg-if",
- "ctr",
+ "ctr 0.9.2",
  "eyeball",
  "futures-core",
  "futures-util",
- "hkdf",
+ "hkdf 0.12.4",
  "hmac 0.12.1",
  "itertools 0.14.0",
  "js_option",
@@ -6676,7 +6703,7 @@ dependencies = [
  "futures-util",
  "getrandom 0.2.17",
  "gloo-utils",
- "hkdf",
+ "hkdf 0.12.4",
  "js-sys",
  "matrix-sdk-base",
  "matrix-sdk-crypto",
@@ -7041,7 +7068,7 @@ dependencies = [
  "bytes",
  "colored 3.1.1",
  "futures-core",
- "http 1.4.0",
+ "http 1.4.2",
  "http-body",
  "http-body-util",
  "hyper",
@@ -7141,7 +7168,7 @@ dependencies = [
  "async-trait",
  "axum",
  "futures",
- "http 1.4.0",
+ "http 1.4.2",
  "include_dir",
  "moltis-common",
  "moltis-config",
@@ -7236,7 +7263,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "http 1.4.0",
+ "http 1.4.2",
  "hyper",
  "hyper-rustls 0.27.9",
  "hyper-util",
@@ -7273,7 +7300,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "bytes",
- "http 1.4.0",
+ "http 1.4.2",
  "moltis-common",
  "moltis-config",
  "moltis-metrics",
@@ -7531,7 +7558,7 @@ dependencies = [
  "futures",
  "gix",
  "hostname 0.4.2",
- "http 1.4.0",
+ "http 1.4.2",
  "include_dir",
  "mdns-sd",
  "moltis-agents",
@@ -7882,7 +7909,7 @@ dependencies = [
  "async-trait",
  "base64 0.22.1",
  "bytes",
- "http 1.4.0",
+ "http 1.4.2",
  "jsonwebtoken",
  "moltis-channels",
  "moltis-common",
@@ -8140,7 +8167,7 @@ dependencies = [
  "encoding_rs",
  "futures",
  "genai",
- "http 1.4.0",
+ "http 1.4.2",
  "json_schema_ast",
  "llama-cpp-2",
  "moltis-agents",
@@ -8297,7 +8324,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "hmac 0.12.1",
- "http 1.4.0",
+ "http 1.4.2",
  "moltis-channels",
  "moltis-common",
  "moltis-metrics",
@@ -8415,7 +8442,7 @@ dependencies = [
  "dashmap 6.1.0",
  "hex",
  "hmac 0.12.1",
- "http 1.4.0",
+ "http 1.4.2",
  "moltis-agents",
  "moltis-channels",
  "moltis-common",
@@ -8426,7 +8453,7 @@ dependencies = [
  "secrecy 0.8.0",
  "serde",
  "serde_json",
- "sha1",
+ "sha1 0.10.6",
  "sha2 0.10.9",
  "thiserror 2.0.18",
  "time",
@@ -8664,6 +8691,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
+ "bytes",
  "dashmap 6.1.0",
  "moltis-channels",
  "moltis-common",
@@ -8674,6 +8702,7 @@ dependencies = [
  "qrcode",
  "rand 0.10.1",
  "serde",
+ "serde-big-array",
  "serde_json",
  "sled",
  "tempfile",
@@ -8709,7 +8738,7 @@ dependencies = [
  "bytes",
  "encoding_rs",
  "futures-util",
- "http 1.4.0",
+ "http 1.4.2",
  "httparse",
  "memchr",
  "mime",
@@ -8900,7 +8929,7 @@ dependencies = [
  "bech32",
  "bip39",
  "bitcoin_hashes",
- "cbc",
+ "cbc 0.1.2",
  "chacha20 0.9.1",
  "chacha20poly1305",
  "getrandom 0.2.17",
@@ -9022,7 +9051,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9158,10 +9187,10 @@ version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51e219e79014df21a225b1860a479e2dcd7cbd9130f4defd4bd0e191ea31d67d"
 dependencies = [
- "base64 0.22.1",
+ "base64 0.21.7",
  "chrono",
  "getrandom 0.2.17",
- "http 1.4.0",
+ "http 1.4.2",
  "rand 0.8.6",
  "reqwest 0.12.28",
  "serde",
@@ -9953,26 +9982,26 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
+checksum = "528ac67416ff8646872a3c02cad9cc4ee5dc9f9540c9b10771855c95cb2e5ae1"
 dependencies = [
  "bytes",
- "prost-derive 0.14.3",
+ "prost-derive 0.14.4",
 ]
 
 [[package]]
 name = "prost-build"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
+checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
 dependencies = [
- "heck 0.5.0",
- "itertools 0.14.0",
+ "heck 0.4.1",
+ "itertools 0.10.5",
  "log",
  "multimap",
  "petgraph",
- "prost 0.14.3",
+ "prost 0.14.4",
  "prost-types",
  "regex",
  "tempfile",
@@ -9985,7 +10014,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -9993,12 +10022,12 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
+checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -10006,11 +10035,11 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
+checksum = "f94967dc7688f3054c7fac87473ffae4cc4c3904800e2d9f5b857246d8963b0a"
 dependencies = [
- "prost 0.14.3",
+ "prost 0.14.4",
 ]
 
 [[package]]
@@ -10527,7 +10556,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http 1.4.0",
+ "http 1.4.2",
  "http-body",
  "http-body-util",
  "hyper",
@@ -10560,7 +10589,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams 0.4.2",
  "web-sys",
- "webpki-roots 1.0.7",
+ "webpki-roots 1.0.8",
 ]
 
 [[package]]
@@ -10576,7 +10605,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http 1.4.0",
+ "http 1.4.2",
  "http-body",
  "http-body-util",
  "hyper",
@@ -10775,7 +10804,7 @@ dependencies = [
  "assign",
  "bytes",
  "date_header",
- "http 1.4.0",
+ "http 1.4.2",
  "js_int",
  "js_option",
  "maplit",
@@ -10800,7 +10829,7 @@ dependencies = [
  "bytes",
  "form_urlencoded",
  "getrandom 0.2.17",
- "http 1.4.0",
+ "http 1.4.2",
  "indexmap 2.14.0",
  "js-sys",
  "js_int",
@@ -10856,7 +10885,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcb45c15badbf4299c6113a6b90df3e7cb64edbe756bbd8e0224144b56b38305"
 dependencies = [
  "headers",
- "http 1.4.0",
+ "http 1.4.2",
  "http-auth",
  "js_int",
  "mime",
@@ -10991,7 +11020,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11096,7 +11125,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11667,13 +11696,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.2",
+]
+
+[[package]]
 name = "sha1-checked"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89f599ac0c323ebb1c6082821a54962b839832b03984598375bff3975b804423"
 dependencies = [
  "digest 0.10.7",
- "sha1",
+ "sha1 0.10.6",
 ]
 
 [[package]]
@@ -11879,7 +11919,7 @@ dependencies = [
  "futures-util",
  "hex",
  "hmac 0.13.0",
- "http 1.4.0",
+ "http 1.4.2",
  "http-body-util",
  "hyper",
  "hyper-rustls 0.27.9",
@@ -11951,6 +11991,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "smoothutf8"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b4ec95892483d6d94284caccfddb9b77111a4dcac33ed25d624248def0fa5f1"
+
+[[package]]
 name = "snafu"
 version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11989,7 +12035,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -12135,7 +12181,7 @@ dependencies = [
  "futures-util",
  "generic-array",
  "hex",
- "hkdf",
+ "hkdf 0.12.4",
  "hmac 0.12.1",
  "itoa",
  "log",
@@ -12146,7 +12192,7 @@ dependencies = [
  "rand 0.8.6",
  "rsa",
  "serde",
- "sha1",
+ "sha1 0.10.6",
  "sha2 0.10.9",
  "smallvec",
  "sqlx-core",
@@ -12173,7 +12219,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "hex",
- "hkdf",
+ "hkdf 0.12.4",
  "hmac 0.12.1",
  "home",
  "itoa",
@@ -12232,7 +12278,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -12612,7 +12658,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -12652,7 +12698,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -12801,9 +12847,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.1"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
@@ -12969,15 +13015,15 @@ dependencies = [
 
 [[package]]
 name = "tokio-websockets"
-version = "0.13.2"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dad543404f98bfc969aeb71994105c592acfc6c43323fddcd016bb208d1c65cb"
+checksum = "d52efb639344a7c6adb8e62c6f3d2c19c001ff1b79a5041ba1c6ed42e19c6aa5"
 dependencies = [
  "base64 0.22.1",
  "bytes",
  "futures-core",
  "futures-sink",
- "http 1.4.0",
+ "http 1.4.2",
  "httparse",
  "rand 0.10.1",
  "ring",
@@ -13115,7 +13161,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
- "http 1.4.0",
+ "http 1.4.2",
  "http-body",
  "http-body-util",
  "iri-string",
@@ -13424,13 +13470,13 @@ dependencies = [
  "byteorder",
  "bytes",
  "data-encoding",
- "http 1.4.0",
+ "http 1.4.2",
  "httparse",
  "log",
  "rand 0.8.6",
  "rustls 0.22.4",
  "rustls-pki-types",
- "sha1",
+ "sha1 0.10.6",
  "thiserror 1.0.69",
  "url",
  "utf-8",
@@ -13444,13 +13490,13 @@ checksum = "4793cb5e56680ecbb1d843515b23b6de9a75eb04b66643e256a396d43be33c13"
 dependencies = [
  "bytes",
  "data-encoding",
- "http 1.4.0",
+ "http 1.4.2",
  "httparse",
  "log",
  "rand 0.9.4",
  "rustls 0.23.39",
  "rustls-pki-types",
- "sha1",
+ "sha1 0.10.6",
  "thiserror 2.0.18",
  "utf-8",
 ]
@@ -13463,11 +13509,11 @@ checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
 dependencies = [
  "bytes",
  "data-encoding",
- "http 1.4.0",
+ "http 1.4.2",
  "httparse",
  "log",
  "rand 0.9.4",
- "sha1",
+ "sha1 0.10.6",
  "thiserror 2.0.18",
  "utf-8",
 ]
@@ -13480,13 +13526,13 @@ checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
 dependencies = [
  "bytes",
  "data-encoding",
- "http 1.4.0",
+ "http 1.4.2",
  "httparse",
  "log",
  "rand 0.9.4",
  "rustls 0.23.39",
  "rustls-pki-types",
- "sha1",
+ "sha1 0.10.6",
  "thiserror 2.0.18",
 ]
 
@@ -13679,7 +13725,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4987bdc12753382e0bec4a65c50738ffaabc998b9cdd1f952fb5f39b0048a96"
 dependencies = [
- "crypto-common 0.2.1",
+ "crypto-common 0.2.2",
  "ctutils",
 ]
 
@@ -13708,16 +13754,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
 dependencies = [
  "base64 0.22.1",
- "cookie_store",
  "log",
  "percent-encoding",
  "rustls 0.23.39",
  "rustls-pki-types",
- "serde",
- "serde_json",
  "ureq-proto",
  "utf8-zero",
- "webpki-roots 1.0.7",
+ "webpki-roots 1.0.8",
 ]
 
 [[package]]
@@ -13727,7 +13770,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
 dependencies = [
  "base64 0.22.1",
- "http 1.4.0",
+ "http 1.4.2",
  "httparse",
  "log",
 ]
@@ -13842,12 +13885,12 @@ dependencies = [
  "arrayvec",
  "base64 0.22.1",
  "base64ct",
- "cbc",
+ "cbc 0.1.2",
  "chacha20poly1305",
- "curve25519-dalek",
+ "curve25519-dalek 4.1.3",
  "ed25519-dalek",
  "getrandom 0.2.17",
- "hkdf",
+ "hkdf 0.12.4",
  "hmac 0.12.1",
  "matrix-pickle",
  "prost 0.13.5",
@@ -13858,7 +13901,7 @@ dependencies = [
  "sha2 0.10.9",
  "subtle",
  "thiserror 2.0.18",
- "x25519-dalek",
+ "x25519-dalek 2.0.1",
  "zeroize",
 ]
 
@@ -13870,12 +13913,10 @@ checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "wacore"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5292fb723da7505e90cfd7a828dd397802b98e0f819a2bc058a6b3a9f2345306"
+version = "0.6.0"
+source = "git+https://github.com/oxidezap/whatsapp-rust?rev=96686eac65460b3bc8e10e3c37f27c0a602c3f54#96686eac65460b3bc8e10e3c37f27c0a602c3f54"
 dependencies = [
- "aes 0.8.4",
- "aes-gcm",
+ "aes 0.9.1",
  "anyhow",
  "async-channel",
  "async-lock",
@@ -13883,24 +13924,27 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "chrono",
- "ctr",
+ "compact_str",
+ "ctr 0.10.1",
  "event-listener",
  "flate2",
  "futures",
  "hex",
- "hkdf",
- "hmac 0.12.1",
+ "hkdf 0.13.0",
+ "hmac 0.13.0",
+ "itoa",
  "log",
  "md5",
- "once_cell",
- "pbkdf2",
- "prost 0.14.3",
+ "portable-atomic",
+ "prost 0.14.4",
  "rand 0.10.1",
  "serde",
  "serde-big-array",
  "serde_json",
- "sha1",
- "sha2 0.10.9",
+ "sha1 0.11.0",
+ "sha2 0.11.0",
+ "smoothutf8",
+ "subtle",
  "thiserror 2.0.18",
  "typed-builder",
  "wacore-appstate",
@@ -13913,20 +13957,20 @@ dependencies = [
 
 [[package]]
 name = "wacore-appstate"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab29b1c5198e16e2619868cc3e48c32f0bcecec936fd20d09460a8f7e374604d"
+version = "0.6.0"
+source = "git+https://github.com/oxidezap/whatsapp-rust?rev=96686eac65460b3bc8e10e3c37f27c0a602c3f54#96686eac65460b3bc8e10e3c37f27c0a602c3f54"
 dependencies = [
  "anyhow",
  "bytemuck",
  "hex",
- "hkdf",
+ "hkdf 0.13.0",
+ "hmac 0.13.0",
  "log",
- "prost 0.14.3",
+ "prost 0.14.4",
  "serde",
  "serde-big-array",
  "serde_json",
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "thiserror 2.0.18",
  "wacore-binary",
  "wacore-libsignal",
@@ -13935,22 +13979,26 @@ dependencies = [
 
 [[package]]
 name = "wacore-binary"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "127a3a6e7554ce002092f1711aa927b0efa3d3fb1ee83506525565c626e68834"
+version = "0.6.0"
+source = "git+https://github.com/oxidezap/whatsapp-rust?rev=96686eac65460b3bc8e10e3c37f27c0a602c3f54#96686eac65460b3bc8e10e3c37f27c0a602c3f54"
 dependencies = [
- "flate2",
- "phf 0.13.1",
- "phf_codegen 0.13.1",
+ "bytes",
+ "compact_str",
+ "hashify",
+ "itoa",
  "serde",
  "serde_json",
+ "smallvec",
+ "smoothutf8",
+ "stable_deref_trait",
+ "yoke",
+ "zlib-rs",
 ]
 
 [[package]]
 name = "wacore-derive"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9546a14730f112eca3bc2e4cbd815df88046fa78530f110c3665492604e770"
+version = "0.6.0"
+source = "git+https://github.com/oxidezap/whatsapp-rust?rev=96686eac65460b3bc8e10e3c37f27c0a602c3f54#96686eac65460b3bc8e10e3c37f27c0a602c3f54"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -13959,51 +14007,49 @@ dependencies = [
 
 [[package]]
 name = "wacore-libsignal"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c89676f7e09708d6b3a58e02bfea42000e3d7bffbc1bf67d0c8bf58ddbdf6373"
+version = "0.6.0"
+source = "git+https://github.com/oxidezap/whatsapp-rust?rev=96686eac65460b3bc8e10e3c37f27c0a602c3f54#96686eac65460b3bc8e10e3c37f27c0a602c3f54"
 dependencies = [
- "aes 0.8.4",
- "aes-gcm",
+ "aes 0.9.1",
  "arrayref",
+ "async-lock",
  "async-trait",
- "cbc",
+ "bytes",
+ "cbc 0.2.1",
  "chrono",
- "ctr",
- "curve25519-dalek",
+ "ctr 0.10.1",
+ "curve25519-dalek 5.0.0-rc.1",
  "derive_more 2.1.1",
  "displaydoc",
  "ghash 0.6.0",
  "hex",
- "hkdf",
- "hmac 0.12.1",
+ "hkdf 0.13.0",
+ "hmac 0.13.0",
  "log",
- "prost 0.14.3",
+ "prost 0.14.4",
  "rand 0.10.1",
  "serde",
- "sha1",
- "sha2 0.10.9",
+ "sha1 0.11.0",
+ "sha2 0.11.0",
  "subtle",
  "thiserror 2.0.18",
  "uuid",
  "waproto",
- "x25519-dalek",
+ "x25519-dalek 3.0.0-rc.1",
 ]
 
 [[package]]
 name = "wacore-noise"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e1c5a0ef2ddaf0f7c5a227649c09de5f354571d95feea4dbac55f2b31c2da53"
+version = "0.6.0"
+source = "git+https://github.com/oxidezap/whatsapp-rust?rev=96686eac65460b3bc8e10e3c37f27c0a602c3f54#96686eac65460b3bc8e10e3c37f27c0a602c3f54"
 dependencies = [
- "aes-gcm",
  "anyhow",
  "bytes",
- "hkdf",
+ "hkdf 0.13.0",
  "log",
- "prost 0.14.3",
+ "prost 0.14.4",
  "rand 0.10.1",
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "thiserror 2.0.18",
  "wacore-binary",
  "wacore-libsignal",
@@ -14037,13 +14083,15 @@ dependencies = [
 
 [[package]]
 name = "waproto"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8fb5d942027d97e5ca1e542a9915388742cc5efab4802910ecc2fd1f430cefe"
+version = "0.6.0"
+source = "git+https://github.com/oxidezap/whatsapp-rust?rev=96686eac65460b3bc8e10e3c37f27c0a602c3f54#96686eac65460b3bc8e10e3c37f27c0a602c3f54"
 dependencies = [
- "prost 0.14.3",
+ "heck 0.5.0",
+ "prost 0.14.4",
  "prost-build",
+ "prost-types",
  "serde",
+ "sha2 0.11.0",
 ]
 
 [[package]]
@@ -14807,14 +14855,14 @@ version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
 dependencies = [
- "webpki-roots 1.0.7",
+ "webpki-roots 1.0.8",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -14827,9 +14875,8 @@ checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
 name = "whatsapp-rust"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b79e16847fe6e7ea8d103b4b575b1a1b77bd57cb4c292f7c50616b72a74374"
+version = "0.6.0"
+source = "git+https://github.com/oxidezap/whatsapp-rust?rev=96686eac65460b3bc8e10e3c37f27c0a602c3f54#96686eac65460b3bc8e10e3c37f27c0a602c3f54"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -14838,12 +14885,14 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "chrono",
- "env_logger",
  "event-listener",
  "futures",
+ "getrandom 0.4.2",
  "hex",
+ "itoa",
  "log",
- "prost 0.14.3",
+ "portable-atomic",
+ "prost 0.14.4",
  "rand 0.10.1",
  "scopeguard",
  "serde",
@@ -14859,30 +14908,28 @@ dependencies = [
 
 [[package]]
 name = "whatsapp-rust-tokio-transport"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0aca6e068f01d56f7d360a04aeb16d34a3edb623e7d43e7cd857682a186c0130"
+version = "0.6.0"
+source = "git+https://github.com/oxidezap/whatsapp-rust?rev=96686eac65460b3bc8e10e3c37f27c0a602c3f54#96686eac65460b3bc8e10e3c37f27c0a602c3f54"
 dependencies = [
  "anyhow",
  "async-channel",
  "async-trait",
  "bytes",
  "futures-util",
- "http 1.4.0",
+ "http 1.4.2",
  "log",
  "rustls 0.23.39",
  "tokio",
  "tokio-rustls 0.26.4",
  "tokio-websockets",
  "wacore",
- "webpki-roots 1.0.7",
+ "webpki-roots 1.0.8",
 ]
 
 [[package]]
 name = "whatsapp-rust-ureq-http-client"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45ae9349f172ab8e50031ef5c429bb56ffdd677fbfeb22ed09fff3ce3b62c135"
+version = "0.6.0"
+source = "git+https://github.com/oxidezap/whatsapp-rust?rev=96686eac65460b3bc8e10e3c37f27c0a602c3f54#96686eac65460b3bc8e10e3c37f27c0a602c3f54"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -14991,7 +15038,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -15026,7 +15073,7 @@ version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
 dependencies = [
- "windows-core 0.57.0",
+ "windows-core",
  "windows-targets 0.52.6",
 ]
 
@@ -15036,23 +15083,10 @@ version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
 dependencies = [
- "windows-implement 0.57.0",
- "windows-interface 0.57.0",
+ "windows-implement",
+ "windows-interface",
  "windows-result 0.1.2",
  "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.62.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
-dependencies = [
- "windows-implement 0.60.2",
- "windows-interface 0.59.3",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
- "windows-strings 0.5.1",
 ]
 
 [[package]]
@@ -15067,32 +15101,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-implement"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "windows-interface"
 version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.59.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -15528,7 +15540,7 @@ dependencies = [
  "base64 0.22.1",
  "deadpool",
  "futures",
- "http 1.4.0",
+ "http 1.4.2",
  "http-body-util",
  "hyper",
  "hyper-util",
@@ -15777,9 +15789,20 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
 dependencies = [
- "curve25519-dalek",
+ "curve25519-dalek 4.1.3",
  "rand_core 0.6.4",
  "serde",
+ "zeroize",
+]
+
+[[package]]
+name = "x25519-dalek"
+version = "3.0.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eee64e8620caa64914d669b1f68f858aaff54e2d0f9ad3b30a613b58a1baa83e"
+dependencies = [
+ "curve25519-dalek 5.0.0-rc.1",
+ "rand_core 0.10.1",
  "zeroize",
 ]
 
@@ -15963,9 +15986,9 @@ dependencies = [
 
 [[package]]
 name = "zlib-rs"
-version = "0.6.3"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
+checksum = "5431d5661c32445236631278f27946e444ddafe4684cac70b185272d4f9c52d5"
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -148,6 +148,19 @@ resolver = "2"
 # Remove once sqlx ≥ 0.9 ships stable.
 sqlx-core   = { git = "https://github.com/moltis-org/sqlx", rev = "33747ad2e2d0c7962c6450faf31591c4e0782c23" }
 sqlx-sqlite = { git = "https://github.com/moltis-org/sqlx", rev = "33747ad2e2d0c7962c6450faf31591c4e0782c23" }
+# whatsapp-rust 0.6.0 plus the DM LID-migration gate (oxidezap/whatsapp-rust#943,
+# merged upstream): accounts the server has not migrated to LID 1:1 get their
+# LID-addressed DMs silently 400-nacked; the gate keeps wire addressing on PN
+# until the account migrates. Pinned to the merge commit of #943; drop this
+# patch section for a plain version bump once a whatsapp-rust release includes
+# it. The whole family is patched to the same rev so wacore/waproto types stay
+# unified (mixing crates.io and git copies makes them incompatible).
+wacore                         = { git = "https://github.com/oxidezap/whatsapp-rust", rev = "96686eac65460b3bc8e10e3c37f27c0a602c3f54" }
+wacore-binary                  = { git = "https://github.com/oxidezap/whatsapp-rust", rev = "96686eac65460b3bc8e10e3c37f27c0a602c3f54" }
+waproto                        = { git = "https://github.com/oxidezap/whatsapp-rust", rev = "96686eac65460b3bc8e10e3c37f27c0a602c3f54" }
+whatsapp-rust                  = { git = "https://github.com/oxidezap/whatsapp-rust", rev = "96686eac65460b3bc8e10e3c37f27c0a602c3f54" }
+whatsapp-rust-tokio-transport  = { git = "https://github.com/oxidezap/whatsapp-rust", rev = "96686eac65460b3bc8e10e3c37f27c0a602c3f54" }
+whatsapp-rust-ureq-http-client = { git = "https://github.com/oxidezap/whatsapp-rust", rev = "96686eac65460b3bc8e10e3c37f27c0a602c3f54" }
 
 [workspace.lints.rust]
 unsafe_code           = "deny"
@@ -175,10 +188,11 @@ askama     = "0.15"
 axum       = { features = ["ws"], version = "0.8" }
 axum-extra = "0.10"
 # Serialization
-postcard   = { features = ["alloc"], version = "1.1" }
-schemars   = "1.2"
-serde      = { features = ["derive"], version = "1" }
-serde_json = "1"
+postcard        = { features = ["alloc"], version = "1.1" }
+schemars        = "1.2"
+serde           = { features = ["derive"], version = "1" }
+serde-big-array = "0.5"
+serde_json      = "1"
 # Error handling
 anyhow    = "1"
 thiserror = "2"
@@ -251,12 +265,12 @@ sysinfo            = "0.34"
 teloxide           = { features = ["macros"], version = "0.17" }
 # WhatsApp (sqlite-storage disabled to avoid libsqlite3-sys conflict with sqlx;
 # re-enable once sqlx 0.9 stabilises).
-wacore                         = { default-features = false, version = "0.5" }
-wacore-binary                  = { default-features = false, version = "0.5" }
-waproto                        = "0.5"
-whatsapp-rust                  = { default-features = false, features = ["tokio-native", "tokio-runtime", "tokio-transport", "ureq-client"], version = "0.5" }
-whatsapp-rust-tokio-transport  = "0.5"
-whatsapp-rust-ureq-http-client = "0.5"
+wacore                         = { default-features = false, version = "0.6" }
+wacore-binary                  = { default-features = false, version = "0.6" }
+waproto                        = "0.6"
+whatsapp-rust                  = { default-features = false, features = ["tokio-native", "tokio-runtime", "tokio-transport", "ureq-client"], version = "0.6" }
+whatsapp-rust-tokio-transport  = "0.6"
+whatsapp-rust-ureq-http-client = "0.6"
 # QR code rendering
 qrcode = "0.14"
 # TLS / certificate generation

--- a/crates/whatsapp/Cargo.toml
+++ b/crates/whatsapp/Cargo.toml
@@ -6,6 +6,7 @@ version.workspace = true
 [dependencies]
 async-trait     = { workspace = true }
 base64          = { workspace = true }
+bytes           = { workspace = true }
 dashmap         = { workspace = true }
 moltis-channels = { workspace = true }
 moltis-common   = { workspace = true }
@@ -16,6 +17,7 @@ postcard        = { workspace = true }
 qrcode          = { workspace = true }
 rand            = { workspace = true }
 serde           = { workspace = true }
+serde-big-array = { workspace = true }
 serde_json      = { workspace = true }
 sled            = { workspace = true }
 thiserror       = { workspace = true }

--- a/crates/whatsapp/src/connection.rs
+++ b/crates/whatsapp/src/connection.rs
@@ -1,9 +1,6 @@
 use std::sync::Arc;
 
-use {
-    tokio_util::sync::CancellationToken,
-    tracing::{info, warn},
-};
+use {tokio_util::sync::CancellationToken, tracing::info};
 
 use moltis_channels::{ChannelEventSink, message_log::MessageLog};
 
@@ -57,8 +54,8 @@ pub async fn start_connection(
     let state_ref_handler = Arc::clone(&state_ref);
     let accounts_handler = Arc::clone(&accounts);
 
-    let mut bot = whatsapp_rust::bot::Bot::builder()
-        .with_backend(backend)
+    let bot = whatsapp_rust::bot::Bot::builder()
+        .with_backend_arc(backend)
         .with_transport_factory(
             whatsapp_rust_tokio_transport::TokioWebSocketTransportFactory::new(),
         )
@@ -66,9 +63,9 @@ pub async fn start_connection(
         .with_runtime(whatsapp_rust::TokioRuntime)
         .skip_history_sync()
         .with_device_props(
-            Some("Moltis".to_string()),
-            None,
-            Some(waproto::whatsapp::device_props::PlatformType::Desktop),
+            wacore::store::DevicePropsOverride::new()
+                .with_os("Moltis")
+                .with_platform_type(waproto::whatsapp::device_props::PlatformType::Desktop),
         )
         .with_push_name("Moltis")
         .on_event(move |event, client| {
@@ -128,31 +125,14 @@ pub async fn start_connection(
     // Spawn the event loop.
     let account_id_task = account_id.clone();
     tokio::spawn(async move {
+        // `Bot::run` now drives the whole lifecycle itself (no JoinHandle);
+        // dropping the future on cancel is the supported teardown path.
         tokio::select! {
-            result = bot.run() => {
-                match result {
-                    Ok(handle) => {
-                        tokio::pin!(handle);
-                        tokio::select! {
-                            _ = &mut handle => {
-                                info!(account_id = %account_id_task, "WhatsApp bot task completed");
-                            },
-                            _ = cancel.cancelled() => {
-                                info!(account_id = %account_id_task, "WhatsApp account cancelled, aborting bot task");
-                                handle.abort();
-                                // Wait for the task to finish after abort so the
-                                // sled store is fully released before we signal done.
-                                let _ = handle.await;
-                            },
-                        }
-                    },
-                    Err(e) => {
-                        warn!(account_id = %account_id_task, error = %e, "WhatsApp bot failed to start");
-                    },
-                }
+            _ = bot.run() => {
+                info!(account_id = %account_id_task, "WhatsApp bot task completed");
             },
             _ = cancel.cancelled() => {
-                info!(account_id = %account_id_task, "WhatsApp account cancelled before start");
+                info!(account_id = %account_id_task, "WhatsApp account cancelled");
             },
         }
         shutdown_clone.mark_done();

--- a/crates/whatsapp/src/handlers.rs
+++ b/crates/whatsapp/src/handlers.rs
@@ -52,12 +52,12 @@ fn current_config(
 
 /// Process an incoming whatsapp-rust event for the given account.
 pub async fn handle_event(
-    event: Event,
+    event: Arc<Event>,
     client: Arc<Client>,
     state: Arc<AccountState>,
     accounts: AccountStateMap,
 ) {
-    match event {
+    match event.as_ref() {
         Event::PairingQrCode { code, .. } => {
             info!(account_id = %state.account_id, "QR code generated for pairing");
 
@@ -71,7 +71,7 @@ pub async fn handle_event(
                 sink.emit(ChannelEvent::PairingQrCode {
                     channel_type: ChannelType::Whatsapp,
                     account_id: state.account_id.clone(),
-                    qr_data: code,
+                    qr_data: code.clone(),
                 })
                 .await;
             }
@@ -91,11 +91,11 @@ pub async fn handle_event(
             // manually add themselves to the allowlist.  Only the PN JID is
             // needed — incoming messages always use the PN format.
             {
-                let own_pn = state.client.get_pn().await;
+                let own_pn = state.client.get_pn();
                 auto_approve_owner_jid(&accounts, &state.account_id, own_pn.as_ref());
             }
 
-            let display_name = state.client.get_push_name().await;
+            let display_name = state.client.get_push_name();
             let display = if display_name.is_empty() {
                 None
             } else {
@@ -111,7 +111,7 @@ pub async fn handle_event(
                 .await;
             }
         },
-        Event::PairSuccess(ref pair) => {
+        Event::PairSuccess(pair) => {
             info!(account_id = %state.account_id, jid = %pair.id, "WhatsApp pairing succeeded");
 
             // Clear QR immediately so the UI stops showing it.
@@ -161,17 +161,24 @@ pub async fn handle_event(
             }
         },
         Event::Message(msg, msg_info) => {
-            handle_message(msg, msg_info, &client, &state, &accounts).await;
+            handle_message(
+                Arc::clone(msg),
+                Arc::clone(msg_info),
+                &client,
+                &state,
+                &accounts,
+            )
+            .await;
         },
         _ => {
-            debug!(account_id = %state.account_id, event = ?std::mem::discriminant(&event), "unhandled WhatsApp event");
+            debug!(account_id = %state.account_id, event = ?std::mem::discriminant(event.as_ref()), "unhandled WhatsApp event");
         },
     }
 }
 
 async fn handle_message(
-    msg: Box<wa::Message>,
-    info: MessageInfo,
+    msg: Arc<wa::Message>,
+    info: Arc<MessageInfo>,
     client: &Client,
     state: &AccountState,
     accounts: &AccountStateMap,
@@ -190,7 +197,7 @@ async fn handle_message(
     let chat_id = chat_jid.to_string();
     // Use the sender's user part as display username.  Resolved later for
     // self-chat so the phone number appears instead of the opaque LID.
-    let mut username = sender_jid.user.clone();
+    let mut username = sender_jid.user.to_string();
     let sender_name = if info.push_name.is_empty() {
         None
     } else {
@@ -217,8 +224,8 @@ async fn handle_message(
     // We still prevent loops by dropping known bot echoes (recent sent IDs
     // and watermark).
     let mut is_owner_self_chat = false;
-    let own_pn = state.client.get_pn().await;
-    let own_lid = state.client.get_lid().await;
+    let own_pn = state.client.get_pn();
+    let own_lid = state.client.get_lid();
     let is_self_chat = is_owner_user(chat_jid, own_pn.as_ref(), own_lid.as_ref());
     let sender_is_owner = is_owner_user(sender_jid, own_pn.as_ref(), own_lid.as_ref());
 
@@ -271,8 +278,8 @@ async fn handle_message(
     // outbound layer resolves it to a full PN JID before sending.
     let chat_id = if is_owner_self_chat {
         if let Some(ref pn) = own_pn {
-            username = pn.user.clone();
-            pn.user.clone()
+            username = pn.user.to_string();
+            pn.user.to_string()
         } else {
             chat_id
         }

--- a/crates/whatsapp/src/memory_store.rs
+++ b/crates/whatsapp/src/memory_store.rs
@@ -11,12 +11,12 @@ use std::{fmt::Write, sync::Arc};
 
 use {
     async_trait::async_trait,
+    bytes::Bytes,
     dashmap::DashMap,
     wacore::{
         appstate::{hash::HashState, processor::AppStateMutationMAC},
         store::{error::Result, traits::*},
     },
-    wacore_binary::jid::Jid,
 };
 
 /// Hex-encode bytes without pulling in the `hex` crate.
@@ -46,19 +46,20 @@ pub struct MemoryStore {
     mutation_mac_indexes: Arc<DashMap<String, Vec<Vec<u8>>>>,
     device_data: Arc<tokio::sync::RwLock<Option<wacore::store::Device>>>,
     device_id: Arc<std::sync::atomic::AtomicI32>,
-    skdm_recipients: Arc<DashMap<String, Vec<String>>>,
     lid_mappings: Arc<DashMap<String, LidPnMappingEntry>>,
     /// Phone number → LID reverse index.
     pn_mappings: Arc<DashMap<String, String>>,
     device_list_records: Arc<DashMap<String, DeviceListRecord>>,
-    /// Keyed by `"{group_jid}:{participant}"`.
-    sender_key_forget_marks: Arc<DashMap<String, bool>>,
+    /// Sender-key distribution status keyed by `(group_jid, device_jid)`.
+    sender_key_devices: Arc<DashMap<(String, String), bool>>,
     /// Base keys keyed by `"{address}:{message_id}"`.
     base_keys: Arc<DashMap<String, Vec<u8>>>,
     /// TC tokens keyed by JID string.
     tc_tokens: Arc<DashMap<String, TcTokenEntry>>,
     /// Sent messages keyed by `"{chat_jid}:{message_id}"` → (payload, timestamp).
     sent_messages: Arc<DashMap<String, (Vec<u8>, i64)>>,
+    /// Message secrets keyed by (chat, sender, msg_id) → (secret, expires_at, message_ts).
+    msg_secrets: Arc<DashMap<(String, String, String), (Vec<u8>, i64, i64)>>,
 }
 
 impl MemoryStore {
@@ -78,8 +79,11 @@ impl SignalStore for MemoryStore {
         Ok(())
     }
 
-    async fn load_identity(&self, address: &str) -> Result<Option<Vec<u8>>> {
-        Ok(self.identities.get(address).map(|v| v.value().clone()))
+    async fn load_identity(&self, address: &str) -> Result<Option<[u8; 32]>> {
+        Ok(self
+            .identities
+            .get(address)
+            .and_then(|v| v.value().as_slice().try_into().ok()))
     }
 
     async fn delete_identity(&self, address: &str) -> Result<()> {
@@ -87,8 +91,11 @@ impl SignalStore for MemoryStore {
         Ok(())
     }
 
-    async fn get_session(&self, address: &str) -> Result<Option<Vec<u8>>> {
-        Ok(self.sessions.get(address).map(|v| v.value().clone()))
+    async fn get_session(&self, address: &str) -> Result<Option<Bytes>> {
+        Ok(self
+            .sessions
+            .get(address)
+            .map(|v| Bytes::from(v.value().clone())))
     }
 
     async fn put_session(&self, address: &str, session: &[u8]) -> Result<()> {
@@ -106,8 +113,20 @@ impl SignalStore for MemoryStore {
         Ok(())
     }
 
-    async fn load_prekey(&self, id: u32) -> Result<Option<Vec<u8>>> {
-        Ok(self.prekeys.get(&id).map(|v| v.value().0.clone()))
+    async fn load_prekey(&self, id: u32) -> Result<Option<Bytes>> {
+        Ok(self
+            .prekeys
+            .get(&id)
+            .map(|v| Bytes::from(v.value().0.clone())))
+    }
+
+    async fn mark_prekeys_uploaded(&self, ids: &[u32]) -> Result<()> {
+        for id in ids {
+            if let Some(mut entry) = self.prekeys.get_mut(id) {
+                entry.value_mut().1 = true;
+            }
+        }
+        Ok(())
     }
 
     async fn remove_prekey(&self, id: u32) -> Result<()> {
@@ -237,6 +256,14 @@ impl AppSyncStore for MemoryStore {
         Ok(())
     }
 
+    async fn clear_mutation_macs(&self, name: &str) -> Result<()> {
+        let prefix = format!("{name}:");
+        self.mutation_macs.retain(|k, _| !k.starts_with(&prefix));
+        self.mutation_mac_indexes
+            .retain(|k, _| !k.starts_with(&prefix));
+        Ok(())
+    }
+
     async fn get_latest_sync_key_id(&self) -> Result<Option<Vec<u8>>> {
         Ok(self
             .latest_sync_key_id
@@ -247,29 +274,98 @@ impl AppSyncStore for MemoryStore {
 }
 
 // ============================================================================
+// MsgSecretStore
+// ============================================================================
+
+#[async_trait]
+impl MsgSecretStore for MemoryStore {
+    async fn put_msg_secrets(&self, entries: Vec<MsgSecretEntry>) -> Result<usize> {
+        let count = entries.len();
+        for entry in entries {
+            let key = (entry.chat, entry.sender, entry.msg_id);
+            match self.msg_secrets.get_mut(&key) {
+                Some(mut existing) => {
+                    let (_, exp, ts) = existing.value_mut();
+                    *exp = merge_msg_secret_expiry(*exp, entry.expires_at);
+                    *ts = merge_msg_secret_message_ts(*ts, entry.message_ts);
+                },
+                None => {
+                    self.msg_secrets
+                        .insert(key, (entry.secret, entry.expires_at, entry.message_ts));
+                },
+            }
+        }
+        Ok(count)
+    }
+
+    async fn get_msg_secret(
+        &self,
+        chat: &str,
+        sender: &str,
+        msg_id: &str,
+    ) -> Result<Option<Vec<u8>>> {
+        Ok(self
+            .msg_secrets
+            .get(&(chat.to_string(), sender.to_string(), msg_id.to_string()))
+            .map(|v| v.value().0.clone()))
+    }
+
+    async fn get_msg_secret_with_ts(
+        &self,
+        chat: &str,
+        sender: &str,
+        msg_id: &str,
+    ) -> Result<Option<(Vec<u8>, i64)>> {
+        Ok(self
+            .msg_secrets
+            .get(&(chat.to_string(), sender.to_string(), msg_id.to_string()))
+            .map(|v| (v.value().0.clone(), v.value().2)))
+    }
+
+    async fn delete_expired_msg_secrets(&self, cutoff_timestamp: i64) -> Result<u32> {
+        let before = self.msg_secrets.len();
+        self.msg_secrets
+            .retain(|_, (_, expires_at, _)| *expires_at == 0 || *expires_at > cutoff_timestamp);
+        Ok((before - self.msg_secrets.len()) as u32)
+    }
+}
+
+// ============================================================================
 // ProtocolStore
 // ============================================================================
 
 #[async_trait]
 impl ProtocolStore for MemoryStore {
-    async fn get_skdm_recipients(&self, group_jid: &str) -> Result<Vec<Jid>> {
+    async fn get_sender_key_devices(&self, group_jid: &str) -> Result<Vec<(String, bool)>> {
         Ok(self
-            .skdm_recipients
-            .get(group_jid)
-            .map(|v| v.value().iter().filter_map(|s| s.parse().ok()).collect())
-            .unwrap_or_default())
+            .sender_key_devices
+            .iter()
+            .filter(|e| e.key().0 == group_jid)
+            .map(|e| (e.key().1.clone(), *e.value()))
+            .collect())
     }
 
-    async fn add_skdm_recipients(&self, group_jid: &str, device_jids: &[Jid]) -> Result<()> {
-        self.skdm_recipients
-            .entry(group_jid.to_string())
-            .or_default()
-            .extend(device_jids.iter().map(|j| j.to_string()));
+    async fn set_sender_key_status(&self, group_jid: &str, entries: &[(&str, bool)]) -> Result<()> {
+        for (device_jid, has_key) in entries {
+            self.sender_key_devices
+                .insert((group_jid.to_string(), (*device_jid).to_string()), *has_key);
+        }
         Ok(())
     }
 
-    async fn clear_skdm_recipients(&self, group_jid: &str) -> Result<()> {
-        self.skdm_recipients.remove(group_jid);
+    async fn clear_sender_key_devices(&self, group_jid: &str) -> Result<()> {
+        self.sender_key_devices.retain(|k, _| k.0 != group_jid);
+        Ok(())
+    }
+
+    async fn delete_sender_key_device_rows(&self, device_jids: &[&str]) -> Result<()> {
+        self.sender_key_devices
+            .retain(|k, _| !device_jids.contains(&k.1.as_str()));
+        Ok(())
+    }
+
+    async fn clear_all_sender_key_devices(&self) -> Result<()> {
+        self.sender_key_devices.clear();
         Ok(())
     }
 
@@ -339,29 +435,9 @@ impl ProtocolStore for MemoryStore {
             .map(|v| v.value().clone()))
     }
 
-    async fn mark_forget_sender_key(&self, group_jid: &str, participant: &str) -> Result<()> {
-        let key = format!("{group_jid}:{participant}");
-        self.sender_key_forget_marks.insert(key, true);
+    async fn delete_devices(&self, user: &str) -> Result<()> {
+        self.device_list_records.remove(user);
         Ok(())
-    }
-
-    async fn consume_forget_marks(&self, group_jid: &str) -> Result<Vec<String>> {
-        let prefix = format!("{group_jid}:");
-        let keys: Vec<String> = self
-            .sender_key_forget_marks
-            .iter()
-            .filter(|e| e.key().starts_with(&prefix))
-            .map(|e| e.key().clone())
-            .collect();
-
-        let mut participants = Vec::new();
-        for key in keys {
-            self.sender_key_forget_marks.remove(&key);
-            if let Some(participant) = key.strip_prefix(&prefix) {
-                participants.push(participant.to_string());
-            }
-        }
-        Ok(participants)
     }
 
     // --- TcToken Storage ---
@@ -479,7 +555,7 @@ mod tests {
             .await
             .unwrap();
         let loaded = store.load_identity("test@s.whatsapp.net").await.unwrap();
-        assert_eq!(loaded, Some(key.to_vec()));
+        assert_eq!(loaded, Some(key));
     }
 
     #[tokio::test]
@@ -488,7 +564,7 @@ mod tests {
         let data = b"session-data";
         store.put_session("addr", data).await.unwrap();
         let loaded = store.get_session("addr").await.unwrap();
-        assert_eq!(loaded, Some(data.to_vec()));
+        assert_eq!(loaded, Some(Bytes::from_static(data)));
         assert!(store.has_session("addr").await.unwrap());
         assert!(!store.has_session("missing").await.unwrap());
     }
@@ -506,7 +582,10 @@ mod tests {
         let store = MemoryStore::new();
         store.store_prekey(1, b"pk1", false).await.unwrap();
         store.store_prekey(2, b"pk2", true).await.unwrap();
-        assert_eq!(store.load_prekey(1).await.unwrap(), Some(b"pk1".to_vec()));
+        assert_eq!(
+            store.load_prekey(1).await.unwrap(),
+            Some(Bytes::from_static(b"pk1"))
+        );
         store.remove_prekey(1).await.unwrap();
         assert!(store.load_prekey(1).await.unwrap().is_none());
     }
@@ -565,25 +644,43 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn skdm_recipients() {
+    async fn sender_key_devices() {
         let store = MemoryStore::new();
-        let recips = store.get_skdm_recipients("group1").await.unwrap();
-        assert!(recips.is_empty());
+        assert!(
+            store
+                .get_sender_key_devices("group1")
+                .await
+                .unwrap()
+                .is_empty()
+        );
 
         store
-            .add_skdm_recipients("group1", &[
-                "dev1@s.whatsapp.net".parse().unwrap(),
-                "dev2@s.whatsapp.net".parse().unwrap(),
+            .set_sender_key_status("group1", &[
+                ("dev1@s.whatsapp.net", true),
+                ("dev2@s.whatsapp.net", false),
             ])
             .await
             .unwrap();
-        let recips = store.get_skdm_recipients("group1").await.unwrap();
-        assert_eq!(recips.len(), 2);
+        let mut devices = store.get_sender_key_devices("group1").await.unwrap();
+        devices.sort();
+        assert_eq!(devices, vec![
+            ("dev1@s.whatsapp.net".to_string(), true),
+            ("dev2@s.whatsapp.net".to_string(), false),
+        ]);
 
-        store.clear_skdm_recipients("group1").await.unwrap();
+        store
+            .delete_sender_key_device_rows(&["dev2@s.whatsapp.net"])
+            .await
+            .unwrap();
+        assert_eq!(
+            store.get_sender_key_devices("group1").await.unwrap().len(),
+            1
+        );
+
+        store.clear_sender_key_devices("group1").await.unwrap();
         assert!(
             store
-                .get_skdm_recipients("group1")
+                .get_sender_key_devices("group1")
                 .await
                 .unwrap()
                 .is_empty()
@@ -640,29 +737,15 @@ mod tests {
             }],
             timestamp: 1000,
             phash: None,
+            raw_id: None,
         };
         store.update_device_list(record).await.unwrap();
         let loaded = store.get_devices("user1").await.unwrap();
         assert!(loaded.is_some());
         assert_eq!(loaded.unwrap().devices.len(), 1);
-    }
 
-    #[tokio::test]
-    async fn forget_marks() {
-        let store = MemoryStore::new();
-        store
-            .mark_forget_sender_key("group1", "user_a")
-            .await
-            .unwrap();
-        store
-            .mark_forget_sender_key("group1", "user_b")
-            .await
-            .unwrap();
-        let marks = store.consume_forget_marks("group1").await.unwrap();
-        assert_eq!(marks.len(), 2);
-        // Consumed — should be empty now.
-        let marks = store.consume_forget_marks("group1").await.unwrap();
-        assert!(marks.is_empty());
+        store.delete_devices("user1").await.unwrap();
+        assert!(store.get_devices("user1").await.unwrap().is_none());
     }
 
     #[tokio::test]

--- a/crates/whatsapp/src/outbound.rs
+++ b/crates/whatsapp/src/outbound.rs
@@ -70,9 +70,9 @@ fn build_media_message(
                 caption,
                 url: Some(upload.url.clone()),
                 direct_path: Some(upload.direct_path.clone()),
-                media_key: Some(upload.media_key.clone()),
-                file_sha256: Some(upload.file_sha256.clone()),
-                file_enc_sha256: Some(upload.file_enc_sha256.clone()),
+                media_key: Some(upload.media_key.to_vec()),
+                file_sha256: Some(upload.file_sha256.to_vec()),
+                file_enc_sha256: Some(upload.file_enc_sha256.to_vec()),
                 file_length: Some(upload.file_length),
                 ..Default::default()
             })),
@@ -85,9 +85,9 @@ fn build_media_message(
                 caption,
                 url: Some(upload.url.clone()),
                 direct_path: Some(upload.direct_path.clone()),
-                media_key: Some(upload.media_key.clone()),
-                file_sha256: Some(upload.file_sha256.clone()),
-                file_enc_sha256: Some(upload.file_enc_sha256.clone()),
+                media_key: Some(upload.media_key.to_vec()),
+                file_sha256: Some(upload.file_sha256.to_vec()),
+                file_enc_sha256: Some(upload.file_enc_sha256.to_vec()),
                 file_length: Some(upload.file_length),
                 ..Default::default()
             })),
@@ -99,9 +99,9 @@ fn build_media_message(
                 mimetype: Some(mime.to_string()),
                 url: Some(upload.url.clone()),
                 direct_path: Some(upload.direct_path.clone()),
-                media_key: Some(upload.media_key.clone()),
-                file_sha256: Some(upload.file_sha256.clone()),
-                file_enc_sha256: Some(upload.file_enc_sha256.clone()),
+                media_key: Some(upload.media_key.to_vec()),
+                file_sha256: Some(upload.file_sha256.to_vec()),
+                file_enc_sha256: Some(upload.file_enc_sha256.to_vec()),
                 file_length: Some(upload.file_length),
                 ..Default::default()
             })),
@@ -114,9 +114,9 @@ fn build_media_message(
                 title: caption,
                 url: Some(upload.url.clone()),
                 direct_path: Some(upload.direct_path.clone()),
-                media_key: Some(upload.media_key.clone()),
-                file_sha256: Some(upload.file_sha256.clone()),
-                file_enc_sha256: Some(upload.file_enc_sha256.clone()),
+                media_key: Some(upload.media_key.to_vec()),
+                file_sha256: Some(upload.file_sha256.to_vec()),
+                file_enc_sha256: Some(upload.file_enc_sha256.to_vec()),
                 file_length: Some(upload.file_length),
                 ..Default::default()
             })),
@@ -176,11 +176,11 @@ impl ChannelOutbound for WhatsAppOutbound {
             conversation: Some(watermarked),
             ..Default::default()
         };
-        let msg_id = client
+        let sent = client
             .send_message(jid, msg)
             .await
             .map_err(|e| moltis_channels::Error::unavailable(format!("whatsapp send_text: {e}")))?;
-        self.record_sent_id(account_id, &msg_id);
+        self.record_sent_id(account_id, &sent.message_id);
 
         #[cfg(feature = "metrics")]
         moltis_metrics::counter!(
@@ -236,16 +236,19 @@ impl ChannelOutbound for WhatsAppOutbound {
         let client = self.get_client(account_id)?;
         let jid = resolve_jid(to)?;
 
-        let upload = client.upload(bytes, media_type).await.map_err(|e| {
-            moltis_channels::Error::unavailable(format!("whatsapp media upload: {e}"))
-        })?;
+        let upload = client
+            .upload(bytes, media_type, Default::default())
+            .await
+            .map_err(|e| {
+                moltis_channels::Error::unavailable(format!("whatsapp media upload: {e}"))
+            })?;
 
         let msg = build_media_message(&media.mime_type, caption, &upload);
 
-        let msg_id = client.send_message(jid, msg).await.map_err(|e| {
+        let sent = client.send_message(jid, msg).await.map_err(|e| {
             moltis_channels::Error::unavailable(format!("whatsapp send_media: {e}"))
         })?;
-        self.record_sent_id(account_id, &msg_id);
+        self.record_sent_id(account_id, &sent.message_id);
 
         #[cfg(feature = "metrics")]
         moltis_metrics::counter!(
@@ -313,6 +316,21 @@ mod tests {
     use super::*;
 
     #[test]
+    fn resolve_jid_passes_lid_through_unchanged() {
+        // Parsing must not alter the JID: whatsapp-rust decides wire
+        // addressing from the account's LID-migration state.
+        let jid = resolve_jid("111111111111111@lid").unwrap_or_else(|e| panic!("resolve: {e:?}"));
+        assert_eq!(jid.to_string(), "111111111111111@lid");
+        assert!(jid.is_lid());
+    }
+
+    #[test]
+    fn resolve_jid_bare_number_becomes_pn() {
+        let jid = resolve_jid("15551234567").unwrap_or_else(|e| panic!("resolve: {e:?}"));
+        assert_eq!(jid.to_string(), "15551234567@s.whatsapp.net");
+    }
+
+    #[test]
     fn decode_data_url_valid() {
         let b64 = base64::engine::general_purpose::STANDARD.encode([0xAB, 0xCD]);
         let url = format!("data:image/png;base64,{b64}");
@@ -339,75 +357,5 @@ mod tests {
             mime_to_media_type("application/octet-stream"),
             MediaType::Document
         ));
-    }
-
-    #[test]
-    fn build_media_message_image() {
-        let upload = UploadResponse {
-            url: "https://example.com/img".into(),
-            direct_path: "/path".into(),
-            media_key: vec![1, 2, 3],
-            file_sha256: vec![4, 5, 6],
-            file_enc_sha256: vec![7, 8, 9],
-            file_length: 1024,
-        };
-        let msg = build_media_message("image/png", Some("caption".into()), &upload);
-        let img = msg
-            .image_message
-            .unwrap_or_else(|| panic!("expected image_message"));
-        assert_eq!(img.mimetype.as_deref(), Some("image/png"));
-        assert_eq!(img.caption.as_deref(), Some("caption"));
-        assert_eq!(img.url.as_deref(), Some("https://example.com/img"));
-        assert_eq!(img.file_length, Some(1024));
-    }
-
-    #[test]
-    fn build_media_message_video() {
-        let upload = UploadResponse {
-            url: "https://example.com/vid".into(),
-            direct_path: "/path".into(),
-            media_key: vec![],
-            file_sha256: vec![],
-            file_enc_sha256: vec![],
-            file_length: 2048,
-        };
-        let msg = build_media_message("video/mp4", None, &upload);
-        let vid = msg
-            .video_message
-            .unwrap_or_else(|| panic!("expected video_message"));
-        assert_eq!(vid.mimetype.as_deref(), Some("video/mp4"));
-        assert!(vid.caption.is_none());
-    }
-
-    #[test]
-    fn build_media_message_audio() {
-        let upload = UploadResponse {
-            url: "https://example.com/aud".into(),
-            direct_path: "/path".into(),
-            media_key: vec![],
-            file_sha256: vec![],
-            file_enc_sha256: vec![],
-            file_length: 512,
-        };
-        let msg = build_media_message("audio/ogg", None, &upload);
-        assert!(msg.audio_message.is_some());
-    }
-
-    #[test]
-    fn build_media_message_document_fallback() {
-        let upload = UploadResponse {
-            url: "https://example.com/doc".into(),
-            direct_path: "/path".into(),
-            media_key: vec![],
-            file_sha256: vec![],
-            file_enc_sha256: vec![],
-            file_length: 4096,
-        };
-        let msg = build_media_message("application/pdf", Some("report.pdf".into()), &upload);
-        let doc = msg
-            .document_message
-            .unwrap_or_else(|| panic!("expected document_message"));
-        assert_eq!(doc.mimetype.as_deref(), Some("application/pdf"));
-        assert_eq!(doc.title.as_deref(), Some("report.pdf"));
     }
 }

--- a/crates/whatsapp/src/sled_store.rs
+++ b/crates/whatsapp/src/sled_store.rs
@@ -11,6 +11,7 @@ use {
     async_trait::async_trait,
     bytes::Bytes,
     serde::{Serialize, de::DeserializeOwned},
+    tracing::{debug, info, warn},
     wacore::{
         appstate::{hash::HashState, processor::AppStateMutationMAC},
         store::{
@@ -666,7 +667,12 @@ impl ProtocolStore for SledStore {
             // decode, so treat them as missing and let usync repopulate.
             Some(v) => match decode_persistent(&v) {
                 Ok(record) => Ok(Some(record)),
-                Err(_) => {
+                Err(e) => {
+                    debug!(
+                        user,
+                        error = %e,
+                        "evicting undecodable device-list record; usync repopulates it"
+                    );
                     self.device_list_records
                         .remove(user.as_bytes())
                         .map_err(db_err)?;
@@ -874,11 +880,20 @@ impl DeviceStore for SledStore {
         };
         match decode_persistent::<wacore::store::Device>(&v) {
             Ok(device) => Ok(Some(device)),
-            Err(_) => {
+            Err(primary) => {
                 // Pre-0.6 record: decode with the legacy shim and upgrade the
                 // stored bytes so subsequent loads use the current layout.
-                let device: wacore::store::Device = decode_persistent::<LegacyDevice05>(&v)?.into();
+                let legacy = decode_persistent::<LegacyDevice05>(&v).map_err(|fallback| {
+                    warn!(
+                        primary = %primary,
+                        fallback = %fallback,
+                        "device record failed both the current and the legacy 0.5 decode"
+                    );
+                    fallback
+                })?;
+                let device: wacore::store::Device = legacy.into();
                 self.save(&device).await?;
+                info!("migrated a pre-0.6 device record to the current layout");
                 Ok(Some(device))
             },
         }

--- a/crates/whatsapp/src/sled_store.rs
+++ b/crates/whatsapp/src/sled_store.rs
@@ -9,16 +9,21 @@ use std::{fmt::Write, path::Path, sync::atomic::AtomicI32};
 
 use {
     async_trait::async_trait,
+    bytes::Bytes,
     serde::{Serialize, de::DeserializeOwned},
     wacore::{
         appstate::{hash::HashState, processor::AppStateMutationMAC},
         store::{
-            error::{Result, StoreError, db_err},
+            error::{Result, StoreError},
             traits::*,
         },
     },
-    wacore_binary::jid::Jid,
 };
+
+/// Wrap a sled error as a `StoreError::Database`.
+fn db_err(e: sled::Error) -> StoreError {
+    StoreError::Database(Box::new(e))
+}
 
 /// Hex-encode bytes without pulling in the `hex` crate.
 fn hex_encode(bytes: &[u8]) -> String {
@@ -44,26 +49,42 @@ pub struct SledStore {
     mutation_mac_indexes: sled::Tree,
     device_data: sled::Tree,
     device_id: AtomicI32,
-    skdm_recipients: sled::Tree,
     lid_mappings: sled::Tree,
     pn_mappings: sled::Tree,
     device_list_records: sled::Tree,
-    sender_key_forget_marks: sled::Tree,
+    sender_key_devices: sled::Tree,
     base_keys: sled::Tree,
     tc_tokens: sled::Tree,
     sent_messages: sled::Tree,
+    msg_secrets: sled::Tree,
 }
 
 fn json_err(e: serde_json::Error) -> StoreError {
-    StoreError::Serialization(e.to_string())
+    StoreError::Serialization(Box::new(e))
 }
 
 fn postcard_err(e: postcard::Error) -> StoreError {
-    StoreError::Serialization(e.to_string())
+    StoreError::Serialization(Box::new(e))
 }
 
 /// Format tag prefixed to every encoded record.
 const FORMAT_POSTCARD: u8 = 0x01;
+
+/// Key prefix for all sender-key-device rows of a group (`<group>\0`).
+/// `\0` cannot appear in a JID, so the prefix is unambiguous.
+fn sender_key_device_prefix(group_jid: &str) -> Vec<u8> {
+    let mut p = Vec::with_capacity(group_jid.len() + 1);
+    p.extend_from_slice(group_jid.as_bytes());
+    p.push(0);
+    p
+}
+
+/// Full row key for a (group, device) pair: `<group>\0<device>`.
+fn sender_key_device_key(group_jid: &str, device_jid: &str) -> Vec<u8> {
+    let mut k = sender_key_device_prefix(group_jid);
+    k.extend_from_slice(device_jid.as_bytes());
+    k
+}
 
 fn encode_persistent<T: Serialize>(value: &T) -> Result<Vec<u8>> {
     let body = postcard::to_allocvec(value).map_err(postcard_err)?;
@@ -106,14 +127,14 @@ impl SledStore {
             mutation_mac_indexes: db.open_tree("mutation_mac_indexes")?,
             device_data: db.open_tree("device_data")?,
             device_id: AtomicI32::new(id_val),
-            skdm_recipients: db.open_tree("skdm_recipients")?,
             lid_mappings: db.open_tree("lid_mappings")?,
             pn_mappings: db.open_tree("pn_mappings")?,
             device_list_records: db.open_tree("device_list_records")?,
-            sender_key_forget_marks: db.open_tree("sender_key_forget_marks")?,
+            sender_key_devices: db.open_tree("sender_key_devices")?,
             base_keys: db.open_tree("base_keys")?,
             tc_tokens: db.open_tree("tc_tokens")?,
             sent_messages: db.open_tree("sent_messages")?,
+            msg_secrets: db.open_tree("msg_secrets")?,
             db,
         })
     }
@@ -132,12 +153,12 @@ impl SignalStore for SledStore {
         Ok(())
     }
 
-    async fn load_identity(&self, address: &str) -> Result<Option<Vec<u8>>> {
+    async fn load_identity(&self, address: &str) -> Result<Option<[u8; 32]>> {
         Ok(self
             .identities
             .get(address.as_bytes())
             .map_err(db_err)?
-            .map(|v| v.to_vec()))
+            .and_then(|v| v.as_ref().try_into().ok()))
     }
 
     async fn delete_identity(&self, address: &str) -> Result<()> {
@@ -145,12 +166,12 @@ impl SignalStore for SledStore {
         Ok(())
     }
 
-    async fn get_session(&self, address: &str) -> Result<Option<Vec<u8>>> {
+    async fn get_session(&self, address: &str) -> Result<Option<Bytes>> {
         Ok(self
             .sessions
             .get(address.as_bytes())
             .map_err(db_err)?
-            .map(|v| v.to_vec()))
+            .map(|v| Bytes::copy_from_slice(&v)))
     }
 
     async fn put_session(&self, address: &str, session: &[u8]) -> Result<()> {
@@ -174,15 +195,29 @@ impl SignalStore for SledStore {
         Ok(())
     }
 
-    async fn load_prekey(&self, id: u32) -> Result<Option<Vec<u8>>> {
+    async fn load_prekey(&self, id: u32) -> Result<Option<Bytes>> {
         match self.prekeys.get(id.to_le_bytes()).map_err(db_err)? {
             Some(v) => {
                 let (record, _uploaded): (Vec<u8>, bool) =
                     serde_json::from_slice(&v).map_err(json_err)?;
-                Ok(Some(record))
+                Ok(Some(Bytes::from(record)))
             },
             None => Ok(None),
         }
+    }
+
+    async fn mark_prekeys_uploaded(&self, ids: &[u32]) -> Result<()> {
+        for id in ids {
+            if let Some(v) = self.prekeys.get(id.to_le_bytes()).map_err(db_err)? {
+                let (record, _uploaded): (Vec<u8>, bool) =
+                    serde_json::from_slice(&v).map_err(json_err)?;
+                let val = serde_json::to_vec(&(record, true)).map_err(json_err)?;
+                self.prekeys
+                    .insert(id.to_le_bytes(), val.as_slice())
+                    .map_err(db_err)?;
+            }
+        }
+        Ok(())
     }
 
     async fn remove_prekey(&self, id: u32) -> Result<()> {
@@ -360,6 +395,23 @@ impl AppSyncStore for SledStore {
         Ok(())
     }
 
+    async fn clear_mutation_macs(&self, name: &str) -> Result<()> {
+        let prefix = format!("{name}:");
+        for tree in [&self.mutation_macs, &self.mutation_mac_indexes] {
+            let mut keys_to_remove = Vec::new();
+            for entry in tree.iter() {
+                let (k, _) = entry.map_err(db_err)?;
+                if String::from_utf8_lossy(&k).starts_with(&prefix) {
+                    keys_to_remove.push(k);
+                }
+            }
+            for key in keys_to_remove {
+                tree.remove(key).map_err(db_err)?;
+            }
+        }
+        Ok(())
+    }
+
     async fn get_latest_sync_key_id(&self) -> Result<Option<Vec<u8>>> {
         Ok(self
             .sync_keys
@@ -370,47 +422,161 @@ impl AppSyncStore for SledStore {
 }
 
 // ============================================================================
+// MsgSecretStore
+// ============================================================================
+
+/// Composite row key `chat\0sender\0msg_id` (`\0` cannot appear in JIDs/ids).
+fn msg_secret_key(chat: &str, sender: &str, msg_id: &str) -> Vec<u8> {
+    let mut k = Vec::with_capacity(chat.len() + sender.len() + msg_id.len() + 2);
+    k.extend_from_slice(chat.as_bytes());
+    k.push(0);
+    k.extend_from_slice(sender.as_bytes());
+    k.push(0);
+    k.extend_from_slice(msg_id.as_bytes());
+    k
+}
+
+#[async_trait]
+impl MsgSecretStore for SledStore {
+    async fn put_msg_secrets(&self, entries: Vec<MsgSecretEntry>) -> Result<usize> {
+        let count = entries.len();
+        for entry in entries {
+            let key = msg_secret_key(&entry.chat, &entry.sender, &entry.msg_id);
+            let (expires_at, message_ts) =
+                match self.msg_secrets.get(key.as_slice()).map_err(db_err)? {
+                    Some(v) => {
+                        let (_, existing_exp, existing_ts): (Vec<u8>, i64, i64) =
+                            decode_persistent(&v)?;
+                        (
+                            merge_msg_secret_expiry(existing_exp, entry.expires_at),
+                            merge_msg_secret_message_ts(existing_ts, entry.message_ts),
+                        )
+                    },
+                    None => (entry.expires_at, entry.message_ts),
+                };
+            let val = encode_persistent(&(entry.secret, expires_at, message_ts))?;
+            self.msg_secrets
+                .insert(key, val.as_slice())
+                .map_err(db_err)?;
+        }
+        Ok(count)
+    }
+
+    async fn get_msg_secret(
+        &self,
+        chat: &str,
+        sender: &str,
+        msg_id: &str,
+    ) -> Result<Option<Vec<u8>>> {
+        match self
+            .msg_secrets
+            .get(msg_secret_key(chat, sender, msg_id))
+            .map_err(db_err)?
+        {
+            Some(v) => {
+                let (secret, ..): (Vec<u8>, i64, i64) = decode_persistent(&v)?;
+                Ok(Some(secret))
+            },
+            None => Ok(None),
+        }
+    }
+
+    async fn get_msg_secret_with_ts(
+        &self,
+        chat: &str,
+        sender: &str,
+        msg_id: &str,
+    ) -> Result<Option<(Vec<u8>, i64)>> {
+        match self
+            .msg_secrets
+            .get(msg_secret_key(chat, sender, msg_id))
+            .map_err(db_err)?
+        {
+            Some(v) => {
+                let (secret, _, message_ts): (Vec<u8>, i64, i64) = decode_persistent(&v)?;
+                Ok(Some((secret, message_ts)))
+            },
+            None => Ok(None),
+        }
+    }
+
+    async fn delete_expired_msg_secrets(&self, cutoff_timestamp: i64) -> Result<u32> {
+        let mut count = 0u32;
+        let mut keys_to_remove = Vec::new();
+        for entry in self.msg_secrets.iter() {
+            let (k, v) = entry.map_err(db_err)?;
+            let (_, expires_at, _): (Vec<u8>, i64, i64) = decode_persistent(&v)?;
+            if expires_at != 0 && expires_at <= cutoff_timestamp {
+                keys_to_remove.push(k);
+            }
+        }
+        for key in keys_to_remove {
+            self.msg_secrets.remove(key).map_err(db_err)?;
+            count += 1;
+        }
+        Ok(count)
+    }
+}
+
+// ============================================================================
 // ProtocolStore
 // ============================================================================
 
 #[async_trait]
 impl ProtocolStore for SledStore {
-    async fn get_skdm_recipients(&self, group_jid: &str) -> Result<Vec<Jid>> {
-        match self
-            .skdm_recipients
-            .get(group_jid.as_bytes())
-            .map_err(db_err)?
-        {
-            // Stored as Vec<String> for serialization, parse back to Jid.
-            Some(v) => {
-                let strings: Vec<String> = decode_persistent(&v)?;
-                Ok(strings.into_iter().filter_map(|s| s.parse().ok()).collect())
-            },
-            None => Ok(Vec::new()),
+    async fn get_sender_key_devices(&self, group_jid: &str) -> Result<Vec<(String, bool)>> {
+        let prefix = sender_key_device_prefix(group_jid);
+        let mut result = Vec::new();
+        for entry in self.sender_key_devices.scan_prefix(&prefix) {
+            let (k, v) = entry.map_err(db_err)?;
+            let device = String::from_utf8_lossy(&k[prefix.len()..]).into_owned();
+            result.push((device, v.first() == Some(&1u8)));
         }
+        Ok(result)
     }
 
-    async fn add_skdm_recipients(&self, group_jid: &str, device_jids: &[Jid]) -> Result<()> {
-        let mut current: Vec<String> = match self
-            .skdm_recipients
-            .get(group_jid.as_bytes())
-            .map_err(db_err)?
-        {
-            Some(v) => decode_persistent(&v)?,
-            None => Vec::new(),
-        };
-        current.extend(device_jids.iter().map(|j| j.to_string()));
-        let val = encode_persistent(&current)?;
-        self.skdm_recipients
-            .insert(group_jid.as_bytes(), val.as_slice())
-            .map_err(db_err)?;
+    async fn set_sender_key_status(&self, group_jid: &str, entries: &[(&str, bool)]) -> Result<()> {
+        for (device_jid, has_key) in entries {
+            let key = sender_key_device_key(group_jid, device_jid);
+            self.sender_key_devices
+                .insert(key, &[u8::from(*has_key)])
+                .map_err(db_err)?;
+        }
         Ok(())
     }
 
-    async fn clear_skdm_recipients(&self, group_jid: &str) -> Result<()> {
-        self.skdm_recipients
-            .remove(group_jid.as_bytes())
-            .map_err(db_err)?;
+    async fn clear_sender_key_devices(&self, group_jid: &str) -> Result<()> {
+        let prefix = sender_key_device_prefix(group_jid);
+        let mut keys_to_remove = Vec::new();
+        for entry in self.sender_key_devices.scan_prefix(&prefix) {
+            let (k, _) = entry.map_err(db_err)?;
+            keys_to_remove.push(k);
+        }
+        for key in keys_to_remove {
+            self.sender_key_devices.remove(key).map_err(db_err)?;
+        }
+        Ok(())
+    }
+
+    async fn delete_sender_key_device_rows(&self, device_jids: &[&str]) -> Result<()> {
+        let mut keys_to_remove = Vec::new();
+        for entry in self.sender_key_devices.iter() {
+            let (k, _) = entry.map_err(db_err)?;
+            let key_str = String::from_utf8_lossy(&k);
+            if let Some((_, device)) = key_str.split_once('\0')
+                && device_jids.contains(&device)
+            {
+                keys_to_remove.push(k);
+            }
+        }
+        for key in keys_to_remove {
+            self.sender_key_devices.remove(key).map_err(db_err)?;
+        }
+        Ok(())
+    }
+
+    async fn clear_all_sender_key_devices(&self) -> Result<()> {
+        self.sender_key_devices.clear().map_err(db_err)?;
         Ok(())
     }
 
@@ -479,7 +645,10 @@ impl ProtocolStore for SledStore {
     }
 
     async fn update_device_list(&self, record: DeviceListRecord) -> Result<()> {
-        let val = encode_persistent(&record)?;
+        // JSON, not postcard: `DeviceListRecord.raw_id` is marked
+        // `skip_serializing_if`, which postcard (non-self-describing) cannot
+        // round-trip. JSON also tolerates future field additions.
+        let val = serde_json::to_vec(&record).map_err(json_err)?;
         self.device_list_records
             .insert(record.user.as_bytes(), val.as_slice())
             .map_err(db_err)?;
@@ -492,36 +661,27 @@ impl ProtocolStore for SledStore {
             .get(user.as_bytes())
             .map_err(db_err)?
         {
-            Some(v) => Ok(Some(decode_persistent(&v)?)),
+            // Device lists are a re-fetchable usync cache: records persisted
+            // by older releases (pre-`raw_id` postcard layout) no longer
+            // decode, so treat them as missing and let usync repopulate.
+            Some(v) => match decode_persistent(&v) {
+                Ok(record) => Ok(Some(record)),
+                Err(_) => {
+                    self.device_list_records
+                        .remove(user.as_bytes())
+                        .map_err(db_err)?;
+                    Ok(None)
+                },
+            },
             None => Ok(None),
         }
     }
 
-    async fn mark_forget_sender_key(&self, group_jid: &str, participant: &str) -> Result<()> {
-        let key = format!("{group_jid}:{participant}");
-        self.sender_key_forget_marks
-            .insert(key.as_bytes(), &[1u8])
+    async fn delete_devices(&self, user: &str) -> Result<()> {
+        self.device_list_records
+            .remove(user.as_bytes())
             .map_err(db_err)?;
         Ok(())
-    }
-
-    async fn consume_forget_marks(&self, group_jid: &str) -> Result<Vec<String>> {
-        let prefix = format!("{group_jid}:");
-        let mut participants = Vec::new();
-        let mut keys_to_remove = Vec::new();
-
-        for entry in self.sender_key_forget_marks.iter() {
-            let (k, _) = entry.map_err(db_err)?;
-            let key_str = String::from_utf8_lossy(&k);
-            if let Some(participant) = key_str.strip_prefix(&prefix) {
-                participants.push(participant.to_string());
-                keys_to_remove.push(k);
-            }
-        }
-        for key in keys_to_remove {
-            self.sender_key_forget_marks.remove(key).map_err(db_err)?;
-        }
-        Ok(participants)
     }
 
     // --- TcToken Storage ---
@@ -622,6 +782,82 @@ impl ProtocolStore for SledStore {
 // DeviceStore
 // ============================================================================
 
+/// Persisted layout of `wacore::store::Device` as of whatsapp-rust 0.5.
+///
+/// postcard is not self-describing, so records written before 0.6 fail to
+/// decode once `Device` gained trailing fields (`server_has_prekeys`,
+/// `nct_salt`, `server_cert_chain`). Losing this record would drop the
+/// WhatsApp pairing and force a QR re-scan, so `load()` falls back to this
+/// shim and upgrades the record in place. Field order, types and serde
+/// attributes must match 0.5 exactly.
+#[derive(serde::Serialize, serde::Deserialize)]
+struct LegacyDevice05 {
+    pn: Option<wacore_binary::jid::Jid>,
+    lid: Option<wacore_binary::jid::Jid>,
+    registration_id: u32,
+    #[serde(with = "wacore::store::device::key_pair_serde")]
+    noise_key: wacore::libsignal::protocol::KeyPair,
+    #[serde(with = "wacore::store::device::key_pair_serde")]
+    identity_key: wacore::libsignal::protocol::KeyPair,
+    #[serde(with = "wacore::store::device::key_pair_serde")]
+    signed_pre_key: wacore::libsignal::protocol::KeyPair,
+    signed_pre_key_id: u32,
+    #[serde(with = "serde_big_array::BigArray")]
+    signed_pre_key_signature: [u8; 64],
+    adv_secret_key: [u8; 32],
+    #[serde(with = "wacore::store::device::account_serde", default)]
+    account: Option<std::sync::Arc<waproto::whatsapp::AdvSignedDeviceIdentity>>,
+    push_name: String,
+    app_version_primary: u32,
+    app_version_secondary: u32,
+    app_version_tertiary: u32,
+    app_version_last_fetched_ms: i64,
+    #[serde(default)]
+    edge_routing_info: Option<Vec<u8>>,
+    #[serde(default)]
+    props_hash: Option<String>,
+    #[serde(default)]
+    next_pre_key_id: u32,
+}
+
+impl From<LegacyDevice05> for wacore::store::Device {
+    fn from(legacy: LegacyDevice05) -> Self {
+        Self {
+            pn: legacy.pn,
+            lid: legacy.lid,
+            registration_id: legacy.registration_id,
+            noise_key: legacy.noise_key,
+            identity_key: legacy.identity_key,
+            signed_pre_key: legacy.signed_pre_key,
+            signed_pre_key_id: legacy.signed_pre_key_id,
+            signed_pre_key_signature: legacy.signed_pre_key_signature,
+            adv_secret_key: legacy.adv_secret_key,
+            account: legacy.account,
+            push_name: legacy.push_name,
+            app_version_primary: legacy.app_version_primary,
+            app_version_secondary: legacy.app_version_secondary,
+            app_version_tertiary: legacy.app_version_tertiary,
+            app_version_last_fetched_ms: legacy.app_version_last_fetched_ms,
+            device_props: Default::default(),
+            client_profile: Default::default(),
+            edge_routing_info: legacy.edge_routing_info,
+            props_hash: legacy.props_hash,
+            next_pre_key_id: legacy.next_pre_key_id,
+            first_unupload_pre_key_id: 0,
+            server_has_prekeys: false,
+            nct_salt: None,
+            nct_salt_sync_seen: false,
+            server_cert_chain: None,
+            login_counter: 0,
+            // 0.5-era records predate the migration flag. `false` is the safe
+            // default: PN wire addressing delivers for both populations, and a
+            // migrated account re-learns the flag from the primary's mapping
+            // sync on the next connect.
+            lid_migrated: false,
+        }
+    }
+}
+
 #[async_trait]
 impl DeviceStore for SledStore {
     async fn save(&self, device: &wacore::store::Device) -> Result<()> {
@@ -633,9 +869,18 @@ impl DeviceStore for SledStore {
     }
 
     async fn load(&self) -> Result<Option<wacore::store::Device>> {
-        match self.device_data.get(b"device").map_err(db_err)? {
-            Some(v) => Ok(Some(decode_persistent(&v)?)),
-            None => Ok(None),
+        let Some(v) = self.device_data.get(b"device").map_err(db_err)? else {
+            return Ok(None);
+        };
+        match decode_persistent::<wacore::store::Device>(&v) {
+            Ok(device) => Ok(Some(device)),
+            Err(_) => {
+                // Pre-0.6 record: decode with the legacy shim and upgrade the
+                // stored bytes so subsequent loads use the current layout.
+                let device: wacore::store::Device = decode_persistent::<LegacyDevice05>(&v)?.into();
+                self.save(&device).await?;
+                Ok(Some(device))
+            },
         }
     }
 
@@ -679,7 +924,7 @@ mod tests {
             .await
             .unwrap();
         let loaded = store.load_identity("test@s.whatsapp.net").await.unwrap();
-        assert_eq!(loaded, Some(key.to_vec()));
+        assert_eq!(loaded, Some(key));
 
         store.delete_identity("test@s.whatsapp.net").await.unwrap();
         assert!(
@@ -697,7 +942,7 @@ mod tests {
         let data = b"session-data";
         store.put_session("addr", data).await.unwrap();
         let loaded = store.get_session("addr").await.unwrap();
-        assert_eq!(loaded, Some(data.to_vec()));
+        assert_eq!(loaded, Some(Bytes::from_static(data)));
         assert!(store.has_session("addr").await.unwrap());
         assert!(!store.has_session("missing").await.unwrap());
     }
@@ -717,7 +962,10 @@ mod tests {
         let store = temp_store();
         store.store_prekey(1, b"pk1", false).await.unwrap();
         store.store_prekey(2, b"pk2", true).await.unwrap();
-        assert_eq!(store.load_prekey(1).await.unwrap(), Some(b"pk1".to_vec()));
+        assert_eq!(
+            store.load_prekey(1).await.unwrap(),
+            Some(Bytes::from_static(b"pk1"))
+        );
         store.remove_prekey(1).await.unwrap();
         assert!(store.load_prekey(1).await.unwrap().is_none());
     }
@@ -809,25 +1057,89 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn skdm_recipients() {
+    async fn sender_key_devices() {
         let store = temp_store();
-        let recips = store.get_skdm_recipients("group1").await.unwrap();
-        assert!(recips.is_empty());
+        assert!(
+            store
+                .get_sender_key_devices("group1@g.us")
+                .await
+                .unwrap()
+                .is_empty()
+        );
 
         store
-            .add_skdm_recipients("group1", &[
-                "dev1@s.whatsapp.net".parse().unwrap(),
-                "dev2@s.whatsapp.net".parse().unwrap(),
+            .set_sender_key_status("group1@g.us", &[
+                ("dev1:1@s.whatsapp.net", true),
+                ("dev2:2@s.whatsapp.net", false),
             ])
             .await
             .unwrap();
-        let recips = store.get_skdm_recipients("group1").await.unwrap();
-        assert_eq!(recips.len(), 2);
+        // Same device in another group must not leak into group1 queries.
+        store
+            .set_sender_key_status("group2@g.us", &[("dev1:1@s.whatsapp.net", true)])
+            .await
+            .unwrap();
 
-        store.clear_skdm_recipients("group1").await.unwrap();
+        let mut devices = store.get_sender_key_devices("group1@g.us").await.unwrap();
+        devices.sort();
+        assert_eq!(devices, vec![
+            ("dev1:1@s.whatsapp.net".to_string(), true),
+            ("dev2:2@s.whatsapp.net".to_string(), false),
+        ]);
+
+        // Delete one device's rows across all groups.
+        store
+            .delete_sender_key_device_rows(&["dev1:1@s.whatsapp.net"])
+            .await
+            .unwrap();
+        assert_eq!(
+            store
+                .get_sender_key_devices("group1@g.us")
+                .await
+                .unwrap()
+                .len(),
+            1
+        );
         assert!(
             store
-                .get_skdm_recipients("group1")
+                .get_sender_key_devices("group2@g.us")
+                .await
+                .unwrap()
+                .is_empty()
+        );
+
+        store.clear_sender_key_devices("group1@g.us").await.unwrap();
+        assert!(
+            store
+                .get_sender_key_devices("group1@g.us")
+                .await
+                .unwrap()
+                .is_empty()
+        );
+    }
+
+    #[tokio::test]
+    async fn clear_all_sender_key_devices_wipes_every_group() {
+        let store = temp_store();
+        store
+            .set_sender_key_status("group1@g.us", &[("dev1:1@s.whatsapp.net", true)])
+            .await
+            .unwrap();
+        store
+            .set_sender_key_status("group2@g.us", &[("dev2:2@s.whatsapp.net", true)])
+            .await
+            .unwrap();
+        store.clear_all_sender_key_devices().await.unwrap();
+        assert!(
+            store
+                .get_sender_key_devices("group1@g.us")
+                .await
+                .unwrap()
+                .is_empty()
+        );
+        assert!(
+            store
+                .get_sender_key_devices("group2@g.us")
                 .await
                 .unwrap()
                 .is_empty()
@@ -884,6 +1196,7 @@ mod tests {
             }],
             timestamp: 1000,
             phash: None,
+            raw_id: None,
         };
         store.update_device_list(record).await.unwrap();
         let loaded = store.get_devices("user1").await.unwrap();
@@ -906,6 +1219,7 @@ mod tests {
                     }],
                     timestamp: 1234,
                     phash: None,
+                    raw_id: None,
                 })
                 .await
                 .unwrap();
@@ -924,20 +1238,51 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn forget_marks() {
+    async fn legacy_device_record_migrates_on_load() {
         let store = temp_store();
+        let mut rng = rand::rng();
+
+        // Simulate a device record persisted by the whatsapp-rust 0.5 build:
+        // same leading fields, no 0.6 trailing fields.
+        let legacy = LegacyDevice05 {
+            pn: Some(wacore_binary::jid::Jid::pn("15551234567")),
+            lid: None,
+            registration_id: 42,
+            noise_key: wacore::libsignal::protocol::KeyPair::generate(&mut rng),
+            identity_key: wacore::libsignal::protocol::KeyPair::generate(&mut rng),
+            signed_pre_key: wacore::libsignal::protocol::KeyPair::generate(&mut rng),
+            signed_pre_key_id: 1,
+            signed_pre_key_signature: [7u8; 64],
+            adv_secret_key: [9u8; 32],
+            account: None,
+            push_name: "Moltis".into(),
+            app_version_primary: 2,
+            app_version_secondary: 3000,
+            app_version_tertiary: 1,
+            app_version_last_fetched_ms: 1000,
+            edge_routing_info: None,
+            props_hash: None,
+            next_pre_key_id: 5,
+        };
+        let bytes = encode_persistent(&legacy).unwrap();
         store
-            .mark_forget_sender_key("group1", "user_a")
-            .await
+            .device_data
+            .insert(b"device", bytes.as_slice())
             .unwrap();
-        store
-            .mark_forget_sender_key("group1", "user_b")
-            .await
-            .unwrap();
-        let marks = store.consume_forget_marks("group1").await.unwrap();
-        assert_eq!(marks.len(), 2);
-        let marks = store.consume_forget_marks("group1").await.unwrap();
-        assert!(marks.is_empty());
+
+        // Load must fall back to the legacy shim, not lose the pairing.
+        let device = store.load().await.unwrap().unwrap();
+        assert_eq!(device.registration_id, 42);
+        assert_eq!(device.push_name, "Moltis");
+        assert_eq!(device.next_pre_key_id, 5);
+        assert_eq!(device.signed_pre_key_signature, [7u8; 64]);
+        assert!(!device.server_has_prekeys);
+        assert!(device.server_cert_chain.is_none());
+
+        // The record is upgraded in place: it now decodes as the current
+        // format without the fallback.
+        let raw = store.device_data.get(b"device").unwrap().unwrap();
+        decode_persistent::<wacore::store::Device>(&raw).unwrap();
     }
 
     #[tokio::test]
@@ -961,9 +1306,9 @@ mod tests {
         {
             let store = SledStore::open(dir.path()).unwrap();
             let identity = store.load_identity("test@s.whatsapp.net").await.unwrap();
-            assert_eq!(identity, Some(vec![1u8; 32]));
+            assert_eq!(identity, Some([1u8; 32]));
             let session = store.get_session("addr").await.unwrap();
-            assert_eq!(session, Some(b"session-data".to_vec()));
+            assert_eq!(session, Some(Bytes::from_static(b"session-data")));
             let id = store.create().await.unwrap();
             assert_eq!(id, 1); // counter persisted
         }

--- a/crates/whatsapp/src/state.rs
+++ b/crates/whatsapp/src/state.rs
@@ -123,14 +123,14 @@ impl AccountState {
         mut msg: waproto::whatsapp::Message,
     ) -> crate::Result<()> {
         watermark_message(&mut msg);
-        let msg_id =
-            self.client
-                .send_message(to, msg)
-                .await
-                .map_err(|e| crate::Error::Whatsapp {
-                    message: e.to_string(),
-                })?;
-        self.record_sent_id(&msg_id);
+        let sent = self
+            .client
+            .send_message(to, msg)
+            .await
+            .map_err(|e| crate::Error::Whatsapp {
+                message: e.to_string(),
+            })?;
+        self.record_sent_id(&sent.message_id);
         Ok(())
     }
 }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel    = "nightly-2025-12-27"
+channel    = "nightly-2026-06-20"
 components = ["clippy", "rustfmt"]
 targets    = ["wasm32-wasip2"]


### PR DESCRIPTION
## Summary

Bumps the whatsapp-rust family 0.5 → 0.6 and pins it to the merge commit of
oxidezap/whatsapp-rust#943 (DM LID-migration gate) via `[patch.crates-io]`.

**Why.** whatsapp-rust 0.5 predates LID addressing. In practice that meant:

- **Inbound**: after WhatsApp migrated a peer's device registry PN → LID,
  Signal sessions desynced — `Bad Mac` / `No session` loops and PDO recovery
  floods that only a re-pair fixed.
- **Outbound**: DMs to `@lid` chats needed a local LID → PN rewrite hack in
  `outbound.rs` to be deliverable at all.

0.6 brings unified LID/PN addressing and migrates Signal sessions on LID
discovery, fixing both natively — the local rewrite hack is removed in this PR.

**Why the rev pin.** 0.6.0 alone regressed delivery for accounts the server
has **not** migrated to LID 1:1 (no `lid_one_on_one_migration_enabled` ab
prop): their LID-addressed DMs are silently 400-nacked (`send()` still returns
`Ok`). I hit this live, reported it in oxidezap/whatsapp-rust#941, and the fix
merged as oxidezap/whatsapp-rust#943 — the client now gates DM wire addressing
on the account's migration state automatically. No release includes it yet, so
the family is pinned to the #943 merge commit; the patch section documents that
it should collapse into a plain version bump on the next whatsapp-rust release.

**Store/pairing work in this PR:**

- Persisted `Device` records migrate in place through a 0.5-layout shim, so
  existing WhatsApp pairings survive the upgrade (postcard is not
  self-describing and 0.6 appended trailing fields — decoding old records with
  the new layout otherwise fails and forces a re-pair).
- Stores reworked for the 0.6 traits: typed `[u8; 32]` identities, `Bytes`
  sessions/prekeys, per-device sender-key tracking (replaces SKDM recipient
  lists + forget marks), `delete_devices`.
- `DeviceListRecord` persists as JSON because its `raw_id` uses
  `skip_serializing_if`, which postcard cannot round-trip; device lists are
  cache and re-fetch on decode mismatch.
- `send_message` returns `SendResult`, `upload` takes `UploadOptions`,
  `DevicePropsOverride` builder, `Arc<Event>` handlers, `Jid.user` is
  `CompactString`.
- Toolchain nightly bump (0.6 uses if-let guards; the newer nightly also fixes
  a rustc query-depth ICE with matrix-sdk).

## Validation

### Completed

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -Z unstable-options --workspace --all-targets -- -D warnings`
      (default features)
- [x] `cargo clippy -Z unstable-options -p moltis-whatsapp --all-features
      --all-targets -- -D warnings`
- [x] `cargo nextest run --workspace` (default features)
- [x] Live validation on a real companion-device pairing (home-server deploy):
      pairing from the 0.5-era store survived the upgrade in place, inbound
      and outbound DMs verified, 3/3 test DMs to a LID-mapped peer delivered
      with `Delivered` receipts and zero nacks — on an account the server has
      not LID-migrated, i.e. the exact population #943 protects.

### Remaining

- [ ] `just lint` / `just test` with `--all-features` — my local environment
      has no CUDA toolchain, so the `cuda` feature builds are left to CI
- [ ] `./scripts/local-validate.sh <PR>` once the PR number exists

## Manual QA

1. Run a gateway with an existing WhatsApp pairing created under 0.5 — it must
   connect without re-pairing (the shim migrates the persisted `Device` record
   on first read).
2. Send a DM from the paired account to a contact whose chat is LID-addressed;
   confirm a `Delivered` receipt arrives and no `ack error=400` appears with
   `RUST_LOG=whatsapp_rust=debug`.
3. Have the contact reply; confirm the inbound message decrypts (no `Bad Mac`
   / `No session`).
4. Restart the gateway; confirm reconnect + no store decode warnings.
