### PR TITLE
Add Kimi K3 provider support

### DIFF
--- a/crates/config/src/template.rs
+++ b/crates/config/src/template.rs
@@ -237,7 +237,7 @@ port = {port}                           # Port number (auto-generated for this i
 # [providers.moonshot]
 # enabled = true
 # api_key = "..."                             # Or set MOONSHOT_API_KEY env var
-# models = ["kimi-k2.5"]                      # Preferred models shown first
+# models = ["kimi-k3", "kimi-k2.7-code-highspeed", "kimi-k2.6"]  # Preferred models shown first
 # base_url = "https://api.moonshot.ai/v1"
 # alias = "moonshot"
 

--- a/crates/provider-setup/src/known_providers.rs
+++ b/crates/provider-setup/src/known_providers.rs
@@ -192,7 +192,7 @@ pub fn known_providers() -> Vec<KnownProvider> {
             display_name: "Moonshot",
             auth_type: AuthType::ApiKey,
             env_key: Some("MOONSHOT_API_KEY"),
-            default_base_url: Some("https://api.moonshot.cn/v1"),
+            default_base_url: Some("https://api.moonshot.ai/v1"),
             requires_model: false,
             key_optional: false,
             local_only: false,

--- a/crates/provider-setup/src/service/tests.rs
+++ b/crates/provider-setup/src/service/tests.rs
@@ -381,6 +381,15 @@ async fn available_includes_default_base_urls() {
         kimi_code.get("defaultBaseUrl").and_then(|u| u.as_str()),
         Some("https://api.kimi.com/coding/v1")
     );
+
+    let moonshot = arr
+        .iter()
+        .find(|p| p.get("name").and_then(|n| n.as_str()) == Some("moonshot"))
+        .expect("moonshot not found");
+    assert_eq!(
+        moonshot.get("defaultBaseUrl").and_then(|u| u.as_str()),
+        Some("https://api.moonshot.ai/v1")
+    );
 }
 
 #[tokio::test]

--- a/crates/providers/src/kimi_code.rs
+++ b/crates/providers/src/kimi_code.rs
@@ -3,7 +3,7 @@
 //! Authentication uses the Kimi device-flow OAuth (same as kimi-cli).
 //! The API is OpenAI-compatible at `https://api.kimi.com/coding/v1`.
 
-use std::pin::Pin;
+use std::{pin::Pin, sync::Arc};
 
 use {
     async_trait::async_trait,
@@ -19,7 +19,9 @@ use {
         SseLineResult, StreamingToolState, finalize_stream, parse_openai_compat_usage_from_payload,
         parse_tool_calls, process_openai_sse_line, to_openai_tools,
     },
-    moltis_agents::model::{ChatMessage, CompletionResponse, LlmProvider, StreamEvent},
+    moltis_agents::model::{
+        ChatMessage, CompletionResponse, LlmProvider, ReasoningEffort, StreamEvent,
+    },
 };
 
 // ── Constants ────────────────────────────────────────────────────────────────
@@ -44,6 +46,7 @@ pub struct KimiCodeProvider {
     client: &'static reqwest::Client,
     base_url: String,
     auth_mode: AuthMode,
+    reasoning_effort: Option<ReasoningEffort>,
 }
 
 impl KimiCodeProvider {
@@ -56,6 +59,7 @@ impl KimiCodeProvider {
             auth_mode: AuthMode::OAuthTokenStore {
                 token_store: TokenStore::new(),
             },
+            reasoning_effort: None,
         }
     }
 
@@ -66,6 +70,7 @@ impl KimiCodeProvider {
             client: crate::shared_http_client(),
             base_url,
             auth_mode: AuthMode::ApiKey { api_key },
+            reasoning_effort: None,
         }
     }
 
@@ -77,6 +82,12 @@ impl KimiCodeProvider {
         match &self.auth_mode {
             AuthMode::ApiKey { api_key } => Ok(api_key.expose_secret().clone()),
             AuthMode::OAuthTokenStore { .. } => self.get_valid_oauth_token().await,
+        }
+    }
+
+    fn apply_reasoning_effort(&self, body: &mut serde_json::Value) {
+        if self.reasoning_effort.is_some() {
+            body["reasoning_effort"] = serde_json::json!("max");
         }
     }
 
@@ -215,6 +226,7 @@ impl LlmProvider for KimiCodeProvider {
             "model": self.model,
             "messages": openai_messages,
         });
+        self.apply_reasoning_effort(&mut body);
 
         if !tools.is_empty() {
             body["tools"] = serde_json::Value::Array(to_openai_tools(tools, true));
@@ -310,6 +322,7 @@ impl LlmProvider for KimiCodeProvider {
                 "stream": true,
                 "stream_options": { "include_usage": true },
             });
+            self.apply_reasoning_effort(&mut body);
 
             if !tools.is_empty() {
                 body["tools"] = serde_json::Value::Array(to_openai_tools(&tools, true));
@@ -437,6 +450,30 @@ impl LlmProvider for KimiCodeProvider {
             }
         })
     }
+
+    fn reasoning_effort(&self) -> Option<ReasoningEffort> {
+        self.reasoning_effort
+    }
+
+    fn with_reasoning_effort(
+        self: Arc<Self>,
+        effort: ReasoningEffort,
+    ) -> Option<Arc<dyn LlmProvider>> {
+        Some(Arc::new(Self {
+            model: self.model.clone(),
+            client: self.client,
+            base_url: self.base_url.clone(),
+            auth_mode: match &self.auth_mode {
+                AuthMode::OAuthTokenStore { .. } => AuthMode::OAuthTokenStore {
+                    token_store: TokenStore::new(),
+                },
+                AuthMode::ApiKey { api_key } => AuthMode::ApiKey {
+                    api_key: Secret::new(api_key.expose_secret().clone()),
+                },
+            },
+            reasoning_effort: Some(effort),
+        }))
+    }
 }
 
 #[allow(clippy::unwrap_used, clippy::expect_used)]
@@ -457,15 +494,36 @@ mod tests {
     async fn start_mock_with_capture(
         response_body: serde_json::Value,
     ) -> (String, Arc<Mutex<Vec<CapturedRequest>>>) {
+        start_mock_with_capture_handler(move || axum::Json(response_body.clone())).await
+    }
+
+    async fn start_mock_sse_with_capture(
+        response_body: &'static str,
+    ) -> (String, Arc<Mutex<Vec<CapturedRequest>>>) {
+        start_mock_with_capture_handler(move || {
+            (
+                [(http::header::CONTENT_TYPE, "text/event-stream")],
+                response_body,
+            )
+        })
+        .await
+    }
+
+    async fn start_mock_with_capture_handler<R, F>(
+        response: F,
+    ) -> (String, Arc<Mutex<Vec<CapturedRequest>>>)
+    where
+        R: axum::response::IntoResponse + Send + 'static,
+        F: Fn() -> R + Clone + Send + Sync + 'static,
+    {
         let captured: Arc<Mutex<Vec<CapturedRequest>>> = Arc::new(Mutex::new(Vec::new()));
         let captured_clone = captured.clone();
-        let resp_body = response_body.clone();
 
         let app = Router::new().route(
             "/chat/completions",
             post(move |req: Request| {
                 let cap = captured_clone.clone();
-                let resp = resp_body.clone();
+                let response = response.clone();
                 async move {
                     let headers: Vec<(String, String)> = req
                         .headers()
@@ -482,7 +540,7 @@ mod tests {
 
                     cap.lock().unwrap().push(CapturedRequest { headers, body });
 
-                    axum::Json(resp)
+                    response()
                 }
             }),
         );
@@ -714,6 +772,52 @@ mod tests {
         assert_eq!(tools_arr.len(), 1);
         assert_eq!(tools_arr[0]["type"], "function");
         assert_eq!(tools_arr[0]["function"]["name"], "read_file");
+    }
+
+    #[tokio::test]
+    async fn complete_sends_reasoning_effort_as_max() {
+        let (base_url, captured) = start_mock_with_capture(mock_completion_response()).await;
+        let provider = Arc::new(KimiCodeProvider::new_with_api_key(
+            Secret::new("sk-kimi".into()),
+            "kimi-k3".into(),
+            base_url,
+        ))
+        .with_reasoning_effort(ReasoningEffort::Low)
+        .unwrap();
+
+        provider
+            .complete(&[ChatMessage::user("hi")], &[])
+            .await
+            .unwrap();
+
+        let reqs = captured.lock().unwrap();
+        let body = reqs[0].body.as_ref().unwrap();
+        assert_eq!(body["reasoning_effort"], "max");
+    }
+
+    #[tokio::test]
+    async fn stream_sends_reasoning_effort_as_max() {
+        use futures::StreamExt as _;
+
+        let (base_url, captured) = start_mock_sse_with_capture("data: [DONE]\n\n").await;
+        let provider = Arc::new(KimiCodeProvider::new_with_api_key(
+            Secret::new("sk-kimi".into()),
+            "kimi-k2.7-code-highspeed".into(),
+            base_url,
+        ))
+        .with_reasoning_effort(ReasoningEffort::High)
+        .unwrap();
+
+        let events: Vec<StreamEvent> = provider
+            .stream_with_tools(vec![ChatMessage::user("hi")], vec![])
+            .collect()
+            .await;
+        assert!(matches!(events.last(), Some(StreamEvent::Done(_))));
+
+        let reqs = captured.lock().unwrap();
+        let body = reqs[0].body.as_ref().unwrap();
+        assert_eq!(body["reasoning_effort"], "max");
+        assert_eq!(body["stream"], true);
     }
 
     #[tokio::test]

--- a/crates/providers/src/kimi_code.rs
+++ b/crates/providers/src/kimi_code.rs
@@ -179,9 +179,11 @@ pub fn has_stored_tokens() -> bool {
 
 /// Known Kimi Code models.
 pub const KIMI_CODE_MODELS: &[(&str, &str)] = &[
+    ("kimi-k3", "Kimi K3"),
+    ("kimi-k2.7-code-highspeed", "Kimi K2.7 Code Highspeed"),
     ("kimi-for-coding", "Kimi For Coding"),
-    ("kimi-k2.5", "Kimi K2.5"),
     ("kimi-k2.6", "Kimi K2.6"),
+    ("kimi-k2.5", "Kimi K2.5"),
 ];
 
 // ── LlmProvider impl ────────────────────────────────────────────────────────

--- a/crates/providers/src/model_capabilities.rs
+++ b/crates/providers/src/model_capabilities.rs
@@ -91,6 +91,9 @@ const GENERIC_CONTEXT_WINDOW_FALLBACKS: &[ContextWindowFallback] = &[
     ContextWindowFallback::Prefix("gpt-4", 128_000),
     ContextWindowFallback::Prefix("gpt-5", 128_000),
     ContextWindowFallback::Prefix("mistral-large", 128_000),
+    ContextWindowFallback::Exact("kimi-k3", 1_000_000),
+    ContextWindowFallback::Prefix("kimi-k2.7-code", 256_000),
+    ContextWindowFallback::Exact("kimi-k2.6", 256_000),
     ContextWindowFallback::Prefix("kimi-", 128_000),
     ContextWindowFallback::Prefix("glm-", 128_000),
     ContextWindowFallback::Prefix("qwen3", 128_000),
@@ -309,6 +312,10 @@ pub fn supports_reasoning_for_model(model_id: &str) -> bool {
     if id.starts_with("grok-3") || id.starts_with("grok-4") {
         return true;
     }
+    // Kimi K3 uses the top-level reasoning_effort field; K2.7 Code also has thinking mode.
+    if id == "kimi-k3" || id.starts_with("kimi-k2.7-code") {
+        return true;
+    }
     false
 }
 
@@ -391,6 +398,12 @@ mod tests {
         assert_eq!(context_window_for_model("gpt-5.6-sol"), 1_050_000);
         assert_eq!(context_window_for_model("codestral-latest"), 256_000);
         assert_eq!(context_window_for_model("gemini-2.0-flash"), 1_000_000);
+        assert_eq!(context_window_for_model("kimi-k3"), 1_000_000);
+        assert_eq!(
+            context_window_for_model("kimi-k2.7-code-highspeed"),
+            256_000
+        );
+        assert_eq!(context_window_for_model("kimi-k2.6"), 256_000);
         assert_eq!(context_window_for_model("kimi-k2.5"), 128_000);
         assert_eq!(context_window_for_model("MiniMax-M3"), 1_000_000);
         assert_eq!(context_window_for_model("MiniMax-M2.7"), 204_800);
@@ -416,7 +429,7 @@ mod tests {
         assert_eq!(context_window_for_model("gpt-4.1"), 128_000);
         assert_eq!(context_window_for_model("gpt-5.3"), 128_000);
         assert_eq!(context_window_for_model("mistral-large-2411"), 128_000);
-        assert_eq!(context_window_for_model("kimi-k2.6"), 128_000);
+        assert_eq!(context_window_for_model("kimi-k2.6-lite"), 128_000);
         assert_eq!(context_window_for_model("glm-5-turbo"), 128_000);
         assert_eq!(context_window_for_model("qwen3-next"), 128_000);
     }
@@ -511,6 +524,7 @@ mod tests {
         // Unknown models default to vision support (better to try and fail
         // with an API error than to silently strip images)
         assert!(supports_vision_for_model("some-unknown-model"));
+        assert!(supports_vision_for_model("kimi-k3"));
         assert!(supports_vision_for_model("kimi-k2.5"));
     }
 
@@ -664,6 +678,8 @@ mod tests {
         assert!(supports_reasoning_for_model("gpt-5"));
         assert!(supports_reasoning_for_model("gpt-5-mini"));
         assert!(supports_reasoning_for_model("gpt-5.2"));
+        assert!(supports_reasoning_for_model("kimi-k3"));
+        assert!(supports_reasoning_for_model("kimi-k2.7-code-highspeed"));
         // xAI Grok reasoning models
         assert!(supports_reasoning_for_model("grok-3"));
         assert!(supports_reasoning_for_model("grok-3-latest"));

--- a/crates/providers/src/model_catalogs.rs
+++ b/crates/providers/src/model_catalogs.rs
@@ -127,8 +127,12 @@ pub(crate) const DEEPSEEK_MODELS: &[(&str, &str)] = &[
 ];
 
 /// Known Moonshot models.
-pub(crate) const MOONSHOT_MODELS: &[(&str, &str)] =
-    &[("kimi-k2.5", "Kimi K2.5"), ("kimi-k2.6", "Kimi K2.6")];
+pub(crate) const MOONSHOT_MODELS: &[(&str, &str)] = &[
+    ("kimi-k3", "Kimi K3"),
+    ("kimi-k2.7-code-highspeed", "Kimi K2.7 Code Highspeed"),
+    ("kimi-k2.6", "Kimi K2.6"),
+    ("kimi-k2.5", "Kimi K2.5"),
+];
 
 /// Known Google Gemini models.
 /// See: <https://ai.google.dev/gemini-api/docs/models>
@@ -236,6 +240,7 @@ pub(crate) const OPENAI_COMPAT_PROVIDERS: &[OpenAiCompatDef] = &[
         models: MOONSHOT_MODELS,
         capabilities: OpenAiProviderCapabilities {
             default_reasoning_content_on_tool_messages: true,
+            reasoning_effort_policy: ReasoningEffortPolicy::KimiMax,
             ..OpenAiProviderCapabilities::DEFAULT
         },
         ..OpenAiCompatDef::DEFAULT

--- a/crates/providers/src/openai/mod.rs
+++ b/crates/providers/src/openai/mod.rs
@@ -21,6 +21,7 @@ pub(crate) enum RateLimitPolicy {
 pub(crate) enum ReasoningEffortPolicy {
     OpenAi,
     DeepSeek,
+    KimiMax,
     Unsupported,
 }
 

--- a/crates/providers/src/openai/provider/core.rs
+++ b/crates/providers/src/openai/provider/core.rs
@@ -261,6 +261,7 @@ impl OpenAiProvider {
                 | ReasoningEffort::High => "high",
                 ReasoningEffort::ExtraHigh => "max",
             }),
+            ReasoningEffortPolicy::KimiMax => self.reasoning_effort.map(|_| "max"),
             ReasoningEffortPolicy::OpenAi => self.reasoning_effort.map(|e| match e {
                 ReasoningEffort::Minimal => {
                     tracing::debug!(

--- a/crates/providers/src/openai/provider/request.rs
+++ b/crates/providers/src/openai/provider/request.rs
@@ -935,6 +935,25 @@ mod tests {
         }
     }
 
+    #[test]
+    fn kimi_reasoning_effort_always_maps_to_max() {
+        for effort in [
+            moltis_agents::model::ReasoningEffort::Minimal,
+            moltis_agents::model::ReasoningEffort::Low,
+            moltis_agents::model::ReasoningEffort::Medium,
+            moltis_agents::model::ReasoningEffort::High,
+            moltis_agents::model::ReasoningEffort::ExtraHigh,
+        ] {
+            let mut p = provider("kimi-k3", "moonshot", "https://api.moonshot.ai/v1")
+                .with_capabilities(OpenAiProviderCapabilities {
+                    reasoning_effort_policy: ReasoningEffortPolicy::KimiMax,
+                    ..OpenAiProviderCapabilities::DEFAULT
+                });
+            p.reasoning_effort = Some(effort);
+            assert_eq!(p.reasoning_effort_str(), Some("max"));
+        }
+    }
+
     // ── Wire-format tests: verify serialized request body (issue #810) ──
 
     /// Kimi router with strict_tools=false must NOT emit `"strict": true` in

--- a/crates/providers/tests/kimi_code_integration.rs
+++ b/crates/providers/tests/kimi_code_integration.rs
@@ -17,9 +17,15 @@ use {
 };
 
 const BASE_URL: &str = "https://api.kimi.com/coding/v1";
-const TEST_MODEL: &str = "kimi-k2.5";
+const TEST_MODEL: &str = "kimi-k3";
 
-const KNOWN_MODELS: &[&str] = &["kimi-for-coding", "kimi-k2.5", "kimi-k2.6"];
+const KNOWN_MODELS: &[&str] = &[
+    "kimi-k3",
+    "kimi-k2.7-code-highspeed",
+    "kimi-for-coding",
+    "kimi-k2.6",
+    "kimi-k2.5",
+];
 
 fn api_key() -> Secret<String> {
     Secret::new(

--- a/crates/providers/tests/moonshot_integration.rs
+++ b/crates/providers/tests/moonshot_integration.rs
@@ -18,11 +18,16 @@ use {
 };
 
 const MOONSHOT_BASE_URL: &str = "https://api.moonshot.ai/v1";
-const TEST_MODEL: &str = "kimi-k2.5";
+const TEST_MODEL: &str = "kimi-k3";
 
 /// Known Moonshot models we catalog. Keep in sync with `MOONSHOT_MODELS` in
 /// `crates/providers/src/lib.rs`.
-const KNOWN_MODELS: &[&str] = &["kimi-k2.5", "kimi-k2.6"];
+const KNOWN_MODELS: &[&str] = &[
+    "kimi-k3",
+    "kimi-k2.7-code-highspeed",
+    "kimi-k2.6",
+    "kimi-k2.5",
+];
 
 fn api_key() -> Secret<String> {
     let key = std::env::var("MOONSHOT_API_KEY")

--- a/crates/web/ui/e2e/specs/onboarding.spec.js
+++ b/crates/web/ui/e2e/specs/onboarding.spec.js
@@ -1192,6 +1192,97 @@ test.describe("Onboarding wizard", () => {
 		expect(pageErrors).toEqual([]);
 	});
 
+	test("moonshot configuration surfaces Kimi K3 in model selection", async ({ page }) => {
+		const pageErrors = watchPageErrors(page);
+		await page.route("**/api/auth/status", async (route) => {
+			await route.fulfill({
+				status: 200,
+				contentType: "application/json",
+				body: JSON.stringify({ authenticated: true, setup_required: false, localhost_only: true }),
+			});
+		});
+
+		await page.addInitScript(() => {
+			const rpcPayloads = {
+				connect: { type: "hello-ok" },
+				"providers.available": [
+					{
+						name: "moonshot",
+						displayName: "Moonshot",
+						authType: "api-key",
+						configured: false,
+						defaultBaseUrl: "https://api.moonshot.ai/v1",
+						baseUrl: "https://api.moonshot.ai/v1",
+						requiresModel: false,
+					},
+				],
+				"providers.validate_key": {
+					valid: true,
+					models: [
+						{ id: "kimi-k3", displayName: "Kimi K3", provider: "moonshot", supportsTools: true },
+						{
+							id: "kimi-k2.7-code-highspeed",
+							displayName: "Kimi K2.7 Code Highspeed",
+							provider: "moonshot",
+							supportsTools: true,
+						},
+					],
+				},
+				"models.test": { ok: true },
+			};
+
+			class FakeWebSocket {
+				static CONNECTING = 0;
+				static OPEN = 1;
+				static CLOSING = 2;
+				static CLOSED = 3;
+
+				readyState = FakeWebSocket.CONNECTING;
+				onopen = null;
+				onmessage = null;
+				onclose = null;
+
+				constructor() {
+					queueMicrotask(() => {
+						this.readyState = FakeWebSocket.OPEN;
+						this.onopen?.({});
+					});
+				}
+
+				send(raw) {
+					const request = JSON.parse(raw || "{}");
+					const payload = rpcPayloads[request.method] || {};
+					const response = { type: "res", id: request.id, ok: true, payload };
+					queueMicrotask(() => this.onmessage?.({ data: JSON.stringify(response) }));
+				}
+
+				close() {
+					this.readyState = FakeWebSocket.CLOSED;
+					this.onclose?.({});
+				}
+			}
+
+			window.WebSocket = FakeWebSocket;
+		});
+
+		await page.goto("/onboarding");
+		await moveToLlmStep(page);
+		await page.getByRole("button", { name: /All providers/ }).click();
+
+		const moonshotRow = page
+			.locator(".onboarding-card .rounded-md.border")
+			.filter({ has: page.getByText("Moonshot", { exact: true }) })
+			.first();
+		await moonshotRow.getByRole("button", { name: "Configure", exact: true }).click();
+		await moonshotRow.locator('input[type="password"]').fill("sk-test-moonshot");
+		await moonshotRow.getByRole("button", { name: "Save", exact: true }).click();
+
+		await expect(moonshotRow.getByText("Select preferred models", { exact: true })).toBeVisible();
+		await expect(moonshotRow.getByText("Kimi K3", { exact: true })).toBeVisible();
+		await expect(moonshotRow.getByText("kimi-k3", { exact: true })).toBeVisible();
+		expect(pageErrors).toEqual([]);
+	});
+
 	test("configured non-default LLM providers appear in recommended onboarding list", async ({ page }) => {
 		const pageErrors = watchPageErrors(page);
 

--- a/crates/web/ui/src/provider-key-help.ts
+++ b/crates/web/ui/src/provider-key-help.ts
@@ -61,7 +61,7 @@ const KEY_SOURCE_BY_PROVIDER: Record<string, KeySource> = {
 	},
 	moonshot: {
 		url: "https://platform.kimi.ai/console/api-keys",
-		label: "Moonshot Platform",
+		label: "Kimi Platform",
 	},
 	"kimi-code": {
 		url: "https://www.kimi.com/code/console",

--- a/crates/web/ui/src/provider-key-help.ts
+++ b/crates/web/ui/src/provider-key-help.ts
@@ -60,7 +60,7 @@ const KEY_SOURCE_BY_PROVIDER: Record<string, KeySource> = {
 		label: "MiniMax Platform",
 	},
 	moonshot: {
-		url: "https://platform.moonshot.ai/console/api-keys",
+		url: "https://platform.kimi.ai/console/api-keys",
 		label: "Moonshot Platform",
 	},
 	"kimi-code": {

--- a/docs/src/choosing-a-provider.md
+++ b/docs/src/choosing-a-provider.md
@@ -10,7 +10,7 @@ supported by Moltis so you can pick the best fit for your use case.
 | **Best overall quality** | Anthropic | Claude Sonnet 4 and Opus 4 excel at tool use, long context, and instruction following |
 | **Widest model range** | OpenAI | GPT-5.6 Sol, Terra, Luna, GPT-4.1, o3/o4-mini reasoning models, image generation |
 | **Best membership option** | OpenAI | GPT-5.6 Sol is a top-quality model and can be available through memberships |
-| **Largest context window** | OpenAI | Up to 1.05M tokens with GPT-5.6 |
+| **Largest context window** | OpenAI, Moonshot | Up to 1.05M tokens with GPT-5.6 and 1M with Kimi K3 |
 | **Best value** | DeepSeek | DeepSeek V3 and R1 offer strong performance at low cost |
 | **Fast inference** | Groq | Hardware-accelerated inference, very low latency |
 | **Free / offline** | Ollama | Run open models locally, no API key needed |
@@ -32,7 +32,7 @@ supported by Moltis so you can pick the best fit for your use case.
 | **MiniMax** | MiniMax M3, M2.7 | Full | Yes | 204.8K-1M | $ | Fast | Strong multilingual, long context |
 | **Z.AI (Zhipu)** | GLM-4, GLM-4 Air | Full | Yes | 128K | $ | Fast | GLM-4 series, competitive quality |
 | **Z.AI Coding** | CodeGeeX, GLM-4 Code | Full | Yes | 128K | $ | Fast | Optimized for code tasks |
-| **Moonshot** | Kimi | Full | Yes | 200K | $ | Medium | Long context, Chinese/English |
+| **Moonshot** | Kimi K3, K2.7 Code, K2.6 | Full | Yes | 256K-1M | $ | Medium | Long context, Chinese/English |
 | **Venice** | Various | Varies | Yes | Varies | $ | Medium | Privacy-focused, uncensored models |
 | **NEAR AI Cloud** | GLM, Qwen, GPT OSS, Claude | Full | Yes | Varies | Varies | Medium | TEE-backed private inference with attestation-aware catalog |
 | **Ollama** | Any GGUF model | Varies | Yes | Varies | Free | Varies | Local inference, no API key |


### PR DESCRIPTION
## Summary
- Add Kimi K3 and Kimi K2.7 Code Highspeed to Moonshot and Kimi Code model catalogs.
- Update Kimi model capabilities, Moonshot reasoning-effort handling, provider setup defaults, config template, docs, and key-help link.
- Add onboarding e2e coverage that verifies Moonshot setup surfaces Kimi K3 in model selection.

## Validation
### Completed
- [x] cargo fmt --all -- --check
- [x] cargo test -p moltis-providers model_capabilities --lib
- [x] cargo test -p moltis-providers openai::provider::request::tests::kimi_reasoning_effort_always_maps_to_max --lib
- [x] cargo test -p moltis-provider-setup available_includes_default_base_urls
- [x] npm run build
- [x] npx tsc --noEmit
- [x] MOLTIS_E2E_ONLY_PROJECT=onboarding npx playwright test e2e/specs/onboarding.spec.js -g "moonshot configuration surfaces Kimi K3 in model selection"
- [x] git diff --check

### Remaining
- [ ] npx biome check --write e2e/specs/onboarding.spec.js reports pre-existing complexity warnings elsewhere in the spec file; no fixes were applied.

## Manual QA
- Verified from Moonshot/Kimi docs that Kimi K3 is available as kimi-k3 on https://api.moonshot.ai/v1 with 1M context.
- Confirmed the onboarding flow can configure Moonshot and display Kimi K3 in preferred model selection via targeted Playwright coverage.