### PR TITLE
fix(caldav): avoid panic on non-ASCII datetime in normalise_datetime

### DIFF
--- a/crates/caldav/src/ical.rs
+++ b/crates/caldav/src/ical.rs
@@ -140,8 +140,10 @@ fn normalise_datetime(raw: &str) -> String {
     if raw.len() == 8 && raw.chars().all(|c| c.is_ascii_digit()) {
         // DATE value: YYYYMMDD -> YYYY-MM-DD
         format!("{}-{}-{}", &raw[..4], &raw[4..6], &raw[6..8])
-    } else if raw.len() >= 15 && raw.contains('T') {
+    } else if raw.is_ascii() && raw.len() >= 15 && raw.contains('T') {
         // DATETIME value: YYYYMMDDTHHMMSS -> YYYY-MM-DDTHH:MM:SS
+        // (require ASCII, like the DATE branch above, so the fixed byte-index
+        // slicing below cannot land inside a multi-byte UTF-8 char and panic)
         let date_part = &raw[..8];
         let time_part = &raw[9..];
         let date = format!(
@@ -234,6 +236,15 @@ mod tests {
             normalise_datetime("20250615T100000Z"),
             "2025-06-15T10:00:00"
         );
+    }
+
+    #[test]
+    fn normalise_datetime_non_ascii_does_not_panic() {
+        // A malformed DATETIME (>=15 bytes, contains 'T') with a multi-byte
+        // char straddling a fixed byte-slice boundary must not panic; it is
+        // returned as-is like any other unrecognized value.
+        let raw = "2025061\u{e9}T00:00:00"; // 'é' straddles byte index 8
+        assert_eq!(normalise_datetime(raw), raw);
     }
 
     #[test]

--- a/crates/caldav/src/ical.rs
+++ b/crates/caldav/src/ical.rs
@@ -140,7 +140,7 @@ fn normalise_datetime(raw: &str) -> String {
     if raw.len() == 8 && raw.chars().all(|c| c.is_ascii_digit()) {
         // DATE value: YYYYMMDD -> YYYY-MM-DD
         format!("{}-{}-{}", &raw[..4], &raw[4..6], &raw[6..8])
-    } else if raw.is_ascii() && raw.len() >= 15 && raw.contains('T') {
+    } else if raw.len() >= 15 && raw.is_ascii() && raw.contains('T') {
         // DATETIME value: YYYYMMDDTHHMMSS -> YYYY-MM-DDTHH:MM:SS
         // (require ASCII, like the DATE branch above, so the fixed byte-index
         // slicing below cannot land inside a multi-byte UTF-8 char and panic)


### PR DESCRIPTION
## Problem

`normalise_datetime` (`crates/caldav/src/ical.rs`) can **panic** on datetime values coming from a remote CalDAV server.

The DATE branch guards its fixed byte-index slicing with an ASCII check:

```rust
if raw.len() == 8 && raw.chars().all(|c| c.is_ascii_digit()) {   // DATE
```

but the DATETIME branch does not:

```rust
} else if raw.len() >= 15 && raw.contains('T') {                 // DATETIME
    let date_part = &raw[..8];      // byte index
    let time_part = &raw[9..];      // byte index
    ... &date_part[..4], &date_part[4..6], &date_part[6..8] ...
```

`&str[..8]` requires byte index 8 to be a char boundary. A value containing a multi-byte UTF-8 character straddling one of these boundaries panics: `byte index 8 is not a char boundary`.

This runs on untrusted network data: `client.rs` → `parse_events(&content.data, …)` (the CalDAV response body) → `extract_datetime` → `normalise_datetime`, on `DTSTART`/`DTEND`. The caller deliberately handles parse **errors** by skipping the event (`Err(e) => { log; continue }`), but a **panic bypasses that** and takes down the calling task — so a malformed or hostile server can crash it (DoS).

## Fix

Require `raw.is_ascii()` in the DATETIME guard, mirroring the DATE branch:

```rust
} else if raw.is_ascii() && raw.len() >= 15 && raw.contains('T') {
```

Valid iCalendar datetimes are always ASCII, so behavior is unchanged for real data; non-ASCII input now falls through to the existing "return as-is" arm instead of panicking.

## Verification

I copied `normalise_datetime` verbatim into a standalone `rustc` harness (this repo pins a nightly toolchain I couldn't install locally, so I exercised the exact function directly):

- **Before:** input `"2025061éT00:00:00"` → `thread panicked: end byte index 8 is not a char boundary; it is inside 'é'` (exit 101).
- **After:** returns the input as-is; and the valid cases still pass — `"20250615T120000"` → `"2025-06-15T12:00:00"`, the `…Z` variant, and `"20250615"` → `"2025-06-15"`.

Added `normalise_datetime_non_ascii_does_not_panic` to the existing `ical.rs` test module (asserts the malformed value is returned unchanged rather than panicking); it fails on current code and passes with the fix. No `unwrap`/`expect` added; `CHANGELOG.md` left untouched per CONTRIBUTING.
