### PR TITLE
feat(slack): support configurable API base URL

### DIFF
--- a/crates/config/src/template.rs
+++ b/crates/config/src/template.rs
@@ -804,6 +804,13 @@ port = {port}                           # Port number (auto-generated for this i
 # [channels]
 # offered = ["telegram", "whatsapp", "msteams", "discord", "slack", "matrix", "nostr", "signal"]
 
+# Example Slack account. api_base_url defaults to Slack; set it only for
+# Slack-compatible proxies, mock servers, or gateways.
+# [channels.slack.my-bot]
+# bot_token = "xoxb-..."
+# app_token = "xapp-..."
+# api_base_url = "https://slack.com/api"
+
 # See docs or defaults.toml for full channel configuration examples
 # (WhatsApp, Telegram, Teams, Discord, Slack, Matrix, Nostr, Signal).
 

--- a/crates/gateway/src/channel_agent_tools.rs
+++ b/crates/gateway/src/channel_agent_tools.rs
@@ -101,6 +101,7 @@ struct ChannelSettingsPatch {
     reply_to_message: Option<bool>,
     thread_replies: Option<bool>,
     stream_mode: Option<ChannelSettingsStreamMode>,
+    api_base_url: Option<String>,
     allowlist_add: Vec<String>,
     allowlist_remove: Vec<String>,
     group_allowlist_add: Vec<String>,
@@ -255,6 +256,10 @@ impl AgentTool for UpdateChannelSettingsTool {
                             "type": "string",
                             "enum": ["edit_in_place", "native", "off"],
                             "description": "Supported by Telegram (`edit_in_place`, `off`) and Slack (`edit_in_place`, `native`, `off`)."
+                        },
+                        "api_base_url": {
+                            "type": "string",
+                            "description": "Slack Web API base URL. Defaults to https://slack.com/api; set only for Slack-compatible proxies, mock servers, or gateways. Supported by Slack."
                         },
                         "channel_override": {
                             "type": "object",
@@ -458,6 +463,15 @@ fn apply_channel_settings_patch(
         validate_stream_mode(channel_type, stream_mode)?;
         config.insert("stream_mode".into(), json!(stream_mode));
         changes.push("stream_mode".to_string());
+    }
+    if let Some(api_base_url) = &patch.api_base_url {
+        ensure_supported(
+            channel_type,
+            "api_base_url",
+            matches!(channel_type, ChannelType::Slack),
+        )?;
+        config.insert("api_base_url".into(), json!(api_base_url.trim()));
+        changes.push("api_base_url".to_string());
     }
     if update_string_array(
         config,
@@ -1060,6 +1074,47 @@ mod tests {
         assert_eq!(
             updated["config"]["channel_overrides"]["chan-1"]["model_provider"],
             "anthropic"
+        );
+    }
+
+    #[tokio::test]
+    async fn update_channel_settings_updates_slack_api_base_url() {
+        let service = Arc::new(RecordingChannelService::new());
+        let store = Arc::new(MemoryChannelStore::new(vec![stored_channel(
+            "slack-main",
+            "slack",
+            json!({
+                "bot_token": "xoxb-secret",
+                "app_token": "xapp-secret",
+                "api_base_url": "https://slack.com/api",
+                "allowlist": []
+            }),
+        )]));
+        let tool = UpdateChannelSettingsTool::new(
+            service.clone() as Arc<dyn ChannelService>,
+            Some(store as Arc<dyn ChannelStore>),
+        );
+
+        tool.execute(json!({
+            "account_id": "slack-main",
+            "settings": {
+                "api_base_url": "https://proxy.example/api"
+            }
+        }))
+        .await
+        .expect("slack api_base_url update");
+
+        let updated = service
+            .updated
+            .lock()
+            .await
+            .clone()
+            .expect("captured update payload");
+        assert_eq!(updated["config"]["bot_token"], "xoxb-secret");
+        assert_eq!(updated["config"]["app_token"], "xapp-secret");
+        assert_eq!(
+            updated["config"]["api_base_url"],
+            "https://proxy.example/api"
         );
     }
 

--- a/crates/gateway/src/channel_agent_tools.rs
+++ b/crates/gateway/src/channel_agent_tools.rs
@@ -9,7 +9,7 @@ use {
     },
     serde::{Deserialize, Serialize},
     serde_json::{Map, Value, json},
-    std::sync::Arc,
+    std::{net::IpAddr, sync::Arc},
 };
 
 use crate::services::ChannelService;
@@ -470,7 +470,8 @@ fn apply_channel_settings_patch(
             "api_base_url",
             matches!(channel_type, ChannelType::Slack),
         )?;
-        config.insert("api_base_url".into(), json!(api_base_url.trim()));
+        let api_base_url = normalize_slack_api_base_url_setting(api_base_url)?;
+        config.insert("api_base_url".into(), json!(api_base_url));
         changes.push("api_base_url".to_string());
     }
     if update_string_array(
@@ -513,6 +514,59 @@ fn apply_channel_settings_patch(
     }
 
     Ok(changes)
+}
+
+fn normalize_slack_api_base_url_setting(api_base_url: &str) -> Result<String> {
+    let trimmed = api_base_url.trim().trim_end_matches('/');
+    let parsed = reqwest::Url::parse(trimmed)
+        .map_err(|e| anyhow!("Slack api_base_url must be an absolute URL: {e}"))?;
+    if !matches!(parsed.scheme(), "http" | "https") || parsed.host_str().is_none() {
+        return Err(anyhow!(
+            "Slack api_base_url must be an absolute HTTP(S) URL"
+        ));
+    }
+    validate_slack_api_base_url_host(&parsed)?;
+    Ok(trimmed.to_string())
+}
+
+fn validate_slack_api_base_url_host(url: &reqwest::Url) -> Result<()> {
+    let host = url
+        .host_str()
+        .ok_or_else(|| anyhow!("Slack api_base_url must include a host"))?;
+    if host.eq_ignore_ascii_case("localhost") {
+        return Err(anyhow!("Slack api_base_url must not target localhost"));
+    }
+    if let Ok(ip) = host.trim_matches(&['[', ']'][..]).parse::<IpAddr>()
+        && is_disallowed_slack_api_ip(&ip)
+    {
+        return Err(anyhow!(
+            "Slack api_base_url must not target private or local IP {ip}"
+        ));
+    }
+    Ok(())
+}
+
+fn is_disallowed_slack_api_ip(ip: &IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(v4) => {
+            let octets = v4.octets();
+            v4.is_loopback()
+                || v4.is_private()
+                || v4.is_link_local()
+                || v4.is_unspecified()
+                || v4.is_broadcast()
+                || v4.is_multicast()
+                || (octets[0] == 100 && (64..=127).contains(&octets[1]))
+        },
+        IpAddr::V6(v6) => {
+            let first = v6.segments()[0];
+            v6.is_loopback()
+                || v6.is_unspecified()
+                || v6.is_multicast()
+                || (first & 0xfe00) == 0xfc00
+                || (first & 0xffc0) == 0xfe80
+        },
+    }
 }
 
 fn ensure_supported(channel_type: ChannelType, field: &str, supported: bool) -> Result<()> {
@@ -1116,6 +1170,37 @@ mod tests {
             updated["config"]["api_base_url"],
             "https://proxy.example/api"
         );
+    }
+
+    #[tokio::test]
+    async fn update_channel_settings_rejects_private_slack_api_base_url() {
+        let service = Arc::new(RecordingChannelService::new());
+        let store = Arc::new(MemoryChannelStore::new(vec![stored_channel(
+            "slack-main",
+            "slack",
+            json!({
+                "bot_token": "xoxb-secret",
+                "app_token": "xapp-secret",
+                "api_base_url": "https://slack.com/api",
+                "allowlist": []
+            }),
+        )]));
+        let tool = UpdateChannelSettingsTool::new(
+            service as Arc<dyn ChannelService>,
+            Some(store as Arc<dyn ChannelStore>),
+        );
+
+        let err = tool
+            .execute(json!({
+                "account_id": "slack-main",
+                "settings": {
+                    "api_base_url": "http://169.254.169.254/latest/meta-data"
+                }
+            }))
+            .await
+            .expect_err("private Slack api_base_url should be rejected");
+
+        assert!(err.to_string().contains("private or local IP"));
     }
 
     #[tokio::test]

--- a/crates/gateway/src/channel_agent_tools.rs
+++ b/crates/gateway/src/channel_agent_tools.rs
@@ -559,6 +559,9 @@ fn is_disallowed_slack_api_ip(ip: &IpAddr) -> bool {
                 || (octets[0] == 100 && (64..=127).contains(&octets[1]))
         },
         IpAddr::V6(v6) => {
+            if let Some(v4) = v6.to_ipv4_mapped() {
+                return is_disallowed_slack_api_ip(&IpAddr::V4(v4));
+            }
             let first = v6.segments()[0];
             v6.is_loopback()
                 || v6.is_unspecified()
@@ -1199,6 +1202,37 @@ mod tests {
             }))
             .await
             .expect_err("private Slack api_base_url should be rejected");
+
+        assert!(err.to_string().contains("private or local IP"));
+    }
+
+    #[tokio::test]
+    async fn update_channel_settings_rejects_ipv4_mapped_slack_api_base_url() {
+        let service = Arc::new(RecordingChannelService::new());
+        let store = Arc::new(MemoryChannelStore::new(vec![stored_channel(
+            "slack-main",
+            "slack",
+            json!({
+                "bot_token": "xoxb-secret",
+                "app_token": "xapp-secret",
+                "api_base_url": "https://slack.com/api",
+                "allowlist": []
+            }),
+        )]));
+        let tool = UpdateChannelSettingsTool::new(
+            service as Arc<dyn ChannelService>,
+            Some(store as Arc<dyn ChannelStore>),
+        );
+
+        let err = tool
+            .execute(json!({
+                "account_id": "slack-main",
+                "settings": {
+                    "api_base_url": "http://[::ffff:169.254.169.254]/latest/meta-data"
+                }
+            }))
+            .await
+            .expect_err("IPv4-mapped private Slack api_base_url should be rejected");
 
         assert!(err.to_string().contains("private or local IP"));
     }

--- a/crates/slack/src/client.rs
+++ b/crates/slack/src/client.rs
@@ -1,3 +1,5 @@
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+
 use slack_morphism::prelude::*;
 
 use moltis_channels::{Error as ChannelError, Result as ChannelResult};
@@ -14,7 +16,61 @@ pub fn normalize_slack_api_base_url(api_base_url: &str) -> ChannelResult<String>
             "Slack api_base_url must be an absolute HTTP(S) URL",
         ));
     }
+    validate_public_host(&parsed)?;
     Ok(trimmed.to_string())
+}
+
+fn validate_public_host(url: &reqwest::Url) -> ChannelResult<()> {
+    let host = url
+        .host_str()
+        .ok_or_else(|| ChannelError::invalid_input("Slack api_base_url must include a host"))?;
+    if host.eq_ignore_ascii_case("localhost") {
+        return Err(ChannelError::invalid_input(
+            "Slack api_base_url must not target localhost",
+        ));
+    }
+    if let Ok(ip) = host.trim_matches(&['[', ']'][..]).parse::<IpAddr>()
+        && is_disallowed_ip(&ip)
+    {
+        return Err(ChannelError::invalid_input(format!(
+            "Slack api_base_url must not target private or local IP {ip}"
+        )));
+    }
+    Ok(())
+}
+
+fn is_disallowed_ip(ip: &IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(v4) => {
+            v4.is_loopback()
+                || v4.is_private()
+                || v4.is_link_local()
+                || v4.is_unspecified()
+                || v4.is_broadcast()
+                || v4.is_multicast()
+                || is_cgnat(*v4)
+        },
+        IpAddr::V6(v6) => {
+            v6.is_loopback()
+                || v6.is_unspecified()
+                || v6.is_multicast()
+                || is_ipv6_unique_local(*v6)
+                || is_ipv6_link_local(*v6)
+        },
+    }
+}
+
+fn is_cgnat(ip: Ipv4Addr) -> bool {
+    let octets = ip.octets();
+    octets[0] == 100 && (64..=127).contains(&octets[1])
+}
+
+fn is_ipv6_unique_local(ip: Ipv6Addr) -> bool {
+    (ip.segments()[0] & 0xfe00) == 0xfc00
+}
+
+fn is_ipv6_link_local(ip: Ipv6Addr) -> bool {
+    (ip.segments()[0] & 0xffc0) == 0xfe80
 }
 
 pub fn slack_client_for_base_url(
@@ -51,6 +107,18 @@ mod tests {
     #[test]
     fn rejects_relative_base_urls() {
         assert!(normalize_slack_api_base_url("/api").is_err());
+    }
+
+    #[test]
+    fn rejects_localhost_base_urls() {
+        assert!(normalize_slack_api_base_url("http://localhost:3000/api").is_err());
+    }
+
+    #[test]
+    fn rejects_private_ip_base_urls() {
+        assert!(normalize_slack_api_base_url("http://169.254.169.254/api").is_err());
+        assert!(normalize_slack_api_base_url("http://10.0.0.1/api").is_err());
+        assert!(normalize_slack_api_base_url("http://[fd00::1]/api").is_err());
     }
 
     #[test]

--- a/crates/slack/src/client.rs
+++ b/crates/slack/src/client.rs
@@ -51,6 +51,9 @@ fn is_disallowed_ip(ip: &IpAddr) -> bool {
                 || is_cgnat(*v4)
         },
         IpAddr::V6(v6) => {
+            if let Some(v4) = v6.to_ipv4_mapped() {
+                return is_disallowed_ip(&IpAddr::V4(v4));
+            }
             v6.is_loopback()
                 || v6.is_unspecified()
                 || v6.is_multicast()
@@ -119,6 +122,7 @@ mod tests {
         assert!(normalize_slack_api_base_url("http://169.254.169.254/api").is_err());
         assert!(normalize_slack_api_base_url("http://10.0.0.1/api").is_err());
         assert!(normalize_slack_api_base_url("http://[fd00::1]/api").is_err());
+        assert!(normalize_slack_api_base_url("http://[::ffff:169.254.169.254]/api").is_err());
     }
 
     #[test]

--- a/crates/slack/src/client.rs
+++ b/crates/slack/src/client.rs
@@ -1,0 +1,71 @@
+use slack_morphism::prelude::*;
+
+use moltis_channels::{Error as ChannelError, Result as ChannelResult};
+
+pub const DEFAULT_SLACK_API_BASE_URL: &str = "https://slack.com/api";
+
+pub fn normalize_slack_api_base_url(api_base_url: &str) -> ChannelResult<String> {
+    let trimmed = api_base_url.trim().trim_end_matches('/');
+    let parsed = reqwest::Url::parse(trimmed).map_err(|e| {
+        ChannelError::invalid_input(format!("Slack api_base_url must be an absolute URL: {e}"))
+    })?;
+    if !matches!(parsed.scheme(), "http" | "https") || parsed.host_str().is_none() {
+        return Err(ChannelError::invalid_input(
+            "Slack api_base_url must be an absolute HTTP(S) URL",
+        ));
+    }
+    Ok(trimmed.to_string())
+}
+
+pub fn slack_client_for_base_url(
+    api_base_url: &str,
+) -> ChannelResult<SlackClient<SlackClientHyperHttpsConnector>> {
+    let api_base_url = normalize_slack_api_base_url(api_base_url)?;
+    let connector = SlackClientHyperConnector::new()
+        .map_err(|e| ChannelError::unavailable(format!("hyper connector: {e}")))?
+        .with_slack_api_url(&api_base_url);
+    Ok(SlackClient::new(connector))
+}
+
+pub fn slack_api_method_url(api_base_url: &str, method: &str) -> ChannelResult<String> {
+    Ok(format!(
+        "{}/{}",
+        normalize_slack_api_base_url(api_base_url)?,
+        method.trim_start_matches('/')
+    ))
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalizes_trailing_slashes() {
+        assert_eq!(
+            normalize_slack_api_base_url("https://proxy.example/api/").unwrap(),
+            "https://proxy.example/api"
+        );
+    }
+
+    #[test]
+    fn rejects_relative_base_urls() {
+        assert!(normalize_slack_api_base_url("/api").is_err());
+    }
+
+    #[test]
+    fn builds_method_url_from_default_base() {
+        assert_eq!(
+            slack_api_method_url(DEFAULT_SLACK_API_BASE_URL, "chat.startStream").unwrap(),
+            "https://slack.com/api/chat.startStream"
+        );
+    }
+
+    #[test]
+    fn builds_method_url_from_trailing_slash_base() {
+        assert_eq!(
+            slack_api_method_url("https://proxy.example/api/", "chat.startStream").unwrap(),
+            "https://proxy.example/api/chat.startStream"
+        );
+    }
+}

--- a/crates/slack/src/config.rs
+++ b/crates/slack/src/config.rs
@@ -10,6 +10,8 @@ use {
     serde::{Deserialize, Serialize, ser::SerializeStruct},
 };
 
+use crate::client::DEFAULT_SLACK_API_BASE_URL;
+
 /// Per-channel model/provider override.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct ChannelOverride {
@@ -64,6 +66,9 @@ pub struct SlackAccountConfig {
     /// Required when `connection_mode` is `socket_mode`.
     #[serde(serialize_with = "secret_serde::serialize_secret")]
     pub app_token: Secret<String>,
+
+    /// Slack Web API base URL.
+    pub api_base_url: String,
 
     /// How this account connects to Slack.
     pub connection_mode: ConnectionMode,
@@ -129,6 +134,7 @@ impl std::fmt::Debug for SlackAccountConfig {
         f.debug_struct("SlackAccountConfig")
             .field("bot_token", &"[REDACTED]")
             .field("app_token", &"[REDACTED]")
+            .field("api_base_url", &self.api_base_url)
             .field("connection_mode", &self.connection_mode)
             .field(
                 "signing_secret",
@@ -156,6 +162,7 @@ impl Default for SlackAccountConfig {
         Self {
             bot_token: Secret::new(String::new()),
             app_token: Secret::new(String::new()),
+            api_base_url: DEFAULT_SLACK_API_BASE_URL.to_string(),
             connection_mode: ConnectionMode::SocketMode,
             signing_secret: None,
             dm_policy: DmPolicy::Allowlist,
@@ -235,7 +242,7 @@ pub struct RedactedConfig<'a>(pub &'a SlackAccountConfig);
 impl Serialize for RedactedConfig<'_> {
     fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         let c = self.0;
-        let mut count = 11; // always-present fields
+        let mut count = 12; // always-present fields
         count += c.signing_secret.is_some() as usize;
         count += c.model.is_some() as usize;
         count += c.model_provider.is_some() as usize;
@@ -245,6 +252,7 @@ impl Serialize for RedactedConfig<'_> {
         let mut s = serializer.serialize_struct("SlackAccountConfig", count)?;
         s.serialize_field("bot_token", secret_serde::REDACTED)?;
         s.serialize_field("app_token", secret_serde::REDACTED)?;
+        s.serialize_field("api_base_url", &c.api_base_url)?;
         s.serialize_field("connection_mode", &c.connection_mode)?;
         if c.signing_secret.is_some() {
             s.serialize_field("signing_secret", secret_serde::REDACTED)?;
@@ -320,6 +328,7 @@ mod tests {
         let cfg: SlackAccountConfig = serde_json::from_value(json).unwrap();
         assert_eq!(cfg.bot_token.expose_secret(), "xoxb-test-token");
         assert_eq!(cfg.app_token.expose_secret(), "xapp-test-token");
+        assert_eq!(cfg.api_base_url, DEFAULT_SLACK_API_BASE_URL);
         assert_eq!(cfg.dm_policy, DmPolicy::Open);
         assert_eq!(cfg.group_policy, GroupPolicy::Allowlist);
         assert_eq!(cfg.mention_mode, MentionMode::Always);
@@ -379,6 +388,7 @@ mod tests {
         assert_eq!(cfg.edit_throttle_ms, 500);
         assert!(cfg.thread_replies);
         assert_eq!(cfg.mention_mode, MentionMode::Mention);
+        assert_eq!(cfg.api_base_url, DEFAULT_SLACK_API_BASE_URL);
         assert!(cfg.channel_overrides.is_empty());
         assert!(cfg.user_overrides.is_empty());
     }
@@ -421,6 +431,7 @@ mod tests {
         assert_eq!(redacted["bot_token"], "[REDACTED]");
         assert_eq!(redacted["app_token"], "[REDACTED]");
         assert_eq!(redacted["signing_secret"], "[REDACTED]");
+        assert_eq!(redacted["api_base_url"], DEFAULT_SLACK_API_BASE_URL);
         // Non-secret fields preserved
         assert_eq!(redacted["model"], "gpt-4o");
         assert!(redacted["thread_replies"].is_boolean());
@@ -437,6 +448,24 @@ mod tests {
         let cfg = SlackAccountConfig::default();
         let redacted = serde_json::to_value(RedactedConfig(&cfg)).unwrap();
         assert!(redacted.get("signing_secret").is_none());
+    }
+
+    #[test]
+    fn custom_api_base_url_round_trips_and_redacts() {
+        let json = serde_json::json!({
+            "bot_token": "xoxb-test",
+            "app_token": "xapp-test",
+            "api_base_url": "https://proxy.example/api",
+        });
+        let cfg: SlackAccountConfig = serde_json::from_value(json).unwrap();
+        assert_eq!(cfg.api_base_url, "https://proxy.example/api");
+
+        let value = serde_json::to_value(&cfg).unwrap();
+        let cfg2: SlackAccountConfig = serde_json::from_value(value).unwrap();
+        assert_eq!(cfg2.api_base_url, "https://proxy.example/api");
+
+        let redacted = serde_json::to_value(RedactedConfig(&cfg2)).unwrap();
+        assert_eq!(redacted["api_base_url"], "https://proxy.example/api");
     }
 
     #[test]

--- a/crates/slack/src/lib.rs
+++ b/crates/slack/src/lib.rs
@@ -5,6 +5,7 @@
 //! policies, and dispatches messages to the chat session.
 
 pub mod channel_webhook_verifier;
+pub mod client;
 pub mod commands;
 pub mod config;
 pub mod markdown;

--- a/crates/slack/src/outbound.rs
+++ b/crates/slack/src/outbound.rs
@@ -19,6 +19,7 @@ use moltis_channels::{
 use moltis_common::types::ReplyPayload;
 
 use crate::{
+    client::{slack_api_method_url, slack_client_for_base_url},
     config::StreamMode,
     markdown::{SLACK_MAX_MESSAGE_LEN, chunk_message, markdown_to_slack},
     state::AccountStateMap,
@@ -46,10 +47,7 @@ impl SlackOutbound {
         let token_str = state.config.bot_token.expose_secret().clone();
         let token = SlackApiToken::new(SlackApiTokenValue::from(token_str));
 
-        let client = SlackClient::new(
-            SlackClientHyperConnector::new()
-                .map_err(|e| ChannelError::unavailable(format!("hyper connector: {e}")))?,
-        );
+        let client = slack_client_for_base_url(&state.config.api_base_url)?;
 
         Ok((client, token))
     }
@@ -102,6 +100,15 @@ impl SlackOutbound {
         Ok(state.config.bot_token.expose_secret().clone())
     }
 
+    /// Get the configured Slack Web API base URL.
+    fn get_api_base_url(&self, account_id: &str) -> ChannelResult<String> {
+        let accounts = self.accounts.read().unwrap_or_else(|e| e.into_inner());
+        let state = accounts
+            .get(account_id)
+            .ok_or_else(|| ChannelError::unknown_account(account_id))?;
+        Ok(state.config.api_base_url.clone())
+    }
+
     /// Native Slack streaming using chat.startStream/appendStream/stopStream.
     async fn send_stream_native(
         &self,
@@ -111,10 +118,12 @@ impl SlackOutbound {
         stream: &mut StreamReceiver,
     ) -> ChannelResult<()> {
         let bot_token = self.get_bot_token(account_id)?;
+        let api_base_url = self.get_api_base_url(account_id)?;
         let http = moltis_common::http_client::build_default_http_client();
         let throttle = self.get_edit_throttle(account_id);
 
-        let stream_id = start_native_stream(&http, &bot_token, to, thread_ts).await?;
+        let stream_id =
+            start_native_stream(&http, &api_base_url, &bot_token, to, thread_ts).await?;
 
         let mut pending = String::new();
         let mut last_append = tokio::time::Instant::now();
@@ -128,8 +137,14 @@ impl SlackOutbound {
                     if last_append.elapsed() >= throttle {
                         let text = markdown_to_slack(&std::mem::take(&mut pending));
                         if !text.is_empty()
-                            && let Err(e) =
-                                append_native_stream(&http, &bot_token, &stream_id, &text).await
+                            && let Err(e) = append_native_stream(
+                                &http,
+                                &api_base_url,
+                                &bot_token,
+                                &stream_id,
+                                &text,
+                            )
+                            .await
                         {
                             debug!(account_id, to, "chat.appendStream failed (will retry): {e}");
                             // Put the text back for next attempt.
@@ -150,13 +165,15 @@ impl SlackOutbound {
         // Flush any remaining text.
         if !pending.is_empty() {
             let text = markdown_to_slack(&pending);
-            if let Err(e) = append_native_stream(&http, &bot_token, &stream_id, &text).await {
+            if let Err(e) =
+                append_native_stream(&http, &api_base_url, &bot_token, &stream_id, &text).await
+            {
                 warn!(account_id, to, "final chat.appendStream failed: {e}");
             }
         }
 
         // Finalize the stream.
-        if let Err(e) = stop_native_stream(&http, &bot_token, &stream_id).await {
+        if let Err(e) = stop_native_stream(&http, &api_base_url, &bot_token, &stream_id).await {
             warn!(account_id, to, "chat.stopStream failed: {e}");
         }
 
@@ -650,6 +667,7 @@ impl ChannelOutbound for SlackOutbound {
 /// Returns `(stream_id, channel)` on success.
 async fn start_native_stream(
     http: &reqwest::Client,
+    api_base_url: &str,
     bot_token: &str,
     channel: &str,
     thread_ts: Option<&str>,
@@ -660,7 +678,7 @@ async fn start_native_stream(
     }
 
     let resp = http
-        .post("https://slack.com/api/chat.startStream")
+        .post(slack_api_method_url(api_base_url, "chat.startStream")?)
         .bearer_auth(bot_token)
         .json(&body)
         .send()
@@ -691,6 +709,7 @@ async fn start_native_stream(
 /// Append text to a native Slack stream via `chat.appendStream`.
 async fn append_native_stream(
     http: &reqwest::Client,
+    api_base_url: &str,
     bot_token: &str,
     stream_id: &str,
     text: &str,
@@ -701,7 +720,7 @@ async fn append_native_stream(
     });
 
     let resp = http
-        .post("https://slack.com/api/chat.appendStream")
+        .post(slack_api_method_url(api_base_url, "chat.appendStream")?)
         .bearer_auth(bot_token)
         .json(&body)
         .send()
@@ -729,13 +748,14 @@ async fn append_native_stream(
 /// Finalize a native Slack stream via `chat.stopStream`.
 async fn stop_native_stream(
     http: &reqwest::Client,
+    api_base_url: &str,
     bot_token: &str,
     stream_id: &str,
 ) -> ChannelResult<()> {
     let body = serde_json::json!({ "stream_id": stream_id });
 
     let resp = http
-        .post("https://slack.com/api/chat.stopStream")
+        .post(slack_api_method_url(api_base_url, "chat.stopStream")?)
         .bearer_auth(bot_token)
         .json(&body)
         .send()

--- a/crates/slack/src/outbound.rs
+++ b/crates/slack/src/outbound.rs
@@ -73,15 +73,6 @@ impl SlackOutbound {
             .map(|(_, ts)| ts.clone())
     }
 
-    /// Get the edit throttle duration for streaming.
-    fn get_edit_throttle(&self, account_id: &str) -> Duration {
-        let accounts = self.accounts.read().unwrap_or_else(|e| e.into_inner());
-        accounts
-            .get(account_id)
-            .map(|s| Duration::from_millis(s.config.edit_throttle_ms))
-            .unwrap_or(Duration::from_millis(500))
-    }
-
     /// Get the stream mode for the given account.
     fn get_stream_mode(&self, account_id: &str) -> StreamMode {
         let accounts = self.accounts.read().unwrap_or_else(|e| e.into_inner());
@@ -91,22 +82,29 @@ impl SlackOutbound {
             .unwrap_or_default()
     }
 
-    /// Get the raw bot token string for API calls not covered by slack-morphism.
-    fn get_bot_token(&self, account_id: &str) -> ChannelResult<String> {
+    /// Get the edit throttle duration for edit-in-place streaming.
+    fn get_edit_throttle(&self, account_id: &str) -> Duration {
         let accounts = self.accounts.read().unwrap_or_else(|e| e.into_inner());
-        let state = accounts
+        accounts
             .get(account_id)
-            .ok_or_else(|| ChannelError::unknown_account(account_id))?;
-        Ok(state.config.bot_token.expose_secret().clone())
+            .map(|s| Duration::from_millis(s.config.edit_throttle_ms))
+            .unwrap_or(Duration::from_millis(500))
     }
 
-    /// Get the configured Slack Web API base URL.
-    fn get_api_base_url(&self, account_id: &str) -> ChannelResult<String> {
+    /// Get native streaming settings in one account lookup.
+    fn get_native_stream_config(
+        &self,
+        account_id: &str,
+    ) -> ChannelResult<(String, String, Duration)> {
         let accounts = self.accounts.read().unwrap_or_else(|e| e.into_inner());
         let state = accounts
             .get(account_id)
             .ok_or_else(|| ChannelError::unknown_account(account_id))?;
-        Ok(state.config.api_base_url.clone())
+        Ok((
+            state.config.bot_token.expose_secret().clone(),
+            state.config.api_base_url.clone(),
+            Duration::from_millis(state.config.edit_throttle_ms),
+        ))
     }
 
     /// Native Slack streaming using chat.startStream/appendStream/stopStream.
@@ -117,10 +115,8 @@ impl SlackOutbound {
         thread_ts: Option<&str>,
         stream: &mut StreamReceiver,
     ) -> ChannelResult<()> {
-        let bot_token = self.get_bot_token(account_id)?;
-        let api_base_url = self.get_api_base_url(account_id)?;
+        let (bot_token, api_base_url, throttle) = self.get_native_stream_config(account_id)?;
         let http = moltis_common::http_client::build_default_http_client();
-        let throttle = self.get_edit_throttle(account_id);
 
         let stream_id =
             start_native_stream(&http, &api_base_url, &bot_token, to, thread_ts).await?;

--- a/crates/slack/src/socket.rs
+++ b/crates/slack/src/socket.rs
@@ -16,6 +16,7 @@ use moltis_channels::{
 };
 
 use crate::{
+    client::slack_client_for_base_url,
     config::SlackAccountConfig,
     markdown::strip_mentions,
     state::{AccountState, AccountStateMap},
@@ -53,9 +54,7 @@ pub async fn start_socket_mode(
         ));
     }
 
-    let client = Arc::new(SlackClient::new(SlackClientHyperConnector::new().map_err(
-        |e| moltis_channels::Error::unavailable(format!("hyper connector: {e}")),
-    )?));
+    let client = Arc::new(slack_client_for_base_url(&config.api_base_url)?);
 
     // Verify the bot token and get the bot user ID.
     let bot_token = SlackApiToken::new(SlackApiTokenValue::from(bot_token_str));

--- a/crates/slack/src/webhook.rs
+++ b/crates/slack/src/webhook.rs
@@ -21,6 +21,7 @@ use moltis_channels::{
 };
 
 use crate::{
+    client::slack_client_for_base_url,
     config::SlackAccountConfig,
     state::{AccountState, AccountStateMap},
 };
@@ -47,9 +48,7 @@ pub async fn register_events_api_account(
         ));
     }
 
-    let client = Arc::new(SlackClient::new(SlackClientHyperConnector::new().map_err(
-        |e| moltis_channels::Error::unavailable(format!("hyper connector: {e}")),
-    )?));
+    let client = Arc::new(slack_client_for_base_url(&config.api_base_url)?);
 
     // Verify the bot token and get the bot user ID.
     let bot_token = SlackApiToken::new(SlackApiTokenValue::from(bot_token_str));

--- a/crates/web/ui/src/onboarding/steps/ChannelStep.tsx
+++ b/crates/web/ui/src/onboarding/steps/ChannelStep.tsx
@@ -596,6 +596,7 @@ function SlackForm({ onConnected, error, setError }: ChannelFormProps): VNode {
 	const [botToken, setBotToken] = useState("");
 	const [connectionMode, setConnectionMode] = useState("socket_mode");
 	const [appToken, setAppToken] = useState("");
+	const [apiBaseUrl, setApiBaseUrl] = useState("");
 	const [signingSecret, setSigningSecret] = useState("");
 	const [dmPolicy, setDmPolicy] = useState("allowlist");
 	const [allowlist, setAllowlist] = useState("");
@@ -641,6 +642,7 @@ function SlackForm({ onConnected, error, setError }: ChannelFormProps): VNode {
 		};
 		if (connectionMode === "socket_mode") config.app_token = appToken.trim();
 		if (connectionMode === "events_api") config.signing_secret = signingSecret.trim();
+		if (apiBaseUrl.trim()) config.api_base_url = apiBaseUrl.trim();
 		Object.assign(config, advancedPatch.value);
 		(
 			addChannel("slack", accountId.trim(), config) as Promise<{
@@ -762,6 +764,24 @@ function SlackForm({ onConnected, error, setError }: ChannelFormProps): VNode {
 					/>
 				</div>
 			)}
+			<div>
+				<label className="text-xs text-[var(--muted)] mb-1 block">Slack API Base URL</label>
+				<input
+					type="url"
+					className="provider-key-input w-full"
+					value={apiBaseUrl}
+					onInput={(e) => setApiBaseUrl(targetValue(e))}
+					placeholder="https://slack.com/api"
+					autoComplete="off"
+					autoCapitalize="none"
+					autoCorrect="off"
+					spellcheck={false}
+					name="slack_api_base_url"
+				/>
+				<div className="text-xs text-[var(--muted)] mt-1">
+					Leave blank for Slack. Set this only for Slack-compatible proxies or test gateways.
+				</div>
+			</div>
 			<div>
 				<label className="text-xs text-[var(--muted)] mb-1 block">DM Policy</label>
 				<select

--- a/crates/web/ui/src/pages/ChannelsPage.tsx
+++ b/crates/web/ui/src/pages/ChannelsPage.tsx
@@ -84,6 +84,7 @@ export interface ChannelConfig {
 	// Slack
 	bot_token?: string;
 	app_token?: string;
+	api_base_url?: string;
 	connection_mode?: string;
 	group_policy?: string;
 	signing_secret?: string;

--- a/crates/web/ui/src/pages/channels/modals/AddSlackModal.tsx
+++ b/crates/web/ui/src/pages/channels/modals/AddSlackModal.tsx
@@ -20,6 +20,7 @@ export function AddSlackModal(): VNode {
 	const accountDraft = useSignal("");
 	const botTokenDraft = useSignal("");
 	const appTokenDraft = useSignal("");
+	const apiBaseUrlDraft = useSignal("");
 	const connectionMode = useSignal("socket_mode");
 	const signingSecretDraft = useSignal("");
 	const advancedConfigPatch = useSignal("");
@@ -65,6 +66,9 @@ export function AddSlackModal(): VNode {
 		if (connectionMode.value === "events_api") {
 			addConfig.signing_secret = signingSecretDraft.value.trim();
 		}
+		if (apiBaseUrlDraft.value.trim()) {
+			addConfig.api_base_url = apiBaseUrlDraft.value.trim();
+		}
 		if (addModel.value) {
 			addConfig.model = addModel.value;
 			const found = modelsSig.value.find((x) => x.id === addModel.value);
@@ -82,6 +86,7 @@ export function AddSlackModal(): VNode {
 				accountDraft.value = "";
 				botTokenDraft.value = "";
 				appTokenDraft.value = "";
+				apiBaseUrlDraft.value = "";
 				signingSecretDraft.value = "";
 				connectionMode.value = "socket_mode";
 				advancedConfigPatch.value = "";
@@ -211,6 +216,24 @@ export function AddSlackModal(): VNode {
 						/>
 					</>
 				)}
+				<label className="text-xs text-[var(--muted)]">Slack API Base URL</label>
+				<input
+					data-field="apiBaseUrl"
+					type="url"
+					placeholder="https://slack.com/api"
+					className="channel-input"
+					value={apiBaseUrlDraft.value}
+					onInput={(e) => {
+						apiBaseUrlDraft.value = targetValue(e);
+					}}
+					autoComplete="off"
+					autoCapitalize="none"
+					autoCorrect="off"
+					spellcheck={false}
+				/>
+				<div className="text-xs text-[var(--muted)] -mt-2">
+					Leave blank for Slack. Set this only for Slack-compatible proxies or test gateways.
+				</div>
 				<label className="text-xs text-[var(--muted)]">Group/Channel Policy</label>
 				<select data-field="groupPolicy" className="channel-select">
 					<option value="open">Open (respond in any channel)</option>

--- a/crates/web/ui/src/pages/channels/modals/EditChannelModal.tsx
+++ b/crates/web/ui/src/pages/channels/modals/EditChannelModal.tsx
@@ -46,6 +46,7 @@ export function EditChannelModal(): VNode | null {
 	const editMatrixOtpCooldown = useSignal("300");
 	const editSignalAccount = useSignal("");
 	const editSignalHttpUrl = useSignal("http://127.0.0.1:8080");
+	const editSlackApiBaseUrl = useSignal("https://slack.com/api");
 	const editChannelNamePatterns = useSignal<string[]>([]);
 	const editCategoryAllowlist = useSignal<string[]>([]);
 	const editAdvancedConfigPatch = useSignal("");
@@ -73,6 +74,7 @@ export function EditChannelModal(): VNode | null {
 		editMatrixOtpCooldown.value = String(ch?.config?.otp_cooldown_secs || 300);
 		editSignalAccount.value = (ch?.config?.account as string) || "";
 		editSignalHttpUrl.value = (ch?.config?.http_url as string) || "http://127.0.0.1:8080";
+		editSlackApiBaseUrl.value = (ch?.config?.api_base_url as string) || "https://slack.com/api";
 		editChannelNamePatterns.value = (ch?.config?.channel_name_patterns || []) as string[];
 		editCategoryAllowlist.value = (ch?.config?.category_allowlist || []) as string[];
 		editAdvancedConfigPatch.value = "";
@@ -95,6 +97,7 @@ export function EditChannelModal(): VNode | null {
 	const isDiscord = chType === ChannelType.Discord;
 	const isWhatsApp = chType === ChannelType.WhatsApp;
 	const isTelegram = chType === ChannelType.Telegram;
+	const isSlack = chType === ChannelType.Slack;
 	const isMatrix = chType === ChannelType.Matrix;
 	const isNostr = chType === ChannelType.Nostr;
 	const isSignal = chType === ChannelType.Signal;
@@ -187,6 +190,9 @@ export function EditChannelModal(): VNode | null {
 		if (isDiscord) {
 			updateConfig.channel_name_patterns = editChannelNamePatterns.value;
 			updateConfig.category_allowlist = editCategoryAllowlist.value;
+		}
+		if (isSlack) {
+			updateConfig.api_base_url = editSlackApiBaseUrl.value.trim() || "https://slack.com/api";
 		}
 		addChannelCredentials(updateConfig, form);
 		addModelToConfig(updateConfig);
@@ -375,6 +381,27 @@ export function EditChannelModal(): VNode | null {
 							Only respond in channels under these Discord categories. Combined with name patterns via OR.
 						</div>
 					</>
+				)}
+				{isSlack && (
+					<div className="flex flex-col gap-1">
+						<label className="text-xs text-[var(--muted)]">Slack API Base URL</label>
+						<input
+							type="url"
+							className="channel-input w-full"
+							value={editSlackApiBaseUrl.value}
+							onInput={(e) => {
+								editSlackApiBaseUrl.value = targetValue(e);
+							}}
+							placeholder="https://slack.com/api"
+							autoComplete="off"
+							autoCapitalize="none"
+							autoCorrect="off"
+							spellcheck={false}
+						/>
+						<div className="text-xs text-[var(--muted)]">
+							Use Slack's default endpoint unless you use a Slack-compatible proxy or test gateway.
+						</div>
+					</div>
 				)}
 				{isNostr && (
 					<>

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -385,6 +385,8 @@ offered = ["slack"]
 [channels.slack.my-bot]
 bot_token = "xoxb-..."
 app_token = "xapp-..."
+# Optional. Defaults to Slack; set only for Slack-compatible proxies/gateways.
+api_base_url = "https://slack.com/api"
 dm_policy = "allowlist"
 allowlist = ["U123456789"]
 ```

--- a/docs/src/slack.md
+++ b/docs/src/slack.md
@@ -87,6 +87,7 @@ offered = ["slack"]
 |-------|----------|---------|-------------|
 | `bot_token` | **yes** | — | Bot user OAuth token (`xoxb-...`) |
 | `app_token` | **yes**\* | — | App-level token for Socket Mode (`xapp-...`). \*Required for `socket_mode`. |
+| `api_base_url` | no | `"https://slack.com/api"` | Slack Web API base URL. Override only for Slack-compatible proxies, mock servers, or gateways. |
 | `connection_mode` | no | `"socket_mode"` | Connection method: `"socket_mode"` or `"events_api"` |
 | `signing_secret` | no\* | — | Signing secret for Events API request verification. \*Required for `events_api`. |
 | `dm_policy` | no | `"allowlist"` | Who can DM the bot: `"open"`, `"allowlist"`, or `"disabled"` |
@@ -116,6 +117,7 @@ offered = ["slack"]
 [channels.slack.my-bot]
 bot_token = "xoxb-..."
 app_token = "xapp-..."
+api_base_url = "https://slack.com/api"
 connection_mode = "socket_mode"
 dm_policy = "allowlist"
 group_policy = "open"
@@ -151,6 +153,25 @@ signing_secret = "abc123..."
 
 This requires your Moltis instance to be reachable from the internet (or use
 [Tailscale Funnel](configuration.md#tailscale-integration)).
+
+### Slack-Compatible Proxies
+
+Moltis normally talks to Slack at `https://slack.com/api`. For testing, local
+development, or Slack-compatible gateways, set `api_base_url`:
+
+```toml
+[channels.slack.proxy]
+bot_token = "xoxb-proxy-token"
+app_token = "xapp-proxy-token"
+api_base_url = "https://proxy.example/api"
+connection_mode = "socket_mode"
+```
+
+For Socket Mode, Moltis calls `apps.connections.open` on this endpoint and
+connects to the WebSocket URL returned by that API.
+
+If using a proxy, ensure it supports Slack's native streaming methods before
+setting `stream_mode = "native"`.
 
 ## Access Control
 

--- a/docs/src/slack.md
+++ b/docs/src/slack.md
@@ -170,6 +170,10 @@ connection_mode = "socket_mode"
 For Socket Mode, Moltis calls `apps.connections.open` on this endpoint and
 connects to the WebSocket URL returned by that API.
 
+The endpoint must be a public HTTP(S) URL. Localhost, private-network,
+link-local, and other non-public IP targets are rejected because Slack API calls
+carry the bot token.
+
 If using a proxy, ensure it supports Slack's native streaming methods before
 setting `stream_mode = "native"`.
 

--- a/docs/src/upstream-proxy.md
+++ b/docs/src/upstream-proxy.md
@@ -48,7 +48,9 @@ Slack streaming messages (progressive edits) are proxied via reqwest.
 However, regular `chat.postMessage` calls go through the `slack-morphism`
 library's built-in hyper connector, which does **not** use the upstream
 proxy. If you need full Slack proxy coverage, also set the `HTTPS_PROXY`
-environment variable.
+environment variable. If you are using a Slack-compatible API gateway instead
+of a generic outbound proxy, configure the Slack channel's `api_base_url`
+instead.
 
 ### Telegram caveat
 


### PR DESCRIPTION
## Summary
- Add `api_base_url` to Slack account config with `https://slack.com/api` as the default.
- Route Slack client construction, Socket Mode startup, Events API auth, outbound replies, and native streaming through the configured API base URL.
- Add Slack API Base URL fields to onboarding and channel settings, plus Slack docs for compatible proxies and gateways.

## Validation

### Completed
- [x] `cargo fmt --all -- --check`
- [x] `cargo check -p moltis-slack`
- [x] `cargo check -p moltis-gateway`
- [x] `cargo test -p moltis-slack`
- [x] `cargo test -p moltis-gateway update_channel_settings_updates_slack_api_base_url`
- [x] `npm run build` from `crates/web/ui`
- [x] `npx tsc --noEmit` from `crates/web/ui`
- [x] `./node_modules/.bin/biome check --write src/` from `crates/web/ui` ran; it reported existing unrelated warnings and applied no fixes.
- [x] `git diff --check`

### Remaining
- [ ] Playwright E2E was not run for the Slack form field change.

## Manual QA
- Not performed locally. Suggested check: open onboarding and Channels Slack add/edit forms, verify Slack API Base URL shows `https://slack.com/api` as placeholder/default guidance, and verify saving a custom proxy endpoint persists to channel config.
