### PR TITLE
fix(web): show dates for older sessions

### DIFF
--- a/crates/web/ui/e2e/specs/sessions.spec.js
+++ b/crates/web/ui/e2e/specs/sessions.spec.js
@@ -78,9 +78,11 @@ test.describe("Session management", () => {
 		await expect(items).not.toHaveCount(0);
 	});
 
-	test("session list distinguishes today from older dates", async ({ page }) => {
+	test("session list distinguishes date buckets and refreshes after midnight", async ({ page }) => {
+		await page.clock.install({ time: new Date(2026, 6, 23, 23, 58) });
 		const pageErrors = await navigateAndWait(page, "/");
 		await waitForWsConnected(page);
+		await page.clock.pauseAt(new Date(2026, 6, 23, 23, 59, 59, 500));
 
 		const expected = await page.evaluate(() => {
 			const store = window.__moltis_stores?.sessionStore;
@@ -130,6 +132,11 @@ test.describe("Session management", () => {
 				page.locator(`#sessionList .session-item[data-session-key="e2e:date-label:${key}"] .session-time`),
 			).toHaveText(label);
 		}
+
+		await page.clock.fastForward(1_000);
+		await expect(
+			page.locator('#sessionList .session-item[data-session-key="e2e:date-label:today"] .session-time'),
+		).toHaveText(expected.yesterday);
 
 		expect(pageErrors).toEqual([]);
 	});

--- a/crates/web/ui/e2e/specs/sessions.spec.js
+++ b/crates/web/ui/e2e/specs/sessions.spec.js
@@ -78,6 +78,62 @@ test.describe("Session management", () => {
 		await expect(items).not.toHaveCount(0);
 	});
 
+	test("session list distinguishes today from older dates", async ({ page }) => {
+		const pageErrors = await navigateAndWait(page, "/");
+		await waitForWsConnected(page);
+
+		const expected = await page.evaluate(() => {
+			const store = window.__moltis_stores?.sessionStore;
+			if (!store) throw new Error("session store unavailable");
+
+			const timestampForDaysAgo = (daysAgo, hour) => {
+				const date = new Date();
+				date.setDate(date.getDate() - daysAgo);
+				date.setHours(hour, 30, 0, 0);
+				return date.getTime();
+			};
+			const timestamps = {
+				today: timestampForDaysAgo(0, 9),
+				yesterday: timestampForDaysAgo(1, 10),
+				weekday: timestampForDaysAgo(3, 11),
+				older: timestampForDaysAgo(10, 12),
+			};
+
+			for (const [key, updatedAt] of Object.entries(timestamps)) {
+				store.upsert({
+					key: `e2e:date-label:${key}`,
+					label: `Date label ${key}`,
+					createdAt: updatedAt,
+					updatedAt,
+				});
+			}
+
+			const olderDate = new Date(timestamps.older);
+			const now = new Date();
+			return {
+				today: new Date(timestamps.today).toLocaleTimeString(undefined, {
+					hour: "2-digit",
+					minute: "2-digit",
+				}),
+				yesterday: new Intl.RelativeTimeFormat(undefined, { numeric: "auto" }).format(-1, "day"),
+				weekday: new Date(timestamps.weekday).toLocaleDateString(undefined, { weekday: "long" }),
+				older: olderDate.toLocaleDateString(undefined, {
+					month: "short",
+					day: "numeric",
+					...(olderDate.getFullYear() === now.getFullYear() ? {} : { year: "numeric" }),
+				}),
+			};
+		});
+
+		for (const [key, label] of Object.entries(expected)) {
+			await expect(
+				page.locator(`#sessionList .session-item[data-session-key="e2e:date-label:${key}"] .session-time`),
+			).toHaveText(label);
+		}
+
+		expect(pageErrors).toEqual([]);
+	});
+
 	test("sessions sidebar uses search and add button row", async ({ page }) => {
 		const pageErrors = await navigateAndWait(page, "/");
 		await waitForWsConnected(page);

--- a/crates/web/ui/src/components/SessionList.tsx
+++ b/crates/web/ui/src/components/SessionList.tsx
@@ -55,8 +55,33 @@ function channelSessionType(s: Session): ChannelType | null {
 	}
 }
 
-function formatHHMM(epochMs: number): string {
-	return new Date(epochMs).toLocaleTimeString(undefined, { hour: "2-digit", minute: "2-digit" });
+const MILLISECONDS_PER_DAY = 24 * 60 * 60 * 1000;
+
+function startOfLocalDay(date: Date): number {
+	return new Date(date.getFullYear(), date.getMonth(), date.getDate()).getTime();
+}
+
+export function formatSessionTimestamp(epochMs: number, nowMs = Date.now()): string {
+	const date = new Date(epochMs);
+	const now = new Date(nowMs);
+	if (!(Number.isFinite(date.getTime()) && Number.isFinite(now.getTime()))) return "";
+
+	const daysAgo = Math.round((startOfLocalDay(now) - startOfLocalDay(date)) / MILLISECONDS_PER_DAY);
+	if (daysAgo === 0) {
+		return date.toLocaleTimeString(undefined, { hour: "2-digit", minute: "2-digit" });
+	}
+	if (daysAgo === 1) {
+		return new Intl.RelativeTimeFormat(undefined, { numeric: "auto" }).format(-1, "day");
+	}
+	if (daysAgo > 1 && daysAgo < 7) {
+		return date.toLocaleDateString(undefined, { weekday: "long" });
+	}
+
+	return date.toLocaleDateString(undefined, {
+		month: "short",
+		day: "numeric",
+		...(date.getFullYear() === now.getFullYear() ? {} : { year: "numeric" }),
+	});
 }
 
 // ── Icon component (renders SVG icon into a ref) ────────────
@@ -239,7 +264,7 @@ function SessionItem({ session, activeKey, depth, keyMap, refreshing }: SessionI
 					)}
 					{ts > 0 && (
 						<span className="session-time" title={new Date(ts).toLocaleString()}>
-							{formatHHMM(ts)}
+							{formatSessionTimestamp(ts)}
 						</span>
 					)}
 				</div>

--- a/crates/web/ui/src/components/SessionList.tsx
+++ b/crates/web/ui/src/components/SessionList.tsx
@@ -4,7 +4,7 @@
 // component that auto-rerenders from sessionStore signals.
 
 import type { VNode } from "preact";
-import { useEffect, useRef } from "preact/hooks";
+import { useEffect, useRef, useState } from "preact/hooks";
 import {
 	makeBranchIcon,
 	makeChatIcon,
@@ -59,6 +59,12 @@ const MILLISECONDS_PER_DAY = 24 * 60 * 60 * 1000;
 
 function startOfLocalDay(date: Date): number {
 	return new Date(date.getFullYear(), date.getMonth(), date.getDate()).getTime();
+}
+
+function millisecondsUntilNextLocalDay(nowMs: number): number {
+	const now = new Date(nowMs);
+	const nextDay = new Date(now.getFullYear(), now.getMonth(), now.getDate() + 1);
+	return Math.max(0, nextDay.getTime() - nowMs);
 }
 
 export function formatSessionTimestamp(epochMs: number, nowMs = Date.now()): string {
@@ -201,10 +207,11 @@ interface SessionItemProps {
 	activeKey: string;
 	depth: number;
 	keyMap: KeyMap;
+	nowMs: number;
 	refreshing: boolean;
 }
 
-function SessionItem({ session, activeKey, depth, keyMap, refreshing }: SessionItemProps): VNode {
+function SessionItem({ session, activeKey, depth, keyMap, nowMs, refreshing }: SessionItemProps): VNode {
 	const isBranch = depth > 0;
 	const active = session.key === activeKey;
 	// Read per-session signals — auto-subscribes for re-render.
@@ -264,7 +271,7 @@ function SessionItem({ session, activeKey, depth, keyMap, refreshing }: SessionI
 					)}
 					{ts > 0 && (
 						<span className="session-time" title={new Date(ts).toLocaleString()}>
-							{formatSessionTimestamp(ts)}
+							{formatSessionTimestamp(ts, nowMs)}
 						</span>
 					)}
 				</div>
@@ -283,6 +290,7 @@ export function SessionList(): VNode {
 	const filterId = projectStore.projectFilterId.value;
 	const tab = sessionStore.sessionListTab.value;
 	const showArchived = sessionStore.showArchivedSessions.value;
+	const [nowMs, setNowMs] = useState(Date.now);
 
 	// Spinner animation via setInterval
 	const spinnersRef = useRef<HTMLDivElement>(null);
@@ -297,6 +305,21 @@ export function SessionList(): VNode {
 			for (const el of els) el.textContent = spinnerFrames[idx];
 		}, 80);
 		return () => clearInterval(timer);
+	}, []);
+
+	// Session date buckets change at local midnight even when no session data
+	// changes. Schedule the next boundary exactly and repeat after each rollover.
+	useEffect(() => {
+		let timer: ReturnType<typeof setTimeout>;
+		const scheduleNextDay = (): void => {
+			const currentTime = Date.now();
+			timer = setTimeout(() => {
+				setNowMs(Date.now());
+				scheduleNextDay();
+			}, millisecondsUntilNextLocalDay(currentTime));
+		};
+		scheduleNextDay();
+		return () => clearTimeout(timer);
 	}, []);
 
 	let filtered = filterId ? allSessions.filter((s) => s.projectId === filterId) : allSessions;
@@ -328,6 +351,7 @@ export function SessionList(): VNode {
 					activeKey={activeKey}
 					depth={depth}
 					keyMap={keyMap}
+					nowMs={nowMs}
 					refreshing={session.key === refreshingKey}
 				/>
 				{children.map((child) => renderTree(child, depth + 1))}


### PR DESCRIPTION
## Summary

- Keep localized `HH:MM` labels for sessions updated today.
- Show localized “yesterday” and weekday labels for recent prior days, then a calendar date for older sessions (including the year when needed).
- Add browser coverage for all four date buckets and preserve the full localized timestamp in the existing tooltip.

No chat session context is applicable: this issue is reproduced from stored session timestamps in the web UI. No documentation update is needed because the change only corrects an existing session-list hint and does not alter configuration, APIs, or workflows.

Fixes #1108

## Validation

### Completed

- [x] `npx biome check --write src/`
- [x] `npm run build`
- [x] `npx tsc --noEmit`
- [x] `MOLTIS_E2E_ONLY_PROJECT=default MOLTIS_BINARY=.../target/debug/moltis npx playwright test e2e/specs/sessions.spec.js --project=default --grep 'session list distinguishes today from older dates'` — 1 passed
- [x] `MOLTIS_E2E_ONLY_PROJECT=default MOLTIS_BINARY=.../target/debug/moltis npx playwright test e2e/specs/sessions.spec.js --project=default` — 29 passed
- [x] `git diff --check`

### Remaining

- [ ] Run `./scripts/local-validate.sh <PR_NUMBER>` after the PR number is assigned, as required by the repository workflow.

## Manual QA

1. Create or load sessions updated today, yesterday, 2–6 days ago, and at least 7 days ago.
2. Confirm the sidebar shows a time, “yesterday”, a weekday, and a calendar date respectively, localized to the browser locale.
3. Hover each hint and confirm the tooltip still shows the complete localized date and time.
