### PR TITLE
fix(web): support ACP-only chat setup

### DIFF
--- a/crates/web/ui/e2e/specs/onboarding.spec.js
+++ b/crates/web/ui/e2e/specs/onboarding.spec.js
@@ -589,6 +589,29 @@ test.describe("Onboarding wizard", () => {
 		expect(pageErrors).toEqual([]);
 	});
 
+	test("LLM step shows detected ACP agents before provider choices", async ({ page }) => {
+		const pageErrors = watchPageErrors(page);
+		await mockOnboardingExternalAgents(page, [
+			{ kind: "acp-copilot", name: "ACP: Copilot", installed: true, isAcp: true, version: null },
+			{ kind: "acp-gemini", name: "ACP: Gemini", installed: false, isAcp: true, version: null },
+			{ kind: "codex", name: "Codex", installed: true, isAcp: false, version: null },
+		]);
+
+		await page.goto("/onboarding");
+		await page.waitForLoadState("networkidle");
+		await waitForOnboardingWsOpen(page);
+		expect(await moveToLlmStep(page)).toBeTruthy();
+
+		const acpPanel = page.locator(".rounded-md.border").filter({ hasText: "Detected ACP agents" });
+		await expect(acpPanel).toBeVisible();
+		await expect(acpPanel.getByText("ACP: Copilot", { exact: true })).toBeVisible();
+		await expect(acpPanel.getByText("ACP: Gemini", { exact: true })).toHaveCount(0);
+		await expect(acpPanel.getByText("Codex", { exact: true })).toHaveCount(0);
+		await expect(acpPanel.getByText(/you can skip LLM setup/)).toBeVisible();
+		await expect(page.getByRole("button", { name: "Skip for now", exact: true })).toBeVisible();
+		expect(pageErrors).toEqual([]);
+	});
+
 	test("mobile onboarding layout avoids horizontal overflow", async ({ page }) => {
 		const pageErrors = watchPageErrors(page);
 		await page.setViewportSize({ width: 375, height: 812 });

--- a/crates/web/ui/input.css
+++ b/crates/web/ui/input.css
@@ -1098,6 +1098,15 @@
     color: var(--text);
     outline: none;
   }
+  .model-combo-btn:disabled {
+    cursor: default;
+    opacity: 0.65;
+  }
+  .model-combo-btn:disabled:hover,
+  .model-combo-btn:disabled:focus {
+    border-color: var(--border);
+    color: var(--muted);
+  }
   #reasoningCombo .model-combo-btn {
     max-width: none;
     width: auto;

--- a/crates/web/ui/src/components/SessionHeader.tsx
+++ b/crates/web/ui/src/components/SessionHeader.tsx
@@ -42,6 +42,7 @@ interface ExternalAgentInfo {
 	kind: string;
 	name: string;
 	installed: boolean;
+	isAcp?: boolean;
 	version?: string | null;
 }
 
@@ -94,6 +95,12 @@ function buildShareUrl(payload: SharePayload): string {
 
 function isSshTargetNode(node: NodeInfo | null): boolean {
 	return node?.platform === "ssh" || String(node?.nodeId || "").startsWith("ssh:");
+}
+
+function refreshModelComboAvailability(): void {
+	void import("../models").then(({ updateModelComboAvailability }) => {
+		updateModelComboAvailability();
+	});
 }
 
 function nodeOptionLabel(node: NodeInfo | null): string {
@@ -157,6 +164,8 @@ export function SessionHeader({
 	const [switchingNode, setSwitchingNode] = useState(false);
 	const [externalAgentOptions, setExternalAgentOptions] = useState<ExternalAgentInfo[]>([]);
 	const [switchingExternalAgent, setSwitchingExternalAgent] = useState(false);
+	const [hasLlmModels, setHasLlmModels] = useState<boolean | null>(null);
+	const acpAutoBindAttemptedRef = useRef<Set<string>>(new Set());
 	const inputRef = useRef<HTMLInputElement>(null);
 
 	const fullName = session ? session.label || session.key : currentKey;
@@ -190,6 +199,18 @@ export function SessionHeader({
 			setDefaultAgentId(parsed.defaultId);
 			setAgentOptions(parsed.agents as AgentOption[]);
 			setAgentOptionsLoaded(true);
+		});
+		return () => {
+			cancelled = true;
+		};
+	}, [currentKey]);
+
+	useEffect(() => {
+		let cancelled = false;
+		setHasLlmModels(null);
+		sendRpc<{ id?: string }[]>("models.list", {}).then((res) => {
+			if (cancelled) return;
+			setHasLlmModels(Boolean(res?.ok && (res.payload || []).length > 0));
 		});
 		return () => {
 			cancelled = true;
@@ -492,6 +513,7 @@ export function SessionHeader({
 						session.external_agent_kind = nextKind || null;
 						session.dataVersion.value++;
 					}
+					refreshModelComboAvailability();
 					fetchSessions();
 				})
 				.finally(() => {
@@ -500,6 +522,33 @@ export function SessionHeader({
 		},
 		[currentExternalAgentKind, currentKey, session, switchingExternalAgent],
 	);
+
+	useEffect(() => {
+		if (isCron || hasLlmModels !== false || currentExternalAgentKind || acpAutoBindAttemptedRef.current.has(currentKey)) {
+			return;
+		}
+		const firstAcpAgent = externalAgentOptions.find((agent) => agent.installed && agent.isAcp);
+		if (!firstAcpAgent) return;
+
+		let cancelled = false;
+		acpAutoBindAttemptedRef.current.add(currentKey);
+		sendRpc("external_agents.bind", { sessionKey: currentKey, kind: firstAcpAgent.kind }).then((bindRes) => {
+			if (cancelled) return;
+			if (!bindRes?.ok) {
+				showToast((bindRes?.error as { message?: string })?.message || "Failed to select ACP agent", "error");
+				return;
+			}
+			if (session) {
+				session.external_agent_kind = firstAcpAgent.kind;
+				session.dataVersion.value++;
+			}
+			refreshModelComboAvailability();
+			fetchSessions();
+		});
+		return () => {
+			cancelled = true;
+		};
+	}, [currentExternalAgentKind, currentKey, externalAgentOptions, hasLlmModels, isCron, session]);
 
 	const agentSelectValue = currentAgentId;
 	const hasCurrentAgentOption = agentOptions.some((agent) => agent.id === agentSelectValue);
@@ -525,15 +574,17 @@ export function SessionHeader({
 
 	const shouldShowNodePicker = !isCron && (nodeOptions.length > 0 || Boolean(currentNodeId));
 	const selectableExternalAgents = externalAgentOptions.filter(
-		(agent) => agent.installed || agent.kind === currentExternalAgentKind,
+		(agent) =>
+			(agent.isAcp || agent.kind === currentExternalAgentKind) &&
+			(agent.installed || agent.kind === currentExternalAgentKind),
 	);
-	const externalAgentSelectOptions: SelectOption[] = [
-		{ value: "", label: "Moltis agent" },
-		...selectableExternalAgents.map((agent) => ({
-			value: agent.kind,
-			label: `${agent.name}${agent.installed ? "" : " (unavailable)"}`,
-		})),
-	];
+	const externalAgentSelectOptions: SelectOption[] = selectableExternalAgents.map((agent) => ({
+		value: agent.kind,
+		label: `${agent.name}${agent.installed ? "" : " (unavailable)"}`,
+	}));
+	if (hasLlmModels !== false) {
+		externalAgentSelectOptions.unshift({ value: "", label: "Built-in LLM agent" });
+	}
 	const shouldShowExternalAgentPicker = !isCron && selectableExternalAgents.length > 0;
 	const externalAgentStatus = currentExternalAgentKind
 		? currentExternalAgent?.installed === false

--- a/crates/web/ui/src/components/SessionHeader.tsx
+++ b/crates/web/ui/src/components/SessionHeader.tsx
@@ -542,11 +542,11 @@ export function SessionHeader({
 		sendRpc("external_agents.bind", { sessionKey: currentKey, kind: firstAcpAgent.kind })
 			.then((bindRes) => {
 				if (cancelled) return;
-				acpAutoBindAttemptedRef.current.add(currentKey);
 				if (!bindRes?.ok) {
 					showToast((bindRes?.error as { message?: string })?.message || "Failed to select ACP agent", "error");
 					return;
 				}
+				acpAutoBindAttemptedRef.current.add(currentKey);
 				if (session) {
 					session.external_agent_kind = firstAcpAgent.kind;
 					session.dataVersion.value++;

--- a/crates/web/ui/src/components/SessionHeader.tsx
+++ b/crates/web/ui/src/components/SessionHeader.tsx
@@ -166,6 +166,7 @@ export function SessionHeader({
 	const [switchingExternalAgent, setSwitchingExternalAgent] = useState(false);
 	const [hasLlmModels, setHasLlmModels] = useState<boolean | null>(null);
 	const acpAutoBindAttemptedRef = useRef<Set<string>>(new Set());
+	const acpAutoBindInFlightRef = useRef<Set<string>>(new Set());
 	const inputRef = useRef<HTMLInputElement>(null);
 
 	const fullName = session ? session.label || session.key : currentKey;
@@ -524,27 +525,38 @@ export function SessionHeader({
 	);
 
 	useEffect(() => {
-		if (isCron || hasLlmModels !== false || currentExternalAgentKind || acpAutoBindAttemptedRef.current.has(currentKey)) {
+		if (
+			isCron ||
+			hasLlmModels !== false ||
+			currentExternalAgentKind ||
+			acpAutoBindAttemptedRef.current.has(currentKey) ||
+			acpAutoBindInFlightRef.current.has(currentKey)
+		) {
 			return;
 		}
 		const firstAcpAgent = externalAgentOptions.find((agent) => agent.installed && agent.isAcp);
 		if (!firstAcpAgent) return;
 
 		let cancelled = false;
-		acpAutoBindAttemptedRef.current.add(currentKey);
-		sendRpc("external_agents.bind", { sessionKey: currentKey, kind: firstAcpAgent.kind }).then((bindRes) => {
-			if (cancelled) return;
-			if (!bindRes?.ok) {
-				showToast((bindRes?.error as { message?: string })?.message || "Failed to select ACP agent", "error");
-				return;
-			}
-			if (session) {
-				session.external_agent_kind = firstAcpAgent.kind;
-				session.dataVersion.value++;
-			}
-			refreshModelComboAvailability();
-			fetchSessions();
-		});
+		acpAutoBindInFlightRef.current.add(currentKey);
+		sendRpc("external_agents.bind", { sessionKey: currentKey, kind: firstAcpAgent.kind })
+			.then((bindRes) => {
+				if (cancelled) return;
+				acpAutoBindAttemptedRef.current.add(currentKey);
+				if (!bindRes?.ok) {
+					showToast((bindRes?.error as { message?: string })?.message || "Failed to select ACP agent", "error");
+					return;
+				}
+				if (session) {
+					session.external_agent_kind = firstAcpAgent.kind;
+					session.dataVersion.value++;
+				}
+				refreshModelComboAvailability();
+				fetchSessions();
+			})
+			.finally(() => {
+				acpAutoBindInFlightRef.current.delete(currentKey);
+			});
 		return () => {
 			cancelled = true;
 		};
@@ -584,6 +596,8 @@ export function SessionHeader({
 	}));
 	if (hasLlmModels !== false) {
 		externalAgentSelectOptions.unshift({ value: "", label: "Built-in LLM agent" });
+	} else if (!currentExternalAgentKind) {
+		externalAgentSelectOptions.unshift({ value: "", label: "Select ACP agent" });
 	}
 	const shouldShowExternalAgentPicker = !isCron && selectableExternalAgents.length > 0;
 	const externalAgentStatus = currentExternalAgentKind

--- a/crates/web/ui/src/models.ts
+++ b/crates/web/ui/src/models.ts
@@ -15,15 +15,16 @@ interface ExternalAgentInfo {
 	isAcp?: boolean;
 }
 
-let installedAcpAgents: ExternalAgentInfo[] = [];
+let installedExternalAgents: ExternalAgentInfo[] = [];
+
+function installedAcpAgents(): ExternalAgentInfo[] {
+	return installedExternalAgents.filter((agent) => agent.isAcp);
+}
 
 function activeExternalAgent(): ExternalAgentInfo | null {
 	const kind = sessionStore.activeSession.value?.external_agent_kind || "";
 	if (!kind) return null;
-	return (
-		installedAcpAgents.find((agent) => agent.kind === kind) ||
-		{ kind, name: "ACP agent", installed: true, isAcp: true }
-	);
+	return installedExternalAgents.find((agent) => agent.kind === kind) || null;
 }
 
 export function updateModelComboAvailability(): void {
@@ -47,15 +48,15 @@ export function updateModelComboAvailability(): void {
 function refreshAcpAgents(): Promise<void> {
 	return sendRpc<ExternalAgentInfo[]>("external_agents.list", {})
 		.then((res) => {
-			installedAcpAgents = res?.ok ? (res.payload || []).filter((agent) => agent.installed && agent.isAcp) : [];
+			installedExternalAgents = res?.ok ? (res.payload || []).filter((agent) => agent.installed) : [];
 		})
 		.catch(() => {
-			installedAcpAgents = [];
+			installedExternalAgents = [];
 		});
 }
 
 function updateAcpOnlyModelComboLabel(): void {
-	if (!(S.modelComboLabel && modelStore.models.value.length === 0 && installedAcpAgents.length > 0)) return;
+	if (!(S.modelComboLabel && modelStore.models.value.length === 0 && installedAcpAgents().length > 0)) return;
 	S.modelComboLabel.textContent = "ACP agent";
 	S.modelComboLabel.title = "Using an ACP agent selected in the session header";
 }
@@ -196,10 +197,11 @@ export function renderModelList(query: string): void {
 	if (filtered.length === 0) {
 		const empty = document.createElement("div");
 		empty.className = "model-dropdown-empty";
-		if (allModels.length === 0 && installedAcpAgents.length > 0) {
+		const acpAgents = installedAcpAgents();
+		if (allModels.length === 0 && acpAgents.length > 0) {
 			empty.textContent = "No LLM models configured. ACP agents are selected from the session header.";
 			S.modelDropdownList.appendChild(empty);
-			installedAcpAgents.forEach((agent) => {
+			acpAgents.forEach((agent) => {
 				const item = document.createElement("div");
 				item.className = "model-dropdown-item model-dropdown-item-unsupported";
 				const label = document.createElement("span");

--- a/crates/web/ui/src/models.ts
+++ b/crates/web/ui/src/models.ts
@@ -5,7 +5,60 @@ import { t } from "./i18n";
 import { showModelNotice } from "./pages/ChatPage";
 import * as S from "./state";
 import { modelStore, REASONING_SEP } from "./stores/model-store";
+import { sessionStore } from "./stores/session-store";
 import type { ModelInfo } from "./types";
+
+interface ExternalAgentInfo {
+	kind: string;
+	name: string;
+	installed: boolean;
+	isAcp?: boolean;
+}
+
+let installedAcpAgents: ExternalAgentInfo[] = [];
+
+function activeExternalAgent(): ExternalAgentInfo | null {
+	const kind = sessionStore.activeSession.value?.external_agent_kind || "";
+	if (!kind) return null;
+	return (
+		installedAcpAgents.find((agent) => agent.kind === kind) ||
+		{ kind, name: "ACP agent", installed: true, isAcp: true }
+	);
+}
+
+export function updateModelComboAvailability(): void {
+	if (!(S.modelComboBtn && S.modelComboLabel)) return;
+	const acpAgent = activeExternalAgent();
+	const disabled = Boolean(acpAgent?.isAcp);
+	(S.modelComboBtn as HTMLButtonElement).disabled = disabled;
+	S.modelComboBtn.setAttribute("aria-disabled", disabled ? "true" : "false");
+	S.modelComboBtn.title = disabled ? `${acpAgent?.name || "ACP agent"} controls model selection` : "";
+	if (disabled) {
+		closeModelDropdown();
+		S.modelComboLabel.textContent = acpAgent?.name || "ACP agent";
+		S.modelComboLabel.title = "Model selection is controlled by the selected ACP agent";
+		return;
+	}
+	const model = modelStore.selectedModel.value;
+	if (model) updateModelComboLabel(model);
+	else updateAcpOnlyModelComboLabel();
+}
+
+function refreshAcpAgents(): Promise<void> {
+	return sendRpc<ExternalAgentInfo[]>("external_agents.list", {})
+		.then((res) => {
+			installedAcpAgents = res?.ok ? (res.payload || []).filter((agent) => agent.installed && agent.isAcp) : [];
+		})
+		.catch(() => {
+			installedAcpAgents = [];
+		});
+}
+
+function updateAcpOnlyModelComboLabel(): void {
+	if (!(S.modelComboLabel && modelStore.models.value.length === 0 && installedAcpAgents.length > 0)) return;
+	S.modelComboLabel.textContent = "ACP agent";
+	S.modelComboLabel.title = "Using an ACP agent selected in the session header";
+}
 
 function setSessionModel(sessionKey: string, modelId: string): void {
 	sendRpc("sessions.patch", { key: sessionKey, model: modelId });
@@ -35,12 +88,14 @@ function updateModelComboLabel(model: ModelInfo): void {
 }
 
 export function fetchModels(): Promise<void> {
-	return modelStore.fetch().then(() => {
+	return Promise.all([modelStore.fetch(), refreshAcpAgents()]).then(() => {
 		// Dual-write to state.js for backward compat
 		S.setModels(modelStore.models.value);
 		S.setSelectedModelId(modelStore.selectedModelId.value);
 		const model = modelStore.selectedModel.value;
 		if (model) updateModelComboLabel(model);
+		else updateAcpOnlyModelComboLabel();
+		updateModelComboAvailability();
 
 		// If the dropdown is currently open, re-render to reflect updated flags
 		// (for example when a model becomes unsupported via a WS event).
@@ -64,6 +119,7 @@ export function selectModel(m: ModelInfo): void {
 }
 
 export function openModelDropdown(): void {
+	if ((S.modelComboBtn as HTMLButtonElement | null)?.disabled) return;
 	if (!S.modelDropdown) return;
 	S.modelDropdown.classList.remove("hidden");
 	(S.modelSearchInput as HTMLInputElement).value = "";
@@ -140,6 +196,24 @@ export function renderModelList(query: string): void {
 	if (filtered.length === 0) {
 		const empty = document.createElement("div");
 		empty.className = "model-dropdown-empty";
+		if (allModels.length === 0 && installedAcpAgents.length > 0) {
+			empty.textContent = "No LLM models configured. ACP agents are selected from the session header.";
+			S.modelDropdownList.appendChild(empty);
+			installedAcpAgents.forEach((agent) => {
+				const item = document.createElement("div");
+				item.className = "model-dropdown-item model-dropdown-item-unsupported";
+				const label = document.createElement("span");
+				label.className = "model-item-label";
+				label.textContent = agent.name;
+				item.appendChild(label);
+				const meta = document.createElement("span");
+				meta.className = "model-item-meta";
+				meta.textContent = "ACP agent";
+				item.appendChild(meta);
+				S.modelDropdownList?.appendChild(item);
+			});
+			return;
+		}
 		empty.textContent = t("common:labels.noMatchingModels");
 		S.modelDropdownList.appendChild(empty);
 		return;
@@ -178,6 +252,7 @@ export function bindModelComboEvents(): void {
 	if (!(S.modelComboBtn && S.modelSearchInput && S.modelDropdownList && S.modelCombo)) return;
 
 	S.modelComboBtn.addEventListener("click", () => {
+		if ((S.modelComboBtn as HTMLButtonElement | null)?.disabled) return;
 		if (S.modelDropdown?.classList.contains("hidden")) {
 			openModelDropdown();
 		} else {

--- a/crates/web/ui/src/onboarding-view.tsx
+++ b/crates/web/ui/src/onboarding-view.tsx
@@ -22,7 +22,7 @@ import { ProviderStep } from "./onboarding/steps/ProviderStep";
 import { RemoteAccessStep } from "./onboarding/steps/RemoteAccessStep";
 import { SkillsStep } from "./onboarding/steps/SkillsStep";
 import { VoiceStep } from "./onboarding/steps/VoiceStep";
-import type { IdentityInfo } from "./onboarding/types";
+import type { ExternalAgentInfo, IdentityInfo } from "./onboarding/types";
 import { fetchVoiceProviders } from "./voice-utils";
 
 // ── Step indicator ──────────────────────────────────────────
@@ -144,13 +144,6 @@ interface SummarySkills {
 	totalSkills: number;
 }
 
-interface SummaryExternalAgent {
-	kind: string;
-	name: string;
-	installed: boolean;
-	isAcp: boolean;
-}
-
 interface SummaryData {
 	identity: IdentityInfo | null;
 	mem: { total?: number; available?: number } | null;
@@ -162,7 +155,7 @@ interface SummaryData {
 	voice: SummaryVoice | null;
 	sandbox: { backend?: string } | null;
 	skills: SummarySkills | null;
-	externalAgents: SummaryExternalAgent[];
+	externalAgents: ExternalAgentInfo[];
 }
 
 // ── SummaryStep ─────────────────────────────────────────────
@@ -240,7 +233,7 @@ function SummaryStep({ onBack, onFinish }: { onBack: () => void; onFinish: () =>
 					(
 						sendRpc("external_agents.list", {}) as Promise<{
 							ok?: boolean;
-							payload?: SummaryExternalAgent[];
+							payload?: ExternalAgentInfo[];
 						}>
 					).catch(() => null),
 				]);
@@ -293,6 +286,8 @@ function SummaryStep({ onBack, onFinish }: { onBack: () => void; onFinish: () =>
 	const activeModel = localStorage.getItem("moltis-model");
 	const configuredProviders = data.providers.filter((p) => p.configured);
 	const installedAcpAgents = data.externalAgents.filter((agent) => agent.installed && agent.isAcp);
+	const hasConfiguredLlm = configuredProviders.length > 0;
+	const hasAcpOnlyAgent = !hasConfiguredLlm && installedAcpAgents.length > 0;
 
 	return (
 		<div className="flex flex-col gap-4">
@@ -320,8 +315,11 @@ function SummaryStep({ onBack, onFinish }: { onBack: () => void; onFinish: () =>
 				</SummaryRow>
 
 				{/* LLMs */}
-				<SummaryRow icon={configuredProviders.length > 0 ? <CheckIcon /> : <ErrorIcon />} label="LLMs">
-					{configuredProviders.length > 0 ? (
+				<SummaryRow
+					icon={hasConfiguredLlm ? <CheckIcon /> : hasAcpOnlyAgent ? <InfoIcon /> : <ErrorIcon />}
+					label="LLMs"
+				>
+					{hasConfiguredLlm ? (
 						<div className="flex flex-col gap-1">
 							<div className="flex flex-wrap gap-1">
 								{configuredProviders.map((p) => (
@@ -336,6 +334,8 @@ function SummaryStep({ onBack, onFinish }: { onBack: () => void; onFinish: () =>
 								</div>
 							) : null}
 						</div>
+					) : hasAcpOnlyAgent ? (
+						<span>No LLM providers configured; ACP agents are available for chat.</span>
 					) : (
 						<span className="text-[var(--error)]">No LLM providers configured</span>
 					)}

--- a/crates/web/ui/src/onboarding/steps/IdentityStep.tsx
+++ b/crates/web/ui/src/onboarding/steps/IdentityStep.tsx
@@ -101,7 +101,7 @@ export function IdentityStep({ onNext, onBack }: { onNext: () => void; onBack?: 
 							className="provider-key-input w-full"
 							value={theme}
 							onInput={(e) => setTheme(targetValue(e))}
-							placeholder="wise owl, chill fox, witty robot{'\u2026'}"
+							placeholder="wise owl, chill fox, witty robot..."
 						/>
 					</div>
 				</div>

--- a/crates/web/ui/src/onboarding/steps/ProviderStep.tsx
+++ b/crates/web/ui/src/onboarding/steps/ProviderStep.tsx
@@ -17,6 +17,7 @@ import {
 import { targetValue } from "../../typed-events";
 import { ErrorPanel } from "../shared";
 import type {
+	ExternalAgentInfo,
 	KeyHelp,
 	LocalModel,
 	ModelSelectorRow,
@@ -607,6 +608,7 @@ export function OnboardingProviderRow(props: OnboardingProviderRowProps): VNode 
 
 export function ProviderStep({ onNext, onBack }: { onNext: () => void; onBack?: (() => void) | null }): VNode {
 	const [providers, setProviders] = useState<ProviderInfo[]>([]);
+	const [acpAgents, setAcpAgents] = useState<ExternalAgentInfo[]>([]);
 	const [loading, setLoading] = useState(true);
 	const [error, setError] = useState<string | null>(null);
 	const [showAllProviders, setShowAllProviders] = useState(false);
@@ -640,6 +642,17 @@ export function ProviderStep({ onNext, onBack }: { onNext: () => void; onBack?: 
 		});
 	}
 
+	function refreshAcpAgents(cancelled?: () => boolean): Promise<unknown> {
+		return sendRpc<ExternalAgentInfo[]>("external_agents.list", {})
+			.then((res) => {
+				if (!cancelled?.() && res?.ok) {
+					setAcpAgents((res.payload || []).filter((agent) => agent.installed && agent.isAcp));
+				}
+				return res;
+			})
+			.catch(() => null);
+	}
+
 	useEffect(() => {
 		let cancelled = false;
 		let attempts = 0;
@@ -650,6 +663,7 @@ export function ProviderStep({ onNext, onBack }: { onNext: () => void; onBack?: 
 				if (res?.ok) {
 					setProviders(sortProviders(res.payload || []));
 					setLoading(false);
+					refreshAcpAgents(() => cancelled);
 					return;
 				}
 				if (
@@ -1130,6 +1144,21 @@ export function ProviderStep({ onNext, onBack }: { onNext: () => void; onBack?: 
 			<p className="text-xs text-[var(--muted)] leading-relaxed">
 				Configure one or more LLM providers to power your agent. You can add more later in Settings.
 			</p>
+			{acpAgents.length > 0 ? (
+				<div className="rounded-md border border-[var(--border)] bg-[var(--surface2)] p-3 flex flex-col gap-2">
+					<div className="text-xs text-[var(--muted)]">Detected ACP agents</div>
+					<div className="flex flex-wrap gap-2">
+						{acpAgents.map((agent) => (
+							<span key={agent.kind} className="provider-item-badge configured">
+								{agent.name}
+							</span>
+						))}
+					</div>
+					<div className="text-xs text-[var(--muted)]">
+						These are available in chat, so you can skip LLM setup if you want to use an ACP agent.
+					</div>
+				</div>
+			) : null}
 			{configuredProviders.length > 0 ? (
 				<div className="rounded-md border border-[var(--border)] bg-[var(--surface2)] p-3 flex flex-col gap-2">
 					<div className="text-xs text-[var(--muted)]">Detected LLM providers</div>

--- a/crates/web/ui/src/onboarding/types.ts
+++ b/crates/web/ui/src/onboarding/types.ts
@@ -14,6 +14,14 @@ export interface ProviderInfo {
 	[key: string]: unknown;
 }
 
+export interface ExternalAgentInfo {
+	kind: string;
+	name: string;
+	installed: boolean;
+	isAcp: boolean;
+	version?: string | null;
+}
+
 export interface ModelSelectorRow {
 	id: string;
 	displayName: string;

--- a/crates/web/ui/src/sessions/session-switch.ts
+++ b/crates/web/ui/src/sessions/session-switch.ts
@@ -2,7 +2,7 @@
 
 import { chatAddMsg, removeThinking, setComposerStopButton, updateCommandInputUI, updateTokenBar } from "../chat-ui";
 import { sendRpc } from "../helpers";
-import { modelDisplayLabel, modelTitle } from "../models";
+import { modelDisplayLabel, modelTitle, updateModelComboAvailability } from "../models";
 import { restoreNodeSelection } from "../nodes-selector";
 import { updateSessionProjectSelect } from "../project-combo";
 import { restoreReasoningFromModelId } from "../reasoning-toggle";
@@ -127,6 +127,7 @@ export function restoreSessionState(entry: SessionMeta, projectId?: string): voi
 	updateCommandInputUI();
 	restoreMcpToggle(!entry.mcpDisabled);
 	restoreNodeSelection(entry.node_id || null);
+	updateModelComboAvailability();
 	updateChatSessionHeader();
 }
 


### PR DESCRIPTION
## Summary
- Show installed ACP agents during LLM onboarding and treat ACP-only setup as valid instead of an error.
- Filter the session header picker to ACP-capable external agents and auto-select an installed ACP agent when no LLM models are configured.
- Disable the bottom model selector while an ACP agent is selected, since ACP model choice is controlled by the external agent.

## Validation
### Completed
- [x] npm run build:css
- [x] npm run build
- [x] npx tsc --noEmit
- [x] git diff --check
- [x] ./scripts/local-validate.sh 1157 ran; local fmt, tsc, i18n, install docs/names, file-size, and zizmor reported pass before local validation stopped on Biome.

### Remaining
- [ ] biome check --write crates/web/ui/src/ blocked locally by Biome CLI/config mismatch: biome.json schema 2.5.3, installed CLI 2.4.6.
- [ ] ./scripts/local-validate.sh 1157 is incomplete for the same Biome CLI/config mismatch.
- [ ] Targeted Playwright onboarding test was not rerun after these edits; earlier run timed out waiting for the Rust web server startup.

## Manual QA
- Confirm an ACP-only environment shows installed ACP agents on the LLM onboarding step and allows skipping LLM provider setup.
- Confirm selecting an ACP agent in the session header disables the bottom model selector and shows the ACP agent name.
- Confirm unbinding ACP re-enables the bottom model selector when LLM models are available.