### PR TITLE
fix(providers): derive openai-codex token expiry from JWT exp claim

### DIFF
--- a/crates/providers/src/openai_codex.rs
+++ b/crates/providers/src/openai_codex.rs
@@ -228,7 +228,7 @@ impl OpenAiCodexProvider {
     fn expires_at_from_jwt(access_token: &str) -> Option<u64> {
         Self::decode_jwt_claims(access_token)?
             .get("exp")
-            .and_then(serde_json::Value::as_u64)
+            .and_then(|v| v.as_u64().or_else(|| v.as_f64().map(|f| f as u64)))
     }
 
     pub(crate) fn resolve_account_id(tokens: &moltis_oauth::OAuthTokens) -> anyhow::Result<String> {
@@ -1071,6 +1071,15 @@ mod tests {
     #[test]
     fn expires_at_derived_from_jwt_exp_claim() {
         let token = format!("h.{}.s", URL_SAFE_NO_PAD.encode(r#"{"exp":1893456000}"#));
+        assert_eq!(
+            OpenAiCodexProvider::expires_at_from_jwt(&token),
+            Some(1893456000)
+        );
+    }
+
+    #[test]
+    fn expires_at_derived_from_decimal_jwt_exp_claim() {
+        let token = format!("h.{}.s", URL_SAFE_NO_PAD.encode(r#"{"exp":1893456000.0}"#));
         assert_eq!(
             OpenAiCodexProvider::expires_at_from_jwt(&token),
             Some(1893456000)

--- a/crates/providers/src/openai_codex.rs
+++ b/crates/providers/src/openai_codex.rs
@@ -127,8 +127,14 @@ impl OpenAiCodexProvider {
                 )
             })?;
 
-        // Check expiry with 5 min buffer
-        if let Some(expires_at) = tokens.expires_at {
+        // Check expiry with 5 min buffer. Stored tokens may lack `expires_at`
+        // (the Codex OAuth response has no `expires_in`), so fall back to the
+        // access token's own JWT `exp` claim — otherwise the refresh below can
+        // never trigger and the token eventually dies with a 401.
+        let expires_at = tokens
+            .expires_at
+            .or_else(|| Self::expires_at_from_jwt(tokens.access_token.expose_secret()));
+        if let Some(expires_at) = expires_at {
             let now = std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
                 .unwrap_or_default()
@@ -149,6 +155,10 @@ impl OpenAiCodexProvider {
                     }
                     if new_tokens.account_id.is_none() {
                         new_tokens.account_id = tokens.account_id.clone();
+                    }
+                    if new_tokens.expires_at.is_none() {
+                        new_tokens.expires_at =
+                            Self::expires_at_from_jwt(new_tokens.access_token.expose_secret());
                     }
                     self.token_store.save("openai-codex", &new_tokens)?;
                     return Ok(new_tokens);
@@ -188,7 +198,8 @@ impl OpenAiCodexProvider {
             })
     }
 
-    fn extract_account_id(jwt: &str) -> Option<String> {
+    /// Decode the payload (claims) segment of a JWT without verifying the signature.
+    fn decode_jwt_claims(jwt: &str) -> Option<serde_json::Value> {
         let parts: Vec<&str> = jwt.split('.').collect();
         if parts.len() < 2 {
             return None;
@@ -203,8 +214,21 @@ impl OpenAiCodexProvider {
             base64::engine::general_purpose::STANDARD.decode(&padded)
         });
         let payload = payload.ok()?;
-        let claims: serde_json::Value = serde_json::from_slice(&payload).ok()?;
+        serde_json::from_slice(&payload).ok()
+    }
+
+    fn extract_account_id(jwt: &str) -> Option<String> {
+        let claims = Self::decode_jwt_claims(jwt)?;
         Self::extract_account_id_from_claims(&claims)
+    }
+
+    /// Best-effort expiry (unix seconds) from the JWT `exp` claim of an access token.
+    /// Codex OAuth responses omit `expires_in`, so stored tokens often have
+    /// `expires_at: None`; without it the proactive refresh below never runs.
+    fn expires_at_from_jwt(access_token: &str) -> Option<u64> {
+        Self::decode_jwt_claims(access_token)?
+            .get("exp")
+            .and_then(serde_json::Value::as_u64)
     }
 
     pub(crate) fn resolve_account_id(tokens: &moltis_oauth::OAuthTokens) -> anyhow::Result<String> {
@@ -1041,6 +1065,39 @@ mod tests {
                 &serde_json::from_str(org).unwrap()
             ),
             Some("org-id".to_string())
+        );
+    }
+
+    #[test]
+    fn expires_at_derived_from_jwt_exp_claim() {
+        let token = format!("h.{}.s", URL_SAFE_NO_PAD.encode(r#"{"exp":1893456000}"#));
+        assert_eq!(
+            OpenAiCodexProvider::expires_at_from_jwt(&token),
+            Some(1893456000)
+        );
+    }
+
+    #[test]
+    fn expires_at_none_without_exp_claim() {
+        let token = format!("h.{}.s", URL_SAFE_NO_PAD.encode(r#"{}"#));
+        assert_eq!(OpenAiCodexProvider::expires_at_from_jwt(&token), None);
+    }
+
+    #[test]
+    fn expires_at_none_for_malformed_token() {
+        assert_eq!(OpenAiCodexProvider::expires_at_from_jwt("not-a-jwt"), None);
+    }
+
+    #[test]
+    fn decode_jwt_claims_handles_standard_base64_padding() {
+        let token = format!(
+            "h.{}.s",
+            base64::engine::general_purpose::STANDARD.encode(r#"{"padding":true}"#)
+        );
+        assert_eq!(
+            OpenAiCodexProvider::decode_jwt_claims(&token)
+                .and_then(|claims| { claims.get("padding").and_then(serde_json::Value::as_bool) }),
+            Some(true)
         );
     }
 


### PR DESCRIPTION
## Summary

Fixes a token-expiry dead end in the `openai-codex` provider that takes down every session after ~10 days with no recovery other than a manual re-login.

`moltis auth login --provider openai-codex` stores tokens in `oauth_tokens.json` with `expires_at: null`, because the Codex OAuth token response carries no `expires_in`. `get_valid_tokens()` only attempts a proactive refresh inside `if let Some(expires_at) = ...`, and there is no reactive refresh on 401 — so the stored access token is served unchanged until it expires, at which point every completion fails with:

```
openai-codex API error HTTP 401 Unauthorized: "Provided authentication token is expired. Please try signing in again." (code: token_expired)
```

This hit a production gateway on 2026-07-15 (moltis 20260603.01, token stored at login on 2026-07-02, worked until ~2026-07-13): all Discord sessions returned the error above, and restarting the gateway or re-logging the Codex CLI did not help, since the stale copy in the token store shadows the CLI fallback.

The access token is a JWT that carries its expiry in the standard `exp` claim, so the information was available all along:

- Extract the existing JWT payload decoding from `extract_account_id` into `decode_jwt_claims` (no behavior change, padded-base64 fallback preserved).
- Derive `expires_at` from the `exp` claim in `get_valid_tokens` when the stored value is missing, so the existing 5-minute-buffer refresh finally engages.
- Backfill `expires_at` on refreshed tokens before saving, so the stored entry self-heals.

Note on behavior: tokens loaded via the Codex CLI fallback (`~/.codex/auth.json`) previously never refreshed either (parsed with `expires_at: None`); with this change an expired CLI token also triggers a refresh, and the result is persisted to the token store. That seems strictly better than serving a token that is known to be dead, but flagging it for review.

## Validation

### Completed

- [x] `cargo fmt --all` (pinned `nightly-2026-06-20`)
- [x] Unit tests added: `exp` claim derivation, missing-`exp` and malformed-token cases, and a pin for the padded-STANDARD base64 fallback in `decode_jwt_claims`

### Remaining

- [ ] `just lint`
- [ ] `just test`

(Running via CI on this PR; happy to iterate on any findings.)

## Manual QA

1. Log in with `moltis auth login --provider openai-codex` and confirm `oauth_tokens.json` has `expires_at: null` (pre-fix state).
2. On a build with this patch, age the token past its JWT `exp` (or edit the stored access token's `exp` to the past while keeping a valid refresh token).
3. Send any message through a session using an `openai-codex::*` model: the provider now refreshes proactively and the stored entry gains a real `expires_at`, instead of failing with HTTP 401 `token_expired`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
