### PR TITLE
fix(slack): allow operator-approved api base hosts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7311,6 +7311,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
+ "url",
 ]
 
 [[package]]

--- a/crates/channels/Cargo.toml
+++ b/crates/channels/Cargo.toml
@@ -16,6 +16,7 @@ serde_json     = { workspace = true }
 thiserror      = { workspace = true }
 tokio          = { workspace = true }
 tracing        = { workspace = true }
+url            = { workspace = true }
 
 [features]
 default = []

--- a/crates/channels/src/lib.rs
+++ b/crates/channels/src/lib.rs
@@ -15,6 +15,7 @@ pub mod message_log;
 pub mod otp;
 pub mod plugin;
 pub mod registry;
+pub mod slack_api_url;
 pub mod store;
 
 pub use {
@@ -35,4 +36,5 @@ pub use {
         web_session_channel_binding,
     },
     registry::{ChannelRegistry, RegistryOutboundRouter},
+    slack_api_url::normalize_slack_api_base_url,
 };

--- a/crates/channels/src/lib.rs
+++ b/crates/channels/src/lib.rs
@@ -36,5 +36,5 @@ pub use {
         web_session_channel_binding,
     },
     registry::{ChannelRegistry, RegistryOutboundRouter},
-    slack_api_url::normalize_slack_api_base_url,
+    slack_api_url::{normalize_slack_api_base_url, validate_slack_api_base_url},
 };

--- a/crates/channels/src/slack_api_url.rs
+++ b/crates/channels/src/slack_api_url.rs
@@ -1,0 +1,219 @@
+//! Validation for user-supplied Slack Web API base URLs.
+//!
+//! `api_base_url` is attacker-influenceable config that the server turns into
+//! outbound HTTP (and WebSocket) requests, so it is an SSRF vector. By default we
+//! reject localhost and private/loopback/link-local/CGNAT/unique-local targets.
+//!
+//! Operators who deliberately front Slack with an internal proxy can opt specific
+//! hosts back in via the `MOLTIS_SLACK_API_BASE_URL_ALLOWLIST` env var
+//! (comma-separated exact hosts). Cloud metadata addresses stay blocked even when
+//! allowlisted, since no legitimate Slack base URL resolves there.
+
+use std::{
+    net::{IpAddr, Ipv4Addr, Ipv6Addr},
+    sync::OnceLock,
+};
+
+use url::Url;
+
+use crate::error::{Error, Result};
+
+/// Env var holding a comma-separated list of exact hosts allowed to bypass the
+/// private-address SSRF guard for Slack `api_base_url`.
+pub const ALLOWLIST_ENV_VAR: &str = "MOLTIS_SLACK_API_BASE_URL_ALLOWLIST";
+
+/// Normalize and validate a Slack Web API base URL, honoring the operator
+/// allowlist from `MOLTIS_SLACK_API_BASE_URL_ALLOWLIST`.
+///
+/// Returns the trimmed URL (no trailing slash) or an `InvalidInput` error.
+pub fn normalize_slack_api_base_url(api_base_url: &str) -> Result<String> {
+    let trimmed = api_base_url.trim().trim_end_matches('/');
+    let parsed = Url::parse(trimmed).map_err(|e| {
+        Error::invalid_input(format!("Slack api_base_url must be an absolute URL: {e}"))
+    })?;
+    if !matches!(parsed.scheme(), "http" | "https") || parsed.host_str().is_none() {
+        return Err(Error::invalid_input(
+            "Slack api_base_url must be an absolute HTTP(S) URL",
+        ));
+    }
+    validate_host(&parsed, host_allowlist())?;
+    Ok(trimmed.to_string())
+}
+
+/// The process-wide allowlist, parsed once from the environment.
+fn host_allowlist() -> &'static [String] {
+    static ALLOW: OnceLock<Vec<String>> = OnceLock::new();
+    ALLOW.get_or_init(|| {
+        std::env::var(ALLOWLIST_ENV_VAR)
+            .ok()
+            .map(|raw| parse_allowlist(&raw))
+            .unwrap_or_default()
+    })
+}
+
+/// Split a comma-separated allowlist into normalized host entries.
+fn parse_allowlist(raw: &str) -> Vec<String> {
+    raw.split(',')
+        .map(normalize_host)
+        .filter(|host| !host.is_empty())
+        .collect()
+}
+
+/// Normalize a host for case-insensitive comparison, stripping IPv6 brackets.
+fn normalize_host(host: &str) -> String {
+    host.trim()
+        .trim_matches(&['[', ']'][..])
+        .to_ascii_lowercase()
+}
+
+/// Validate the URL's host against the SSRF policy, given an allowlist.
+///
+/// Order matters: cloud-metadata addresses are rejected before the allowlist is
+/// consulted, so an allowlisted entry can never reach the metadata service.
+fn validate_host(url: &Url, allowlist: &[String]) -> Result<()> {
+    let host = url
+        .host_str()
+        .ok_or_else(|| Error::invalid_input("Slack api_base_url must include a host"))?;
+    let normalized = normalize_host(host);
+    let parsed_ip = normalized.parse::<IpAddr>().ok();
+
+    if let Some(ip) = parsed_ip
+        && is_cloud_metadata_ip(&ip)
+    {
+        return Err(Error::invalid_input(format!(
+            "Slack api_base_url must not target the cloud metadata address {ip}"
+        )));
+    }
+
+    if allowlist.contains(&normalized) {
+        return Ok(());
+    }
+
+    if normalized == "localhost" {
+        return Err(Error::invalid_input(
+            "Slack api_base_url must not target localhost",
+        ));
+    }
+    if let Some(ip) = parsed_ip
+        && is_disallowed_ip(&ip)
+    {
+        return Err(Error::invalid_input(format!(
+            "Slack api_base_url must not target private or local IP {ip}"
+        )));
+    }
+    Ok(())
+}
+
+/// Cloud metadata endpoints (AWS/GCP/Azure IMDS). Blocked unconditionally.
+fn is_cloud_metadata_ip(ip: &IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(v4) => *v4 == Ipv4Addr::new(169, 254, 169, 254),
+        IpAddr::V6(v6) => {
+            if let Some(v4) = v6.to_ipv4_mapped() {
+                return is_cloud_metadata_ip(&IpAddr::V4(v4));
+            }
+            // AWS IMDS over IPv6.
+            *v6 == Ipv6Addr::new(0xfd00, 0xec2, 0, 0, 0, 0, 0, 0x254)
+        },
+    }
+}
+
+fn is_disallowed_ip(ip: &IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(v4) => {
+            v4.is_loopback()
+                || v4.is_private()
+                || v4.is_link_local()
+                || v4.is_unspecified()
+                || v4.is_broadcast()
+                || v4.is_multicast()
+                || is_cgnat(*v4)
+        },
+        IpAddr::V6(v6) => {
+            if let Some(v4) = v6.to_ipv4_mapped() {
+                return is_disallowed_ip(&IpAddr::V4(v4));
+            }
+            v6.is_loopback()
+                || v6.is_unspecified()
+                || v6.is_multicast()
+                || is_ipv6_unique_local(*v6)
+                || is_ipv6_link_local(*v6)
+        },
+    }
+}
+
+fn is_cgnat(ip: Ipv4Addr) -> bool {
+    let octets = ip.octets();
+    octets[0] == 100 && (64..=127).contains(&octets[1])
+}
+
+fn is_ipv6_unique_local(ip: Ipv6Addr) -> bool {
+    (ip.segments()[0] & 0xfe00) == 0xfc00
+}
+
+fn is_ipv6_link_local(ip: Ipv6Addr) -> bool {
+    (ip.segments()[0] & 0xffc0) == 0xfe80
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    fn check(url: &str, allowlist: &[&str]) -> Result<()> {
+        let allow: Vec<String> = allowlist.iter().map(|host| normalize_host(host)).collect();
+        validate_host(&Url::parse(url).unwrap(), &allow)
+    }
+
+    #[test]
+    fn public_host_passes_with_empty_allowlist() {
+        assert!(check("https://slack.com/api", &[]).is_ok());
+        assert!(check("https://proxy.example.com/api", &[]).is_ok());
+    }
+
+    #[test]
+    fn localhost_and_private_ips_rejected_by_default() {
+        assert!(check("http://localhost/api", &[]).is_err());
+        assert!(check("http://127.0.0.1/api", &[]).is_err());
+        assert!(check("http://10.0.0.5/api", &[]).is_err());
+        assert!(check("http://192.168.1.1/api", &[]).is_err());
+        assert!(check("http://100.64.0.1/api", &[]).is_err());
+        assert!(check("http://[fc00::1]/api", &[]).is_err());
+        assert!(check("http://[fe80::1]/api", &[]).is_err());
+    }
+
+    #[test]
+    fn allowlisted_hosts_pass() {
+        assert!(check("http://localhost/api", &["localhost"]).is_ok());
+        assert!(check("http://127.0.0.1:8080/api", &["127.0.0.1"]).is_ok());
+        assert!(check("http://proxy.internal/api", &["proxy.internal"]).is_ok());
+        assert!(check("http://[::1]/api", &["::1"]).is_ok());
+    }
+
+    #[test]
+    fn allowlist_is_case_insensitive_and_host_scoped() {
+        assert!(check("http://Proxy.Internal/api", &["proxy.internal"]).is_ok());
+        // Allowlisting one private host does not open others.
+        assert!(check("http://10.0.0.9/api", &["127.0.0.1"]).is_err());
+    }
+
+    #[test]
+    fn cloud_metadata_blocked_even_when_allowlisted() {
+        assert!(check("http://169.254.169.254/api", &["169.254.169.254"]).is_err());
+        assert!(check("http://[fd00:ec2::254]/api", &["fd00:ec2::254"]).is_err());
+    }
+
+    #[test]
+    fn normalize_trims_trailing_slash_and_whitespace() {
+        assert_eq!(
+            normalize_slack_api_base_url("  https://slack.com/api/  ").unwrap(),
+            "https://slack.com/api"
+        );
+    }
+
+    #[test]
+    fn normalize_rejects_non_http_scheme() {
+        assert!(normalize_slack_api_base_url("ftp://slack.com/api").is_err());
+        assert!(normalize_slack_api_base_url("not-a-url").is_err());
+    }
+}

--- a/crates/channels/src/slack_api_url.rs
+++ b/crates/channels/src/slack_api_url.rs
@@ -3,11 +3,19 @@
 //! `api_base_url` is attacker-influenceable config that the server turns into
 //! outbound HTTP (and WebSocket) requests, so it is an SSRF vector. By default we
 //! reject localhost and private/loopback/link-local/CGNAT/unique-local targets.
+//! [`normalize_slack_api_base_url`] checks syntax and literal-IP hosts;
+//! [`validate_slack_api_base_url`] additionally resolves DNS hostnames and
+//! applies the same policy to every resolved address, so a name like
+//! `proxy.internal` pointing at a private or metadata address is rejected too.
 //!
 //! Operators who deliberately front Slack with an internal proxy can opt specific
 //! hosts back in via the `MOLTIS_SLACK_API_BASE_URL_ALLOWLIST` env var
 //! (comma-separated exact hosts). Cloud metadata addresses stay blocked even when
 //! allowlisted, since no legitimate Slack base URL resolves there.
+//!
+//! Known limitation: DNS is checked when the config is validated (account
+//! registration / config save), not re-pinned at connect time, so a record that
+//! is rebound afterwards is not re-checked on every request.
 
 use std::{
     net::{IpAddr, Ipv4Addr, Ipv6Addr},
@@ -38,6 +46,41 @@ pub fn normalize_slack_api_base_url(api_base_url: &str) -> Result<String> {
     }
     validate_host(&parsed, host_allowlist())?;
     Ok(trimmed.to_string())
+}
+
+/// Normalize and validate a Slack Web API base URL, additionally resolving DNS
+/// hostnames and rejecting any that resolve to private, local, or
+/// cloud-metadata addresses.
+///
+/// Use this at trust boundaries (account registration, config save). Hot paths
+/// whose config already passed validation can use the cheaper
+/// [`normalize_slack_api_base_url`]. Fails closed: a host that does not resolve
+/// is rejected.
+pub async fn validate_slack_api_base_url(api_base_url: &str) -> Result<String> {
+    let normalized = normalize_slack_api_base_url(api_base_url)?;
+    let parsed = Url::parse(&normalized).map_err(|e| {
+        Error::invalid_input(format!("Slack api_base_url must be an absolute URL: {e}"))
+    })?;
+    let host = parsed
+        .host_str()
+        .ok_or_else(|| Error::invalid_input("Slack api_base_url must include a host"))?;
+    let normalized_host = normalize_host(host);
+    if normalized_host.parse::<IpAddr>().is_ok() {
+        // Literal IPs were fully checked by `normalize_slack_api_base_url`.
+        return Ok(normalized);
+    }
+    let port = parsed.port_or_known_default().unwrap_or(443);
+    let resolved: Vec<IpAddr> = tokio::net::lookup_host((normalized_host.as_str(), port))
+        .await
+        .map_err(|e| {
+            Error::invalid_input(format!(
+                "Slack api_base_url host {normalized_host} did not resolve: {e}"
+            ))
+        })?
+        .map(|addr| addr.ip())
+        .collect();
+    check_resolved_ips(&normalized_host, &resolved, host_allowlist())?;
+    Ok(normalized)
 }
 
 /// The process-wide allowlist, parsed once from the environment.
@@ -100,6 +143,33 @@ fn validate_host(url: &Url, allowlist: &[String]) -> Result<()> {
         return Err(Error::invalid_input(format!(
             "Slack api_base_url must not target private or local IP {ip}"
         )));
+    }
+    Ok(())
+}
+
+/// Apply the SSRF policy to a hostname's resolved addresses.
+///
+/// Cloud-metadata addresses are rejected even for allowlisted hosts; private
+/// and local addresses are rejected unless the host is allowlisted. An empty
+/// resolution set is rejected so validation fails closed.
+fn check_resolved_ips(host: &str, ips: &[IpAddr], allowlist: &[String]) -> Result<()> {
+    if ips.is_empty() {
+        return Err(Error::invalid_input(format!(
+            "Slack api_base_url host {host} did not resolve to any address"
+        )));
+    }
+    let host_allowlisted = allowlist.iter().any(|entry| entry == host);
+    for ip in ips {
+        if is_cloud_metadata_ip(ip) {
+            return Err(Error::invalid_input(format!(
+                "Slack api_base_url host {host} resolves to the cloud metadata address {ip}"
+            )));
+        }
+        if !host_allowlisted && is_disallowed_ip(ip) {
+            return Err(Error::invalid_input(format!(
+                "Slack api_base_url host {host} resolves to private or local IP {ip}"
+            )));
+        }
     }
     Ok(())
 }
@@ -215,5 +285,74 @@ mod tests {
     fn normalize_rejects_non_http_scheme() {
         assert!(normalize_slack_api_base_url("ftp://slack.com/api").is_err());
         assert!(normalize_slack_api_base_url("not-a-url").is_err());
+    }
+
+    fn check_resolved(host: &str, ips: &[&str], allowlist: &[&str]) -> Result<()> {
+        let ips: Vec<IpAddr> = ips.iter().map(|ip| ip.parse().unwrap()).collect();
+        let allow: Vec<String> = allowlist
+            .iter()
+            .map(|entry| normalize_host(entry))
+            .collect();
+        check_resolved_ips(host, &ips, &allow)
+    }
+
+    #[test]
+    fn hostname_resolving_to_private_ip_rejected_by_default() {
+        assert!(check_resolved("proxy.internal", &["127.0.0.1"], &[]).is_err());
+        assert!(check_resolved("proxy.internal", &["10.0.0.5"], &[]).is_err());
+        assert!(check_resolved("proxy.internal", &["fe80::1"], &[]).is_err());
+        // One private address among public ones still rejects.
+        assert!(check_resolved("proxy.internal", &["93.184.216.34", "192.168.1.1"], &[]).is_err());
+    }
+
+    #[test]
+    fn hostname_resolving_to_public_ips_passes() {
+        assert!(check_resolved("slack.com", &["3.122.0.1", "2600:1f18::1"], &[]).is_ok());
+    }
+
+    #[test]
+    fn allowlisted_hostname_may_resolve_to_private_ip() {
+        assert!(check_resolved("proxy.internal", &["10.0.0.5"], &["proxy.internal"]).is_ok());
+        // Allowlisting one host does not open others.
+        assert!(check_resolved("other.internal", &["10.0.0.5"], &["proxy.internal"]).is_err());
+    }
+
+    #[test]
+    fn hostname_resolving_to_metadata_rejected_even_when_allowlisted() {
+        assert!(
+            check_resolved("proxy.internal", &["169.254.169.254"], &["proxy.internal"]).is_err()
+        );
+        assert!(check_resolved("proxy.internal", &["fd00:ec2::254"], &["proxy.internal"]).is_err());
+        assert!(
+            check_resolved("proxy.internal", &["::ffff:169.254.169.254"], &[
+                "proxy.internal"
+            ])
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn empty_resolution_fails_closed() {
+        assert!(check_resolved("proxy.internal", &[], &[]).is_err());
+        assert!(check_resolved("proxy.internal", &[], &["proxy.internal"]).is_err());
+    }
+
+    #[tokio::test]
+    async fn validate_rejects_literal_private_ips_without_dns() {
+        assert!(
+            validate_slack_api_base_url("http://127.0.0.1/api")
+                .await
+                .is_err()
+        );
+        assert!(
+            validate_slack_api_base_url("http://169.254.169.254/api")
+                .await
+                .is_err()
+        );
+        assert!(
+            validate_slack_api_base_url("http://localhost/api")
+                .await
+                .is_err()
+        );
     }
 }

--- a/crates/gateway/src/channel_agent_tools.rs
+++ b/crates/gateway/src/channel_agent_tools.rs
@@ -9,7 +9,7 @@ use {
     },
     serde::{Deserialize, Serialize},
     serde_json::{Map, Value, json},
-    std::{net::IpAddr, sync::Arc},
+    std::sync::Arc,
 };
 
 use crate::services::ChannelService;
@@ -470,7 +470,8 @@ fn apply_channel_settings_patch(
             "api_base_url",
             matches!(channel_type, ChannelType::Slack),
         )?;
-        let api_base_url = normalize_slack_api_base_url_setting(api_base_url)?;
+        let api_base_url = moltis_channels::normalize_slack_api_base_url(api_base_url)
+            .map_err(|e| anyhow!("{e}"))?;
         config.insert("api_base_url".into(), json!(api_base_url));
         changes.push("api_base_url".to_string());
     }
@@ -514,62 +515,6 @@ fn apply_channel_settings_patch(
     }
 
     Ok(changes)
-}
-
-fn normalize_slack_api_base_url_setting(api_base_url: &str) -> Result<String> {
-    let trimmed = api_base_url.trim().trim_end_matches('/');
-    let parsed = reqwest::Url::parse(trimmed)
-        .map_err(|e| anyhow!("Slack api_base_url must be an absolute URL: {e}"))?;
-    if !matches!(parsed.scheme(), "http" | "https") || parsed.host_str().is_none() {
-        return Err(anyhow!(
-            "Slack api_base_url must be an absolute HTTP(S) URL"
-        ));
-    }
-    validate_slack_api_base_url_host(&parsed)?;
-    Ok(trimmed.to_string())
-}
-
-fn validate_slack_api_base_url_host(url: &reqwest::Url) -> Result<()> {
-    let host = url
-        .host_str()
-        .ok_or_else(|| anyhow!("Slack api_base_url must include a host"))?;
-    if host.eq_ignore_ascii_case("localhost") {
-        return Err(anyhow!("Slack api_base_url must not target localhost"));
-    }
-    if let Ok(ip) = host.trim_matches(&['[', ']'][..]).parse::<IpAddr>()
-        && is_disallowed_slack_api_ip(&ip)
-    {
-        return Err(anyhow!(
-            "Slack api_base_url must not target private or local IP {ip}"
-        ));
-    }
-    Ok(())
-}
-
-fn is_disallowed_slack_api_ip(ip: &IpAddr) -> bool {
-    match ip {
-        IpAddr::V4(v4) => {
-            let octets = v4.octets();
-            v4.is_loopback()
-                || v4.is_private()
-                || v4.is_link_local()
-                || v4.is_unspecified()
-                || v4.is_broadcast()
-                || v4.is_multicast()
-                || (octets[0] == 100 && (64..=127).contains(&octets[1]))
-        },
-        IpAddr::V6(v6) => {
-            if let Some(v4) = v6.to_ipv4_mapped() {
-                return is_disallowed_slack_api_ip(&IpAddr::V4(v4));
-            }
-            let first = v6.segments()[0];
-            v6.is_loopback()
-                || v6.is_unspecified()
-                || v6.is_multicast()
-                || (first & 0xfe00) == 0xfc00
-                || (first & 0xffc0) == 0xfe80
-        },
-    }
 }
 
 fn ensure_supported(channel_type: ChannelType, field: &str, supported: bool) -> Result<()> {
@@ -1197,7 +1142,7 @@ mod tests {
             .execute(json!({
                 "account_id": "slack-main",
                 "settings": {
-                    "api_base_url": "http://169.254.169.254/latest/meta-data"
+                    "api_base_url": "http://10.0.0.1/api"
                 }
             }))
             .await
@@ -1234,7 +1179,7 @@ mod tests {
             .await
             .expect_err("IPv4-mapped private Slack api_base_url should be rejected");
 
-        assert!(err.to_string().contains("private or local IP"));
+        assert!(err.to_string().contains("cloud metadata address"));
     }
 
     #[tokio::test]

--- a/crates/slack/src/client.rs
+++ b/crates/slack/src/client.rs
@@ -1,80 +1,10 @@
-use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
-
 use slack_morphism::prelude::*;
 
-use moltis_channels::{Error as ChannelError, Result as ChannelResult};
+use moltis_channels::{
+    Error as ChannelError, Result as ChannelResult, normalize_slack_api_base_url,
+};
 
 pub const DEFAULT_SLACK_API_BASE_URL: &str = "https://slack.com/api";
-
-pub fn normalize_slack_api_base_url(api_base_url: &str) -> ChannelResult<String> {
-    let trimmed = api_base_url.trim().trim_end_matches('/');
-    let parsed = reqwest::Url::parse(trimmed).map_err(|e| {
-        ChannelError::invalid_input(format!("Slack api_base_url must be an absolute URL: {e}"))
-    })?;
-    if !matches!(parsed.scheme(), "http" | "https") || parsed.host_str().is_none() {
-        return Err(ChannelError::invalid_input(
-            "Slack api_base_url must be an absolute HTTP(S) URL",
-        ));
-    }
-    validate_public_host(&parsed)?;
-    Ok(trimmed.to_string())
-}
-
-fn validate_public_host(url: &reqwest::Url) -> ChannelResult<()> {
-    let host = url
-        .host_str()
-        .ok_or_else(|| ChannelError::invalid_input("Slack api_base_url must include a host"))?;
-    if host.eq_ignore_ascii_case("localhost") {
-        return Err(ChannelError::invalid_input(
-            "Slack api_base_url must not target localhost",
-        ));
-    }
-    if let Ok(ip) = host.trim_matches(&['[', ']'][..]).parse::<IpAddr>()
-        && is_disallowed_ip(&ip)
-    {
-        return Err(ChannelError::invalid_input(format!(
-            "Slack api_base_url must not target private or local IP {ip}"
-        )));
-    }
-    Ok(())
-}
-
-fn is_disallowed_ip(ip: &IpAddr) -> bool {
-    match ip {
-        IpAddr::V4(v4) => {
-            v4.is_loopback()
-                || v4.is_private()
-                || v4.is_link_local()
-                || v4.is_unspecified()
-                || v4.is_broadcast()
-                || v4.is_multicast()
-                || is_cgnat(*v4)
-        },
-        IpAddr::V6(v6) => {
-            if let Some(v4) = v6.to_ipv4_mapped() {
-                return is_disallowed_ip(&IpAddr::V4(v4));
-            }
-            v6.is_loopback()
-                || v6.is_unspecified()
-                || v6.is_multicast()
-                || is_ipv6_unique_local(*v6)
-                || is_ipv6_link_local(*v6)
-        },
-    }
-}
-
-fn is_cgnat(ip: Ipv4Addr) -> bool {
-    let octets = ip.octets();
-    octets[0] == 100 && (64..=127).contains(&octets[1])
-}
-
-fn is_ipv6_unique_local(ip: Ipv6Addr) -> bool {
-    (ip.segments()[0] & 0xfe00) == 0xfc00
-}
-
-fn is_ipv6_link_local(ip: Ipv6Addr) -> bool {
-    (ip.segments()[0] & 0xffc0) == 0xfe80
-}
 
 pub fn slack_client_for_base_url(
     api_base_url: &str,

--- a/crates/slack/src/client.rs
+++ b/crates/slack/src/client.rs
@@ -2,9 +2,22 @@ use slack_morphism::prelude::*;
 
 use moltis_channels::{
     Error as ChannelError, Result as ChannelResult, normalize_slack_api_base_url,
+    validate_slack_api_base_url,
 };
 
 pub const DEFAULT_SLACK_API_BASE_URL: &str = "https://slack.com/api";
+
+/// Build a Slack client after full base-URL validation, including DNS
+/// resolution of hostname targets against the SSRF policy.
+///
+/// Use this at account registration. Hot paths whose config already passed
+/// registration can use the cheaper [`slack_client_for_base_url`].
+pub async fn validated_slack_client_for_base_url(
+    api_base_url: &str,
+) -> ChannelResult<SlackClient<SlackClientHyperHttpsConnector>> {
+    validate_slack_api_base_url(api_base_url).await?;
+    slack_client_for_base_url(api_base_url)
+}
 
 pub fn slack_client_for_base_url(
     api_base_url: &str,

--- a/crates/slack/src/socket.rs
+++ b/crates/slack/src/socket.rs
@@ -21,7 +21,7 @@ use moltis_channels::{
 };
 
 use crate::{
-    client::slack_client_for_base_url,
+    client::validated_slack_client_for_base_url,
     config::SlackAccountConfig,
     markdown::strip_mentions,
     outbound::SlackOutbound,
@@ -62,7 +62,7 @@ pub async fn start_socket_mode(
         ));
     }
 
-    let client = Arc::new(slack_client_for_base_url(&config.api_base_url)?);
+    let client = Arc::new(validated_slack_client_for_base_url(&config.api_base_url).await?);
 
     // Verify the bot token and get the bot user ID.
     let bot_token = SlackApiToken::new(SlackApiTokenValue::from(bot_token_str));

--- a/crates/slack/src/webhook.rs
+++ b/crates/slack/src/webhook.rs
@@ -21,7 +21,7 @@ use moltis_channels::{
 };
 
 use crate::{
-    client::slack_client_for_base_url,
+    client::validated_slack_client_for_base_url,
     config::SlackAccountConfig,
     state::{AccountState, AccountStateMap},
 };
@@ -48,7 +48,7 @@ pub async fn register_events_api_account(
         ));
     }
 
-    let client = Arc::new(slack_client_for_base_url(&config.api_base_url)?);
+    let client = Arc::new(validated_slack_client_for_base_url(&config.api_base_url).await?);
 
     // Verify the bot token and get the bot user ID.
     let bot_token = SlackApiToken::new(SlackApiTokenValue::from(bot_token_str));

--- a/docs/src/slack.md
+++ b/docs/src/slack.md
@@ -178,6 +178,23 @@ The endpoint must be a public HTTP(S) URL. Localhost, private-network,
 link-local, and other non-public IP targets are rejected because Slack API calls
 carry the bot token.
 
+#### Allowing internal hosts
+
+If you deliberately front Slack with a proxy on an internal host, an operator can
+allow specific hosts back in with the `MOLTIS_SLACK_API_BASE_URL_ALLOWLIST`
+environment variable — a comma-separated list of exact hostnames or IPs:
+
+```sh
+MOLTIS_SLACK_API_BASE_URL_ALLOWLIST="proxy.internal,127.0.0.1"
+```
+
+Only hosts on this list bypass the private-address guard, and matching is on the
+exact host (so `localhost` and `127.0.0.1` must each be listed if you want both).
+The allowlist is intentionally an environment variable, not a web-editable
+setting, so this SSRF exception stays under operator control. Cloud metadata
+addresses (`169.254.169.254`, `fd00:ec2::254`) remain blocked even when
+allowlisted.
+
 If using a proxy, ensure it supports Slack's native streaming methods before
 setting `stream_mode = "native"`.
 

--- a/docs/src/slack.md
+++ b/docs/src/slack.md
@@ -176,7 +176,10 @@ connects to the WebSocket URL returned by that API.
 
 The endpoint must be a public HTTP(S) URL. Localhost, private-network,
 link-local, and other non-public IP targets are rejected because Slack API calls
-carry the bot token.
+carry the bot token. Hostnames are resolved via DNS when the account starts, and
+every resolved address is checked against the same policy — a DNS name pointing
+at a private or cloud-metadata address is rejected, and a hostname that fails to
+resolve is rejected too (validation fails closed).
 
 #### Allowing internal hosts
 
@@ -193,7 +196,7 @@ exact host (so `localhost` and `127.0.0.1` must each be listed if you want both)
 The allowlist is intentionally an environment variable, not a web-editable
 setting, so this SSRF exception stays under operator control. Cloud metadata
 addresses (`169.254.169.254`, `fd00:ec2::254`) remain blocked even when
-allowlisted.
+allowlisted, including when an allowlisted hostname resolves to one.
 
 If using a proxy, ensure it supports Slack's native streaming methods before
 setting `stream_mode = "native"`.

--- a/justfile
+++ b/justfile
@@ -99,7 +99,7 @@ build-release-with-wasm: build-wasm-artifacts
 dev-server:
     cargo build --bin moltis
     just codesign-debug
-    MOLTIS_CONFIG_DIR=.moltis/config MOLTIS_DATA_DIR=.moltis/ cargo run --bin moltis
+    MOLTIS_SLACK_API_BASE_URL_ALLOWLIST=localhost,127.0.0.1 MOLTIS_CONFIG_DIR=.moltis/config MOLTIS_DATA_DIR=.moltis/ cargo run --bin moltis
 
 # Build Debian package for the current architecture
 deb: build-release build-wasm-artifacts

--- a/plans/slack-slash-command-manifest-snippet.md
+++ b/plans/slack-slash-command-manifest-snippet.md
@@ -1,0 +1,145 @@
+# Slack Slash Command Manifest Snippet
+
+Date: 2026-07-23
+
+## Problem
+
+Moltis has Slack slash-command handlers for commands like `/new`, `/model`,
+`/stop`, and `/help`, but Slack only sends those payloads if each slash command
+is registered in the Slack app manifest. If a user types `/new` in a Slack DM
+without the command registered, Slack handles it itself instead of delivering a
+message or command event to Moltis.
+
+Moltis already has a command manifest generator in `crates/slack/src/commands.rs`,
+but the Slack channel setup flow does not surface it where users need it.
+
+## Goals
+
+1. Show a copyable Slack manifest snippet when adding or editing a Slack channel.
+2. Use Moltis' configured public URL for webhook-based Slack channels.
+3. Use a valid placeholder URL for Socket Mode channels, with clear wording that
+   Slack requires the field but Socket Mode delivery does not use it.
+4. Make it obvious that slash commands are optional but recommended and require
+   updating/reinstalling the Slack app.
+5. Keep the generated command list sourced from `moltis_channels::commands` so it
+   stays in sync with supported channel commands.
+
+## Non-Goals
+
+1. Automatically registering Slack slash commands at runtime. Slack does not
+   support this the way Discord does.
+2. Making text messages like `/new` in Slack DMs bypass Slack command handling.
+   Slack intercepts slash-prefixed input before Moltis sees it.
+3. Adding a second command registry specific to Slack.
+
+## Design
+
+### Manifest generation
+
+Reuse `moltis_slack::commands::generate_manifest_snippet(request_url_base)` as
+the source of truth. The generated YAML should continue to derive commands from
+`moltis_channels::commands::all_commands()`.
+
+For webhook / Events API mode, use Moltis' public base URL:
+
+```yaml
+slash_commands:
+  - command: /new
+    url: https://moltis.example.com/api/channels/slack/{{account_id}}/commands
+    description: "Start a new session"
+    usage_hint: ""
+    should_escape: false
+```
+
+For Socket Mode, use a valid-looking placeholder URL because Slack manifests
+still require `url` in slash command definitions even though delivery happens via
+Socket Mode:
+
+```yaml
+slash_commands:
+  - command: /new
+    url: https://example.com/moltis-socket-mode-placeholder
+    description: "Start a new session"
+    usage_hint: ""
+    should_escape: false
+```
+
+The UI copy should explain:
+
+> Slack requires a URL for slash commands in the app manifest. When Socket Mode
+> is enabled, Slack delivers these commands over Socket Mode and this placeholder
+> URL is not used.
+
+### UI placement
+
+In the Slack channel add/edit flow, add a section after the connection mode and
+account ID are known:
+
+1. Title: `Slack slash commands`
+2. Short explanation: `Paste this into your Slack app manifest under features.slash_commands, save, then reinstall the app.`
+3. Copyable code block with the generated snippet.
+4. Checklist:
+   - Paste under `features.slash_commands`.
+   - Save the manifest.
+   - Reinstall or update the Slack app in the workspace.
+   - Try `/help` or `/new` in Slack.
+
+If the public URL is missing for webhook mode, show a warning and either disable
+the generated snippet or render it with `https://YOUR_MOLTIS_PUBLIC_URL` so the
+user knows what must be configured.
+
+### API shape
+
+Expose the generated snippet through whichever layer currently backs channel
+configuration UI. Prefer a small Slack-specific helper over duplicating manifest
+formatting in the frontend.
+
+Suggested response fields:
+
+```json
+{
+  "slash_commands_manifest": "slash_commands:\n  - command: /new\n...",
+  "slash_commands_url_mode": "webhook",
+  "slash_commands_note": "Paste into features.slash_commands and reinstall the Slack app."
+}
+```
+
+Use `slash_commands_url_mode = "socket_mode_placeholder"` when the channel is in
+Socket Mode.
+
+## Implementation Plan
+
+1. Locate the Slack channel add/edit UI and the backend endpoint/model that feeds
+   it.
+2. Add a backend helper that computes the request URL base from:
+   - Slack account ID.
+   - Slack connection mode.
+   - Moltis configured public URL for webhook mode.
+   - A constant placeholder URL for Socket Mode.
+3. Thread the generated manifest snippet into the Slack channel setup response or
+   view model.
+4. Add a copyable code block and checklist in the Slack channel setup UI.
+5. Add tests for:
+   - Webhook mode uses the configured public URL and account ID.
+   - Socket Mode uses the placeholder URL.
+   - Generated snippet includes `/new`, `/model`, and `/help`.
+   - Missing public URL in webhook mode produces a clear warning or placeholder.
+
+## Files To Inspect
+
+- `crates/slack/src/commands.rs` — manifest generation.
+- `crates/slack/src/socket.rs` — Socket Mode slash command handling.
+- `crates/slack/src/webhook.rs` — webhook slash command handling.
+- `crates/httpd/src/server/gateway.rs` — Slack command webhook route.
+- Slack channel add/edit UI files under `crates/web/ui`.
+- Config schema for the public/external URL used by Moltis.
+
+## Manual QA
+
+1. Add a Slack channel in Socket Mode.
+2. Confirm the setup screen shows a manifest snippet with placeholder URLs.
+3. Paste commands into the Slack app manifest and reinstall the app.
+4. Type `/help` in a Slack DM and confirm Moltis responds with command help.
+5. Type `/new` in a Slack DM and confirm Moltis creates a new session.
+6. Repeat with webhook mode and confirm generated URLs point at the configured
+   public Moltis URL plus `/api/channels/slack/{account_id}/commands`.


### PR DESCRIPTION
## Summary
- Move Slack API base URL validation into the channels crate for shared use by gateway and Slack client code.
- Add an operator-controlled `MOLTIS_SLACK_API_BASE_URL_ALLOWLIST` for deliberate internal Slack proxy hosts while keeping cloud metadata endpoints blocked.
- Document the allowlist behavior and add a Slack slash-command manifest planning note.

## Validation
### Completed
- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p moltis-channels slack_api_url`

### Remaining
- [ ] Full CI on GitHub

## Manual QA
- Not run locally. Suggested: configure Slack `api_base_url` to an internal proxy host with and without `MOLTIS_SLACK_API_BASE_URL_ALLOWLIST` and confirm only the allowlisted host is accepted.