### PR TITLE
feat(slack): acknowledge messages with reactions and add reaction triggers

### DIFF
--- a/crates/channels/src/plugin.rs
+++ b/crates/channels/src/plugin.rs
@@ -645,6 +645,16 @@ pub struct ChannelReplyTarget {
     /// top-level chat.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub thread_id: Option<String>,
+    /// Platform-specific ID of the *exact* inbound message to acknowledge with
+    /// reactions, distinct from [`Self::message_id`] (the reply/thread anchor).
+    ///
+    /// For threaded replies these differ: `message_id` points at the thread
+    /// root (so replies land in the right thread) while `ack_message_id` points
+    /// at the specific message the user just sent (so the 👀/✅/❌ reaction lands
+    /// on it). Channels set this only when the bot is directly addressed and the
+    /// channel supports acknowledgment reactions; `None` disables ack reactions.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ack_message_id: Option<String>,
 }
 
 impl ChannelReplyTarget {
@@ -1115,6 +1125,7 @@ mod tests {
     async fn default_update_location_returns_false() {
         let sink = DummySink;
         let target = ChannelReplyTarget {
+            ack_message_id: None,
             channel_type: ChannelType::Telegram,
             account_id: "bot1".into(),
             chat_id: "42".into(),
@@ -1127,6 +1138,7 @@ mod tests {
     #[test]
     fn outbound_to_without_thread_id() {
         let target = ChannelReplyTarget {
+            ack_message_id: None,
             channel_type: ChannelType::Telegram,
             account_id: "bot1".into(),
             chat_id: "12345".into(),
@@ -1139,6 +1151,7 @@ mod tests {
     #[test]
     fn outbound_to_with_thread_id() {
         let target = ChannelReplyTarget {
+            ack_message_id: None,
             channel_type: ChannelType::Telegram,
             account_id: "bot1".into(),
             chat_id: "-100999".into(),
@@ -1151,6 +1164,7 @@ mod tests {
     #[test]
     fn reply_target_thread_id_serde_roundtrip() {
         let target = ChannelReplyTarget {
+            ack_message_id: None,
             channel_type: ChannelType::Telegram,
             account_id: "bot1".into(),
             chat_id: "-100999".into(),
@@ -1452,6 +1466,7 @@ mod tests {
     #[test]
     fn channel_reply_target_converts_to_hook_channel_binding() {
         let target = ChannelReplyTarget {
+            ack_message_id: None,
             channel_type: ChannelType::Telegram,
             account_id: "bot1".into(),
             chat_id: "-100999".into(),

--- a/crates/channels/src/plugin/tests/binding_tests.rs
+++ b/crates/channels/src/plugin/tests/binding_tests.rs
@@ -21,6 +21,7 @@ fn resolve_session_channel_binding_classifies_special_sessions() {
 #[test]
 fn resolve_session_channel_binding_extracts_channel_target() {
     let binding_json = serde_json::to_string(&ChannelReplyTarget {
+        ack_message_id: None,
         channel_type: ChannelType::Telegram,
         account_id: "bot-main".into(),
         chat_id: "-100123".into(),

--- a/crates/chat/src/agent_loop.rs
+++ b/crates/chat/src/agent_loop.rs
@@ -642,6 +642,7 @@ mod tests {
 
     fn channel_target() -> moltis_channels::ChannelReplyTarget {
         moltis_channels::ChannelReplyTarget {
+            ack_message_id: None,
             channel_type: moltis_channels::ChannelType::Telegram,
             account_id: "bot".into(),
             chat_id: "chat".into(),

--- a/crates/chat/src/channels.rs
+++ b/crates/chat/src/channels.rs
@@ -1417,6 +1417,7 @@ mod tests {
     async fn generated_image_payload_dispatches_to_telegram_as_media() {
         let outbound = Arc::new(RecordingOutbound::default());
         let targets = vec![ChannelReplyTarget {
+            ack_message_id: None,
             channel_type: ChannelType::Telegram,
             account_id: "telegram-main".into(),
             chat_id: "-100123".into(),
@@ -1452,6 +1453,7 @@ mod tests {
     async fn generated_image_payload_dispatches_to_matrix_as_media() {
         let outbound = Arc::new(RecordingOutbound::default());
         let targets = vec![ChannelReplyTarget {
+            ack_message_id: None,
             channel_type: ChannelType::Matrix,
             account_id: "matrix-main".into(),
             chat_id: "!room:example.org".into(),

--- a/crates/config/src/template.rs
+++ b/crates/config/src/template.rs
@@ -815,6 +815,9 @@ port = {port}                           # Port number (auto-generated for this i
 # api_base_url = "https://slack.com/api"
 # dm_policy = "allowlist"
 # allowlist = []
+# thread_replies = true
+# ack_reactions = true       # 👀 on receipt, ✅/❌ on completion (DMs + @mentions)
+# reaction_triggers = false  # route user reactions into the agent (react ✅ to approve)
 # otp_self_approval = true
 # otp_cooldown_secs = 300
 

--- a/crates/discord/src/commands.rs
+++ b/crates/discord/src/commands.rs
@@ -107,6 +107,7 @@ async fn handle_slash_command(
     };
 
     let reply_to = moltis_channels::plugin::ChannelReplyTarget {
+        ack_message_id: None,
         channel_type: moltis_channels::ChannelType::Discord,
         account_id: account_id.to_string(),
         chat_id: command.channel_id.to_string(),
@@ -166,6 +167,7 @@ async fn handle_component_interaction(
     };
 
     let reply_to = moltis_channels::plugin::ChannelReplyTarget {
+        ack_message_id: None,
         channel_type: moltis_channels::ChannelType::Discord,
         account_id: account_id.to_string(),
         chat_id: component.channel_id.to_string(),

--- a/crates/discord/src/handler/implementation.rs
+++ b/crates/discord/src/handler/implementation.rs
@@ -900,6 +900,7 @@ impl EventHandler for Handler {
         }
 
         let reply_to = ChannelReplyTarget {
+            ack_message_id: None,
             channel_type: ChannelType::Discord,
             account_id: self.account_id.clone(),
             chat_id: chat_id.clone(),

--- a/crates/gateway/src/channel_events.rs
+++ b/crates/gateway/src/channel_events.rs
@@ -333,6 +333,89 @@ fn start_channel_typing_loop(
     Some(done_tx)
 }
 
+/// Emoji shortcodes for acknowledgment reactions (Slack-style names). Only
+/// channels that populate [`ChannelReplyTarget::ack_message_id`] receive these;
+/// today that is Slack, whose Web API expects shortcodes (not raw glyphs).
+const ACK_RECEIVED_EMOJI: &str = "eyes";
+const ACK_SUCCESS_EMOJI: &str = "white_check_mark";
+const ACK_ERROR_EMOJI: &str = "x";
+
+/// Add the "received" reaction (👀) to the exact inbound message when the
+/// channel asked for acknowledgment reactions (`ack_message_id` set). This
+/// signals "I got your message and I'm working on it" before any reply text
+/// arrives — the primary ack path for Slack, whose bots cannot show typing.
+///
+/// Best-effort: a missing outbound or a reaction API error is logged at debug
+/// (`already_reacted` / `missing_scope` are expected) and never blocks the turn.
+async fn channel_ack_received(state: &Arc<GatewayState>, reply_to: &ChannelReplyTarget) {
+    let Some(message_id) = reply_to.ack_message_id.as_deref() else {
+        return;
+    };
+    let Some(outbound) = state.services.channel_outbound_arc() else {
+        return;
+    };
+    if let Err(e) = outbound
+        .add_reaction(
+            &reply_to.account_id,
+            &reply_to.chat_id,
+            message_id,
+            ACK_RECEIVED_EMOJI,
+        )
+        .await
+    {
+        debug!(
+            account_id = %reply_to.account_id,
+            chat_id = %reply_to.chat_id,
+            "ack reaction (received) failed: {e}"
+        );
+    }
+}
+
+/// Finalize acknowledgment reactions after the turn: remove 👀 and add ✅ on
+/// success or ❌ on failure. Best-effort; mirrors [`channel_ack_received`].
+async fn channel_ack_finish(
+    state: &Arc<GatewayState>,
+    reply_to: &ChannelReplyTarget,
+    success: bool,
+) {
+    let Some(message_id) = reply_to.ack_message_id.as_deref() else {
+        return;
+    };
+    let Some(outbound) = state.services.channel_outbound_arc() else {
+        return;
+    };
+    if let Err(e) = outbound
+        .remove_reaction(
+            &reply_to.account_id,
+            &reply_to.chat_id,
+            message_id,
+            ACK_RECEIVED_EMOJI,
+        )
+        .await
+    {
+        debug!(
+            account_id = %reply_to.account_id,
+            chat_id = %reply_to.chat_id,
+            "ack reaction (remove received) failed: {e}"
+        );
+    }
+    let emoji = if success {
+        ACK_SUCCESS_EMOJI
+    } else {
+        ACK_ERROR_EMOJI
+    };
+    if let Err(e) = outbound
+        .add_reaction(&reply_to.account_id, &reply_to.chat_id, message_id, emoji)
+        .await
+    {
+        debug!(
+            account_id = %reply_to.account_id,
+            chat_id = %reply_to.chat_id,
+            "ack reaction (finish) failed: {e}"
+        );
+    }
+}
+
 async fn resolve_channel_agent_id(
     state: &Arc<GatewayState>,
     session_key: &str,

--- a/crates/gateway/src/channel_events/dispatch.rs
+++ b/crates/gateway/src/channel_events/dispatch.rs
@@ -11,6 +11,12 @@ pub(in crate::channel_events) async fn dispatch_to_chat(
         // does not delay channel feedback.
         let typing_done = start_channel_typing_loop(state, &reply_to);
 
+        // Acknowledge receipt with a reaction (👀) on the exact inbound message
+        // before any reply text arrives. No-op unless the channel populated
+        // `ack_message_id` (i.e. the bot was directly addressed and reactions
+        // are enabled). Finalized to ✅/❌ after the turn completes below.
+        channel_ack_received(state, &reply_to).await;
+
         let session_key = if let Some(ref sm) = state.services.session_metadata {
             resolve_channel_session(&reply_to, sm).await
         } else {
@@ -222,6 +228,9 @@ pub(in crate::channel_events) async fn dispatch_to_chat(
         if let Some(done_tx) = typing_done {
             let _ = done_tx.send(());
         }
+
+        // Swap the 👀 acknowledgment for ✅ (success) or ❌ (failure).
+        channel_ack_finish(state, &reply_to, send_result.is_ok()).await;
 
         if let Err(e) = send_result {
             error!("channel dispatch_to_chat failed: {e}");

--- a/crates/gateway/src/channel_events/tests.rs
+++ b/crates/gateway/src/channel_events/tests.rs
@@ -29,6 +29,7 @@ fn channel_event_serialization() {
 #[test]
 fn channel_session_key_format() {
     let target = ChannelReplyTarget {
+        ack_message_id: None,
         channel_type: ChannelType::Telegram,
         account_id: "bot1".into(),
         chat_id: "12345".into(),
@@ -41,6 +42,7 @@ fn channel_session_key_format() {
 #[test]
 fn channel_session_key_group() {
     let target = ChannelReplyTarget {
+        ack_message_id: None,
         channel_type: ChannelType::Telegram,
         account_id: "bot1".into(),
         chat_id: "-100999".into(),
@@ -56,6 +58,7 @@ fn channel_session_key_group() {
 #[test]
 fn channel_session_key_forum_topic() {
     let target = ChannelReplyTarget {
+        ack_message_id: None,
         channel_type: ChannelType::Telegram,
         account_id: "bot1".into(),
         chat_id: "-100999".into(),

--- a/crates/gateway/src/session/tests.rs
+++ b/crates/gateway/src/session/tests.rs
@@ -985,6 +985,7 @@ mod tests {
         let key = "telegram:bot-main:-100123";
         metadata.upsert(key, None).await.unwrap();
         let binding_json = serde_json::to_string(&moltis_channels::ChannelReplyTarget {
+            ack_message_id: None,
             channel_type: moltis_channels::ChannelType::Telegram,
             account_id: "bot-main".to_string(),
             chat_id: "-100123".to_string(),

--- a/crates/matrix/src/handler/implementation.rs
+++ b/crates/matrix/src/handler/implementation.rs
@@ -300,6 +300,7 @@ pub async fn handle_room_message(
     .await;
 
     let reply_to = ChannelReplyTarget {
+        ack_message_id: None,
         channel_type: ChannelType::Matrix,
         account_id: account_id.clone(),
         chat_id: room_id.clone(),
@@ -569,6 +570,7 @@ pub async fn handle_poll_response(
     record_message_received();
 
     let reply_to = ChannelReplyTarget {
+        ack_message_id: None,
         channel_type: ChannelType::Matrix,
         account_id: account_id.clone(),
         chat_id: room_id,

--- a/crates/msteams/src/plugin.rs
+++ b/crates/msteams/src/plugin.rs
@@ -443,6 +443,7 @@ impl MsTeamsPlugin {
 
         let message_id = activity.id.clone();
         let reply_to = ChannelReplyTarget {
+            ack_message_id: None,
             channel_type: ChannelType::MsTeams,
             account_id: account_id.to_string(),
             chat_id: chat_id.clone(),

--- a/crates/nostr/src/bus.rs
+++ b/crates/nostr/src/bus.rs
@@ -309,6 +309,7 @@ async fn handle_event(
 
     // 9. Intercept slash commands before dispatching to the LLM.
     let reply_to = moltis_channels::ChannelReplyTarget {
+        ack_message_id: None,
         channel_type: moltis_channels::ChannelType::Nostr,
         account_id: account_id.to_string(),
         chat_id: sender_hex.clone(),

--- a/crates/signal/src/inbound.rs
+++ b/crates/signal/src/inbound.rs
@@ -118,6 +118,7 @@ pub async fn handle_event(
     }
 
     let reply_to = ChannelReplyTarget {
+        ack_message_id: None,
         channel_type: ChannelType::Signal,
         account_id: account_id.to_string(),
         chat_id: chat_id.clone(),

--- a/crates/slack/src/config.rs
+++ b/crates/slack/src/config.rs
@@ -120,6 +120,22 @@ pub struct SlackAccountConfig {
     /// Reply in threads (default: true).
     pub thread_replies: bool,
 
+    /// Acknowledge inbound messages with emoji reactions (👀 on receipt, ✅ on
+    /// success, ❌ on error). Only applied when the bot is directly addressed
+    /// (DM or @mention). Default: true.
+    pub ack_reactions: bool,
+
+    /// Route inbound emoji reactions from users into the agent as messages
+    /// (e.g. "react ✅ to approve"). The bot's own acknowledgment reactions are
+    /// always ignored. Default: false.
+    pub reaction_triggers: bool,
+
+    /// When `reaction_triggers` is enabled, only these emoji (shortcodes, no
+    /// colons — e.g. `white_check_mark`) trigger the agent. Empty means any
+    /// emoji triggers. Default: empty.
+    #[serde(default)]
+    pub reaction_trigger_emojis: Vec<String>,
+
     /// Per-channel model/provider overrides (channel_id -> override).
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub channel_overrides: HashMap<String, ChannelOverride>,
@@ -157,6 +173,9 @@ impl std::fmt::Debug for SlackAccountConfig {
             .field("stream_mode", &self.stream_mode)
             .field("edit_throttle_ms", &self.edit_throttle_ms)
             .field("thread_replies", &self.thread_replies)
+            .field("ack_reactions", &self.ack_reactions)
+            .field("reaction_triggers", &self.reaction_triggers)
+            .field("reaction_trigger_emojis", &self.reaction_trigger_emojis)
             .field("channel_overrides", &self.channel_overrides)
             .field("user_overrides", &self.user_overrides)
             .field("otp_self_approval", &self.otp_self_approval)
@@ -184,6 +203,9 @@ impl Default for SlackAccountConfig {
             stream_mode: StreamMode::EditInPlace,
             edit_throttle_ms: 500,
             thread_replies: true,
+            ack_reactions: true,
+            reaction_triggers: false,
+            reaction_trigger_emojis: Vec::new(),
             channel_overrides: HashMap::new(),
             user_overrides: HashMap::new(),
             otp_self_approval: true,
@@ -252,8 +274,9 @@ pub struct RedactedConfig<'a>(pub &'a SlackAccountConfig);
 impl Serialize for RedactedConfig<'_> {
     fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         let c = self.0;
-        let mut count = 14; // always-present fields
+        let mut count = 16; // always-present fields
         count += c.signing_secret.is_some() as usize;
+        count += !c.reaction_trigger_emojis.is_empty() as usize;
         count += c.model.is_some() as usize;
         count += c.model_provider.is_some() as usize;
         count += c.agent_id.is_some() as usize;
@@ -284,6 +307,11 @@ impl Serialize for RedactedConfig<'_> {
         s.serialize_field("stream_mode", &c.stream_mode)?;
         s.serialize_field("edit_throttle_ms", &c.edit_throttle_ms)?;
         s.serialize_field("thread_replies", &c.thread_replies)?;
+        s.serialize_field("ack_reactions", &c.ack_reactions)?;
+        s.serialize_field("reaction_triggers", &c.reaction_triggers)?;
+        if !c.reaction_trigger_emojis.is_empty() {
+            s.serialize_field("reaction_trigger_emojis", &c.reaction_trigger_emojis)?;
+        }
         if !c.channel_overrides.is_empty() {
             s.serialize_field("channel_overrides", &c.channel_overrides)?;
         }
@@ -399,12 +427,35 @@ mod tests {
         assert_eq!(cfg.stream_mode, StreamMode::EditInPlace);
         assert_eq!(cfg.edit_throttle_ms, 500);
         assert!(cfg.thread_replies);
+        assert!(cfg.ack_reactions);
         assert!(cfg.otp_self_approval);
         assert_eq!(cfg.otp_cooldown_secs, 300);
         assert_eq!(cfg.mention_mode, MentionMode::Mention);
         assert_eq!(cfg.api_base_url, DEFAULT_SLACK_API_BASE_URL);
         assert!(cfg.channel_overrides.is_empty());
         assert!(cfg.user_overrides.is_empty());
+    }
+
+    #[test]
+    fn ack_reactions_round_trip_and_redaction() {
+        // Defaults to true when absent.
+        let cfg: SlackAccountConfig = serde_json::from_value(serde_json::json!({
+            "bot_token": "xoxb-test",
+            "app_token": "xapp-test",
+        }))
+        .unwrap();
+        assert!(cfg.ack_reactions);
+
+        // Explicit false round-trips through the redacted view.
+        let cfg: SlackAccountConfig = serde_json::from_value(serde_json::json!({
+            "bot_token": "xoxb-test",
+            "app_token": "xapp-test",
+            "ack_reactions": false,
+        }))
+        .unwrap();
+        assert!(!cfg.ack_reactions);
+        let redacted = serde_json::to_value(RedactedConfig(&cfg)).unwrap();
+        assert_eq!(redacted["ack_reactions"], serde_json::json!(false));
     }
 
     #[test]

--- a/crates/slack/src/config.rs
+++ b/crates/slack/src/config.rs
@@ -133,7 +133,7 @@ pub struct SlackAccountConfig {
     /// When `reaction_triggers` is enabled, only these emoji (shortcodes, no
     /// colons — e.g. `white_check_mark`) trigger the agent. Empty means any
     /// emoji triggers. Default: empty.
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub reaction_trigger_emojis: Vec<String>,
 
     /// Per-channel model/provider overrides (channel_id -> override).

--- a/crates/slack/src/socket.rs
+++ b/crates/slack/src/socket.rs
@@ -207,12 +207,15 @@ async fn push_events_callback(
                 .as_ref()
                 .map(|ts| ts.to_string());
 
+            let message_ts = Some(mention_event.origin.ts.to_string());
+
             handle_inbound(
                 &listener_state.account_id,
                 &channel,
                 &user,
                 text,
                 thread_ts,
+                message_ts,
                 None,
                 true, // is_mention
                 &listener_state.accounts,
@@ -282,6 +285,7 @@ async fn command_events_callback(
 
     if let Some(sink) = event_sink {
         let reply_to = ChannelReplyTarget {
+            ack_message_id: None,
             channel_type: ChannelType::Slack,
             account_id: account_id.to_string(),
             chat_id: event.channel_id.to_string(),
@@ -349,6 +353,7 @@ async fn interaction_events_callback(
 
     if let Some(sink) = event_sink {
         let reply_to = ChannelReplyTarget {
+            ack_message_id: None,
             channel_type: ChannelType::Slack,
             account_id: account_id.to_string(),
             chat_id: channel_id,
@@ -409,8 +414,10 @@ pub(crate) async fn handle_message_event(
         .unwrap_or("");
 
     let thread_ts = event.origin.thread_ts.as_ref().map(|ts| ts.to_string());
+    // The exact ts of this inbound message (for acknowledgment reactions).
+    let message_ts = event.origin.ts.to_string();
     // Use thread_ts if available, otherwise use the message ts for threading.
-    let reply_thread = thread_ts.or_else(|| Some(event.origin.ts.to_string()));
+    let reply_thread = thread_ts.or_else(|| Some(message_ts.clone()));
 
     // Detect if this is a mention.
     let bot_user_id = {
@@ -427,6 +434,7 @@ pub(crate) async fn handle_message_event(
         &user_id,
         text,
         reply_thread,
+        Some(message_ts),
         event.sender.username.clone(),
         is_mention,
         accounts,
@@ -444,6 +452,7 @@ pub(crate) async fn handle_inbound(
     user_id: &str,
     text: &str,
     thread_ts: Option<String>,
+    message_ts: Option<String>,
     username: Option<String>,
     is_mention: bool,
     accounts: &AccountStateMap,
@@ -572,9 +581,15 @@ pub(crate) async fn handle_inbound(
         }
     }
 
+    // Acknowledge with reactions only when the bot is directly addressed
+    // (DM or @mention) — never on general channel chatter — and the account
+    // has ack reactions enabled.
+    let ack_message_id = ack_reaction_target(config.ack_reactions, is_dm, is_mention, message_ts);
+
     // Dispatch to chat.
     if let Some(sink) = &event_sink {
         let reply_to = ChannelReplyTarget {
+            ack_message_id,
             channel_type: ChannelType::Slack,
             account_id: account_id.to_string(),
             chat_id: channel_id.to_string(),
@@ -629,22 +644,147 @@ pub(crate) async fn handle_reaction_event(
         _ => return,
     };
 
-    let event_sink = {
+    dispatch_reaction(
+        account_id, user_id, emoji, channel_id, message_ts, added, accounts,
+    )
+    .await;
+}
+
+/// Core reaction handling shared by Socket Mode and the Events API.
+///
+/// Always emits a [`ChannelEvent::ReactionChange`] for observers; additionally
+/// routes the reaction into the agent as a synthetic message when
+/// `reaction_triggers` is enabled and the reaction is eligible.
+pub(crate) async fn dispatch_reaction(
+    account_id: &str,
+    user_id: &str,
+    emoji: &str,
+    channel_id: String,
+    message_ts: String,
+    added: bool,
+    accounts: &AccountStateMap,
+) {
+    let (config, event_sink, bot_user_id) = {
         let accts = accounts.read().unwrap_or_else(|e| e.into_inner());
-        accts.get(account_id).and_then(|s| s.event_sink.clone())
+        match accts.get(account_id) {
+            Some(state) => (
+                state.config.clone(),
+                state.event_sink.clone(),
+                state.bot_user_id.clone(),
+            ),
+            None => return,
+        }
     };
 
-    if let Some(sink) = event_sink {
-        sink.emit(ChannelEvent::ReactionChange {
-            channel_type: ChannelType::Slack,
-            account_id: account_id.to_string(),
-            chat_id: channel_id,
-            message_id: message_ts,
-            user_id: user_id.to_string(),
-            emoji: emoji.to_string(),
-            added,
-        })
-        .await;
+    let Some(sink) = event_sink else {
+        return;
+    };
+
+    // Always surface the raw reaction change to observers (web UI, hooks).
+    sink.emit(ChannelEvent::ReactionChange {
+        channel_type: ChannelType::Slack,
+        account_id: account_id.to_string(),
+        chat_id: channel_id.clone(),
+        message_id: message_ts.clone(),
+        user_id: user_id.to_string(),
+        emoji: emoji.to_string(),
+        added,
+    })
+    .await;
+
+    // Optionally route the reaction into the agent as a message. The bot's own
+    // acknowledgment reactions (👀/✅/❌) are always ignored to avoid loops.
+    let is_self = bot_user_id.as_deref() == Some(user_id);
+    if !reaction_should_trigger(
+        config.reaction_triggers,
+        added,
+        is_self,
+        emoji,
+        &config.reaction_trigger_emojis,
+    ) {
+        return;
+    }
+
+    let is_dm = channel_id.starts_with('D');
+    let access_granted = check_access(
+        is_dm,
+        user_id,
+        &channel_id,
+        &config.dm_policy,
+        &config.group_policy,
+        &config.allowlist,
+        &config.channel_allowlist,
+    );
+    if !access_granted {
+        debug!(
+            account_id,
+            user_id, "slack reaction trigger denied by access control"
+        );
+        return;
+    }
+
+    // Thread the synthetic message under the reacted message so the agent sees
+    // the original content as thread context (dispatch fetches thread history).
+    let reply_to = ChannelReplyTarget {
+        channel_type: ChannelType::Slack,
+        account_id: account_id.to_string(),
+        chat_id: channel_id,
+        message_id: Some(message_ts),
+        thread_id: None,
+        // Never acknowledge a reaction trigger with another reaction.
+        ack_message_id: None,
+    };
+
+    let meta = ChannelMessageMeta {
+        channel_type: ChannelType::Slack,
+        sender_name: None,
+        username: None,
+        sender_id: Some(user_id.to_string()),
+        message_kind: Some(ChannelMessageKind::Text),
+        model: config
+            .resolve_model(&reply_to.chat_id, user_id)
+            .map(String::from),
+        agent_id: config
+            .resolve_agent_id(&reply_to.chat_id, user_id)
+            .map(String::from),
+        audio_filename: None,
+        documents: None,
+    };
+
+    let synthetic = format!("<@{user_id}> reacted :{emoji}: to this message.");
+    sink.dispatch_to_chat(&synthetic, reply_to, meta).await;
+}
+
+/// Decide whether an inbound reaction should be routed to the agent.
+///
+/// Triggers only when: the feature is enabled, the reaction was *added* (not
+/// removed), it is not the bot's own reaction, and — if an emoji allowlist is
+/// configured — the emoji is on it. An empty allowlist matches any emoji.
+fn reaction_should_trigger(
+    enabled: bool,
+    added: bool,
+    is_self: bool,
+    emoji: &str,
+    allowlist: &[String],
+) -> bool {
+    enabled && added && !is_self && (allowlist.is_empty() || allowlist.iter().any(|e| e == emoji))
+}
+
+/// Decide which inbound message (if any) to acknowledge with reactions.
+///
+/// Returns the message ts only when acknowledgment reactions are enabled for
+/// the account and the bot was directly addressed — a 1:1 DM or an @mention.
+/// General channel chatter never earns a reaction (avoids emoji noise).
+fn ack_reaction_target(
+    ack_reactions_enabled: bool,
+    is_dm: bool,
+    is_mention: bool,
+    message_ts: Option<String>,
+) -> Option<String> {
+    if ack_reactions_enabled && (is_dm || is_mention) {
+        message_ts
+    } else {
+        None
     }
 }
 
@@ -867,6 +1007,63 @@ async fn send_otp_status(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn ack_target_dm_is_acknowledged() {
+        assert_eq!(
+            ack_reaction_target(true, true, false, Some("111.222".into())),
+            Some("111.222".into())
+        );
+    }
+
+    #[test]
+    fn ack_target_mention_is_acknowledged() {
+        assert_eq!(
+            ack_reaction_target(true, false, true, Some("111.222".into())),
+            Some("111.222".into())
+        );
+    }
+
+    #[test]
+    fn ack_target_unaddressed_channel_message_is_not_acknowledged() {
+        assert_eq!(
+            ack_reaction_target(true, false, false, Some("111.222".into())),
+            None
+        );
+    }
+
+    #[test]
+    fn ack_target_disabled_config_never_acknowledges() {
+        assert_eq!(
+            ack_reaction_target(false, true, true, Some("111.222".into())),
+            None
+        );
+    }
+
+    #[test]
+    fn reaction_trigger_requires_enabled_added_and_not_self() {
+        // Disabled → never.
+        assert!(!reaction_should_trigger(false, true, false, "x", &[]));
+        // Removal → never.
+        assert!(!reaction_should_trigger(true, false, false, "x", &[]));
+        // Bot's own reaction → never.
+        assert!(!reaction_should_trigger(true, true, true, "eyes", &[]));
+        // Enabled add by another user with no allowlist → trigger.
+        assert!(reaction_should_trigger(true, true, false, "x", &[]));
+    }
+
+    #[test]
+    fn reaction_trigger_respects_emoji_allowlist() {
+        let allow = vec!["white_check_mark".to_string()];
+        assert!(reaction_should_trigger(
+            true,
+            true,
+            false,
+            "white_check_mark",
+            &allow
+        ));
+        assert!(!reaction_should_trigger(true, true, false, "x", &allow));
+    }
 
     #[test]
     fn dm_open_allows_anyone() {

--- a/crates/slack/src/socket.rs
+++ b/crates/slack/src/socket.rs
@@ -694,7 +694,20 @@ pub(crate) async fn dispatch_reaction(
 
     // Optionally route the reaction into the agent as a message. The bot's own
     // acknowledgment reactions (👀/✅/❌) are always ignored to avoid loops.
-    let is_self = bot_user_id.as_deref() == Some(user_id);
+    //
+    // Fail closed: if the bot user id is unknown we cannot distinguish the bot's
+    // own reactions, so treat the reactor as "self" and skip. Triggering here
+    // would let the bot's own ACK reactions fire agent turns and loop.
+    let is_self = match bot_user_id.as_deref() {
+        Some(bot_id) => bot_id == user_id,
+        None => {
+            debug!(
+                account_id,
+                user_id, "slack reaction trigger skipped: bot_user_id unknown"
+            );
+            true
+        },
+    };
     if !reaction_should_trigger(
         config.reaction_triggers,
         added,

--- a/crates/slack/src/webhook.rs
+++ b/crates/slack/src/webhook.rs
@@ -262,6 +262,7 @@ pub async fn handle_verified_interaction_webhook(
 
     if let Some(sink) = event_sink {
         let reply_to = ChannelReplyTarget {
+            ack_message_id: None,
             channel_type: ChannelType::Slack,
             account_id: account_id.to_string(),
             chat_id: channel_id.to_string(),
@@ -312,6 +313,7 @@ pub async fn handle_verified_command_webhook(
 
     if let Some(sink) = event_sink {
         let reply_to = ChannelReplyTarget {
+            ack_message_id: None,
             channel_type: ChannelType::Slack,
             account_id: account_id.to_string(),
             chat_id: channel_id,
@@ -369,10 +371,12 @@ async fn dispatch_event_callback(
                 .get("thread_ts")
                 .and_then(|v| v.as_str())
                 .map(String::from);
+            let message_ts = event.get("ts").and_then(|v| v.as_str()).map(String::from);
 
             if !channel.is_empty() && !user.is_empty() {
                 crate::socket::handle_inbound(
-                    account_id, channel, user, text, thread_ts, None, true, // is_mention
+                    account_id, channel, user, text, thread_ts, message_ts, None,
+                    true, // is_mention
                     accounts,
                 )
                 .await;
@@ -390,25 +394,16 @@ async fn dispatch_event_callback(
 
                 if !user.is_empty() && !reaction.is_empty() && !item_channel.is_empty() {
                     let added = event_type == "reaction_added";
-
-                    // Dispatch reaction via the event sink directly since
-                    // handle_reaction_event expects a SlackReactionsItem.
-                    let event_sink = {
-                        let accts = accounts.read().unwrap_or_else(|e| e.into_inner());
-                        accts.get(account_id).and_then(|s| s.event_sink.clone())
-                    };
-                    if let Some(sink) = event_sink {
-                        sink.emit(moltis_channels::ChannelEvent::ReactionChange {
-                            channel_type: ChannelType::Slack,
-                            account_id: account_id.to_string(),
-                            chat_id: item_channel.to_string(),
-                            message_id: message_ts.to_string(),
-                            user_id: user.to_string(),
-                            emoji: reaction.to_string(),
-                            added,
-                        })
-                        .await;
-                    }
+                    crate::socket::dispatch_reaction(
+                        account_id,
+                        user,
+                        reaction,
+                        item_channel.to_string(),
+                        message_ts.to_string(),
+                        added,
+                        accounts,
+                    )
+                    .await;
                 }
             }
         },
@@ -493,6 +488,7 @@ pub async fn handle_interaction_webhook(
 
     if let Some(sink) = event_sink {
         let reply_to = ChannelReplyTarget {
+            ack_message_id: None,
             channel_type: ChannelType::Slack,
             account_id: account_id.to_string(),
             chat_id: channel_id.to_string(),

--- a/crates/telegram/src/handlers/callbacks.rs
+++ b/crates/telegram/src/handlers/callbacks.rs
@@ -389,6 +389,7 @@ pub(super) async fn handle_callback_query(
         .map(|tid| tid.0.0.to_string());
     let sender_id = query.from.id.0.to_string();
     let reply_target = ChannelReplyTarget {
+        ack_message_id: None,
         channel_type: ChannelType::Telegram,
         account_id: account_id.to_string(),
         chat_id: chat_id.clone(),

--- a/crates/telegram/src/handlers/implementation.rs
+++ b/crates/telegram/src/handlers/implementation.rs
@@ -53,6 +53,7 @@ fn outbound_to_for_msg(msg: &Message) -> String {
 
 fn reply_target_for_msg(account_id: &str, msg: &Message) -> ChannelReplyTarget {
     ChannelReplyTarget {
+        ack_message_id: None,
         channel_type: ChannelType::Telegram,
         account_id: account_id.to_string(),
         chat_id: msg.chat.id.0.to_string(),
@@ -453,6 +454,7 @@ pub async fn handle_message_direct(
         // Handle location sharing: update stored location and resolve any pending tool request.
         let resolved = if let Some(ref sink) = event_sink {
             let reply_target = ChannelReplyTarget {
+                ack_message_id: None,
                 channel_type: ChannelType::Telegram,
                 account_id: account_id.to_string(),
                 chat_id: msg.chat.id.0.to_string(),
@@ -834,6 +836,7 @@ pub async fn handle_edited_location(
 
     if let Some(ref sink) = event_sink {
         let reply_target = ChannelReplyTarget {
+            ack_message_id: None,
             channel_type: ChannelType::Telegram,
             account_id: account_id.to_string(),
             chat_id: msg.chat.id.0.to_string(),
@@ -926,6 +929,7 @@ pub async fn handle_callback_query(
         .map(|tid| tid.0.0.to_string());
     let sender_id = query.from.id.0.to_string();
     let reply_target = ChannelReplyTarget {
+        ack_message_id: None,
         channel_type: ChannelType::Telegram,
         account_id: account_id.to_string(),
         chat_id: chat_id.clone(),

--- a/crates/telephony/src/plugin.rs
+++ b/crates/telephony/src/plugin.rs
@@ -94,6 +94,7 @@ impl TelephonyPlugin {
         let config = self.accounts.get(account_id).map(|a| &a.config);
 
         let reply_to = moltis_channels::ChannelReplyTarget {
+            ack_message_id: None,
             channel_type: moltis_channels::ChannelType::Telephony,
             account_id: account_id.to_string(),
             chat_id: call_id.to_string(),

--- a/crates/web/ui/e2e/specs/channels-slack.spec.js
+++ b/crates/web/ui/e2e/specs/channels-slack.spec.js
@@ -1,0 +1,97 @@
+const { expect, test } = require("../base-test");
+const { navigateAndWait, waitForWsConnected, watchPageErrors } = require("../helpers");
+
+// Inject a WebSocket stub that serves a single configured Slack channel and
+// captures the channels.update payload the edit modal sends on save.
+async function installSlackChannelMock(page, channel) {
+	await page.evaluate(async (mockChannel) => {
+		const appScript = document.querySelector('script[type="module"][src*="js/app.js"]');
+		if (!appScript) throw new Error("app.js script not found");
+		const appUrl = new URL(appScript.src, window.location.origin).href;
+		const marker = "js/app.js";
+		const markerIdx = appUrl.indexOf(marker);
+		if (markerIdx < 0) throw new Error("app.js marker not found in script URL");
+		const prefix = appUrl.slice(0, markerIdx);
+		const state = await import(`${prefix}js/state.js`);
+		const channelsPage = await import(`${prefix}js/page-channels.js`);
+		const wsOpen = typeof WebSocket === "undefined" ? 1 : WebSocket.OPEN;
+		window.__slackUpdateRequest = null;
+		state.setConnected(true);
+		state.setWs({
+			readyState: wsOpen,
+			send(raw) {
+				const req = JSON.parse(raw || "{}");
+				const resolver = state.pending[req.id];
+				if (!resolver) return;
+				if (req.method === "channels.status") {
+					resolver({ ok: true, payload: { channels: [mockChannel] } });
+				} else if (req.method === "channels.senders.list") {
+					resolver({ ok: true, payload: { senders: [] } });
+				} else if (req.method === "agents.list") {
+					resolver({ ok: true, payload: { agents: [] } });
+				} else if (req.method === "channels.update") {
+					window.__slackUpdateRequest = req.params || null;
+					resolver({ ok: true, payload: {} });
+				} else {
+					resolver({ ok: true, payload: {} });
+				}
+				delete state.pending[req.id];
+			},
+		});
+		if (typeof state.refreshChannelsPage === "function") {
+			state.refreshChannelsPage();
+		} else {
+			await channelsPage.prefetchChannels();
+		}
+		await new Promise((resolve) => setTimeout(resolve, 100));
+	}, channel);
+}
+
+test.describe("Slack channel settings", () => {
+	test("ack_reactions and reaction_triggers toggles round-trip through the edit modal", async ({ page }) => {
+		const pageErrors = watchPageErrors(page);
+		await navigateAndWait(page, "/settings/channels");
+		await waitForWsConnected(page);
+
+		await installSlackChannelMock(page, {
+			type: "slack",
+			account_id: "test-bot",
+			name: "Test Slack",
+			status: "connected",
+			config: {
+				api_base_url: "https://slack.com/api",
+				ack_reactions: true,
+				reaction_triggers: false,
+			},
+		});
+
+		// Card renders from the mocked channels.status response.
+		await expect(page.getByText("Test Slack", { exact: true })).toBeVisible({ timeout: 10_000 });
+
+		// Open the edit modal for the mocked Slack channel.
+		await page.locator('button[title="Edit test-bot"]').click();
+		const modal = page.locator(".modal-box");
+		await expect(modal.getByText("Acknowledge with reactions", { exact: true })).toBeVisible();
+
+		const ackCheckbox = modal
+			.locator("label", { hasText: "Acknowledge with reactions" })
+			.locator('input[type="checkbox"]');
+		const triggerCheckbox = modal.locator("label", { hasText: "Reaction triggers" }).locator('input[type="checkbox"]');
+
+		// Reflects current config: ack on, triggers off.
+		await expect(ackCheckbox).toBeChecked();
+		await expect(triggerCheckbox).not.toBeChecked();
+
+		// Flip both.
+		await ackCheckbox.uncheck();
+		await triggerCheckbox.check();
+
+		await modal.getByRole("button", { name: "Save Changes", exact: true }).click();
+
+		await expect
+			.poll(() => page.evaluate(() => window.__slackUpdateRequest))
+			.toMatchObject({ config: { ack_reactions: false, reaction_triggers: true } });
+
+		expect(pageErrors).toEqual([]);
+	});
+});

--- a/crates/web/ui/src/pages/ChannelsPage.tsx
+++ b/crates/web/ui/src/pages/ChannelsPage.tsx
@@ -89,6 +89,8 @@ export interface ChannelConfig {
 	group_policy?: string;
 	signing_secret?: string;
 	channel_allowlist?: string[];
+	ack_reactions?: boolean;
+	reaction_triggers?: boolean;
 	// Matrix
 	homeserver?: string;
 	user_id?: string;

--- a/crates/web/ui/src/pages/channels/modals/EditChannelModal.tsx
+++ b/crates/web/ui/src/pages/channels/modals/EditChannelModal.tsx
@@ -47,6 +47,8 @@ export function EditChannelModal(): VNode | null {
 	const editSignalAccount = useSignal("");
 	const editSignalHttpUrl = useSignal("http://127.0.0.1:8080");
 	const editSlackApiBaseUrl = useSignal("https://slack.com/api");
+	const editSlackAckReactions = useSignal(true);
+	const editSlackReactionTriggers = useSignal(false);
 	const editChannelNamePatterns = useSignal<string[]>([]);
 	const editCategoryAllowlist = useSignal<string[]>([]);
 	const editAdvancedConfigPatch = useSignal("");
@@ -75,6 +77,8 @@ export function EditChannelModal(): VNode | null {
 		editSignalAccount.value = (ch?.config?.account as string) || "";
 		editSignalHttpUrl.value = (ch?.config?.http_url as string) || "http://127.0.0.1:8080";
 		editSlackApiBaseUrl.value = (ch?.config?.api_base_url as string) || "https://slack.com/api";
+		editSlackAckReactions.value = ch?.config?.ack_reactions !== false;
+		editSlackReactionTriggers.value = ch?.config?.reaction_triggers === true;
 		editChannelNamePatterns.value = (ch?.config?.channel_name_patterns || []) as string[];
 		editCategoryAllowlist.value = (ch?.config?.category_allowlist || []) as string[];
 		editAdvancedConfigPatch.value = "";
@@ -193,6 +197,8 @@ export function EditChannelModal(): VNode | null {
 		}
 		if (isSlack) {
 			updateConfig.api_base_url = editSlackApiBaseUrl.value.trim() || "https://slack.com/api";
+			updateConfig.ack_reactions = editSlackAckReactions.value;
+			updateConfig.reaction_triggers = editSlackReactionTriggers.value;
 		}
 		addChannelCredentials(updateConfig, form);
 		addModelToConfig(updateConfig);
@@ -401,6 +407,37 @@ export function EditChannelModal(): VNode | null {
 						<div className="text-xs text-[var(--muted)]">
 							Use Slack's default endpoint unless you use a Slack-compatible proxy or test gateway.
 						</div>
+						<label className="flex items-start gap-2 cursor-pointer mt-1">
+							<input
+								type="checkbox"
+								checked={editSlackAckReactions.value}
+								onChange={(e) => {
+									editSlackAckReactions.value = targetChecked(e);
+								}}
+							/>
+							<span className="flex flex-col gap-1">
+								<span className="text-xs font-medium text-[var(--text-strong)]">Acknowledge with reactions</span>
+								<span className="text-xs text-[var(--muted)]">
+									React to messages that mention the bot (or DMs) with 👀 on receipt, then ✅ or ❌ when done.
+								</span>
+							</span>
+						</label>
+						<label className="flex items-start gap-2 cursor-pointer">
+							<input
+								type="checkbox"
+								checked={editSlackReactionTriggers.value}
+								onChange={(e) => {
+									editSlackReactionTriggers.value = targetChecked(e);
+								}}
+							/>
+							<span className="flex flex-col gap-1">
+								<span className="text-xs font-medium text-[var(--text-strong)]">Reaction triggers</span>
+								<span className="text-xs text-[var(--muted)]">
+									Let users drive the bot by reacting to a message (e.g. react ✅ to approve). Restrict which emoji
+									trigger it via <code>reaction_trigger_emojis</code> in Advanced config.
+								</span>
+							</span>
+						</label>
 					</div>
 				)}
 				{isNostr && (

--- a/crates/whatsapp/src/handlers.rs
+++ b/crates/whatsapp/src/handlers.rs
@@ -402,6 +402,7 @@ async fn handle_message(
     // Check for slash commands.
     if let Some(cmd) = text.strip_prefix('/') {
         let reply_to = ChannelReplyTarget {
+            ack_message_id: None,
             channel_type: ChannelType::Whatsapp,
             account_id: state.account_id.clone(),
             chat_id: chat_id.clone(),
@@ -433,6 +434,7 @@ async fn handle_message(
 
     let account_id = &state.account_id;
     let reply_to = ChannelReplyTarget {
+        ack_message_id: None,
         channel_type: ChannelType::Whatsapp,
         account_id: state.account_id.clone(),
         chat_id: chat_id.clone(),

--- a/docs/src/slack.md
+++ b/docs/src/slack.md
@@ -301,6 +301,14 @@ flows like "react ✅ to approve" or "react 👍 to continue".
 This requires the `reactions:read` scope and the `reaction_added` event
 subscription.
 
+```admonish note title="Thread context on threaded replies"
+Slack's `reaction_added` event only carries the reacted message's own
+timestamp, not its thread root. When a user reacts to a message that is itself a
+reply inside a thread, the agent is threaded under that reply and sees only the
+reacted message as context — not the whole thread. Reactions on top-level
+messages are unaffected.
+```
+
 ## Troubleshooting
 
 ### Bot doesn't respond

--- a/docs/src/slack.md
+++ b/docs/src/slack.md
@@ -46,6 +46,8 @@ Before configuring Moltis, create a Slack app:
    - `im:history` — read DM history
    - `im:read` — view DM metadata
    - `channels:history` — read channel messages (for `mention_mode = "always"`)
+   - `reactions:write` — add acknowledgment reactions (👀/✅/❌; see [Acknowledgment Reactions](#acknowledgment-reactions))
+   - `reactions:read` — read reactions (only for inbound reaction triggers)
 4. Click **Install to Workspace** and copy the **Bot User OAuth Token** (`xoxb-...`)
 5. For Socket Mode (recommended):
    - Go to **Socket Mode** and enable it
@@ -102,6 +104,9 @@ offered = ["slack"]
 | `stream_mode` | no | `"edit_in_place"` | Streaming mode: `"edit_in_place"`, `"native"`, or `"off"` |
 | `edit_throttle_ms` | no | `500` | Minimum milliseconds between streaming edit updates |
 | `thread_replies` | no | `true` | Reply in threads |
+| `ack_reactions` | no | `true` | Acknowledge inbound messages with emoji reactions (👀 → ✅/❌). Only applied when the bot is directly addressed (DM or @mention). |
+| `reaction_triggers` | no | `false` | Route inbound user reactions into the agent as messages (e.g. react ✅ to approve). |
+| `reaction_trigger_emojis` | no | `[]` | When `reaction_triggers` is on, only these emoji shortcodes trigger the agent. Empty = any emoji. |
 | `channel_overrides` | no | `{}` | Per-channel model/provider overrides (see below) |
 | `user_overrides` | no | `{}` | Per-user model/provider overrides (see below) |
 
@@ -133,6 +138,7 @@ model_provider = "anthropic"
 stream_mode = "edit_in_place"
 edit_throttle_ms = 500
 thread_replies = true
+ack_reactions = true
 
 # Per-channel override: use a different model in a specific Slack channel
 [channels.slack.my-bot.channel_overrides.C0123456789]
@@ -259,6 +265,41 @@ The `edit_in_place` mode throttles updates to `edit_throttle_ms` milliseconds
 By default (`thread_replies = true`), the bot replies in a thread attached to
 the user's message. Set `thread_replies = false` to have the bot reply directly
 in the channel.
+
+## Acknowledgment Reactions
+
+Because Slack bots cannot show a typing indicator, Moltis acknowledges messages
+with emoji reactions so you know your message was received and is being worked
+on:
+
+- 👀 (`eyes`) is added as soon as the message starts processing.
+- ✅ (`white_check_mark`) replaces it when the reply is delivered.
+- ❌ (`x`) replaces it if the turn fails.
+
+Reactions are only added when the bot is **directly addressed** — a direct
+message, or a channel message that @mentions the bot — never on general channel
+chatter. Set `ack_reactions = false` to disable them.
+
+The bot needs the `reactions:write` OAuth scope (and `reactions:read` if you
+also use inbound reaction triggers). Reaction failures are non-fatal and never
+block the reply.
+
+## Reaction Triggers
+
+With `reaction_triggers = true`, when a user adds an emoji reaction to a message,
+Moltis routes it into the agent as a synthetic message (threaded under the
+reacted message so the agent sees the original content as context). This enables
+flows like "react ✅ to approve" or "react 👍 to continue".
+
+- The bot's own acknowledgment reactions (👀/✅/❌) are always ignored, so
+  triggers never loop.
+- Only *added* reactions trigger (not removals), and only from senders who pass
+  the normal DM/channel access policy.
+- Restrict which emoji count with `reaction_trigger_emojis` (shortcodes without
+  colons, e.g. `["white_check_mark", "thumbsup"]`). Empty means any emoji.
+
+This requires the `reactions:read` scope and the `reaction_added` event
+subscription.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary

Slack bots cannot show a typing indicator, so users had no signal that a message was received and is being worked on. This adds Slack **acknowledgment reactions** and **inbound reaction triggers**, and fixes a confirmed wrong-message bug in threaded replies. Ideas drawn from `hermes-agent` and `openclaw`, both of which converge on the same 👀→✅/❌ shape.

### Acknowledgment reactions (default on, `ack_reactions`)
- 👀 (`eyes`) added when the turn starts, swapped for ✅ (`white_check_mark`) on success or ❌ (`x`) on failure.
- Only when the bot is **directly addressed** — a DM or an @mention — never on general channel chatter.
- Driven from the gateway `dispatch_to_chat` boundary (already wraps the whole turn). All reaction calls are best-effort, logged at `debug` (`already_reacted`/`missing_scope` are expected). Emoji sent as shortcodes, never raw glyphs.

### Wrong-message fix
Reactions and threaded replies shared `ChannelReplyTarget::message_id`, which holds the *thread anchor* (thread root, or own ts for top-level messages). For a reply inside an existing thread this pointed at the wrong message, so the bot reacted to / replied to the wrong one (reproduced by the reporter). Added a dedicated `ack_message_id` carrying the exact inbound ts.

### Inbound reaction triggers (opt-in, `reaction_triggers`)
- A user reaction is routed into the agent as a synthetic threaded message (e.g. react ✅ to approve), via one `dispatch_reaction` path shared by Socket Mode and the Events API.
- The bot's own 👀/✅/❌ markers are always ignored (no loops); only *added* reactions fire; access policy is enforced; optional `reaction_trigger_emojis` allowlist.

### Also
Config fields (+ redaction), edit-modal UI toggles for both, `reactions:write`/`reactions:read` scope docs, config template, and docs.

### Deferred (designed, not in this PR)
Two ideas from the same references were intentionally left out because they need capabilities that can't be verified without a live Slack workspace, and shipping them unverified risks reaction flicker / rate limits / a non-functional status surface:
- **Phase reactions** (🧠/🛠️/🌆 during the turn) — needs a per-turn controller wired into the agentic loop (`agent_loop.rs`), not `run_streaming` (the no-tools path). Design captured in bd `moltis-v2hr`.
- **Live typing status** via `assistant.threads.setStatus` — only works when the app is a Slack AI/Assistant app inside assistant threads. bd `moltis-eqx2`.

## Validation

### Completed
- [x] `cargo test -p moltis-slack` (97 passed)
- [x] `cargo test -p moltis-channels` (104 passed)
- [x] `cargo test -p moltis-gateway channel_events`
- [x] `cargo fmt --all -- --check` (clean)
- [x] `cargo clippy -p moltis-slack -p moltis-channels -p moltis-gateway --all-targets` (clean)
- [x] `cd crates/web/ui && ./node_modules/.bin/tsc --noEmit` (clean)
- [x] `cd crates/web/ui && npm run build:all`
- [x] `cd crates/web/ui && npx playwright test e2e/specs/channels-slack.spec.js` (1 passed)

### Remaining
- [ ] `./scripts/local-validate.sh <PR#>` (full OS-aware clippy/test/app builds)

## Manual QA
1. Configure a Slack account (Socket Mode), keep `ack_reactions` on (default).
2. @mention the bot in a channel, or DM it → the message gets 👀 immediately, then ✅ when the reply lands (❌ if the turn errors).
3. Post an unaddressed message in a channel → no reaction (avoids emoji noise).
4. Reply inside an existing thread → the reaction/reply lands on the correct (just-sent) message.
5. Enable **Reaction triggers** in the channel edit modal; react ✅ to a message → the bot responds in-thread. Confirm the bot's own 👀/✅ never re-trigger.
6. Toggle both off in the edit modal and confirm behavior stops.

https://claude.ai/code/session_016mWjaPu4o3E5dBhZU6tPUL