### PR TITLE
Add GPT-5.6 model support

### DIFF
--- a/crates/config/src/template.rs
+++ b/crates/config/src/template.rs
@@ -159,7 +159,7 @@ port = {port}                           # Port number (auto-generated for this i
 # [providers.openai]
 # enabled = true
 # api_key = "sk-..."                          # Or set OPENAI_API_KEY env var
-# models = ["gpt-5.3", "gpt-5.2"]            # Preferred models shown first
+# models = ["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"]  # Preferred models shown first
 # fetch_models = true
 # stream_transport = "sse"                     # "sse" | "websocket" | "auto"
 # base_url = "https://api.openai.com/v1"     # API endpoint (change for Azure, etc.)
@@ -272,7 +272,7 @@ port = {port}                           # Port number (auto-generated for this i
                                       #   "live-reload"            - Re-read MEMORY.md before each turn
                                       #   "frozen-at-session-start" - Freeze the first MEMORY.md snapshot per session
 # workspace_file_max_chars = 32000  # Optional: per-file prompt cap for AGENTS.md / TOOLS.md before truncation.
-# priority_models = ["claude-opus-4-5", "gpt-5.2", "gemini-3-flash"]  # Optional: models to pin first in selectors
+# priority_models = ["claude-opus-4-5", "gpt-5.6-sol", "gemini-3-flash"]  # Optional: models to pin first in selectors
 
 # ── Compaction ─────────────────────────────────────────────────────────────
 # Strategy used to shrink a session when its context window fills up, or when

--- a/crates/providers/src/model_capabilities.rs
+++ b/crates/providers/src/model_capabilities.rs
@@ -60,6 +60,13 @@ pub fn context_window_for_model_with_config(
 /// Inner heuristic — kept private so callers go through the public wrappers.
 fn context_window_for_model_inner(model_id: &str) -> u32 {
     let model_id = capability_model_id(model_id);
+    // GPT-5.6 Sol, Terra, Luna, and the Sol alias support a 1.05M-token context window.
+    if matches!(
+        model_id,
+        "gpt-5.6" | "gpt-5.6-sol" | "gpt-5.6-terra" | "gpt-5.6-luna"
+    ) {
+        return 1_050_000;
+    }
     // Codestral has the largest window at 256k.
     if model_id.starts_with("codestral") {
         return 256_000;
@@ -342,6 +349,10 @@ mod tests {
         assert_eq!(context_window_for_model("gpt-4o"), 128_000);
         assert_eq!(context_window_for_model("gpt-4o-mini"), 128_000);
         assert_eq!(context_window_for_model("gpt-4-turbo"), 128_000);
+        assert_eq!(context_window_for_model("gpt-5.6"), 1_050_000);
+        assert_eq!(context_window_for_model("gpt-5.6-sol"), 1_050_000);
+        assert_eq!(context_window_for_model("gpt-5.6-terra"), 1_050_000);
+        assert_eq!(context_window_for_model("gpt-5.6-luna"), 1_050_000);
         assert_eq!(context_window_for_model("o3"), 200_000);
         assert_eq!(context_window_for_model("o3-mini"), 200_000);
         assert_eq!(context_window_for_model("o4-mini"), 200_000);

--- a/crates/providers/src/model_catalogs.rs
+++ b/crates/providers/src/model_catalogs.rs
@@ -412,6 +412,19 @@ mod tests {
     }
 
     #[test]
+    fn openai_catalog_includes_gpt_5_6_models() {
+        let models = crate::openai::default_model_catalog();
+        let ids: Vec<&str> = models.iter().map(|model| model.id.as_str()).collect();
+
+        for model_id in ["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"] {
+            assert!(
+                ids.contains(&model_id),
+                "missing {model_id} in OpenAI defaults"
+            );
+        }
+    }
+
+    #[test]
     fn anthropic_catalog_uses_documented_claude_46_aliases() {
         let anthropic_ids: Vec<&str> = ANTHROPIC_MODELS.iter().map(|(id, _)| *id).collect();
 

--- a/crates/providers/src/openai/catalog.rs
+++ b/crates/providers/src/openai/catalog.rs
@@ -21,6 +21,9 @@ impl ModelCatalogEntry {
 }
 
 const DEFAULT_OPENAI_MODELS: &[ModelCatalogEntry] = &[
+    ModelCatalogEntry::new("gpt-5.6-sol", "GPT-5.6 Sol"),
+    ModelCatalogEntry::new("gpt-5.6-terra", "GPT-5.6 Terra"),
+    ModelCatalogEntry::new("gpt-5.6-luna", "GPT-5.6 Luna"),
     ModelCatalogEntry::new("gpt-5.2", "GPT-5.2"),
     ModelCatalogEntry::new("gpt-5.2-chat-latest", "GPT-5.2 Chat Latest"),
     ModelCatalogEntry::new("gpt-5-mini", "GPT-5 Mini"),
@@ -158,7 +161,7 @@ fn parse_model_entry(entry: &serde_json::Value) -> Option<DiscoveredModel> {
 fn is_recommended_openai_model(model_id: &str) -> bool {
     matches!(
         model_id,
-        "gpt-5.4" | "gpt-5.4-mini" | "gpt-5.4-pro" | "o4-mini" | "o3"
+        "gpt-5.6" | "gpt-5.6-sol" | "gpt-5.6-terra" | "gpt-5.6-luna" | "o4-mini" | "o3"
     )
 }
 

--- a/crates/providers/src/openai_codex.rs
+++ b/crates/providers/src/openai_codex.rs
@@ -40,6 +40,20 @@ pub struct OpenAiCodexProvider {
     reasoning_effort: Option<ReasoningEffort>,
 }
 
+// The ChatGPT Codex backend advertises 372K for GPT-5.6 and its variants,
+// distinct from the 1.05M context window exposed by the OpenAI API.
+const GPT_5_6_CODEX_CONTEXT_WINDOW: u32 = 372_000;
+
+fn codex_context_window(model_id: &str) -> u32 {
+    if matches!(
+        model_id,
+        "gpt-5.6" | "gpt-5.6-sol" | "gpt-5.6-terra" | "gpt-5.6-luna"
+    ) {
+        return GPT_5_6_CODEX_CONTEXT_WINDOW;
+    }
+    200_000
+}
+
 fn codex_done_arguments(evt: &serde_json::Value) -> Option<&str> {
     evt.get("arguments")
         .and_then(|v| v.as_str())
@@ -371,6 +385,10 @@ impl LlmProvider for OpenAiCodexProvider {
 
     fn supports_tools(&self) -> bool {
         super::supports_tools_for_model(&self.model)
+    }
+
+    fn context_window(&self) -> u32 {
+        codex_context_window(&self.model)
     }
 
     fn reasoning_effort(&self) -> Option<ReasoningEffort> {
@@ -843,6 +861,17 @@ mod tests {
     }
 
     #[test]
+    fn gpt_5_6_models_use_codex_context_window() {
+        for model_id in ["gpt-5.6", "gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"] {
+            let provider = OpenAiCodexProvider::new(model_id.to_string());
+            assert_eq!(provider.context_window(), GPT_5_6_CODEX_CONTEXT_WINDOW);
+        }
+
+        let existing_model = OpenAiCodexProvider::new("gpt-5.4".to_string());
+        assert_eq!(existing_model.context_window(), 200_000);
+    }
+
+    #[test]
     fn apply_reasoning_is_noop_when_effort_not_configured() {
         let provider = OpenAiCodexProvider::new("gpt-5.4".to_string());
         let mut body = serde_json::json!({
@@ -1256,6 +1285,9 @@ mod tests {
     #[test]
     fn default_codex_models_includes_latest() {
         let ids: Vec<&str> = DEFAULT_CODEX_MODELS.iter().map(|(id, _)| *id).collect();
+        for model_id in ["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"] {
+            assert!(ids.contains(&model_id), "missing {model_id} in defaults");
+        }
         assert!(ids.contains(&"gpt-5.4"), "missing gpt-5.4 in defaults");
         assert!(
             ids.contains(&"gpt-5.3-codex-spark"),

--- a/crates/providers/src/openai_codex/catalog.rs
+++ b/crates/providers/src/openai_codex/catalog.rs
@@ -19,6 +19,9 @@ const CODEX_MODELS_ENDPOINT: &str = "https://chatgpt.com/backend-api/codex/model
 pub(super) const CODEX_MODELS_CLIENT_VERSION: &str = "1.0.0";
 
 pub(super) const DEFAULT_CODEX_MODELS: &[(&str, &str)] = &[
+    ("gpt-5.6-sol", "GPT-5.6 Sol"),
+    ("gpt-5.6-terra", "GPT-5.6 Terra"),
+    ("gpt-5.6-luna", "GPT-5.6 Luna"),
     ("gpt-5.4", "GPT-5.4"),
     ("gpt-5.3-codex-spark", "GPT-5.3 Codex Spark"),
     ("gpt-5.3-codex", "GPT-5.3 Codex"),

--- a/docs/src/choosing-a-provider.md
+++ b/docs/src/choosing-a-provider.md
@@ -8,9 +8,9 @@ supported by Moltis so you can pick the best fit for your use case.
 | Goal | Provider | Why |
 |------|----------|-----|
 | **Best overall quality** | Anthropic | Claude Sonnet 4 and Opus 4 excel at tool use, long context, and instruction following |
-| **Widest model range** | OpenAI | GPT-5.5, GPT-4.1, o3/o4-mini reasoning models, image generation |
-| **Best membership option** | OpenAI | GPT-5.5 is a top-quality model and can be available through memberships |
-| **Largest context window** | Google Gemini | Up to 1M tokens with Gemini 2.5 Pro |
+| **Widest model range** | OpenAI | GPT-5.6 Sol, Terra, Luna, GPT-4.1, o3/o4-mini reasoning models, image generation |
+| **Best membership option** | OpenAI | GPT-5.6 Sol is a top-quality model and can be available through memberships |
+| **Largest context window** | OpenAI | Up to 1.05M tokens with GPT-5.6 |
 | **Best value** | DeepSeek | DeepSeek V3 and R1 offer strong performance at low cost |
 | **Fast inference** | Groq | Hardware-accelerated inference, very low latency |
 | **Free / offline** | Ollama | Run open models locally, no API key needed |
@@ -21,8 +21,8 @@ supported by Moltis so you can pick the best fit for your use case.
 | Provider | Top Models | Tool Use | Streaming | Context | Price Tier | Speed | Notes |
 |----------|-----------|----------|-----------|---------|------------|-------|-------|
 | **Anthropic** | Claude Sonnet 4, Opus 4 | Full | Yes | 200K | $$ | Fast | Best tool-use reliability |
-| **OpenAI** | GPT-5.5, GPT-4.1, o3, o4-mini | Full | Yes | 128K-1M | $$ / Subscription | Fast | Widest ecosystem, GPT-5.5 quality, reasoning models |
-| **Google Gemini** | Gemini 2.5 Pro, 2.5 Flash | Full | Yes | 1M | $ | Fast | Largest context, competitive pricing |
+| **OpenAI** | GPT-5.6 Sol, Terra, Luna, GPT-4.1, o3, o4-mini | Full | Yes | 128K-1.05M | $$ / Subscription | Fast | Widest ecosystem, GPT-5.6 quality, reasoning models |
+| **Google Gemini** | Gemini 2.5 Pro, 2.5 Flash | Full | Yes | 1M | $ | Fast | Competitive pricing |
 | **DeepSeek** | V3, R1 | Full | Yes | 128K | $ | Medium | Excellent quality-to-price ratio |
 | **Groq** | Llama 3, Mixtral, Gemma | Partial | Yes | 128K | $ | Very fast | Speed-optimized hardware inference |
 | **xAI** | Grok 3, Grok 3 Mini | Yes | Yes | 128K | $$ | Fast | Strong reasoning capabilities |
@@ -63,7 +63,7 @@ let you explore without cost pressure.
 **Anthropic** and **OpenAI** are the most battle-tested for tool use and
 complex multi-step tasks. Anthropic's Claude models tend to follow
 instructions precisely; OpenAI offers a broader model range including
-GPT-5.5 and reasoning models (o3, o4-mini). GPT-5.5 is especially strong
+GPT-5.6 Sol, Terra, Luna, and reasoning models (o3, o4-mini). GPT-5.6 Sol is especially strong
 when you want high overall quality and can use membership-based access.
 
 ### For cost-sensitive workloads

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -97,7 +97,7 @@ enabled = true
 
 [providers.openai]
 enabled = true
-models = ["gpt-5.3", "gpt-5.2"]
+models = ["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"]
 stream_transport = "sse"        # "sse", "websocket", or "auto"
 
 [providers.gemini]
@@ -109,7 +109,7 @@ enabled = true
 models = ["qwen2.5-coder-7b-q4_k_m"]
 
 [chat]
-priority_models = ["gpt-5.2"]
+priority_models = ["gpt-5.6-sol"]
 ```
 
 See [Providers](providers.md) for the full list of supported providers and configuration options.

--- a/docs/src/providers.md
+++ b/docs/src/providers.md
@@ -75,7 +75,7 @@ enabled = true
 
 [providers.openai]
 enabled = true
-models = ["gpt-5.3", "gpt-5.2"]
+models = ["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"]
 stream_transport = "sse"              # "sse", "websocket", or "auto"
 
 [providers.gemini]
@@ -86,7 +86,7 @@ models = ["gemini-2.5-flash", "gemini-2.5-pro"]
 # base_url = "https://generativelanguage.googleapis.com/v1beta/openai"
 
 [chat]
-priority_models = ["gpt-5.2"]
+priority_models = ["gpt-5.6-sol"]
 ```
 
 ### Provider Entry Options


### PR DESCRIPTION
## Summary

- Register GPT-5.6 Sol, Terra, and Luna in the OpenAI and OpenAI Codex fallback catalogs.
- Apply the documented OpenAI API 1.05M context window and the ChatGPT/Codex backend 372K limit.
- Replace superseded OpenAI model references in configuration examples and provider-selection documentation.

## Validation

### Completed

- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p moltis-providers --features provider-openai-codex --lib`
- [x] `cargo test -p moltis-config --lib`
- [x] `cargo +nightly-2026-06-20 clippy -Z unstable-options -p moltis-providers --features provider-openai-codex --all-targets -- -D warnings`
- [x] `cargo +nightly-2026-06-20 build -p moltis-providers --features provider-openai-codex`
- [x] `git diff --check`
- [x] `GIT_CONFIG_NOSYSTEM=1 ./scripts/local-validate.sh 1146` attempted: rustfmt, TypeScript, i18n, install checks, and zizmor passed.

### Remaining

- [ ] Full local validation is blocked by pre-existing `crates/agents/src/runner/tests/basic.rs` exceeding the 1,500-line file-size limit and by the environment lacking a global `biome` executable.
- [ ] Full all-features lint/test gates cannot complete locally because `llama-cpp-sys-2` bindgen cannot find the system C header `stdbool.h`.
- [ ] `mdbook build docs` cannot run because `mdbook` is not installed.

## Manual QA

1. Configure either the `openai` API-key provider or `openai-codex` OAuth provider.
2. With model discovery unavailable, verify Sol, Terra, and Luna appear in the provider selector.
3. Select `gpt-5.6` or `gpt-5.6-sol` and confirm API conversations use the larger API context limit while Codex conversations compact according to the Codex backend limit.