### PR TITLE
fix(slack): challenge unknown allowlist DMs with OTP

### DIFF
--- a/crates/channels/src/otp.rs
+++ b/crates/channels/src/otp.rs
@@ -17,7 +17,7 @@ use crate::{
 };
 
 /// How long an OTP code stays valid.
-const OTP_TTL: Duration = Duration::from_secs(300);
+pub const OTP_TTL: Duration = Duration::from_secs(300);
 
 /// Maximum wrong-code attempts before lockout.
 const MAX_ATTEMPTS: u32 = 3;

--- a/crates/channels/src/plugin.rs
+++ b/crates/channels/src/plugin.rs
@@ -188,7 +188,7 @@ impl ChannelType {
                     supports_threads: true,
                     supports_voice_ingest: false,
                     supports_pairing: false,
-                    supports_otp: false,
+                    supports_otp: true,
                     supports_reactions: true,
                     supports_location: true,
                 },

--- a/crates/channels/src/plugin.rs
+++ b/crates/channels/src/plugin.rs
@@ -220,7 +220,7 @@ impl ChannelType {
                     supports_threads: true,
                     supports_voice_ingest: false,
                     supports_pairing: false,
-                    supports_otp: false,
+                    supports_otp: true,
                     supports_reactions: true,
                     supports_location: false,
                 },

--- a/crates/config/src/template.rs
+++ b/crates/config/src/template.rs
@@ -815,6 +815,15 @@ port = {port}                           # Port number (auto-generated for this i
 # otp_self_approval = true
 # otp_cooldown_secs = 300
 
+# Example Microsoft Teams account.
+# [channels.msteams.my-bot]
+# app_id = "00000000-0000-0000-0000-000000000000"
+# app_password = "..."
+# dm_policy = "allowlist"
+# allowlist = []
+# otp_self_approval = true
+# otp_cooldown_secs = 300
+
 # See docs or defaults.toml for full channel configuration examples
 # (WhatsApp, Telegram, Teams, Discord, Slack, Matrix, Nostr, Signal).
 

--- a/crates/config/src/template.rs
+++ b/crates/config/src/template.rs
@@ -810,6 +810,10 @@ port = {port}                           # Port number (auto-generated for this i
 # bot_token = "xoxb-..."
 # app_token = "xapp-..."
 # api_base_url = "https://slack.com/api"
+# dm_policy = "allowlist"
+# allowlist = []
+# otp_self_approval = true
+# otp_cooldown_secs = 300
 
 # See docs or defaults.toml for full channel configuration examples
 # (WhatsApp, Telegram, Teams, Discord, Slack, Matrix, Nostr, Signal).

--- a/crates/httpd/src/server/gateway.rs
+++ b/crates/httpd/src/server/gateway.rs
@@ -72,6 +72,26 @@ fn telephony_webhook_url(
     ))
 }
 
+/// Whether an inbound call should be rejected under the account's DM policy.
+///
+/// An empty allowlist with an explicit `Allowlist` policy means "deny
+/// everyone" — not "allow everyone" (`is_allowed()` treats empty lists as
+/// open, so the empty case is short-circuited here).
+#[cfg(feature = "telephony")]
+fn inbound_call_rejected(
+    policy: moltis_channels::gating::DmPolicy,
+    caller: &str,
+    allowlist: &[String],
+) -> bool {
+    match policy {
+        moltis_channels::gating::DmPolicy::Disabled => true,
+        moltis_channels::gating::DmPolicy::Allowlist => {
+            allowlist.is_empty() || !moltis_channels::gating::is_allowed(caller, allowlist)
+        },
+        moltis_channels::gating::DmPolicy::Open => false,
+    }
+}
+
 #[cfg(feature = "telephony")]
 fn telnyx_payload_string(payload: &serde_json::Value, field: &str) -> Option<String> {
     payload[field]
@@ -721,17 +741,11 @@ pub async fn prepare_gateway(
                                         .and_then(|call_id| manager.get_call(&call_id));
                                     if let Some(config_view) = plugin_guard.account_config(&account_id)
                                     {
-                                        let policy = config_view.dm_policy();
-                                        let rejected = match policy {
-                                            moltis_channels::gating::DmPolicy::Disabled => true,
-                                            moltis_channels::gating::DmPolicy::Allowlist => {
-                                                !moltis_channels::gating::is_allowed(
-                                                    &caller,
-                                                    config_view.allowlist(),
-                                                )
-                                            },
-                                            moltis_channels::gating::DmPolicy::Open => false,
-                                        };
+                                        let rejected = inbound_call_rejected(
+                                            config_view.dm_policy(),
+                                            &caller,
+                                            config_view.allowlist(),
+                                        );
                                         if rejected {
                                             tracing::info!(account_id = %account_id, caller = %caller, "rejecting Telnyx inbound call");
                                             let _ = provider.hangup_call(provider_call_id).await;
@@ -886,20 +900,10 @@ pub async fn prepare_gateway(
                             use moltis_channels::ChannelPlugin as _;
                             if let Some(config_view) = plugin_guard.account_config(&account_id) {
                                 let policy = config_view.dm_policy();
-                                match policy {
-                                    moltis_channels::gating::DmPolicy::Disabled => {
-                                        tracing::info!(account_id = %account_id, caller = %caller, "rejecting inbound call: inbound_policy=disabled");
-                                        let twiml = provider.build_hangup_response();
-                                        return (StatusCode::OK, [(axum::http::header::CONTENT_TYPE, "text/xml")], twiml).into_response();
-                                    },
-                                    moltis_channels::gating::DmPolicy::Allowlist => {
-                                        if !moltis_channels::gating::is_allowed(caller, config_view.allowlist()) {
-                                            tracing::info!(account_id = %account_id, caller = %caller, "rejecting inbound call: not on allowlist");
-                                            let twiml = provider.build_hangup_response();
-                                            return (StatusCode::OK, [(axum::http::header::CONTENT_TYPE, "text/xml")], twiml).into_response();
-                                        }
-                                    },
-                                    moltis_channels::gating::DmPolicy::Open => {},
+                                if inbound_call_rejected(policy.clone(), caller, config_view.allowlist()) {
+                                    tracing::info!(account_id = %account_id, caller = %caller, policy = ?policy, "rejecting inbound call");
+                                    let twiml = provider.build_hangup_response();
+                                    return (StatusCode::OK, [(axum::http::header::CONTENT_TYPE, "text/xml")], twiml).into_response();
                                 }
                             }
                         }

--- a/crates/httpd/src/server/gateway/tests.rs
+++ b/crates/httpd/src/server/gateway/tests.rs
@@ -46,3 +46,36 @@ fn telephony_webhook_url_prefers_account_webhook_base() {
         "https://phone.example.com/base/api/channels/telephony/default/answer"
     );
 }
+
+#[test]
+fn inbound_call_rejected_denies_empty_allowlist() {
+    use moltis_channels::gating::DmPolicy;
+
+    use super::inbound_call_rejected;
+
+    // An empty allowlist with an explicit Allowlist policy denies everyone.
+    assert!(inbound_call_rejected(
+        DmPolicy::Allowlist,
+        "+15551234567",
+        &[]
+    ));
+
+    let allowlist = vec!["+15551234567".to_string()];
+    assert!(!inbound_call_rejected(
+        DmPolicy::Allowlist,
+        "+15551234567",
+        &allowlist
+    ));
+    assert!(inbound_call_rejected(
+        DmPolicy::Allowlist,
+        "+15559999999",
+        &allowlist
+    ));
+
+    assert!(inbound_call_rejected(
+        DmPolicy::Disabled,
+        "+15551234567",
+        &allowlist
+    ));
+    assert!(!inbound_call_rejected(DmPolicy::Open, "+15559999999", &[]));
+}

--- a/crates/matrix/src/handler/implementation.rs
+++ b/crates/matrix/src/handler/implementation.rs
@@ -595,7 +595,10 @@ fn should_auto_join_invite(
         let dm_allowed = match config.dm_policy {
             DmPolicy::Disabled => false,
             DmPolicy::Open => true,
-            DmPolicy::Allowlist => gating::is_allowed(inviter_id, &config.user_allowlist),
+            DmPolicy::Allowlist => {
+                !config.user_allowlist.is_empty()
+                    && gating::is_allowed(inviter_id, &config.user_allowlist)
+            },
         };
         if !dm_allowed {
             return false;

--- a/crates/matrix/src/handler/implementation.rs
+++ b/crates/matrix/src/handler/implementation.rs
@@ -621,8 +621,10 @@ fn should_auto_join_invite(
         AutoJoinPolicy::Always => true,
         AutoJoinPolicy::Off => false,
         AutoJoinPolicy::Allowlist => {
-            gating::is_allowed(inviter_id, &config.user_allowlist)
-                || gating::is_allowed(room_id, &config.room_allowlist)
+            (!config.user_allowlist.is_empty()
+                && gating::is_allowed(inviter_id, &config.user_allowlist))
+                || (!config.room_allowlist.is_empty()
+                    && gating::is_allowed(room_id, &config.room_allowlist))
         },
     }
 }

--- a/crates/matrix/src/handler/tests.rs
+++ b/crates/matrix/src/handler/tests.rs
@@ -390,6 +390,23 @@ fn dm_invite_allowlist_checks_user_allowlist() {
 }
 
 #[test]
+fn dm_invite_empty_allowlist_denies_all() {
+    let cfg = MatrixAccountConfig {
+        auto_join: AutoJoinPolicy::Always,
+        dm_policy: DmPolicy::Allowlist,
+        user_allowlist: vec![],
+        ..Default::default()
+    };
+
+    assert!(!should_auto_join_invite(
+        &cfg,
+        "@mallory:example.org",
+        "!dm:example.org",
+        true,
+    ));
+}
+
+#[test]
 fn dm_invite_open_policy_allows_any_user() {
     let cfg = MatrixAccountConfig {
         auto_join: AutoJoinPolicy::Always,

--- a/crates/matrix/src/handler/tests.rs
+++ b/crates/matrix/src/handler/tests.rs
@@ -285,6 +285,24 @@ fn auto_join_allowlist_uses_existing_user_and_room_allowlists() {
 }
 
 #[test]
+fn auto_join_allowlist_with_empty_allowlists_denies_all() {
+    let cfg = MatrixAccountConfig {
+        auto_join: AutoJoinPolicy::Allowlist,
+        room_policy: GroupPolicy::Open,
+        user_allowlist: vec![],
+        room_allowlist: vec![],
+        ..Default::default()
+    };
+
+    assert!(!should_auto_join_invite(
+        &cfg,
+        "@mallory:example.org",
+        "!any:example.org",
+        false,
+    ));
+}
+
+#[test]
 fn auto_join_never_bypasses_room_allowlist() {
     let cfg = MatrixAccountConfig {
         auto_join: AutoJoinPolicy::Always,

--- a/crates/metrics/src/definitions.rs
+++ b/crates/metrics/src/definitions.rs
@@ -128,6 +128,11 @@ pub mod channels {
     pub const ACTIVE: &str = "moltis_channels_active";
     /// Channel errors
     pub const ERRORS_TOTAL: &str = "moltis_channel_errors_total";
+    /// OTP challenges issued to non-allowlisted users (label: channel)
+    pub const OTP_CHALLENGES_TOTAL: &str = "moltis_channel_otp_challenges_total";
+    /// OTP verification attempts (labels: channel, result: approved, wrong_code,
+    /// locked_out, expired)
+    pub const OTP_VERIFICATIONS_TOTAL: &str = "moltis_channel_otp_verifications_total";
 }
 
 /// Channel webhook middleware metrics (signature verification, dedup, rate limiting)

--- a/crates/msteams/src/config.rs
+++ b/crates/msteams/src/config.rs
@@ -105,6 +105,12 @@ pub struct MsTeamsAccountConfig {
     /// Group/team allowlist.
     pub group_allowlist: Vec<String>,
 
+    /// Enable OTP self-approval for non-allowlisted DM users.
+    pub otp_self_approval: bool,
+
+    /// Cooldown in seconds after failed OTP attempts.
+    pub otp_cooldown_secs: u64,
+
     /// Optional shared secret validated against `?secret=...` on webhook calls.
     #[serde(
         default,
@@ -192,6 +198,8 @@ impl std::fmt::Debug for MsTeamsAccountConfig {
             .field("mention_mode", &self.mention_mode)
             .field("allowlist", &self.allowlist)
             .field("group_allowlist", &self.group_allowlist)
+            .field("otp_self_approval", &self.otp_self_approval)
+            .field("otp_cooldown_secs", &self.otp_cooldown_secs)
             .field(
                 "webhook_secret",
                 &self.webhook_secret.as_ref().map(|_| "[REDACTED]"),
@@ -212,8 +220,8 @@ pub struct RedactedConfig<'a>(pub &'a MsTeamsAccountConfig);
 impl Serialize for RedactedConfig<'_> {
     fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         let c = self.0;
-        // Count: 14 always-present + conditional optional fields.
-        let mut count = 14;
+        // Count: 16 always-present + conditional optional fields.
+        let mut count = 16;
         count += c.webhook_secret.is_some() as usize;
         count += c.model.is_some() as usize;
         count += c.model_provider.is_some() as usize;
@@ -233,6 +241,8 @@ impl Serialize for RedactedConfig<'_> {
         s.serialize_field("mention_mode", &c.mention_mode)?;
         s.serialize_field("allowlist", &c.allowlist)?;
         s.serialize_field("group_allowlist", &c.group_allowlist)?;
+        s.serialize_field("otp_self_approval", &c.otp_self_approval)?;
+        s.serialize_field("otp_cooldown_secs", &c.otp_cooldown_secs)?;
         if c.webhook_secret.is_some() {
             s.serialize_field("webhook_secret", secret_serde::REDACTED)?;
         }
@@ -331,6 +341,8 @@ impl Default for MsTeamsAccountConfig {
             mention_mode: MentionMode::Mention,
             allowlist: Vec::new(),
             group_allowlist: Vec::new(),
+            otp_self_approval: true,
+            otp_cooldown_secs: 300,
             webhook_secret: None,
             model: None,
             model_provider: None,
@@ -470,6 +482,26 @@ mod tests {
         assert_eq!(cfg.reply_style, ReplyStyle::TopLevel);
         assert_eq!(cfg.history_limit, 50);
         assert_eq!(cfg.tenant_id, "botframework.com");
+        assert!(cfg.otp_self_approval);
+        assert_eq!(cfg.otp_cooldown_secs, 300);
+    }
+
+    #[test]
+    fn otp_fields_round_trip() {
+        let json = serde_json::json!({
+            "app_id": "test-id",
+            "app_password": "test-pw",
+            "otp_self_approval": false,
+            "otp_cooldown_secs": 60,
+        });
+        let cfg: MsTeamsAccountConfig = serde_json::from_value(json).unwrap();
+        assert!(!cfg.otp_self_approval);
+        assert_eq!(cfg.otp_cooldown_secs, 60);
+
+        let value = serde_json::to_value(&cfg).unwrap();
+        let cfg2: MsTeamsAccountConfig = serde_json::from_value(value).unwrap();
+        assert!(!cfg2.otp_self_approval);
+        assert_eq!(cfg2.otp_cooldown_secs, 60);
     }
 
     #[test]

--- a/crates/msteams/src/plugin.rs
+++ b/crates/msteams/src/plugin.rs
@@ -1,6 +1,7 @@
 use std::{
     collections::{HashMap, HashSet},
     sync::{Arc, RwLock},
+    time::Duration,
 };
 
 use {
@@ -14,10 +15,14 @@ use moltis_channels::{
     Result as ChannelResult,
     gating::{DmPolicy, GroupPolicy, is_allowed},
     message_log::{MessageLog, MessageLogEntry},
+    otp::{
+        OtpChallengeInfo, OtpInitResult, OtpVerifyResult, approve_sender_via_otp,
+        emit_otp_challenge, emit_otp_resolution,
+    },
     plugin::{
         ChannelAttachment, ChannelHealthSnapshot, ChannelMessageKind, ChannelMessageMeta,
-        ChannelOutbound, ChannelPlugin, ChannelReplyTarget, ChannelStatus, ChannelStreamOutbound,
-        ChannelThreadContext, ChannelType, ThreadMessage,
+        ChannelOtpProvider, ChannelOutbound, ChannelPlugin, ChannelReplyTarget, ChannelStatus,
+        ChannelStreamOutbound, ChannelThreadContext, ChannelType, ThreadMessage,
     },
 };
 
@@ -36,6 +41,34 @@ fn unix_now() -> i64 {
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap_or_default()
         .as_secs() as i64
+}
+
+const OTP_CHALLENGE_MSG: &str = "To use this bot, please enter the verification code.\n\nAsk the bot owner for the code; it is visible in the web UI under Channels > Senders.\n\nThe code expires in 5 minutes.";
+const OTP_TTL: Duration = Duration::from_secs(300);
+
+fn policy_allowed(
+    config: &MsTeamsAccountConfig,
+    is_group: bool,
+    chat_id: &str,
+    peer_id: &str,
+) -> bool {
+    if is_group {
+        match config.group_policy {
+            GroupPolicy::Open => true,
+            GroupPolicy::Allowlist => {
+                !config.group_allowlist.is_empty() && is_allowed(chat_id, &config.group_allowlist)
+            },
+            GroupPolicy::Disabled => false,
+        }
+    } else {
+        match config.dm_policy {
+            DmPolicy::Open => true,
+            DmPolicy::Allowlist => {
+                !config.allowlist.is_empty() && is_allowed(peer_id, &config.allowlist)
+            },
+            DmPolicy::Disabled => false,
+        }
+    }
 }
 
 /// Microsoft Teams channel plugin.
@@ -107,11 +140,27 @@ impl MsTeamsPlugin {
         let parsed: MsTeamsAccountConfig = serde_json::from_value(config)?;
         let mut accounts = self.accounts.write().unwrap_or_else(|e| e.into_inner());
         if let Some(state) = accounts.get_mut(account_id) {
+            state
+                .otp
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .set_cooldown(parsed.otp_cooldown_secs);
             state.config = parsed;
             Ok(())
         } else {
             Err(ChannelError::unknown_account(account_id))
         }
+    }
+
+    pub fn pending_otp_challenges(&self, account_id: &str) -> Vec<OtpChallengeInfo> {
+        let accounts = self.accounts.read().unwrap_or_else(|e| e.into_inner());
+        accounts
+            .get(account_id)
+            .map(|s| {
+                let otp = s.otp.lock().unwrap_or_else(|e| e.into_inner());
+                otp.list_pending()
+            })
+            .unwrap_or_default()
     }
 
     /// Acquire an authenticated token for Graph API calls on behalf of the given account.
@@ -289,19 +338,7 @@ impl MsTeamsPlugin {
         let effective_mention_mode =
             resolve_mention_mode(&config, team_id.as_deref(), channel_id.as_deref());
 
-        let policy_allowed = if is_group {
-            match config.group_policy {
-                GroupPolicy::Open => true,
-                GroupPolicy::Allowlist => is_allowed(&chat_id, &config.group_allowlist),
-                GroupPolicy::Disabled => false,
-            }
-        } else {
-            match config.dm_policy {
-                DmPolicy::Open => true,
-                DmPolicy::Allowlist => is_allowed(&peer_id, &config.allowlist),
-                DmPolicy::Disabled => false,
-            }
-        };
+        let policy_allowed = policy_allowed(&config, is_group, &chat_id, &peer_id);
         let mention_allowed = if is_group {
             match effective_mention_mode {
                 moltis_channels::gating::MentionMode::Always => true,
@@ -352,6 +389,17 @@ impl MsTeamsPlugin {
         }
 
         if !access_granted {
+            if !is_group && config.dm_policy == DmPolicy::Allowlist && config.otp_self_approval {
+                self.handle_otp_flow(
+                    account_id,
+                    &peer_id,
+                    sender_name.as_deref(),
+                    text.as_deref().unwrap_or_default(),
+                    &chat_id,
+                    event_sink.as_deref(),
+                )
+                .await;
+            }
             return Ok(());
         }
 
@@ -535,6 +583,165 @@ impl MsTeamsPlugin {
         Ok(())
     }
 
+    async fn handle_otp_flow(
+        &self,
+        account_id: &str,
+        peer_id: &str,
+        sender_name: Option<&str>,
+        text: &str,
+        chat_id: &str,
+        event_sink: Option<&dyn ChannelEventSink>,
+    ) {
+        let has_pending = {
+            let accounts = self.accounts.read().unwrap_or_else(|e| e.into_inner());
+            accounts
+                .get(account_id)
+                .map(|s| {
+                    let otp = s.otp.lock().unwrap_or_else(|e| e.into_inner());
+                    otp.has_pending(peer_id)
+                })
+                .unwrap_or(false)
+        };
+
+        if has_pending {
+            let body = text.trim();
+            let is_code = body.len() == 6 && body.chars().all(|c| c.is_ascii_digit());
+            if !is_code {
+                return;
+            }
+
+            let result = {
+                let accounts = self.accounts.read().unwrap_or_else(|e| e.into_inner());
+                match accounts.get(account_id) {
+                    Some(s) => {
+                        let mut otp = s.otp.lock().unwrap_or_else(|e| e.into_inner());
+                        otp.verify(peer_id, body)
+                    },
+                    None => return,
+                }
+            };
+
+            match result {
+                OtpVerifyResult::Approved => {
+                    approve_sender_via_otp(
+                        event_sink,
+                        ChannelType::MsTeams,
+                        account_id,
+                        peer_id,
+                        peer_id,
+                        Some(peer_id),
+                    )
+                    .await;
+                    self.send_otp_status(
+                        account_id,
+                        chat_id,
+                        "Verified! You now have access to this bot.",
+                    )
+                    .await;
+                },
+                OtpVerifyResult::WrongCode { attempts_left } => {
+                    let msg = format!(
+                        "Incorrect code. {attempts_left} attempt{} remaining.",
+                        if attempts_left == 1 {
+                            ""
+                        } else {
+                            "s"
+                        }
+                    );
+                    self.send_otp_status(account_id, chat_id, &msg).await;
+                },
+                OtpVerifyResult::LockedOut => {
+                    self.send_otp_status(
+                        account_id,
+                        chat_id,
+                        "Too many failed attempts. Please try again later.",
+                    )
+                    .await;
+                    emit_otp_resolution(
+                        event_sink,
+                        ChannelType::MsTeams,
+                        account_id,
+                        peer_id,
+                        Some(peer_id),
+                        "locked_out",
+                    )
+                    .await;
+                },
+                OtpVerifyResult::Expired => {
+                    self.send_otp_status(
+                        account_id,
+                        chat_id,
+                        "Your code has expired. Send any message to get a new one.",
+                    )
+                    .await;
+                    emit_otp_resolution(
+                        event_sink,
+                        ChannelType::MsTeams,
+                        account_id,
+                        peer_id,
+                        Some(peer_id),
+                        "expired",
+                    )
+                    .await;
+                },
+                OtpVerifyResult::NoPending => {},
+            }
+            return;
+        }
+
+        let init_result = {
+            let accounts = self.accounts.read().unwrap_or_else(|e| e.into_inner());
+            match accounts.get(account_id) {
+                Some(s) => {
+                    let mut otp = s.otp.lock().unwrap_or_else(|e| e.into_inner());
+                    otp.initiate(
+                        peer_id,
+                        Some(peer_id.to_string()),
+                        sender_name.map(String::from),
+                    )
+                },
+                None => return,
+            }
+        };
+
+        match init_result {
+            OtpInitResult::Created(code) => {
+                self.send_otp_status(account_id, chat_id, OTP_CHALLENGE_MSG)
+                    .await;
+                let expires_at = std::time::SystemTime::now()
+                    .checked_add(OTP_TTL)
+                    .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+                    .map(|d| d.as_secs() as i64)
+                    .unwrap_or_default();
+                emit_otp_challenge(
+                    event_sink,
+                    ChannelType::MsTeams,
+                    account_id,
+                    peer_id,
+                    Some(peer_id),
+                    sender_name,
+                    code,
+                    expires_at,
+                )
+                .await;
+            },
+            OtpInitResult::AlreadyPending | OtpInitResult::LockedOut => {},
+        }
+    }
+
+    async fn send_otp_status(&self, account_id: &str, chat_id: &str, text: &str) {
+        if let Err(error) = self
+            .outbound
+            .send_text(account_id, chat_id, text, None)
+            .await
+        {
+            warn!(
+                account_id,
+                chat_id, "failed to send Teams OTP status: {error}"
+            );
+        }
+    }
+
     /// Handle conversationUpdate activities (welcome cards).
     async fn handle_conversation_update(
         &self,
@@ -687,7 +894,7 @@ impl ChannelPlugin for MsTeamsPlugin {
         let mut accounts = self.accounts.write().unwrap_or_else(|e| e.into_inner());
         accounts.insert(account_id.to_string(), AccountState {
             account_id: account_id.to_string(),
-            config: cfg,
+            config: cfg.clone(),
             message_log: self.message_log.clone(),
             event_sink: self.event_sink.clone(),
             http,
@@ -696,6 +903,7 @@ impl ChannelPlugin for MsTeamsPlugin {
             service_urls: Arc::new(RwLock::new(HashMap::new())),
             jwt_validator,
             welcomed_conversations: Arc::new(RwLock::new(HashSet::new())),
+            otp: std::sync::Mutex::new(moltis_channels::otp::OtpState::new(cfg.otp_cooldown_secs)),
         });
         Ok(())
     }
@@ -783,6 +991,16 @@ impl ChannelPlugin for MsTeamsPlugin {
 
     fn thread_context(&self) -> Option<&dyn ChannelThreadContext> {
         Some(self)
+    }
+
+    fn as_otp_provider(&self) -> Option<&dyn ChannelOtpProvider> {
+        Some(self)
+    }
+}
+
+impl ChannelOtpProvider for MsTeamsPlugin {
+    fn pending_otp_challenges(&self, account_id: &str) -> Vec<OtpChallengeInfo> {
+        MsTeamsPlugin::pending_otp_challenges(self, account_id)
     }
 }
 
@@ -878,6 +1096,22 @@ mod tests {
         moltis_channels::{InboundMode, plugin::ChannelType},
     };
 
+    fn test_account_state(config: MsTeamsAccountConfig) -> AccountState {
+        AccountState {
+            account_id: "test".into(),
+            config,
+            message_log: None,
+            event_sink: None,
+            http: reqwest::Client::new(),
+            token_cache: Arc::new(tokio::sync::Mutex::new(None)),
+            graph_token_cache: Arc::new(tokio::sync::Mutex::new(None)),
+            service_urls: Arc::new(RwLock::new(HashMap::new())),
+            jwt_validator: None,
+            welcomed_conversations: Arc::new(RwLock::new(HashSet::new())),
+            otp: std::sync::Mutex::new(moltis_channels::otp::OtpState::new(300)),
+        }
+    }
+
     #[test]
     fn descriptor_coherence() {
         let plugin = MsTeamsPlugin::new();
@@ -887,11 +1121,76 @@ mod tests {
         assert_eq!(desc.display_name, "Microsoft Teams");
         assert_eq!(desc.capabilities.inbound_mode, InboundMode::Webhook);
 
-        // OTP: MsTeams does NOT implement ChannelOtpProvider
-        assert!(!desc.capabilities.supports_otp);
-        assert!(plugin.as_otp_provider().is_none());
+        // OTP: MsTeams implements ChannelOtpProvider
+        assert!(desc.capabilities.supports_otp);
+        assert!(plugin.as_otp_provider().is_some());
 
         // Threads: MsTeams now implements ChannelThreadContext
         assert!(plugin.thread_context().is_some());
+    }
+
+    #[test]
+    fn empty_dm_allowlist_denies_all() {
+        let cfg = MsTeamsAccountConfig {
+            dm_policy: DmPolicy::Allowlist,
+            allowlist: vec![],
+            ..Default::default()
+        };
+        assert!(!policy_allowed(&cfg, false, "dm-chat", "user-id"));
+    }
+
+    #[test]
+    fn empty_group_allowlist_denies_all() {
+        let cfg = MsTeamsAccountConfig {
+            group_policy: GroupPolicy::Allowlist,
+            group_allowlist: vec![],
+            ..Default::default()
+        };
+        assert!(!policy_allowed(&cfg, true, "group-chat", "user-id"));
+    }
+
+    #[test]
+    fn removing_last_allowlist_entry_denies_access() {
+        let mut cfg = MsTeamsAccountConfig {
+            dm_policy: DmPolicy::Allowlist,
+            allowlist: vec!["user-id".into()],
+            ..Default::default()
+        };
+        assert!(policy_allowed(&cfg, false, "dm-chat", "user-id"));
+        cfg.allowlist.clear();
+        assert!(!policy_allowed(&cfg, false, "dm-chat", "user-id"));
+
+        let mut group_cfg = MsTeamsAccountConfig {
+            group_policy: GroupPolicy::Allowlist,
+            group_allowlist: vec!["group-chat".into()],
+            ..Default::default()
+        };
+        assert!(policy_allowed(&group_cfg, true, "group-chat", "user-id"));
+        group_cfg.group_allowlist.clear();
+        assert!(!policy_allowed(&group_cfg, true, "group-chat", "user-id"));
+    }
+
+    #[test]
+    fn pending_otp_challenges_are_exposed_via_provider_trait() {
+        let plugin = MsTeamsPlugin::new();
+        {
+            let mut map = plugin.accounts.write().unwrap();
+            map.insert(
+                "test".into(),
+                test_account_state(MsTeamsAccountConfig::default()),
+            );
+        }
+
+        {
+            let map = plugin.accounts.read().unwrap();
+            let state = map.get("test").unwrap();
+            let mut otp = state.otp.lock().unwrap();
+            otp.initiate("user-id", Some("user-id".into()), Some("Alice".into()));
+        }
+
+        let provider = plugin.as_otp_provider().unwrap();
+        let pending = provider.pending_otp_challenges("test");
+        assert_eq!(pending.len(), 1);
+        assert_eq!(pending[0].peer_id, "user-id");
     }
 }

--- a/crates/msteams/src/plugin.rs
+++ b/crates/msteams/src/plugin.rs
@@ -1,7 +1,6 @@
 use std::{
     collections::{HashMap, HashSet},
     sync::{Arc, RwLock},
-    time::Duration,
 };
 
 use {
@@ -16,7 +15,7 @@ use moltis_channels::{
     gating::{DmPolicy, GroupPolicy, is_allowed},
     message_log::{MessageLog, MessageLogEntry},
     otp::{
-        OtpChallengeInfo, OtpInitResult, OtpVerifyResult, approve_sender_via_otp,
+        OTP_TTL, OtpChallengeInfo, OtpInitResult, OtpVerifyResult, approve_sender_via_otp,
         emit_otp_challenge, emit_otp_resolution,
     },
     plugin::{
@@ -44,7 +43,23 @@ fn unix_now() -> i64 {
 }
 
 const OTP_CHALLENGE_MSG: &str = "To use this bot, please enter the verification code.\n\nAsk the bot owner for the code; it is visible in the web UI under Channels > Senders.\n\nThe code expires in 5 minutes.";
-const OTP_TTL: Duration = Duration::from_secs(300);
+
+#[cfg(feature = "metrics")]
+fn record_otp_verification(result: &OtpVerifyResult) {
+    let label = match result {
+        OtpVerifyResult::Approved => "approved",
+        OtpVerifyResult::WrongCode { .. } => "wrong_code",
+        OtpVerifyResult::LockedOut => "locked_out",
+        OtpVerifyResult::Expired => "expired",
+        OtpVerifyResult::NoPending => return,
+    };
+    moltis_metrics::counter!(
+        moltis_metrics::channels::OTP_VERIFICATIONS_TOTAL,
+        moltis_metrics::labels::CHANNEL => "msteams",
+        "result" => label
+    )
+    .increment(1);
+}
 
 fn policy_allowed(
     config: &MsTeamsAccountConfig,
@@ -621,6 +636,9 @@ impl MsTeamsPlugin {
                 }
             };
 
+            #[cfg(feature = "metrics")]
+            record_otp_verification(&result);
+
             match result {
                 OtpVerifyResult::Approved => {
                     approve_sender_via_otp(
@@ -629,7 +647,7 @@ impl MsTeamsPlugin {
                         account_id,
                         peer_id,
                         peer_id,
-                        Some(peer_id),
+                        sender_name.or(Some(peer_id)),
                     )
                     .await;
                     self.send_otp_status(
@@ -662,7 +680,7 @@ impl MsTeamsPlugin {
                         ChannelType::MsTeams,
                         account_id,
                         peer_id,
-                        Some(peer_id),
+                        sender_name.or(Some(peer_id)),
                         "locked_out",
                     )
                     .await;
@@ -679,7 +697,7 @@ impl MsTeamsPlugin {
                         ChannelType::MsTeams,
                         account_id,
                         peer_id,
-                        Some(peer_id),
+                        sender_name.or(Some(peer_id)),
                         "expired",
                     )
                     .await;
@@ -706,6 +724,12 @@ impl MsTeamsPlugin {
 
         match init_result {
             OtpInitResult::Created(code) => {
+                #[cfg(feature = "metrics")]
+                moltis_metrics::counter!(
+                    moltis_metrics::channels::OTP_CHALLENGES_TOTAL,
+                    moltis_metrics::labels::CHANNEL => "msteams"
+                )
+                .increment(1);
                 self.send_otp_status(account_id, chat_id, OTP_CHALLENGE_MSG)
                     .await;
                 let expires_at = std::time::SystemTime::now()

--- a/crates/msteams/src/state.rs
+++ b/crates/msteams/src/state.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use {
-    moltis_channels::{ChannelEventSink, message_log::MessageLog},
+    moltis_channels::{ChannelEventSink, message_log::MessageLog, otp::OtpState},
     reqwest::Client,
     tokio::sync::Mutex,
 };
@@ -30,4 +30,5 @@ pub struct AccountState {
     pub jwt_validator: Option<Arc<BotFrameworkJwtValidator>>,
     /// Tracks which conversations have received a welcome card/message.
     pub welcomed_conversations: Arc<RwLock<std::collections::HashSet<String>>>,
+    pub otp: std::sync::Mutex<OtpState>,
 }

--- a/crates/signal/src/inbound.rs
+++ b/crates/signal/src/inbound.rs
@@ -306,7 +306,9 @@ fn group_access_allowed(
     };
     let policy_allows = match cfg.group_policy {
         GroupPolicy::Open => true,
-        GroupPolicy::Allowlist => is_allowed(group_id, &cfg.group_allowlist),
+        GroupPolicy::Allowlist => {
+            !cfg.group_allowlist.is_empty() && is_allowed(group_id, &cfg.group_allowlist)
+        },
         GroupPolicy::Disabled => false,
     };
     if !policy_allows {
@@ -521,6 +523,21 @@ mod tests {
     #[test]
     fn groups_are_disabled_by_default() {
         let cfg = SignalAccountConfig::default();
+        assert!(!crate::inbound::group_access_allowed(
+            Some("group-id"),
+            "hello",
+            None,
+            &cfg
+        ));
+    }
+
+    #[test]
+    fn empty_group_allowlist_denies_all() {
+        let cfg = SignalAccountConfig {
+            group_policy: GroupPolicy::Allowlist,
+            mention_mode: MentionMode::Always,
+            ..Default::default()
+        };
         assert!(!crate::inbound::group_access_allowed(
             Some("group-id"),
             "hello",

--- a/crates/slack/src/config.rs
+++ b/crates/slack/src/config.rs
@@ -127,6 +127,12 @@ pub struct SlackAccountConfig {
     /// Per-user model/provider overrides (user_id -> override).
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub user_overrides: HashMap<String, UserOverride>,
+
+    /// Enable OTP self-approval for non-allowlisted DM users.
+    pub otp_self_approval: bool,
+
+    /// Cooldown in seconds after failed OTP attempts.
+    pub otp_cooldown_secs: u64,
 }
 
 impl std::fmt::Debug for SlackAccountConfig {
@@ -153,6 +159,8 @@ impl std::fmt::Debug for SlackAccountConfig {
             .field("thread_replies", &self.thread_replies)
             .field("channel_overrides", &self.channel_overrides)
             .field("user_overrides", &self.user_overrides)
+            .field("otp_self_approval", &self.otp_self_approval)
+            .field("otp_cooldown_secs", &self.otp_cooldown_secs)
             .finish()
     }
 }
@@ -178,6 +186,8 @@ impl Default for SlackAccountConfig {
             thread_replies: true,
             channel_overrides: HashMap::new(),
             user_overrides: HashMap::new(),
+            otp_self_approval: true,
+            otp_cooldown_secs: 300,
         }
     }
 }
@@ -242,7 +252,7 @@ pub struct RedactedConfig<'a>(pub &'a SlackAccountConfig);
 impl Serialize for RedactedConfig<'_> {
     fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         let c = self.0;
-        let mut count = 12; // always-present fields
+        let mut count = 14; // always-present fields
         count += c.signing_secret.is_some() as usize;
         count += c.model.is_some() as usize;
         count += c.model_provider.is_some() as usize;
@@ -280,6 +290,8 @@ impl Serialize for RedactedConfig<'_> {
         if !c.user_overrides.is_empty() {
             s.serialize_field("user_overrides", &c.user_overrides)?;
         }
+        s.serialize_field("otp_self_approval", &c.otp_self_approval)?;
+        s.serialize_field("otp_cooldown_secs", &c.otp_cooldown_secs)?;
         s.end()
     }
 }
@@ -387,6 +399,8 @@ mod tests {
         assert_eq!(cfg.stream_mode, StreamMode::EditInPlace);
         assert_eq!(cfg.edit_throttle_ms, 500);
         assert!(cfg.thread_replies);
+        assert!(cfg.otp_self_approval);
+        assert_eq!(cfg.otp_cooldown_secs, 300);
         assert_eq!(cfg.mention_mode, MentionMode::Mention);
         assert_eq!(cfg.api_base_url, DEFAULT_SLACK_API_BASE_URL);
         assert!(cfg.channel_overrides.is_empty());
@@ -441,6 +455,24 @@ mod tests {
         assert_eq!(storage["bot_token"], "xoxb-secret");
         assert_eq!(storage["app_token"], "xapp-secret");
         assert_eq!(storage["signing_secret"], "sign-secret");
+    }
+
+    #[test]
+    fn otp_fields_round_trip() {
+        let json = serde_json::json!({
+            "bot_token": "xoxb-test",
+            "app_token": "xapp-test",
+            "otp_self_approval": false,
+            "otp_cooldown_secs": 60,
+        });
+        let cfg: SlackAccountConfig = serde_json::from_value(json).unwrap();
+        assert!(!cfg.otp_self_approval);
+        assert_eq!(cfg.otp_cooldown_secs, 60);
+
+        let value = serde_json::to_value(&cfg).unwrap();
+        let cfg2: SlackAccountConfig = serde_json::from_value(value).unwrap();
+        assert!(!cfg2.otp_self_approval);
+        assert_eq!(cfg2.otp_cooldown_secs, 60);
     }
 
     #[test]

--- a/crates/slack/src/plugin.rs
+++ b/crates/slack/src/plugin.rs
@@ -12,9 +12,10 @@ use {
 use moltis_channels::{
     ChannelConfigView, Error as ChannelError, Result as ChannelResult,
     message_log::MessageLog,
+    otp::OtpChallengeInfo,
     plugin::{
-        ChannelEventSink, ChannelHealthSnapshot, ChannelOutbound, ChannelPlugin, ChannelStatus,
-        ChannelStreamOutbound, ChannelThreadContext,
+        ChannelEventSink, ChannelHealthSnapshot, ChannelOtpProvider, ChannelOutbound,
+        ChannelPlugin, ChannelStatus, ChannelStreamOutbound, ChannelThreadContext,
     },
 };
 
@@ -50,6 +51,17 @@ impl SlackPlugin {
     pub fn with_event_sink(mut self, sink: Arc<dyn ChannelEventSink>) -> Self {
         self.event_sink = Some(sink);
         self
+    }
+
+    pub fn pending_otp_challenges(&self, account_id: &str) -> Vec<OtpChallengeInfo> {
+        let accounts = self.accounts.read().unwrap_or_else(|e| e.into_inner());
+        accounts
+            .get(account_id)
+            .map(|s| {
+                let otp = s.otp.lock().unwrap_or_else(|e| e.into_inner());
+                otp.list_pending()
+            })
+            .unwrap_or_default()
     }
 
     /// Ingest an Events API webhook request.
@@ -236,6 +248,11 @@ impl ChannelPlugin for SlackPlugin {
         let parsed: SlackAccountConfig = serde_json::from_value(config)?;
         let mut accounts = self.accounts.write().unwrap_or_else(|e| e.into_inner());
         if let Some(state) = accounts.get_mut(account_id) {
+            state
+                .otp
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .set_cooldown(parsed.otp_cooldown_secs);
             state.config = parsed;
             Ok(())
         } else {
@@ -257,6 +274,10 @@ impl ChannelPlugin for SlackPlugin {
 
     fn thread_context(&self) -> Option<&dyn ChannelThreadContext> {
         Some(&self.outbound)
+    }
+
+    fn as_otp_provider(&self) -> Option<&dyn ChannelOtpProvider> {
+        Some(self)
     }
 
     fn channel_webhook_verifier(
@@ -300,10 +321,29 @@ impl ChannelStatus for SlackPlugin {
     }
 }
 
+impl ChannelOtpProvider for SlackPlugin {
+    fn pending_otp_challenges(&self, account_id: &str) -> Vec<OtpChallengeInfo> {
+        SlackPlugin::pending_otp_challenges(self, account_id)
+    }
+}
+
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod tests {
-    use super::*;
+    use {super::*, tokio_util::sync::CancellationToken};
+
+    fn test_account_state(config: SlackAccountConfig) -> crate::state::AccountState {
+        crate::state::AccountState {
+            account_id: "test".into(),
+            config,
+            message_log: None,
+            event_sink: None,
+            cancel: CancellationToken::new(),
+            bot_user_id: Some("Ubot".into()),
+            pending_threads: HashMap::new(),
+            otp: std::sync::Mutex::new(moltis_channels::otp::OtpState::new(300)),
+        }
+    }
 
     #[test]
     fn plugin_id_and_name() {
@@ -389,14 +429,72 @@ mod tests {
         assert!(desc.capabilities.supports_threads);
         assert!(plugin.thread_context().is_some());
 
-        // OTP: Slack does NOT implement ChannelOtpProvider
-        assert!(!desc.capabilities.supports_otp);
-        assert!(plugin.as_otp_provider().is_none());
+        // OTP: Slack implements ChannelOtpProvider
+        assert!(desc.capabilities.supports_otp);
+        assert!(plugin.as_otp_provider().is_some());
 
         // Reactions: Slack supports reactions
         assert!(desc.capabilities.supports_reactions);
 
         // Interactive: Slack supports interactive messages
         assert!(desc.capabilities.supports_interactive);
+    }
+
+    #[test]
+    fn update_account_config_preserves_otp_state() {
+        let plugin = SlackPlugin::new();
+        {
+            let mut map = plugin.accounts.write().unwrap();
+            map.insert(
+                "test".into(),
+                test_account_state(SlackAccountConfig::default()),
+            );
+        }
+
+        {
+            let map = plugin.accounts.read().unwrap();
+            let state = map.get("test").unwrap();
+            let mut otp = state.otp.lock().unwrap();
+            otp.initiate("U123", Some("alice".into()), None);
+        }
+
+        plugin
+            .update_account_config(
+                "test",
+                serde_json::json!({
+                    "bot_token": "xoxb-test",
+                    "app_token": "xapp-test",
+                    "otp_cooldown_secs": 60,
+                }),
+            )
+            .unwrap();
+
+        let pending = plugin.pending_otp_challenges("test");
+        assert_eq!(pending.len(), 1);
+        assert_eq!(pending[0].peer_id, "U123");
+    }
+
+    #[test]
+    fn pending_otp_challenges_are_exposed_via_provider_trait() {
+        let plugin = SlackPlugin::new();
+        {
+            let mut map = plugin.accounts.write().unwrap();
+            map.insert(
+                "test".into(),
+                test_account_state(SlackAccountConfig::default()),
+            );
+        }
+
+        {
+            let map = plugin.accounts.read().unwrap();
+            let state = map.get("test").unwrap();
+            let mut otp = state.otp.lock().unwrap();
+            otp.initiate("U123", Some("alice".into()), None);
+        }
+
+        let provider = plugin.as_otp_provider().unwrap();
+        let pending = provider.pending_otp_challenges("test");
+        assert_eq!(pending.len(), 1);
+        assert_eq!(pending[0].peer_id, "U123");
     }
 }

--- a/crates/slack/src/socket.rs
+++ b/crates/slack/src/socket.rs
@@ -1,4 +1,4 @@
-use std::{sync::Arc, time::Duration};
+use std::sync::Arc;
 
 use {
     secrecy::ExposeSecret,
@@ -11,7 +11,7 @@ use moltis_channels::{
     gating::{DmPolicy, GroupPolicy, is_allowed},
     message_log::MessageLogEntry,
     otp::{
-        OtpInitResult, OtpVerifyResult, approve_sender_via_otp, emit_otp_challenge,
+        OTP_TTL, OtpInitResult, OtpVerifyResult, approve_sender_via_otp, emit_otp_challenge,
         emit_otp_resolution,
     },
     plugin::{
@@ -29,7 +29,6 @@ use crate::{
 };
 
 const OTP_CHALLENGE_MSG: &str = "To use this bot, please enter the verification code.\n\nAsk the bot owner for the code; it is visible in the web UI under Channels > Senders.\n\nThe code expires in 5 minutes.";
-const OTP_TTL: Duration = Duration::from_secs(300);
 
 /// State stored in the Socket Mode listener for callback access.
 #[derive(Clone)]
@@ -716,6 +715,9 @@ async fn handle_otp_flow(
             }
         };
 
+        #[cfg(feature = "metrics")]
+        record_otp_verification(&result);
+
         match result {
             OtpVerifyResult::Approved => {
                 approve_sender_via_otp(
@@ -800,6 +802,12 @@ async fn handle_otp_flow(
 
     match init_result {
         OtpInitResult::Created(code) => {
+            #[cfg(feature = "metrics")]
+            moltis_metrics::counter!(
+                moltis_metrics::channels::OTP_CHALLENGES_TOTAL,
+                moltis_metrics::labels::CHANNEL => "slack"
+            )
+            .increment(1);
             send_otp_status(accounts, account_id, channel_id, OTP_CHALLENGE_MSG).await;
             let expires_at = std::time::SystemTime::now()
                 .checked_add(OTP_TTL)
@@ -820,6 +828,23 @@ async fn handle_otp_flow(
         },
         OtpInitResult::AlreadyPending | OtpInitResult::LockedOut => {},
     }
+}
+
+#[cfg(feature = "metrics")]
+fn record_otp_verification(result: &OtpVerifyResult) {
+    let label = match result {
+        OtpVerifyResult::Approved => "approved",
+        OtpVerifyResult::WrongCode { .. } => "wrong_code",
+        OtpVerifyResult::LockedOut => "locked_out",
+        OtpVerifyResult::Expired => "expired",
+        OtpVerifyResult::NoPending => return,
+    };
+    moltis_metrics::counter!(
+        moltis_metrics::channels::OTP_VERIFICATIONS_TOTAL,
+        moltis_metrics::labels::CHANNEL => "slack",
+        "result" => label
+    )
+    .increment(1);
 }
 
 async fn send_otp_status(

--- a/crates/slack/src/socket.rs
+++ b/crates/slack/src/socket.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 
 use {
     secrecy::ExposeSecret,
@@ -10,8 +10,13 @@ use moltis_channels::{
     config_view::ChannelConfigView,
     gating::{DmPolicy, GroupPolicy, is_allowed},
     message_log::MessageLogEntry,
+    otp::{
+        OtpInitResult, OtpVerifyResult, approve_sender_via_otp, emit_otp_challenge,
+        emit_otp_resolution,
+    },
     plugin::{
-        ChannelEvent, ChannelMessageKind, ChannelMessageMeta, ChannelReplyTarget, ChannelType,
+        ChannelEvent, ChannelEventSink, ChannelMessageKind, ChannelMessageMeta, ChannelOutbound,
+        ChannelReplyTarget, ChannelType,
     },
 };
 
@@ -19,8 +24,12 @@ use crate::{
     client::slack_client_for_base_url,
     config::SlackAccountConfig,
     markdown::strip_mentions,
+    outbound::SlackOutbound,
     state::{AccountState, AccountStateMap},
 };
+
+const OTP_CHALLENGE_MSG: &str = "To use this bot, please enter the verification code.\n\nAsk the bot owner for the code; it is visible in the web UI under Channels > Senders.\n\nThe code expires in 5 minutes.";
+const OTP_TTL: Duration = Duration::from_secs(300);
 
 /// State stored in the Socket Mode listener for callback access.
 #[derive(Clone)]
@@ -38,7 +47,7 @@ pub async fn start_socket_mode(
     config: SlackAccountConfig,
     accounts: AccountStateMap,
     message_log: Option<Arc<dyn moltis_channels::message_log::MessageLog>>,
-    event_sink: Option<Arc<dyn moltis_channels::ChannelEventSink>>,
+    event_sink: Option<Arc<dyn ChannelEventSink>>,
 ) -> moltis_channels::Result<()> {
     let bot_token_str = config.bot_token.expose_secret().clone();
     let app_token_str = config.app_token.expose_secret().clone();
@@ -69,6 +78,8 @@ pub async fn start_socket_mode(
 
     let cancel = tokio_util::sync::CancellationToken::new();
 
+    let otp_cooldown_secs = config.otp_cooldown_secs;
+
     {
         let mut accts = accounts.write().unwrap_or_else(|e| e.into_inner());
         accts.insert(account_id.to_string(), AccountState {
@@ -79,6 +90,7 @@ pub async fn start_socket_mode(
             cancel: cancel.clone(),
             bot_user_id: Some(bot_user_id),
             pending_threads: std::collections::HashMap::new(),
+            otp: std::sync::Mutex::new(moltis_channels::otp::OtpState::new(otp_cooldown_secs)),
         });
     }
 
@@ -512,6 +524,18 @@ pub(crate) async fn handle_inbound(
             account_id,
             user_id, channel_id, "slack message denied by access control"
         );
+        if is_dm && config.dm_policy == DmPolicy::Allowlist && config.otp_self_approval {
+            handle_otp_flow(
+                accounts,
+                account_id,
+                user_id,
+                username.as_deref(),
+                text,
+                channel_id,
+                event_sink.as_deref(),
+            )
+            .await;
+        }
         return;
     }
 
@@ -638,15 +662,180 @@ pub(crate) fn check_access(
     if is_dm {
         match dm_policy {
             DmPolicy::Open => true,
-            DmPolicy::Allowlist => is_allowed(user_id, user_allowlist),
+            DmPolicy::Allowlist => {
+                !user_allowlist.is_empty() && is_allowed(user_id, user_allowlist)
+            },
             DmPolicy::Disabled => false,
         }
     } else {
         match group_policy {
             GroupPolicy::Open => true,
-            GroupPolicy::Allowlist => is_allowed(channel_id, channel_allowlist),
+            GroupPolicy::Allowlist => {
+                !channel_allowlist.is_empty() && is_allowed(channel_id, channel_allowlist)
+            },
             GroupPolicy::Disabled => false,
         }
+    }
+}
+
+async fn handle_otp_flow(
+    accounts: &AccountStateMap,
+    account_id: &str,
+    user_id: &str,
+    username: Option<&str>,
+    text: &str,
+    channel_id: &str,
+    event_sink: Option<&dyn ChannelEventSink>,
+) {
+    let has_pending = {
+        let accts = accounts.read().unwrap_or_else(|e| e.into_inner());
+        accts
+            .get(account_id)
+            .map(|s| {
+                let otp = s.otp.lock().unwrap_or_else(|e| e.into_inner());
+                otp.has_pending(user_id)
+            })
+            .unwrap_or(false)
+    };
+
+    if has_pending {
+        let body = text.trim();
+        let is_code = body.len() == 6 && body.chars().all(|c| c.is_ascii_digit());
+        if !is_code {
+            return;
+        }
+
+        let result = {
+            let accts = accounts.read().unwrap_or_else(|e| e.into_inner());
+            match accts.get(account_id) {
+                Some(s) => {
+                    let mut otp = s.otp.lock().unwrap_or_else(|e| e.into_inner());
+                    otp.verify(user_id, body)
+                },
+                None => return,
+            }
+        };
+
+        match result {
+            OtpVerifyResult::Approved => {
+                approve_sender_via_otp(
+                    event_sink,
+                    ChannelType::Slack,
+                    account_id,
+                    user_id,
+                    user_id,
+                    username,
+                )
+                .await;
+                send_otp_status(
+                    accounts,
+                    account_id,
+                    channel_id,
+                    "Verified! You now have access to this bot.",
+                )
+                .await;
+            },
+            OtpVerifyResult::WrongCode { attempts_left } => {
+                let msg = format!(
+                    "Incorrect code. {attempts_left} attempt{} remaining.",
+                    if attempts_left == 1 {
+                        ""
+                    } else {
+                        "s"
+                    }
+                );
+                send_otp_status(accounts, account_id, channel_id, &msg).await;
+            },
+            OtpVerifyResult::LockedOut => {
+                send_otp_status(
+                    accounts,
+                    account_id,
+                    channel_id,
+                    "Too many failed attempts. Please try again later.",
+                )
+                .await;
+                emit_otp_resolution(
+                    event_sink,
+                    ChannelType::Slack,
+                    account_id,
+                    user_id,
+                    username,
+                    "locked_out",
+                )
+                .await;
+            },
+            OtpVerifyResult::Expired => {
+                send_otp_status(
+                    accounts,
+                    account_id,
+                    channel_id,
+                    "Your code has expired. Send any message to get a new one.",
+                )
+                .await;
+                emit_otp_resolution(
+                    event_sink,
+                    ChannelType::Slack,
+                    account_id,
+                    user_id,
+                    username,
+                    "expired",
+                )
+                .await;
+            },
+            OtpVerifyResult::NoPending => {},
+        }
+        return;
+    }
+
+    let init_result = {
+        let accts = accounts.read().unwrap_or_else(|e| e.into_inner());
+        match accts.get(account_id) {
+            Some(s) => {
+                let mut otp = s.otp.lock().unwrap_or_else(|e| e.into_inner());
+                otp.initiate(user_id, username.map(String::from), None)
+            },
+            None => return,
+        }
+    };
+
+    match init_result {
+        OtpInitResult::Created(code) => {
+            send_otp_status(accounts, account_id, channel_id, OTP_CHALLENGE_MSG).await;
+            let expires_at = std::time::SystemTime::now()
+                .checked_add(OTP_TTL)
+                .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+                .map(|d| d.as_secs() as i64)
+                .unwrap_or_default();
+            emit_otp_challenge(
+                event_sink,
+                ChannelType::Slack,
+                account_id,
+                user_id,
+                username,
+                None,
+                code,
+                expires_at,
+            )
+            .await;
+        },
+        OtpInitResult::AlreadyPending | OtpInitResult::LockedOut => {},
+    }
+}
+
+async fn send_otp_status(
+    accounts: &AccountStateMap,
+    account_id: &str,
+    channel_id: &str,
+    text: &str,
+) {
+    let outbound = SlackOutbound {
+        accounts: Arc::clone(accounts),
+    };
+    if let Err(e) = outbound.send_text(account_id, channel_id, text, None).await {
+        warn!(
+            account_id,
+            channel_id, "failed to send slack OTP status: {e}"
+        );
     }
 }
 
@@ -685,6 +874,19 @@ mod tests {
             &DmPolicy::Allowlist,
             &GroupPolicy::Open,
             &["U123".to_string()],
+            &[],
+        ));
+    }
+
+    #[test]
+    fn empty_dm_allowlist_denies_all() {
+        assert!(!check_access(
+            true,
+            "U123",
+            "D456",
+            &DmPolicy::Allowlist,
+            &GroupPolicy::Open,
+            &[],
             &[],
         ));
     }
@@ -734,6 +936,43 @@ mod tests {
             &GroupPolicy::Allowlist,
             &[],
             &["C456".to_string()],
+        ));
+    }
+
+    #[test]
+    fn empty_channel_allowlist_denies_all() {
+        assert!(!check_access(
+            false,
+            "U123",
+            "C456",
+            &DmPolicy::Allowlist,
+            &GroupPolicy::Allowlist,
+            &[],
+            &[],
+        ));
+    }
+
+    #[test]
+    fn removing_last_allowlist_entry_denies_access() {
+        let mut allowlist = vec!["U123".to_string()];
+        assert!(check_access(
+            true,
+            "U123",
+            "D456",
+            &DmPolicy::Allowlist,
+            &GroupPolicy::Open,
+            &allowlist,
+            &[],
+        ));
+        allowlist.clear();
+        assert!(!check_access(
+            true,
+            "U123",
+            "D456",
+            &DmPolicy::Allowlist,
+            &GroupPolicy::Open,
+            &allowlist,
+            &[],
         ));
     }
 

--- a/crates/slack/src/state.rs
+++ b/crates/slack/src/state.rs
@@ -1,10 +1,10 @@
 use std::{
     collections::HashMap,
-    sync::{Arc, RwLock},
+    sync::{Arc, Mutex, RwLock},
 };
 
 use {
-    moltis_channels::{ChannelEventSink, message_log::MessageLog},
+    moltis_channels::{ChannelEventSink, message_log::MessageLog, otp::OtpState},
     tokio_util::sync::CancellationToken,
 };
 
@@ -25,4 +25,5 @@ pub struct AccountState {
     /// Pending thread timestamps keyed by `channel_id:user_id`.
     /// Used to route replies into the correct thread.
     pub pending_threads: HashMap<String, String>,
+    pub otp: Mutex<OtpState>,
 }

--- a/crates/slack/src/webhook.rs
+++ b/crates/slack/src/webhook.rs
@@ -66,6 +66,8 @@ pub async fn register_events_api_account(
 
     let cancel = tokio_util::sync::CancellationToken::new();
 
+    let otp_cooldown_secs = config.otp_cooldown_secs;
+
     {
         let mut accts = accounts.write().unwrap_or_else(|e| e.into_inner());
         accts.insert(account_id.to_string(), AccountState {
@@ -76,6 +78,7 @@ pub async fn register_events_api_account(
             cancel,
             bot_user_id: Some(bot_user_id),
             pending_threads: std::collections::HashMap::new(),
+            otp: std::sync::Mutex::new(moltis_channels::otp::OtpState::new(otp_cooldown_secs)),
         });
     }
 
@@ -726,6 +729,7 @@ mod tests {
                 cancel: tokio_util::sync::CancellationToken::new(),
                 bot_user_id: Some("B123".to_string()),
                 pending_threads: std::collections::HashMap::new(),
+                otp: Mutex::new(moltis_channels::otp::OtpState::new(300)),
             });
         }
 
@@ -755,6 +759,7 @@ mod tests {
                 cancel: tokio_util::sync::CancellationToken::new(),
                 bot_user_id: Some("B123".to_string()),
                 pending_threads: std::collections::HashMap::new(),
+                otp: Mutex::new(moltis_channels::otp::OtpState::new(300)),
             });
         }
 
@@ -789,6 +794,7 @@ mod tests {
                 cancel: tokio_util::sync::CancellationToken::new(),
                 bot_user_id: Some("B123".to_string()),
                 pending_threads: std::collections::HashMap::new(),
+                otp: Mutex::new(moltis_channels::otp::OtpState::new(300)),
             });
         }
 

--- a/docs/src/channels.md
+++ b/docs/src/channels.md
@@ -227,7 +227,7 @@ All allowlist fields across all channels share the same matching behavior:
 
 ### OTP Self-Approval
 
-Channels that support OTP (Telegram, Discord, Matrix, WhatsApp) allow non-allowlisted
+Channels that support OTP (Telegram, Microsoft Teams, Slack, Discord, Matrix, WhatsApp) allow non-allowlisted
 users to self-approve by entering a 6-digit code. The code appears in the web UI
 under **Channels > Senders**. See each channel's page for details.
 

--- a/docs/src/channels/telephony.md
+++ b/docs/src/channels/telephony.md
@@ -54,7 +54,7 @@ provider has complete credentials.
 enabled = true                         # Enable phone calls globally
 provider = "twilio"                    # twilio | telnyx | plivo
 inbound_policy = "disabled"            # disabled | allowlist | open
-allowlist = ["+15559876543"]           # Allowed inbound callers (E.164)
+allowlist = ["+15559876543"]           # Allowed inbound callers (E.164); empty list denies all calls
 max_duration_secs = 3600               # Max call duration (default: 1 hour)
 
 [phone.twilio]
@@ -132,7 +132,7 @@ Configure these in your provider's phone number or call-control settings, or the
 ## Security
 
 - **Webhook verification**: Twilio webhooks are verified using HMAC-SHA1 signature validation; Plivo and Telnyx verification are used when their signature credentials are configured
-- **Inbound access control**: Phone numbers can be restricted via allowlist
+- **Inbound access control**: Phone numbers can be restricted via allowlist. With `inbound_policy = "allowlist"`, an empty allowlist rejects all inbound calls
 - **Credential storage**: Provider credentials are stored in the credential store when configured from Settings > Phone
 - **Max duration**: Calls are automatically terminated after the configured max duration
 

--- a/docs/src/matrix.md
+++ b/docs/src/matrix.md
@@ -291,7 +291,7 @@ picker list from `moltis.toml`.
 | `mention_mode` | no | `"mention"` | When the bot responds in rooms: `"always"`, `"mention"`, or `"none"` |
 | `room_allowlist` | no | `[]` | Matrix room IDs or aliases allowed to interact with the bot |
 | `user_allowlist` | no | `[]` | Matrix user IDs allowed to DM the bot |
-| `auto_join` | no | `"always"` | Invite handling: `"always"`, `"allowlist"`, or `"off"` |
+| `auto_join` | no | `"always"` | Invite handling: `"always"`, `"allowlist"`, or `"off"`. With `"allowlist"`, invites are accepted only when the inviter is on `user_allowlist` or the room is on `room_allowlist`; empty allowlists deny all invites |
 | `model` | no | — | Override the default model for this account |
 | `model_provider` | no | — | Provider for the overridden model |
 | `stream_mode` | no | `"edit_in_place"` | How streaming replies are sent: `"edit_in_place"` or `"off"` |

--- a/docs/src/metrics-and-tracing.md
+++ b/docs/src/metrics-and-tracing.md
@@ -273,6 +273,8 @@ This allows you to:
 | `moltis_channels_active` | Gauge | — | Loaded channel plugins |
 | `moltis_channel_messages_received_total` | Counter | channel | Inbound messages |
 | `moltis_channel_messages_sent_total` | Counter | channel | Outbound messages |
+| `moltis_channel_otp_challenges_total` | Counter | channel | OTP challenges issued to non-allowlisted users |
+| `moltis_channel_otp_verifications_total` | Counter | channel, result | OTP verification attempts (`approved`, `wrong_code`, `locked_out`, `expired`) |
 
 ### Telegram-Specific Metrics
 

--- a/docs/src/slack.md
+++ b/docs/src/slack.md
@@ -95,6 +95,8 @@ offered = ["slack"]
 | `mention_mode` | no | `"mention"` | When the bot responds in channels: `"always"`, `"mention"`, or `"none"` |
 | `allowlist` | no | `[]` | Slack user IDs allowed to DM the bot (when `dm_policy = "allowlist"`) |
 | `channel_allowlist` | no | `[]` | Slack channel IDs allowed to interact with the bot |
+| `otp_self_approval` | no | `true` | Enable OTP self-approval for non-allowlisted DM users |
+| `otp_cooldown_secs` | no | `300` | Cooldown after failed OTP attempts |
 | `model` | no | — | Override the default model for this channel |
 | `model_provider` | no | — | Provider for the overridden model |
 | `stream_mode` | no | `"edit_in_place"` | Streaming mode: `"edit_in_place"`, `"native"`, or `"off"` |
@@ -124,6 +126,8 @@ group_policy = "open"
 mention_mode = "mention"
 allowlist = ["U0123456789", "U9876543210"]
 channel_allowlist = ["C0123456789"]
+otp_self_approval = true
+otp_cooldown_secs = 300
 model = "claude-sonnet-4-20250514"
 model_provider = "anthropic"
 stream_mode = "edit_in_place"
@@ -185,16 +189,21 @@ Slack uses the same gating system as Telegram, Discord, and other channels.
 
 | Value | Behavior |
 |-------|----------|
-| `"allowlist"` | Only users listed in `allowlist` can DM (default) |
+| `"allowlist"` | Only users listed in `allowlist` can DM (default). If the allowlist is empty, unknown users receive an OTP challenge when `otp_self_approval = true`. |
 | `"open"` | Anyone in the workspace can DM the bot |
 | `"disabled"` | DMs are silently ignored |
+
+When `dm_policy = "allowlist"` and `otp_self_approval = true`, unknown DM users
+receive a verification prompt. The PIN is visible to the bot owner in the web UI
+under **Channels → Senders**. After a correct PIN reply, Moltis adds the sender's
+Slack user ID, such as `U0123456789`, to the account allowlist.
 
 ### Group Policy
 
 | Value | Behavior |
 |-------|----------|
 | `"open"` | Bot responds in any channel it's invited to (default) |
-| `"allowlist"` | Only channels listed in `channel_allowlist` are allowed |
+| `"allowlist"` | Only channels listed in `channel_allowlist` are allowed. An empty channel allowlist denies all channels. |
 | `"disabled"` | Channel messages are silently ignored |
 
 ### Mention Mode

--- a/docs/src/teams.md
+++ b/docs/src/teams.md
@@ -127,6 +127,8 @@ app_password = "your-client-secret-here"
 | `mention_mode` | no | `"mention"` | When the bot responds in groups: `"always"`, `"mention"`, or `"none"` |
 | `allowlist` | no | `[]` | AAD object IDs or user IDs allowed to DM the bot |
 | `group_allowlist` | no | `[]` | Conversation/team IDs allowed for group messages |
+| `otp_self_approval` | no | `true` | Enable OTP self-approval for non-allowlisted DM users |
+| `otp_cooldown_secs` | no | `300` | Cooldown after failed OTP attempts |
 | `model` | no | — | Override the default model for this channel |
 | `model_provider` | no | — | Provider for the overridden model |
 | `stream_mode` | no | `"edit_in_place"` | `"edit_in_place"` (live updates) or `"off"` (send once complete) |
@@ -158,6 +160,8 @@ dm_policy = "allowlist"
 group_policy = "open"
 mention_mode = "mention"
 allowlist = ["00000000-0000-0000-0000-000000000001"]
+otp_self_approval = true
+otp_cooldown_secs = 300
 stream_mode = "edit_in_place"
 edit_throttle_ms = 1500
 welcome_card = true
@@ -193,9 +197,14 @@ Controls who can send direct messages to the bot.
 
 | Value | Behavior |
 |-------|----------|
-| `"allowlist"` | Only users listed in `allowlist` can DM (default) |
+| `"allowlist"` | Only users listed in `allowlist` can DM (default). If the allowlist is empty, unknown users receive an OTP challenge when `otp_self_approval = true`. |
 | `"open"` | Anyone who can reach the bot can DM it |
 | `"disabled"` | DMs are silently ignored |
+
+When `dm_policy = "allowlist"` and `otp_self_approval = true`, unknown DM users
+receive a verification prompt. The PIN is visible to the bot owner in the web UI
+under **Channels → Senders**. After a correct PIN reply, Moltis adds the sender's
+Teams user ID to the account allowlist.
 
 ### Group Policy
 
@@ -204,7 +213,7 @@ Controls who can interact with the bot in group chats and team channels.
 | Value | Behavior |
 |-------|----------|
 | `"open"` | Bot responds in any group chat (default) |
-| `"allowlist"` | Only conversations listed in `group_allowlist` are allowed |
+| `"allowlist"` | Only conversations listed in `group_allowlist` are allowed. An empty group allowlist denies all groups. |
 | `"disabled"` | Group messages are silently ignored |
 
 ### Mention Mode


### PR DESCRIPTION
## Summary
- Fix Slack allowlist semantics so empty DM/channel allowlists deny access instead of becoming open
- Add Slack OTP self-approval for non-allowlisted DM users using the shared channel OTP flow
- Fix additional empty-allowlist bypasses in Microsoft Teams, Signal group access, and Matrix DM invite auto-join
- Add Microsoft Teams OTP self-approval for non-allowlisted DM users and expose Teams OTP capability/provider
- Close two remaining empty-allowlist gaps: Matrix `auto_join = "allowlist"` with empty allowlists no longer auto-joins any invite, and telephony inbound-call gating (Twilio/Telnyx) no longer accepts all callers when the allowlist is empty (shared `inbound_call_rejected()` helper with unit tests)
- Record `moltis_channel_otp_challenges_total` / `moltis_channel_otp_verifications_total` metrics in the new Slack and Teams OTP flows, mirroring Telegram
- Export the canonical `OTP_TTL` from `moltis-channels` (removes duplicated local constants); Teams OTP events now carry the sender display name
- Document the new Slack/Teams OTP settings, empty-allowlist denial for Matrix auto-join and telephony, the new metrics, and update config template examples

Follow-ups filed: `moltis-agox` (propagate OTP approval failures — Greptile P1/P2, pre-existing across all channels), `moltis-8q2c` (extract shared OTP flow into `moltis-channels`).

## Validation
### Completed
- [x] `cargo test -p moltis-slack`
- [x] `cargo test -p moltis-channels`
- [x] `cargo test -p moltis-msteams`
- [x] `cargo test -p moltis-signal`
- [x] `cargo test -p moltis-matrix`
- [x] `cargo test -p moltis-config`
- [x] `cargo test -p moltis-httpd --lib` (telephony gating helper)
- [x] `cargo check -p moltis-slack --features metrics` / `-p moltis-msteams --features metrics`
- [x] `just lint`
- [x] `cargo fmt --all -- --check`
- [x] `git diff --check`

### Remaining
- [ ] Full `just test` not run locally

## Manual QA
- Not run. Behavior is covered by channel access-control/config/provider unit tests; live Slack/Teams OTP flows require configured workspace apps.