### PR TITLE
Improve agent and sandbox status feedback

### DIFF
--- a/crates/gateway/src/external_agents.rs
+++ b/crates/gateway/src/external_agents.rs
@@ -15,7 +15,7 @@ use {
     moltis_sessions::{MessageContent, PersistedMessage},
     serde_json::Value,
     tokio::sync::Mutex,
-    tracing::{info, warn},
+    tracing::warn,
 };
 
 use moltis_tools::approval::{ApprovalDecision, ApprovalManager};
@@ -546,13 +546,6 @@ impl ExternalAgentChatService {
             .map_err(|error| error.to_string())?;
         let mut session = live_session.lock().await;
         let external_session_id = session.external_session_id().map(str::to_string);
-        info!(
-            session_key = %session_key,
-            external_agent = kind.as_str(),
-            external_session_id = external_session_id.as_deref().unwrap_or("pending"),
-            prompt_chars = text.len(),
-            "external agent prompt"
-        );
         if external_session_id.is_some() {
             self.session_metadata
                 .set_external_agent(&session_key, Some(kind), external_session_id.clone())
@@ -650,13 +643,6 @@ impl ExternalAgentChatService {
             seq,
             run_id: Some(run_id.clone()),
         };
-        info!(
-            session_key = %session_key,
-            external_agent = kind.as_str(),
-            response_chars = assistant_text.len(),
-            duration_ms,
-            "external agent response"
-        );
         self.session_store
             .append(&session_key, &assistant_msg.to_value())
             .await
@@ -783,7 +769,6 @@ impl ExternalAgentChatService {
                 "sessionKey": session_key,
                 "entry": {
                     "key": session_key,
-                    "external_agent_kind": entry.external_agent_kind.map(|kind| kind.as_str()),
                     "externalAgentKind": entry.external_agent_kind.map(|kind| kind.as_str()),
                     "externalSessionId": entry.external_session_id,
                     "version": entry.version,
@@ -798,7 +783,7 @@ impl ExternalAgentChatService {
         if !self.external_agents.config.enabled {
             return None;
         }
-        let session_key = resolve_session_key(params, &self.state).await;
+        let session_key = resolve_connection_session_key(params, &self.state).await;
         let entry = self.session_metadata.get(&session_key).await?;
         let kind = entry.external_agent_kind?;
         let history = self
@@ -842,6 +827,18 @@ impl ExternalAgentChatService {
             },
         })))
     }
+}
+
+async fn resolve_connection_session_key(params: &Value, state: &GatewayState) -> String {
+    let Some(conn_id) = params.get("_conn_id").and_then(|value| value.as_str()) else {
+        return "main".to_string();
+    };
+    let registry = state.client_registry.read().await;
+    registry
+        .active_sessions
+        .get(conn_id)
+        .cloned()
+        .unwrap_or_else(|| "main".to_string())
 }
 
 async fn resolve_session_key(params: &Value, state: &GatewayState) -> String {
@@ -1322,7 +1319,7 @@ mod tests {
             .expect("send external agent prompt");
 
         let full_context = chat
-            .full_context(serde_json::json!({ "sessionKey": "main" }))
+            .full_context(serde_json::json!({ "_conn_id": "conn-1", "sessionKey": "other" }))
             .await
             .expect("full context");
 

--- a/crates/gateway/src/external_agents.rs
+++ b/crates/gateway/src/external_agents.rs
@@ -15,7 +15,7 @@ use {
     moltis_sessions::{MessageContent, PersistedMessage},
     serde_json::Value,
     tokio::sync::Mutex,
-    tracing::warn,
+    tracing::{info, warn},
 };
 
 use moltis_tools::approval::{ApprovalDecision, ApprovalManager};
@@ -546,9 +546,18 @@ impl ExternalAgentChatService {
             .map_err(|error| error.to_string())?;
         let mut session = live_session.lock().await;
         let external_session_id = session.external_session_id().map(str::to_string);
+        info!(
+            session_key = %session_key,
+            external_agent = kind.as_str(),
+            external_session_id = external_session_id.as_deref().unwrap_or("pending"),
+            prompt_chars = text.len(),
+            "external agent prompt"
+        );
         if external_session_id.is_some() {
             self.session_metadata
                 .set_external_agent(&session_key, Some(kind), external_session_id.clone())
+                .await;
+            self.broadcast_external_agent_session_update(&session_key)
                 .await;
         }
         let mut events = match session.send_prompt(&text, Some(&context)).await {
@@ -611,6 +620,8 @@ impl ExternalAgentChatService {
             self.session_metadata
                 .set_external_agent(&session_key, Some(kind), Some(external_session_id))
                 .await;
+            self.broadcast_external_agent_session_update(&session_key)
+                .await;
         }
         drop(session);
         if let Some(error) = external_error {
@@ -639,6 +650,13 @@ impl ExternalAgentChatService {
             seq,
             run_id: Some(run_id.clone()),
         };
+        info!(
+            session_key = %session_key,
+            external_agent = kind.as_str(),
+            response_chars = assistant_text.len(),
+            duration_ms,
+            "external agent response"
+        );
         self.session_store
             .append(&session_key, &assistant_msg.to_value())
             .await
@@ -721,6 +739,9 @@ impl ChatService for ExternalAgentChatService {
     }
 
     async fn full_context(&self, params: Value) -> ServiceResult {
+        if let Some(context) = self.external_full_context(&params).await {
+            return context;
+        }
         self.inner.full_context(params).await
     }
 
@@ -746,6 +767,80 @@ impl ChatService for ExternalAgentChatService {
 
     async fn peek(&self, params: Value) -> ServiceResult {
         self.inner.peek(params).await
+    }
+}
+
+impl ExternalAgentChatService {
+    async fn broadcast_external_agent_session_update(&self, session_key: &str) {
+        let Some(entry) = self.session_metadata.get(session_key).await else {
+            return;
+        };
+        crate::broadcast::broadcast(
+            &self.state,
+            "session",
+            serde_json::json!({
+                "kind": "patched",
+                "sessionKey": session_key,
+                "entry": {
+                    "key": session_key,
+                    "external_agent_kind": entry.external_agent_kind.map(|kind| kind.as_str()),
+                    "externalAgentKind": entry.external_agent_kind.map(|kind| kind.as_str()),
+                    "externalSessionId": entry.external_session_id,
+                    "version": entry.version,
+                },
+            }),
+            BroadcastOpts::default(),
+        )
+        .await;
+    }
+
+    async fn external_full_context(&self, params: &Value) -> Option<ServiceResult> {
+        if !self.external_agents.config.enabled {
+            return None;
+        }
+        let session_key = resolve_session_key(params, &self.state).await;
+        let entry = self.session_metadata.get(&session_key).await?;
+        let kind = entry.external_agent_kind?;
+        let history = self
+            .session_store
+            .read(&session_key)
+            .await
+            .unwrap_or_default();
+        let context = context_from_history(&history);
+        let messages: Vec<Value> = context
+            .recent_turns
+            .iter()
+            .map(|turn| {
+                serde_json::json!({
+                    "role": turn.role,
+                    "content": turn.content,
+                })
+            })
+            .collect();
+        let llm_outputs: Vec<Value> = history
+            .iter()
+            .filter(|entry| entry.get("role").and_then(|role| role.as_str()) == Some("assistant"))
+            .cloned()
+            .collect();
+        let total_chars = messages
+            .iter()
+            .map(|message| serde_json::to_string(message).unwrap_or_default().len())
+            .sum::<usize>();
+
+        Some(Ok(serde_json::json!({
+            "messages": messages,
+            "llmOutputs": llm_outputs,
+            "messageCount": context.recent_turns.len(),
+            "systemPromptChars": 0,
+            "totalChars": total_chars,
+            "truncated": history.len() > context.recent_turns.len(),
+            "workspaceFiles": [],
+            "promptMemory": null,
+            "externalAgent": {
+                "kind": kind.as_str(),
+                "sessionId": entry.external_session_id,
+            },
+        })))
     }
 }
 
@@ -1203,6 +1298,41 @@ mod tests {
                 .and_then(|entry| entry.external_session_id),
             Some("fake-session-1".to_string())
         );
+    }
+
+    #[tokio::test]
+    async fn full_context_for_bound_external_agent_uses_persisted_history() {
+        let dir = tempfile::tempdir().unwrap();
+        let session_store = Arc::new(SessionStore::new(dir.path().to_path_buf()));
+        let metadata = Arc::new(SqliteSessionMetadata::new(sqlite_pool().await));
+        let agent_state = Arc::new(FakeAgentState::default());
+        let external_agents = fake_external_agents(Arc::clone(&metadata), Arc::clone(&agent_state));
+        external_agents
+            .bind(serde_json::json!({ "sessionKey": "main", "kind": "codex" }))
+            .await
+            .expect("bind external agent");
+        let chat = test_chat_service(
+            Arc::clone(&external_agents),
+            Arc::clone(&metadata),
+            Arc::clone(&session_store),
+        )
+        .await;
+        chat.send(serde_json::json!({ "sessionKey": "main", "text": "one" }))
+            .await
+            .expect("send external agent prompt");
+
+        let full_context = chat
+            .full_context(serde_json::json!({ "sessionKey": "main" }))
+            .await
+            .expect("full context");
+
+        assert_eq!(full_context["messageCount"], 2);
+        assert_eq!(full_context["messages"][0]["role"], "user");
+        assert_eq!(full_context["messages"][0]["content"], "one");
+        assert_eq!(full_context["messages"][1]["role"], "assistant");
+        assert_eq!(full_context["messages"][1]["content"], "reply to one");
+        assert_eq!(full_context["externalAgent"]["kind"], "codex");
+        assert_eq!(full_context["externalAgent"]["sessionId"], "fake-session-1");
     }
 
     #[tokio::test]

--- a/crates/tools/src/sandbox/apple.rs
+++ b/crates/tools/src/sandbox/apple.rs
@@ -4,6 +4,10 @@
 use std::collections::HashMap;
 #[cfg(target_os = "macos")]
 use std::process::Command;
+#[cfg(target_os = "macos")]
+use std::sync::mpsc;
+#[cfg(target_os = "macos")]
+use std::time::Instant;
 
 #[cfg(target_os = "macos")]
 use async_trait::async_trait;
@@ -585,12 +589,16 @@ fn is_apple_container_service_running() -> bool {
 /// Returns `true` if the service was successfully started.
 #[cfg(target_os = "macos")]
 fn try_start_apple_container_service() -> bool {
-    tracing::info!("apple container service is not running, starting it automatically");
+    tracing::info!(
+        "apple container service is not running, starting it automatically; first startup can take about a minute"
+    );
+    let progress_done = spawn_apple_container_start_progress_logger();
     let result = Command::new("container")
         .args(["system", "start"])
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped())
         .status();
+    let _ = progress_done.send(());
     match result {
         Ok(status) if status.success() => {
             tracing::info!("apple container service started successfully");
@@ -611,6 +619,34 @@ fn try_start_apple_container_service() -> bool {
             false
         },
     }
+}
+
+#[cfg(target_os = "macos")]
+fn spawn_apple_container_start_progress_logger() -> mpsc::Sender<()> {
+    const PROGRESS_INTERVAL: std::time::Duration = std::time::Duration::from_secs(10);
+    spawn_apple_container_start_progress_logger_with_interval(PROGRESS_INTERVAL)
+}
+
+#[cfg(target_os = "macos")]
+pub(crate) fn spawn_apple_container_start_progress_logger_with_interval(
+    progress_interval: std::time::Duration,
+) -> mpsc::Sender<()> {
+    let (done_tx, done_rx) = mpsc::channel();
+    std::thread::spawn(move || {
+        let started_at = Instant::now();
+        loop {
+            match done_rx.recv_timeout(progress_interval) {
+                Ok(()) | Err(mpsc::RecvTimeoutError::Disconnected) => break,
+                Err(mpsc::RecvTimeoutError::Timeout) => {
+                    tracing::info!(
+                        elapsed_secs = started_at.elapsed().as_secs(),
+                        "still starting apple container service"
+                    );
+                },
+            }
+        }
+    });
+    done_tx
 }
 
 /// Ensure the Apple Container system service is running, starting it if needed.

--- a/crates/tools/src/sandbox/tests/apple.rs
+++ b/crates/tools/src/sandbox/tests/apple.rs
@@ -163,6 +163,16 @@ fn test_should_restart_after_readiness_error() {
     ));
 }
 
+#[cfg(target_os = "macos")]
+#[test]
+fn test_apple_container_start_progress_logger_stops_on_done_signal() {
+    let done = spawn_apple_container_start_progress_logger_with_interval(
+        std::time::Duration::from_millis(1),
+    );
+
+    done.send(()).unwrap();
+}
+
 #[test]
 fn test_apple_container_bootstrap_command_uses_portable_sleep() {
     let command = apple_container_bootstrap_command();

--- a/crates/web/ui/src/app.tsx
+++ b/crates/web/ui/src/app.tsx
@@ -202,13 +202,13 @@ gon.onChange("vault_status", showVaultBanner as (v: unknown) => void);
 
 function upsertSessionFromEvent(entry: SessionEntry | null): boolean {
 	if (!entry?.key) return false;
-	sessionStore.upsert(entry as never);
 	const legacy = S.sessions.slice() as SessionEntry[];
 	const idx = legacy.findIndex((session) => session.key === entry.key);
 	let nextEntry = { ...entry };
 	if (idx >= 0) {
 		nextEntry = { ...legacy[idx], ...entry };
 	}
+	sessionStore.upsert(nextEntry as never);
 	S.setSessions(insertSessionInOrder(legacy as never[], nextEntry as never));
 	renderSessionList();
 	return true;

--- a/crates/web/ui/src/sessions/session-render.ts
+++ b/crates/web/ui/src/sessions/session-render.ts
@@ -113,6 +113,7 @@ interface ExternalAgentInfo {
 
 const installedExternalAgents = new Set<string>();
 let externalAgentsLoaded = false;
+let externalAgentsLoadingPromise: Promise<void> | null = null;
 
 /** History message with an optional seq field, used for resuming chat sequence counters. */
 interface SeqHistoryMessage extends HistoryMessage {
@@ -527,7 +528,11 @@ export function renderWelcomeAgentPicker(
 
 function hasInstalledExternalAgent(): boolean {
 	if (externalAgentsLoaded) return installedExternalAgents.size > 0;
-	void refreshExternalAgentAvailability();
+	if (!externalAgentsLoadingPromise) {
+		externalAgentsLoadingPromise = refreshExternalAgentAvailability().finally(() => {
+			externalAgentsLoadingPromise = null;
+		});
+	}
 	return false;
 }
 
@@ -543,9 +548,7 @@ function refreshExternalAgentAvailability(): Promise<void> {
 			externalAgentsLoaded = true;
 			refreshWelcomeCardIfNeeded();
 		})
-		.catch(() => {
-			externalAgentsLoaded = true;
-		});
+		.catch(() => {});
 }
 
 function hasChatBackend(): boolean {

--- a/crates/web/ui/src/sessions/session-render.ts
+++ b/crates/web/ui/src/sessions/session-render.ts
@@ -106,6 +106,14 @@ interface AgentInfo {
 	emoji?: string;
 }
 
+interface ExternalAgentInfo {
+	installed?: boolean;
+	isAcp?: boolean;
+}
+
+const installedExternalAgents = new Set<string>();
+let externalAgentsLoaded = false;
+
 /** History message with an optional seq field, used for resuming chat sequence counters. */
 interface SeqHistoryMessage extends HistoryMessage {
 	seq?: number;
@@ -517,11 +525,38 @@ export function renderWelcomeAgentPicker(
 	});
 }
 
+function hasInstalledExternalAgent(): boolean {
+	if (externalAgentsLoaded) return installedExternalAgents.size > 0;
+	void refreshExternalAgentAvailability();
+	return false;
+}
+
+function refreshExternalAgentAvailability(): Promise<void> {
+	return sendRpc("external_agents.list", {})
+		.then((res) => {
+			if (!res?.ok) return;
+			installedExternalAgents.clear();
+			const agents = Array.isArray(res.payload) ? (res.payload as ExternalAgentInfo[]) : [];
+			for (const agent of agents) {
+				if (agent?.installed) installedExternalAgents.add(String(agent.isAcp ? "acp" : "external"));
+			}
+			externalAgentsLoaded = true;
+			refreshWelcomeCardIfNeeded();
+		})
+		.catch(() => {
+			externalAgentsLoaded = true;
+		});
+}
+
+function hasChatBackend(): boolean {
+	return modelStore.models.value.length > 0 || hasInstalledExternalAgent();
+}
+
 function showWelcomeCard(): void {
 	if (!S.chatMsgBox) return;
 	S.chatMsgBox.classList.add("chat-messages-empty");
 
-	if (modelStore.models.value.length === 0) {
+	if (!hasChatBackend()) {
 		const noProvTpl = S.$<HTMLTemplateElement>("tpl-no-providers-card");
 		if (!noProvTpl) return;
 		const noProvCard = (noProvTpl.content.cloneNode(true) as DocumentFragment).firstElementChild as HTMLElement;
@@ -557,12 +592,12 @@ export function refreshWelcomeCardIfNeeded(): void {
 	if (!S.chatMsgBox) return;
 	const welcomeCard = S.chatMsgBox.querySelector("#welcomeCard");
 	const noProvCard = S.chatMsgBox.querySelector("#noProvidersCard");
-	const hasModels = modelStore.models.value.length > 0;
+	const chatBackendAvailable = hasChatBackend();
 
-	if (hasModels && noProvCard) {
+	if (chatBackendAvailable && noProvCard) {
 		noProvCard.remove();
 		showWelcomeCard();
-	} else if (!hasModels && welcomeCard) {
+	} else if (!chatBackendAvailable && welcomeCard) {
 		welcomeCard.remove();
 		showWelcomeCard();
 	}


### PR DESCRIPTION
## Summary
- Broadcast external-agent session metadata after external session IDs become available.
- Return persisted external-agent history from full context requests and keep the web session store merge-safe.
- Treat installed external agents as available chat backends and add Apple Container startup progress logging.

## Validation
### Completed
- [x] `cargo fmt --all -- --check`
- [x] `npm ci`
- [x] `cd crates/web/ui && npx biome check --write src/` (completed with existing repo warnings)
- [x] `cd crates/web/ui && npm run build`
- [x] `cd crates/web/ui && npx tsc --noEmit`
- [x] `cargo test -p moltis-gateway full_context_for_bound_external_agent_uses_persisted_history`
- [x] `cargo test -p moltis-tools apple_container_start_progress_logger`
- [x] `PATH="crates/web/ui/node_modules/.bin:$PATH" LOCAL_VALIDATE_PROGRESS_INTERVAL=120 ./scripts/local-validate.sh 1155`
- [x] PR CI checks pass after rerunning jobs that were waiting on local statuses

### Remaining
- [x] None

## Manual QA
- Not performed; covered by focused tests, full local validation, and PR CI.