### PR TITLE
docs: forbid Claude session URLs in commits and PRs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -289,7 +289,9 @@ Conventional commits: `feat|fix|docs|style|refactor|test|chore(scope): descripti
 - Prefer descriptive commit subjects over terse "change stuff" summaries.
 - For bug fixes, behavioral changes, and non-obvious refactors, include a commit body that explains the concrete problem, the root cause, and why the chosen fix is correct.
 - Write commit messages so `git log` is useful without opening the diff first.
-**No `Co-Authored-By` trailers.** Update `README.md` features list with `feat` commits.
+**No `Co-Authored-By` trailers.** Do **not** add `Claude-Session:` URLs (or any
+other AI/assistant session links) to commit messages or PR descriptions. Update
+`README.md` features list with `feat` commits.
 
 ### Releases
 


### PR DESCRIPTION
## Summary

Extends the git-workflow rule in `CLAUDE.md` (alongside the existing no-`Co-Authored-By`-trailer rule) to explicitly disallow `Claude-Session:` / AI-assistant session links in commit messages and PR descriptions.

## Validation
Docs-only change; no code affected.