### PR TITLE
Move ACP selection into the chat model picker

### DIFF
--- a/crates/web/ui/e2e/specs/agents.spec.js
+++ b/crates/web/ui/e2e/specs/agents.spec.js
@@ -509,6 +509,7 @@ test.describe("Agents settings page", () => {
 		await waitForWsConnected(page);
 		await createSession(page);
 		const sessionKey = await page.evaluate(() => window.__moltis_stores?.sessionStore?.activeSessionKey?.value || "");
+		await page.evaluate(() => window.__moltis_stores?.modelStore?.select("e2e/model"));
 
 		await expect(page.getByTestId("external-agent-picker")).toHaveCount(0);
 		const picker = page.locator("#modelComboBtn");

--- a/crates/web/ui/e2e/specs/agents.spec.js
+++ b/crates/web/ui/e2e/specs/agents.spec.js
@@ -525,6 +525,9 @@ test.describe("Agents settings page", () => {
 		const dropdown = page.locator("#modelDropdownList");
 		await expect(dropdown.getByText("E2E Model", { exact: true })).toBeVisible();
 		await expect(page.getByText("ACP: Copilot", { exact: true })).toBeVisible();
+		await expect(
+			dropdown.locator(".model-dropdown-item", { hasText: "ACP: Copilot" }).locator(".model-item-provider"),
+		).toHaveText("ACP agent");
 		await expect(page.getByText("ACP: Codex", { exact: true })).toBeVisible();
 		await expect(page.getByText("ACP: Claude", { exact: true })).toBeVisible();
 		await expect(page.getByText("ACP: Pi", { exact: true })).toBeVisible();

--- a/crates/web/ui/e2e/specs/agents.spec.js
+++ b/crates/web/ui/e2e/specs/agents.spec.js
@@ -46,7 +46,7 @@ async function deleteAgentByName(page, agentName) {
 	await expect(testCard).toHaveCount(0, { timeout: 10_000 });
 }
 
-async function mockExternalAgentsRpc(page, listPayload, modelsPayload, bindFailures = 0) {
+async function mockExternalAgentsRpc(page, listPayload, modelsPayload, bindFailures = 0, holdBackendSwitches = false) {
 	if (Array.isArray(modelsPayload)) {
 		await page.route(
 			"**/api/bootstrap?**",
@@ -60,11 +60,30 @@ async function mockExternalAgentsRpc(page, listPayload, modelsPayload, bindFailu
 			{ times: 1 },
 		);
 	}
+	await page.route(/\/api\/sessions(?:\?.*)?$/, async (route) => {
+		const response = await route.fetch();
+		const payload = await response.json();
+		const bindings = await page.evaluate(() => window.__externalAgentE2EBindings || {});
+		const sessions = Array.isArray(payload) ? payload : payload.sessions;
+		if (Array.isArray(sessions)) {
+			for (const session of sessions) {
+				if (Object.hasOwn(bindings, session.key)) session.external_agent_kind = bindings[session.key];
+			}
+		}
+		await route.fulfill({ response, json: payload });
+	});
 	await page.addInitScript(
-		({ externalAgentsListPayload, modelListPayload, bindFailureCount }) => {
+		({ externalAgentsListPayload, modelListPayload, bindFailureCount, holdSwitches }) => {
 			if (window.__externalAgentE2EPatched) return;
 			window.__externalAgentE2EPatched = true;
 			window.__externalAgentE2ERequests = [];
+			window.__externalAgentE2EBindings = {};
+			window.__externalAgentE2EPendingResponses = [];
+			window.__externalAgentE2EHoldSwitches = holdSwitches;
+			window.__releaseExternalAgentE2EResponses = () => {
+				const pending = window.__externalAgentE2EPendingResponses.splice(0);
+				for (const sendResponse of pending) sendResponse();
+			};
 			let failuresRemaining = bindFailureCount;
 			const agentsPayload = externalAgentsListPayload || [
 				{ kind: "codex", name: "Codex", installed: true, isAcp: false, version: null },
@@ -90,6 +109,14 @@ async function mockExternalAgentsRpc(page, listPayload, modelsPayload, bindFailu
 				});
 			}
 
+			function respondToBackendSwitch(sendResponse) {
+				if (window.__externalAgentE2EHoldSwitches) {
+					window.__externalAgentE2EPendingResponses.push(sendResponse);
+					return;
+				}
+				sendResponse();
+			}
+
 			WebSocket.prototype.send = function (payload) {
 				try {
 					var parsed = JSON.parse(payload);
@@ -109,13 +136,22 @@ async function mockExternalAgentsRpc(page, listPayload, modelsPayload, bindFailu
 							respondError(this, parsed.id, "simulated bind failure");
 							return;
 						}
-						respond(this, parsed.id, { ok: true });
+						respondToBackendSwitch(() => {
+							window.__externalAgentE2EBindings[parsed.params?.sessionKey] = parsed.params?.kind;
+							respond(this, parsed.id, { ok: true });
+						});
 						return;
 					}
 					if (parsed?.method === "external_agents.unbind") {
 						window.__externalAgentE2ERequests.push({ method: parsed.method, params: parsed.params || {} });
-						respond(this, parsed.id, { ok: true });
+						respondToBackendSwitch(() => {
+							window.__externalAgentE2EBindings[parsed.params?.sessionKey] = null;
+							respond(this, parsed.id, { ok: true });
+						});
 						return;
+					}
+					if (parsed?.method === "sessions.patch") {
+						window.__externalAgentE2ERequests.push({ method: parsed.method, params: parsed.params || {} });
 					}
 				} catch (_err) {
 					// Fall through to the original sender.
@@ -123,7 +159,12 @@ async function mockExternalAgentsRpc(page, listPayload, modelsPayload, bindFailu
 				return originalSend.call(this, payload);
 			};
 		},
-		{ externalAgentsListPayload: listPayload, modelListPayload: modelsPayload, bindFailureCount: bindFailures },
+		{
+			externalAgentsListPayload: listPayload,
+			modelListPayload: modelsPayload,
+			bindFailureCount: bindFailures,
+			holdSwitches: holdBackendSwitches,
+		},
 	);
 }
 
@@ -467,11 +508,18 @@ test.describe("Agents settings page", () => {
 		await expectPageContentMounted(page);
 		await waitForWsConnected(page);
 		await createSession(page);
+		const sessionKey = await page.evaluate(() => window.__moltis_stores?.sessionStore?.activeSessionKey?.value || "");
 
 		await expect(page.getByTestId("external-agent-picker")).toHaveCount(0);
 		const picker = page.locator("#modelComboBtn");
 		await expect(picker).toBeEnabled({ timeout: 10_000 });
 		await expect(page.locator("#reasoningCombo")).toBeVisible();
+		await page.locator("#reasoningComboBtn").click();
+		await page
+			.locator("#reasoningDropdownList .model-dropdown-item")
+			.filter({ hasText: /^High$/ })
+			.click();
+		await expect(page.locator("#reasoningComboLabel")).toHaveText("High");
 		await picker.click();
 		const dropdown = page.locator("#modelDropdownList");
 		await expect(dropdown.getByText("E2E Model", { exact: true })).toBeVisible();
@@ -493,10 +541,15 @@ test.describe("Agents settings page", () => {
 		await expect
 			.poll(
 				async () =>
-					page.evaluate(() =>
-						(window.__externalAgentE2ERequests || []).some(
-							(req) => req.method === "external_agents.bind" && req.params?.kind === "acp-copilot",
-						),
+					page.evaluate(
+						(key) =>
+							(window.__externalAgentE2ERequests || []).some(
+								(req) =>
+									req.method === "external_agents.bind" &&
+									req.params?.sessionKey === key &&
+									req.params?.kind === "acp-copilot",
+							),
+						sessionKey,
 					),
 				{ timeout: 10_000 },
 			)
@@ -510,14 +563,33 @@ test.describe("Agents settings page", () => {
 		await expect
 			.poll(
 				async () =>
-					page.evaluate(() =>
-						(window.__externalAgentE2ERequests || []).some((req) => req.method === "external_agents.unbind"),
+					page.evaluate(
+						(key) =>
+							(window.__externalAgentE2ERequests || []).some(
+								(req) => req.method === "external_agents.unbind" && req.params?.sessionKey === key,
+							),
+						sessionKey,
 					),
 				{ timeout: 10_000 },
 			)
 			.toBe(true);
 		await expect(page.locator("#modelComboLabel")).toHaveText("E2E Model");
 		await expect(page.locator("#reasoningCombo")).toBeVisible();
+		await expect(page.locator("#reasoningComboLabel")).toHaveText("High");
+		await expect
+			.poll(
+				async () =>
+					page.evaluate(
+						(key) =>
+							(window.__externalAgentE2ERequests || []).some(
+								(req) =>
+									req.method === "sessions.patch" && req.params?.key === key && req.params?.model === "e2e/model",
+							),
+						sessionKey,
+					),
+				{ timeout: 10_000 },
+			)
+			.toBe(true);
 
 		expect(pageErrors).toEqual([]);
 	});
@@ -553,18 +625,67 @@ test.describe("Agents settings page", () => {
 			.toBe(true);
 		await expect(page.getByTestId("external-agent-picker")).toHaveCount(0);
 		await page.locator("#modelComboBtn").click();
-		await expect(page.getByText("ACP: Copilot (unavailable)", { exact: true })).toHaveCount(0);
-		await expect(page.getByText("ACP: Codex (unavailable)", { exact: true })).toHaveCount(0);
-		await expect(page.getByText("ACP: opencode (unavailable)", { exact: true })).toHaveCount(0);
-		await expect(page.getByText("ACP: Gemini (unavailable)", { exact: true })).toHaveCount(0);
-		await expect(page.getByText("ACP: Augment (unavailable)", { exact: true })).toHaveCount(0);
-		await expect(page.getByText("ACP: Kiro (unavailable)", { exact: true })).toHaveCount(0);
-		await expect(page.getByText("ACP: OpenClaw (unavailable)", { exact: true })).toHaveCount(0);
-		await expect(page.getByText("ACP: OpenHands (unavailable)", { exact: true })).toHaveCount(0);
-		await expect(page.getByText("ACP: Kimi (unavailable)", { exact: true })).toHaveCount(0);
-		await expect(page.getByText("ACP: Stakpak (unavailable)", { exact: true })).toHaveCount(0);
-		await expect(page.getByText("ACP: fast-agent (unavailable)", { exact: true })).toHaveCount(0);
+		const dropdown = page.locator("#modelDropdownList");
+		for (const name of [
+			"ACP: Copilot",
+			"ACP: Codex",
+			"ACP: opencode",
+			"ACP: Gemini",
+			"ACP: Augment",
+			"ACP: Kiro",
+			"ACP: OpenClaw",
+			"ACP: OpenHands",
+			"ACP: Kimi",
+			"ACP: Stakpak",
+			"ACP: fast-agent",
+		]) {
+			await expect(dropdown.getByText(name, { exact: true })).toHaveCount(0);
+		}
 
+		expect(pageErrors).toEqual([]);
+	});
+
+	test("backend switch only disables the originating session selector", async ({ page }) => {
+		const pageErrors = watchPageErrors(page);
+		await mockExternalAgentsRpc(
+			page,
+			[{ kind: "acp-copilot", name: "ACP: Copilot", installed: true, isAcp: true, version: null }],
+			[{ id: "e2e/model", displayName: "E2E Model", provider: "e2e", supportsReasoning: true }],
+			0,
+			true,
+		);
+		await page.goto("/chats");
+		await expectPageContentMounted(page);
+		await waitForWsConnected(page);
+
+		const firstSessionKey = await page.evaluate(
+			() => window.__moltis_stores?.sessionStore?.activeSessionKey?.value || "",
+		);
+		const picker = page.locator("#modelComboBtn");
+		await expect(picker).toBeEnabled({ timeout: 10_000 });
+		await picker.click();
+		await page.locator("#modelDropdownList").getByText("ACP: Copilot", { exact: true }).click();
+		await expect(picker).toBeDisabled();
+
+		await createSession(page);
+		const secondSessionKey = await page.evaluate(
+			() => window.__moltis_stores?.sessionStore?.activeSessionKey?.value || "",
+		);
+		expect(secondSessionKey).not.toBe(firstSessionKey);
+		await expect(picker).toBeEnabled();
+
+		await page.evaluate(() => window.__releaseExternalAgentE2EResponses?.());
+		await expect
+			.poll(
+				async () =>
+					page.evaluate(
+						(key) => window.__moltis_stores?.sessionStore?.getByKey?.(key)?.external_agent_kind || null,
+						firstSessionKey,
+					),
+				{ timeout: 10_000 },
+			)
+			.toBe("acp-copilot");
+		await expect(picker).toBeEnabled();
 		expect(pageErrors).toEqual([]);
 	});
 

--- a/crates/web/ui/e2e/specs/agents.spec.js
+++ b/crates/web/ui/e2e/specs/agents.spec.js
@@ -599,13 +599,13 @@ test.describe("Agents settings page", () => {
 		expect(pageErrors).toEqual([]);
 	});
 
-	test("ACP-only sessions retry auto-bind after a failed attempt", async ({ page }) => {
+	test("ACP-only sessions continue retrying failed auto-bind attempts", async ({ page }) => {
 		const pageErrors = watchPageErrors(page);
 		await mockExternalAgentsRpc(
 			page,
 			[{ kind: "acp-copilot", name: "ACP: Copilot", installed: true, isAcp: true, version: null }],
 			[],
-			1,
+			3,
 		);
 		await page.goto("/chats");
 		await expectPageContentMounted(page);
@@ -624,7 +624,7 @@ test.describe("Agents settings page", () => {
 					),
 				{ timeout: 10_000 },
 			)
-			.toBe(2);
+			.toBe(4);
 		await expect(page.locator("#modelComboLabel")).toHaveText("ACP: Copilot");
 		expect(pageErrors).toEqual([]);
 	});

--- a/crates/web/ui/e2e/specs/agents.spec.js
+++ b/crates/web/ui/e2e/specs/agents.spec.js
@@ -46,7 +46,7 @@ async function deleteAgentByName(page, agentName) {
 	await expect(testCard).toHaveCount(0, { timeout: 10_000 });
 }
 
-async function mockExternalAgentsRpc(page, listPayload, modelsPayload) {
+async function mockExternalAgentsRpc(page, listPayload, modelsPayload, bindFailures = 0) {
 	if (Array.isArray(modelsPayload)) {
 		await page.route(
 			"**/api/bootstrap?**",
@@ -61,12 +61,12 @@ async function mockExternalAgentsRpc(page, listPayload, modelsPayload) {
 		);
 	}
 	await page.addInitScript(
-		({ externalAgentsListPayload, modelListPayload }) => {
+		({ externalAgentsListPayload, modelListPayload, bindFailureCount }) => {
 			if (window.__externalAgentE2EPatched) return;
 			window.__externalAgentE2EPatched = true;
 			window.__externalAgentE2ERequests = [];
-			window.__externalAgentE2EModelsPayload = modelListPayload;
-			window.__externalAgentE2EListPayload = externalAgentsListPayload || [
+			let failuresRemaining = bindFailureCount;
+			const agentsPayload = externalAgentsListPayload || [
 				{ kind: "codex", name: "Codex", installed: true, isAcp: false, version: null },
 				{ kind: "claude-code", name: "Claude Code", installed: false, isAcp: false, version: null },
 			];
@@ -81,26 +81,40 @@ async function mockExternalAgentsRpc(page, listPayload, modelsPayload) {
 				});
 			}
 
+			function respondError(socket, id, message) {
+				queueMicrotask(() => {
+					const event = new MessageEvent("message", {
+						data: JSON.stringify({ type: "res", id, ok: false, error: { message } }),
+					});
+					if (typeof socket.onmessage === "function") socket.onmessage(event);
+				});
+			}
+
 			WebSocket.prototype.send = function (payload) {
 				try {
 					var parsed = JSON.parse(payload);
-					if (parsed?.method === "models.list" && Array.isArray(window.__externalAgentE2EModelsPayload)) {
-						respond(this, parsed.id, window.__externalAgentE2EModelsPayload);
+					if (parsed?.method === "models.list" && Array.isArray(modelListPayload)) {
+						respond(this, parsed.id, modelListPayload);
 						return;
 					}
 					if (parsed?.method === "external_agents.list") {
 						window.__externalAgentE2ERequests.push({ method: parsed.method, params: parsed.params || {} });
-						respond(this, parsed.id, window.__externalAgentE2EListPayload);
+						respond(this, parsed.id, agentsPayload);
 						return;
 					}
 					if (parsed?.method === "external_agents.bind") {
 						window.__externalAgentE2ERequests.push({ method: parsed.method, params: parsed.params || {} });
-						respond(this, parsed.id, { ok: true, sessionKey: parsed.params?.sessionKey, kind: parsed.params?.kind });
+						if (failuresRemaining > 0) {
+							failuresRemaining--;
+							respondError(this, parsed.id, "simulated bind failure");
+							return;
+						}
+						respond(this, parsed.id, { ok: true });
 						return;
 					}
 					if (parsed?.method === "external_agents.unbind") {
 						window.__externalAgentE2ERequests.push({ method: parsed.method, params: parsed.params || {} });
-						respond(this, parsed.id, { ok: true, sessionKey: parsed.params?.sessionKey });
+						respond(this, parsed.id, { ok: true });
 						return;
 					}
 				} catch (_err) {
@@ -109,7 +123,7 @@ async function mockExternalAgentsRpc(page, listPayload, modelsPayload) {
 				return originalSend.call(this, payload);
 			};
 		},
-		{ externalAgentsListPayload: listPayload, modelListPayload: modelsPayload },
+		{ externalAgentsListPayload: listPayload, modelListPayload: modelsPayload, bindFailureCount: bindFailures },
 	);
 }
 
@@ -582,6 +596,36 @@ test.describe("Agents settings page", () => {
 			.toBe(1);
 		await expect(page.locator("#modelComboLabel")).toHaveText("ACP: Copilot");
 		await expect(page.locator("#modelComboBtn")).toBeEnabled();
+		expect(pageErrors).toEqual([]);
+	});
+
+	test("ACP-only sessions retry auto-bind after a failed attempt", async ({ page }) => {
+		const pageErrors = watchPageErrors(page);
+		await mockExternalAgentsRpc(
+			page,
+			[{ kind: "acp-copilot", name: "ACP: Copilot", installed: true, isAcp: true, version: null }],
+			[],
+			1,
+		);
+		await page.goto("/chats");
+		await expectPageContentMounted(page);
+		await waitForWsConnected(page);
+
+		const sessionKey = await page.evaluate(() => window.__moltis_stores?.sessionStore?.activeSessionKey?.value || "");
+		await expect
+			.poll(
+				async () =>
+					page.evaluate(
+						(key) =>
+							(window.__externalAgentE2ERequests || []).filter(
+								(req) => req.method === "external_agents.bind" && req.params?.sessionKey === key,
+							).length,
+						sessionKey,
+					),
+				{ timeout: 10_000 },
+			)
+			.toBe(2);
+		await expect(page.locator("#modelComboLabel")).toHaveText("ACP: Copilot");
 		expect(pageErrors).toEqual([]);
 	});
 

--- a/crates/web/ui/e2e/specs/agents.spec.js
+++ b/crates/web/ui/e2e/specs/agents.spec.js
@@ -46,50 +46,71 @@ async function deleteAgentByName(page, agentName) {
 	await expect(testCard).toHaveCount(0, { timeout: 10_000 });
 }
 
-async function mockExternalAgentsRpc(page, listPayload) {
-	await page.addInitScript((externalAgentsListPayload) => {
-		if (window.__externalAgentE2EPatched) return;
-		window.__externalAgentE2EPatched = true;
-		window.__externalAgentE2ERequests = [];
-		window.__externalAgentE2EListPayload = externalAgentsListPayload || [
-			{ kind: "codex", name: "Codex", installed: true, isAcp: false, version: null },
-			{ kind: "claude-code", name: "Claude Code", installed: false, isAcp: false, version: null },
-		];
-		const originalSend = WebSocket.prototype.send;
-
-		function respond(socket, id, payload) {
-			queueMicrotask(() => {
-				const event = new MessageEvent("message", {
-					data: JSON.stringify({ type: "res", id, ok: true, payload }),
+async function mockExternalAgentsRpc(page, listPayload, modelsPayload) {
+	if (Array.isArray(modelsPayload)) {
+		await page.route(
+			"**/api/bootstrap?**",
+			async (route) => {
+				await route.fulfill({
+					status: 200,
+					contentType: "application/json",
+					body: JSON.stringify({ models: modelsPayload }),
 				});
-				if (typeof socket.onmessage === "function") socket.onmessage(event);
-			});
-		}
+			},
+			{ times: 1 },
+		);
+	}
+	await page.addInitScript(
+		({ externalAgentsListPayload, modelListPayload }) => {
+			if (window.__externalAgentE2EPatched) return;
+			window.__externalAgentE2EPatched = true;
+			window.__externalAgentE2ERequests = [];
+			window.__externalAgentE2EModelsPayload = modelListPayload;
+			window.__externalAgentE2EListPayload = externalAgentsListPayload || [
+				{ kind: "codex", name: "Codex", installed: true, isAcp: false, version: null },
+				{ kind: "claude-code", name: "Claude Code", installed: false, isAcp: false, version: null },
+			];
+			const originalSend = WebSocket.prototype.send;
 
-		WebSocket.prototype.send = function (payload) {
-			try {
-				var parsed = JSON.parse(payload);
-				if (parsed?.method === "external_agents.list") {
-					window.__externalAgentE2ERequests.push({ method: parsed.method, params: parsed.params || {} });
-					respond(this, parsed.id, window.__externalAgentE2EListPayload);
-					return;
-				}
-				if (parsed?.method === "external_agents.bind") {
-					window.__externalAgentE2ERequests.push({ method: parsed.method, params: parsed.params || {} });
-					respond(this, parsed.id, { ok: true, sessionKey: parsed.params?.sessionKey, kind: parsed.params?.kind });
-					return;
-				}
-				if (parsed?.method === "external_agents.unbind") {
-					window.__externalAgentE2ERequests.push({ method: parsed.method, params: parsed.params || {} });
-					respond(this, parsed.id, { ok: true, sessionKey: parsed.params?.sessionKey });
-					return;
-				}
-			} catch (_err) {
-				// Fall through to the original sender.
+			function respond(socket, id, payload) {
+				queueMicrotask(() => {
+					const event = new MessageEvent("message", {
+						data: JSON.stringify({ type: "res", id, ok: true, payload }),
+					});
+					if (typeof socket.onmessage === "function") socket.onmessage(event);
+				});
 			}
-			return originalSend.call(this, payload);
-		};
-	}, listPayload);
+
+			WebSocket.prototype.send = function (payload) {
+				try {
+					var parsed = JSON.parse(payload);
+					if (parsed?.method === "models.list" && Array.isArray(window.__externalAgentE2EModelsPayload)) {
+						respond(this, parsed.id, window.__externalAgentE2EModelsPayload);
+						return;
+					}
+					if (parsed?.method === "external_agents.list") {
+						window.__externalAgentE2ERequests.push({ method: parsed.method, params: parsed.params || {} });
+						respond(this, parsed.id, window.__externalAgentE2EListPayload);
+						return;
+					}
+					if (parsed?.method === "external_agents.bind") {
+						window.__externalAgentE2ERequests.push({ method: parsed.method, params: parsed.params || {} });
+						respond(this, parsed.id, { ok: true, sessionKey: parsed.params?.sessionKey, kind: parsed.params?.kind });
+						return;
+					}
+					if (parsed?.method === "external_agents.unbind") {
+						window.__externalAgentE2ERequests.push({ method: parsed.method, params: parsed.params || {} });
+						respond(this, parsed.id, { ok: true, sessionKey: parsed.params?.sessionKey });
+						return;
+					}
+				} catch (_err) {
+					// Fall through to the original sender.
+				}
+				return originalSend.call(this, payload);
+			};
+		},
+		{ externalAgentsListPayload: listPayload, modelListPayload: modelsPayload },
+	);
 }
 
 async function expectActiveSessionExternalAgent(page, kind) {
@@ -407,31 +428,39 @@ test.describe("Agents settings page", () => {
 		expect(pageErrors).toEqual([]);
 	});
 
-	test("external-agent picker labels named ACP agents", async ({ page }) => {
+	test("composer selector lists and binds named ACP agents", async ({ page }) => {
 		const pageErrors = watchPageErrors(page);
-		await mockExternalAgentsRpc(page, [
-			{ kind: "acp-copilot", name: "ACP: Copilot", installed: true, isAcp: true, version: null },
-			{ kind: "acp-codex", name: "ACP: Codex", installed: true, isAcp: true, version: null },
-			{ kind: "acp-claude", name: "ACP: Claude", installed: true, isAcp: true, version: null },
-			{ kind: "acp-pi", name: "ACP: Pi", installed: true, isAcp: true, version: null },
-			{ kind: "acp-opencode", name: "ACP: opencode", installed: true, isAcp: true, version: null },
-			{ kind: "acp-gemini", name: "ACP: Gemini", installed: true, isAcp: true, version: null },
-			{ kind: "acp-augment", name: "ACP: Augment", installed: true, isAcp: true, version: null },
-			{ kind: "acp-kiro", name: "ACP: Kiro", installed: true, isAcp: true, version: null },
-			{ kind: "acp-openclaw", name: "ACP: OpenClaw", installed: true, isAcp: true, version: null },
-			{ kind: "acp-openhands", name: "ACP: OpenHands", installed: true, isAcp: true, version: null },
-			{ kind: "acp-kimi", name: "ACP: Kimi", installed: true, isAcp: true, version: null },
-			{ kind: "acp-stakpak", name: "ACP: Stakpak", installed: true, isAcp: true, version: null },
-			{ kind: "acp-fast-agent", name: "ACP: fast-agent", installed: true, isAcp: true, version: null },
-		]);
+		await mockExternalAgentsRpc(
+			page,
+			[
+				{ kind: "acp-copilot", name: "ACP: Copilot", installed: true, isAcp: true, version: null },
+				{ kind: "acp-codex", name: "ACP: Codex", installed: true, isAcp: true, version: null },
+				{ kind: "acp-claude", name: "ACP: Claude", installed: true, isAcp: true, version: null },
+				{ kind: "acp-pi", name: "ACP: Pi", installed: true, isAcp: true, version: null },
+				{ kind: "acp-opencode", name: "ACP: opencode", installed: true, isAcp: true, version: null },
+				{ kind: "acp-gemini", name: "ACP: Gemini", installed: true, isAcp: true, version: null },
+				{ kind: "acp-augment", name: "ACP: Augment", installed: true, isAcp: true, version: null },
+				{ kind: "acp-kiro", name: "ACP: Kiro", installed: true, isAcp: true, version: null },
+				{ kind: "acp-openclaw", name: "ACP: OpenClaw", installed: true, isAcp: true, version: null },
+				{ kind: "acp-openhands", name: "ACP: OpenHands", installed: true, isAcp: true, version: null },
+				{ kind: "acp-kimi", name: "ACP: Kimi", installed: true, isAcp: true, version: null },
+				{ kind: "acp-stakpak", name: "ACP: Stakpak", installed: true, isAcp: true, version: null },
+				{ kind: "acp-fast-agent", name: "ACP: fast-agent", installed: true, isAcp: true, version: null },
+			],
+			[{ id: "e2e/model", displayName: "E2E Model", provider: "e2e", supportsReasoning: true }],
+		);
 		await page.goto("/chats");
 		await expectPageContentMounted(page);
 		await waitForWsConnected(page);
 		await createSession(page);
 
-		const picker = page.getByTestId("external-agent-picker");
-		await expect(picker).toBeVisible({ timeout: 10_000 });
-		await picker.locator("button").click();
+		await expect(page.getByTestId("external-agent-picker")).toHaveCount(0);
+		const picker = page.locator("#modelComboBtn");
+		await expect(picker).toBeEnabled({ timeout: 10_000 });
+		await expect(page.locator("#reasoningCombo")).toBeVisible();
+		await picker.click();
+		const dropdown = page.locator("#modelDropdownList");
+		await expect(dropdown.getByText("E2E Model", { exact: true })).toBeVisible();
 		await expect(page.getByText("ACP: Copilot", { exact: true })).toBeVisible();
 		await expect(page.getByText("ACP: Codex", { exact: true })).toBeVisible();
 		await expect(page.getByText("ACP: Claude", { exact: true })).toBeVisible();
@@ -458,11 +487,28 @@ test.describe("Agents settings page", () => {
 				{ timeout: 10_000 },
 			)
 			.toBe(true);
+		await expect(picker).toBeEnabled();
+		await expect(page.locator("#modelComboLabel")).toHaveText("ACP: Copilot");
+		await expect(page.locator("#reasoningCombo")).toBeHidden();
+
+		await picker.click();
+		await dropdown.getByText("E2E Model", { exact: true }).click();
+		await expect
+			.poll(
+				async () =>
+					page.evaluate(() =>
+						(window.__externalAgentE2ERequests || []).some((req) => req.method === "external_agents.unbind"),
+					),
+				{ timeout: 10_000 },
+			)
+			.toBe(true);
+		await expect(page.locator("#modelComboLabel")).toHaveText("E2E Model");
+		await expect(page.locator("#reasoningCombo")).toBeVisible();
 
 		expect(pageErrors).toEqual([]);
 	});
 
-	test("external-agent picker is hidden when no external agents are installed", async ({ page }) => {
+	test("composer selector hides unavailable ACP agents", async ({ page }) => {
 		const pageErrors = watchPageErrors(page);
 		await mockExternalAgentsRpc(page, [
 			{ kind: "acp-copilot", name: "ACP: Copilot", installed: false, isAcp: true, version: null },
@@ -492,6 +538,7 @@ test.describe("Agents settings page", () => {
 			)
 			.toBe(true);
 		await expect(page.getByTestId("external-agent-picker")).toHaveCount(0);
+		await page.locator("#modelComboBtn").click();
 		await expect(page.getByText("ACP: Copilot (unavailable)", { exact: true })).toHaveCount(0);
 		await expect(page.getByText("ACP: Codex (unavailable)", { exact: true })).toHaveCount(0);
 		await expect(page.getByText("ACP: opencode (unavailable)", { exact: true })).toHaveCount(0);
@@ -504,6 +551,37 @@ test.describe("Agents settings page", () => {
 		await expect(page.getByText("ACP: Stakpak (unavailable)", { exact: true })).toHaveCount(0);
 		await expect(page.getByText("ACP: fast-agent (unavailable)", { exact: true })).toHaveCount(0);
 
+		expect(pageErrors).toEqual([]);
+	});
+
+	test("ACP-only sessions auto-bind once", async ({ page }) => {
+		const pageErrors = watchPageErrors(page);
+		await mockExternalAgentsRpc(
+			page,
+			[{ kind: "acp-copilot", name: "ACP: Copilot", installed: true, isAcp: true, version: null }],
+			[],
+		);
+		await page.goto("/chats");
+		await expectPageContentMounted(page);
+		await waitForWsConnected(page);
+		await createSession(page);
+
+		const sessionKey = await page.evaluate(() => window.__moltis_stores?.sessionStore?.activeSessionKey?.value || "");
+		await expect
+			.poll(
+				async () =>
+					page.evaluate(
+						(key) =>
+							(window.__externalAgentE2ERequests || []).filter(
+								(req) => req.method === "external_agents.bind" && req.params?.sessionKey === key,
+							).length,
+						sessionKey,
+					),
+				{ timeout: 10_000 },
+			)
+			.toBe(1);
+		await expect(page.locator("#modelComboLabel")).toHaveText("ACP: Copilot");
+		await expect(page.locator("#modelComboBtn")).toBeEnabled();
 		expect(pageErrors).toEqual([]);
 	});
 

--- a/crates/web/ui/e2e/specs/chat-input.spec.js
+++ b/crates/web/ui/e2e/specs/chat-input.spec.js
@@ -460,7 +460,7 @@ test.describe("Chat input and slash commands", () => {
 		const box = await dropdown.boundingBox();
 		expect(box?.width || 0).toBeGreaterThan(360);
 
-		const item = page.locator("#modelDropdownList .model-dropdown-item").first();
+		const item = page.locator("#modelDropdownList .model-dropdown-item", { hasText: displayName });
 		await expect(item).toHaveAttribute("title", fullTitle);
 		await expect(item.locator(".model-item-label")).toHaveAttribute("title", fullTitle);
 		await item.click();

--- a/crates/web/ui/e2e/specs/reasoning-toggle.spec.js
+++ b/crates/web/ui/e2e/specs/reasoning-toggle.spec.js
@@ -197,8 +197,10 @@ test.describe("reasoning effort toggle", () => {
 		const modelBtn = page.locator("#modelComboBtn");
 		await modelBtn.click();
 
-		const items = page.locator("#modelDropdownList .model-dropdown-item");
-		// Only the base model should appear, not the 3 reasoning variants
+		const items = page
+			.locator("#modelDropdownList .model-dropdown-item")
+			.filter({ has: page.locator(".model-item-provider") });
+		// Only the base model should appear among the model entries, not the 3 reasoning variants.
 		await expect(items).toHaveCount(1);
 		await expect(items.first()).toContainText("Claude Opus 4.5");
 

--- a/crates/web/ui/src/components/SessionHeader.tsx
+++ b/crates/web/ui/src/components/SessionHeader.tsx
@@ -38,14 +38,6 @@ interface AgentOption {
 	[key: string]: unknown;
 }
 
-interface ExternalAgentInfo {
-	kind: string;
-	name: string;
-	installed: boolean;
-	isAcp?: boolean;
-	version?: string | null;
-}
-
 interface SelectOption {
 	value: string;
 	label: string;
@@ -95,12 +87,6 @@ function buildShareUrl(payload: SharePayload): string {
 
 function isSshTargetNode(node: NodeInfo | null): boolean {
 	return node?.platform === "ssh" || String(node?.nodeId || "").startsWith("ssh:");
-}
-
-function refreshModelComboAvailability(): void {
-	void import("../models").then(({ updateModelComboAvailability }) => {
-		updateModelComboAvailability();
-	});
 }
 
 function nodeOptionLabel(node: NodeInfo | null): string {
@@ -162,11 +148,6 @@ export function SessionHeader({
 	const [agentOptionsLoaded, setAgentOptionsLoaded] = useState(initialAgentOptions.length > 0);
 	const [nodeOptions, setNodeOptions] = useState<NodeInfo[]>([]);
 	const [switchingNode, setSwitchingNode] = useState(false);
-	const [externalAgentOptions, setExternalAgentOptions] = useState<ExternalAgentInfo[]>([]);
-	const [switchingExternalAgent, setSwitchingExternalAgent] = useState(false);
-	const [hasLlmModels, setHasLlmModels] = useState<boolean | null>(null);
-	const acpAutoBindAttemptedRef = useRef<Set<string>>(new Set());
-	const acpAutoBindInFlightRef = useRef<Set<string>>(new Set());
 	const inputRef = useRef<HTMLInputElement>(null);
 
 	const fullName = session ? session.label || session.key : currentKey;
@@ -182,11 +163,6 @@ export function SessionHeader({
 	const showArchivedSessions = sessionStore.showArchivedSessions.value;
 	const currentAgentId = session?.agent_id || defaultAgentId || "main";
 	const currentNodeId = session?.node_id || "";
-	const currentExternalAgentKind = session?.external_agent_kind || "";
-	const currentExternalAgent = currentExternalAgentKind
-		? externalAgentOptions.find((agent) => agent.kind === currentExternalAgentKind) || null
-		: null;
-	const currentExternalAgentName = currentExternalAgent?.name || currentExternalAgentKind;
 
 	useEffect(() => {
 		let cancelled = false;
@@ -200,29 +176,6 @@ export function SessionHeader({
 			setDefaultAgentId(parsed.defaultId);
 			setAgentOptions(parsed.agents as AgentOption[]);
 			setAgentOptionsLoaded(true);
-		});
-		return () => {
-			cancelled = true;
-		};
-	}, [currentKey]);
-
-	useEffect(() => {
-		let cancelled = false;
-		setHasLlmModels(null);
-		sendRpc<{ id?: string }[]>("models.list", {}).then((res) => {
-			if (cancelled) return;
-			setHasLlmModels(Boolean(res?.ok && (res.payload || []).length > 0));
-		});
-		return () => {
-			cancelled = true;
-		};
-	}, [currentKey]);
-
-	useEffect(() => {
-		let cancelled = false;
-		sendRpc<ExternalAgentInfo[]>("external_agents.list", {}).then((res) => {
-			if (cancelled || !res?.ok) return;
-			setExternalAgentOptions(Array.isArray(res.payload) ? res.payload : []);
 		});
 		return () => {
 			cancelled = true;
@@ -497,71 +450,6 @@ export function SessionHeader({
 		[currentKey, session, switchingNode],
 	);
 
-	const onExternalAgentChange = useCallback(
-		(nextKind: string) => {
-			if (switchingExternalAgent || nextKind === currentExternalAgentKind) return;
-			setSwitchingExternalAgent(true);
-			const request = nextKind
-				? sendRpc("external_agents.bind", { sessionKey: currentKey, kind: nextKind })
-				: sendRpc("external_agents.unbind", { sessionKey: currentKey });
-			request
-				.then((res) => {
-					if (!res?.ok) {
-						showToast((res?.error as { message?: string })?.message || "Failed to update external agent", "error");
-						return;
-					}
-					if (session) {
-						session.external_agent_kind = nextKind || null;
-						session.dataVersion.value++;
-					}
-					refreshModelComboAvailability();
-					fetchSessions();
-				})
-				.finally(() => {
-					setSwitchingExternalAgent(false);
-				});
-		},
-		[currentExternalAgentKind, currentKey, session, switchingExternalAgent],
-	);
-
-	useEffect(() => {
-		if (
-			isCron ||
-			hasLlmModels !== false ||
-			currentExternalAgentKind ||
-			acpAutoBindAttemptedRef.current.has(currentKey) ||
-			acpAutoBindInFlightRef.current.has(currentKey)
-		) {
-			return;
-		}
-		const firstAcpAgent = externalAgentOptions.find((agent) => agent.installed && agent.isAcp);
-		if (!firstAcpAgent) return;
-
-		let cancelled = false;
-		acpAutoBindInFlightRef.current.add(currentKey);
-		sendRpc("external_agents.bind", { sessionKey: currentKey, kind: firstAcpAgent.kind })
-			.then((bindRes) => {
-				if (cancelled) return;
-				if (!bindRes?.ok) {
-					showToast((bindRes?.error as { message?: string })?.message || "Failed to select ACP agent", "error");
-					return;
-				}
-				acpAutoBindAttemptedRef.current.add(currentKey);
-				if (session) {
-					session.external_agent_kind = firstAcpAgent.kind;
-					session.dataVersion.value++;
-				}
-				refreshModelComboAvailability();
-				fetchSessions();
-			})
-			.finally(() => {
-				acpAutoBindInFlightRef.current.delete(currentKey);
-			});
-		return () => {
-			cancelled = true;
-		};
-	}, [currentExternalAgentKind, currentKey, externalAgentOptions, hasLlmModels, isCron, session]);
-
 	const agentSelectValue = currentAgentId;
 	const hasCurrentAgentOption = agentOptions.some((agent) => agent.id === agentSelectValue);
 	let agentSelectOptions: SelectOption[] = agentOptions.map((agent) => {
@@ -585,28 +473,6 @@ export function SessionHeader({
 	const shouldShowAgentPicker = !isCron && agentOptionsLoaded && (agentOptions.length > 1 || !hasCurrentAgentOption);
 
 	const shouldShowNodePicker = !isCron && (nodeOptions.length > 0 || Boolean(currentNodeId));
-	const selectableExternalAgents = externalAgentOptions.filter(
-		(agent) =>
-			(agent.isAcp || agent.kind === currentExternalAgentKind) &&
-			(agent.installed || agent.kind === currentExternalAgentKind),
-	);
-	const externalAgentSelectOptions: SelectOption[] = selectableExternalAgents.map((agent) => ({
-		value: agent.kind,
-		label: `${agent.name}${agent.installed ? "" : " (unavailable)"}`,
-	}));
-	if (hasLlmModels !== false) {
-		externalAgentSelectOptions.unshift({ value: "", label: "Built-in LLM agent" });
-	} else if (!currentExternalAgentKind) {
-		externalAgentSelectOptions.unshift({ value: "", label: "Select ACP agent" });
-	}
-	const shouldShowExternalAgentPicker = !isCron && selectableExternalAgents.length > 0;
-	const externalAgentStatus = currentExternalAgentKind
-		? currentExternalAgent?.installed === false
-			? `${currentExternalAgentName} unavailable`
-			: session?.externalSessionId
-				? `${currentExternalAgentName} session ${session.externalSessionId}`
-				: `${currentExternalAgentName} bound`
-		: "";
 	const hasCurrentNodeOption = currentNodeId === "" || nodeOptions.some((node) => node.nodeId === currentNodeId);
 	let nodeSelectOptions: SelectOption[] = [
 		{ value: "", label: "Local" },
@@ -703,25 +569,6 @@ export function SessionHeader({
 						fullWidth={false}
 						disabled={switchingNode}
 					/>
-				)}
-				{showSelectors && shouldShowExternalAgentPicker && (
-					<div className="flex items-center gap-1.5" data-testid="external-agent-picker">
-						<ComboSelect
-							options={externalAgentSelectOptions}
-							value={currentExternalAgentKind}
-							onChange={onExternalAgentChange}
-							placeholder="External agent"
-							searchable={false}
-							allowEmpty={false}
-							fullWidth={false}
-							disabled={switchingExternalAgent}
-						/>
-						{externalAgentStatus && (
-							<span className="text-xs text-[var(--text-muted)]" title={externalAgentStatus}>
-								{externalAgentStatus}
-							</span>
-						)}
-					</div>
 				)}
 				{!nameOwnLine && showName && nameControl}
 				{!nameOwnLine && renameCta}

--- a/crates/web/ui/src/models.ts
+++ b/crates/web/ui/src/models.ts
@@ -15,6 +15,10 @@ let modelsLoaded = false;
 let switchingBackend = false;
 const acpAutoBindAttempted = new Set<string>();
 const acpAutoBindInFlight = new Set<string>();
+const acpAutoBindFailures = new Map<string, number>();
+const acpAutoBindRetryTimers = new Map<string, number>();
+const ACP_AUTO_BIND_RETRY_BASE_MS = 1_000;
+const ACP_AUTO_BIND_RETRY_MAX_MS = 30_000;
 
 function installedAcpAgents(): ExternalAgentInfo[] {
 	return externalAgents.filter((agent) => agent.installed && agent.isAcp);
@@ -78,6 +82,25 @@ function setExternalAgentKind(sessionKey: string, kind: string | null): void {
 	session.dataVersion.value++;
 }
 
+function clearAcpAutoBindRetry(sessionKey: string): void {
+	const timer = acpAutoBindRetryTimers.get(sessionKey);
+	if (timer !== undefined) window.clearTimeout(timer);
+	acpAutoBindRetryTimers.delete(sessionKey);
+	acpAutoBindFailures.delete(sessionKey);
+}
+
+function scheduleAcpAutoBindRetry(sessionKey: string): void {
+	if (acpAutoBindRetryTimers.has(sessionKey)) return;
+	const failures = (acpAutoBindFailures.get(sessionKey) || 0) + 1;
+	acpAutoBindFailures.set(sessionKey, failures);
+	const delay = Math.min(ACP_AUTO_BIND_RETRY_BASE_MS * 2 ** Math.min(failures - 1, 5), ACP_AUTO_BIND_RETRY_MAX_MS);
+	const timer = window.setTimeout(() => {
+		acpAutoBindRetryTimers.delete(sessionKey);
+		if (sessionStore.activeSessionKey.value === sessionKey) updateModelComboAvailability();
+	}, delay);
+	acpAutoBindRetryTimers.set(sessionKey, timer);
+}
+
 function maybeAutoBindAcp(): void {
 	const session = sessionStore.activeSession.value;
 	const sessionKey = sessionStore.activeSessionKey.value;
@@ -96,14 +119,20 @@ function maybeAutoBindAcp(): void {
 	const agent = installedAcpAgents()[0];
 	if (!agent) return;
 	acpAutoBindInFlight.add(sessionKey);
-	void bindAcpAgent(agent)
+	void bindAcpAgent(agent, false)
 		.then((bound) => {
-			if (bound) acpAutoBindAttempted.add(sessionKey);
+			if (bound) {
+				acpAutoBindAttempted.add(sessionKey);
+				clearAcpAutoBindRetry(sessionKey);
+			}
 		})
-		.finally(() => acpAutoBindInFlight.delete(sessionKey));
+		.finally(() => {
+			acpAutoBindInFlight.delete(sessionKey);
+			if (!acpAutoBindAttempted.has(sessionKey)) scheduleAcpAutoBindRetry(sessionKey);
+		});
 }
 
-async function bindAcpAgent(agent: ExternalAgentInfo): Promise<boolean> {
+async function bindAcpAgent(agent: ExternalAgentInfo, notifyFailure = true): Promise<boolean> {
 	if (switchingBackend) return false;
 	const sessionKey = sessionStore.activeSessionKey.value;
 	if (!sessionKey || sessionKey.startsWith("cron:")) return false;
@@ -116,14 +145,14 @@ async function bindAcpAgent(agent: ExternalAgentInfo): Promise<boolean> {
 	try {
 		const res = await sendRpc("external_agents.bind", { sessionKey, kind: agent.kind });
 		if (!res?.ok) {
-			showToast(res?.error?.message || "Failed to select ACP agent", "error");
+			if (notifyFailure) showToast(res?.error?.message || "Failed to select ACP agent", "error");
 			return false;
 		}
 		setExternalAgentKind(sessionKey, agent.kind);
 		closeModelDropdown();
 		return true;
 	} catch {
-		showToast("Failed to select ACP agent", "error");
+		if (notifyFailure) showToast("Failed to select ACP agent", "error");
 		return false;
 	} finally {
 		switchingBackend = false;

--- a/crates/web/ui/src/models.ts
+++ b/crates/web/ui/src/models.ts
@@ -12,6 +12,7 @@ import { showToast } from "./ui";
 let externalAgents: ExternalAgentInfo[] = [];
 let externalAgentsLoaded = false;
 let modelsLoaded = false;
+let fetchModelsGeneration = 0;
 const switchingBackendSessions = new Set<string>();
 const acpAutoBindAttempted = new Set<string>();
 const acpAutoBindInFlight = new Set<string>();
@@ -59,15 +60,14 @@ export function updateModelComboAvailability(): void {
 	maybeAutoBindAcp();
 }
 
-function refreshAcpAgents(): Promise<boolean> {
+function fetchAcpAgents(): Promise<ExternalAgentInfo[] | null> {
 	return sendRpc<ExternalAgentInfo[]>("external_agents.list", {})
 		.then((res) => {
-			if (!res?.ok) return false;
-			externalAgents = res.payload || [];
-			return true;
+			if (!res?.ok) return null;
+			return res.payload || [];
 		})
 		.catch(() => {
-			return false;
+			return null;
 		});
 }
 
@@ -195,9 +195,12 @@ function updateModelComboLabel(model: ModelInfo): void {
 }
 
 export function fetchModels(): Promise<void> {
-	return Promise.all([modelStore.fetch(), refreshAcpAgents()]).then(([didLoadModels, didLoadAgents]) => {
+	const generation = ++fetchModelsGeneration;
+	return Promise.all([modelStore.fetch(), fetchAcpAgents()]).then(([didLoadModels, agents]) => {
+		if (generation !== fetchModelsGeneration) return;
 		modelsLoaded = didLoadModels;
-		externalAgentsLoaded = didLoadAgents;
+		externalAgentsLoaded = agents !== null;
+		if (agents !== null) externalAgents = agents;
 		// Dual-write to state.js for backward compat
 		S.setModels(modelStore.models.value);
 		S.setSelectedModelId(modelStore.selectedModelId.value);

--- a/crates/web/ui/src/models.ts
+++ b/crates/web/ui/src/models.ts
@@ -6,59 +6,121 @@ import { showModelNotice } from "./pages/ChatPage";
 import * as S from "./state";
 import { modelStore, REASONING_SEP } from "./stores/model-store";
 import { sessionStore } from "./stores/session-store";
-import type { ModelInfo } from "./types";
+import type { ExternalAgentInfo, ModelInfo } from "./types";
+import { showToast } from "./ui";
 
-interface ExternalAgentInfo {
-	kind: string;
-	name: string;
-	installed: boolean;
-	isAcp?: boolean;
-}
-
-let installedExternalAgents: ExternalAgentInfo[] = [];
+let externalAgents: ExternalAgentInfo[] = [];
+let externalAgentsLoaded = false;
+let modelsLoaded = false;
+let switchingBackend = false;
+const acpAutoBindAttempted = new Set<string>();
 
 function installedAcpAgents(): ExternalAgentInfo[] {
-	return installedExternalAgents.filter((agent) => agent.isAcp);
+	return externalAgents.filter((agent) => agent.installed && agent.isAcp);
+}
+
+function selectableAcpAgents(): ExternalAgentInfo[] {
+	return sessionStore.activeSessionKey.value.startsWith("cron:") ? [] : installedAcpAgents();
 }
 
 function activeExternalAgent(): ExternalAgentInfo | null {
 	const kind = sessionStore.activeSession.value?.external_agent_kind || "";
 	if (!kind) return null;
-	return installedExternalAgents.find((agent) => agent.kind === kind) || null;
+	return externalAgents.find((agent) => agent.kind === kind) || null;
 }
 
 export function updateModelComboAvailability(): void {
 	if (!(S.modelComboBtn && S.modelComboLabel)) return;
-	const acpAgent = activeExternalAgent();
-	const disabled = Boolean(acpAgent?.isAcp);
-	(S.modelComboBtn as HTMLButtonElement).disabled = disabled;
-	S.modelComboBtn.setAttribute("aria-disabled", disabled ? "true" : "false");
-	S.modelComboBtn.title = disabled ? `${acpAgent?.name || "ACP agent"} controls model selection` : "";
-	if (disabled) {
-		closeModelDropdown();
-		S.modelComboLabel.textContent = acpAgent?.name || "ACP agent";
-		S.modelComboLabel.title = "Model selection is controlled by the selected ACP agent";
+	const externalKind = sessionStore.activeSession.value?.external_agent_kind || "";
+	const externalAgent = activeExternalAgent();
+	document
+		.getElementById("reasoningCombo")
+		?.classList.toggle("hidden", Boolean(externalKind) || !modelStore.supportsReasoning.value);
+	(S.modelComboBtn as HTMLButtonElement).disabled = switchingBackend;
+	S.modelComboBtn.setAttribute("aria-disabled", switchingBackend ? "true" : "false");
+	S.modelComboBtn.title = switchingBackend ? "Switching chat backend" : "Select model or ACP agent";
+	if (externalKind) {
+		const label = externalAgent?.name || externalKind;
+		const unavailable = externalAgent?.installed === false;
+		S.modelComboLabel.textContent = unavailable ? `${label} (unavailable)` : label;
+		S.modelComboLabel.title = unavailable ? `${label} is unavailable` : `Using ${label}`;
 		return;
 	}
 	const model = modelStore.selectedModel.value;
 	if (model) updateModelComboLabel(model);
 	else updateAcpOnlyModelComboLabel();
+	maybeAutoBindAcp();
 }
 
-function refreshAcpAgents(): Promise<void> {
+function refreshAcpAgents(): Promise<boolean> {
 	return sendRpc<ExternalAgentInfo[]>("external_agents.list", {})
 		.then((res) => {
-			installedExternalAgents = res?.ok ? (res.payload || []).filter((agent) => agent.installed) : [];
+			if (!res?.ok) return false;
+			externalAgents = res.payload || [];
+			return true;
 		})
 		.catch(() => {
-			installedExternalAgents = [];
+			return false;
 		});
 }
 
 function updateAcpOnlyModelComboLabel(): void {
-	if (!(S.modelComboLabel && modelStore.models.value.length === 0 && installedAcpAgents().length > 0)) return;
+	if (!(S.modelComboLabel && modelStore.models.value.length === 0 && selectableAcpAgents().length > 0)) return;
 	S.modelComboLabel.textContent = "ACP agent";
-	S.modelComboLabel.title = "Using an ACP agent selected in the session header";
+	S.modelComboLabel.title = "Select an ACP agent";
+}
+
+function setExternalAgentKind(sessionKey: string, kind: string | null): void {
+	const session = sessionStore.getByKey(sessionKey);
+	if (!session) return;
+	session.external_agent_kind = kind;
+	session.dataVersion.value++;
+}
+
+function maybeAutoBindAcp(): void {
+	const session = sessionStore.activeSession.value;
+	const sessionKey = sessionStore.activeSessionKey.value;
+	if (
+		!(session && sessionKey) ||
+		sessionKey.startsWith("cron:") ||
+		!modelsLoaded ||
+		!externalAgentsLoaded ||
+		modelStore.models.value.length > 0 ||
+		session.external_agent_kind ||
+		acpAutoBindAttempted.has(sessionKey)
+	) {
+		return;
+	}
+	const agent = installedAcpAgents()[0];
+	if (!agent) return;
+	acpAutoBindAttempted.add(sessionKey);
+	void bindAcpAgent(agent);
+}
+
+async function bindAcpAgent(agent: ExternalAgentInfo): Promise<void> {
+	if (switchingBackend) return;
+	const sessionKey = sessionStore.activeSessionKey.value;
+	if (!sessionKey || sessionKey.startsWith("cron:")) return;
+	if (sessionStore.activeSession.value?.external_agent_kind === agent.kind) {
+		closeModelDropdown();
+		return;
+	}
+	switchingBackend = true;
+	updateModelComboAvailability();
+	try {
+		const res = await sendRpc("external_agents.bind", { sessionKey, kind: agent.kind });
+		if (!res?.ok) {
+			showToast(res?.error?.message || "Failed to select ACP agent", "error");
+			return;
+		}
+		setExternalAgentKind(sessionKey, agent.kind);
+		closeModelDropdown();
+	} catch {
+		showToast("Failed to select ACP agent", "error");
+	} finally {
+		switchingBackend = false;
+		if (sessionStore.activeSessionKey.value === sessionKey) updateModelComboAvailability();
+	}
 }
 
 function setSessionModel(sessionKey: string, modelId: string): void {
@@ -89,7 +151,9 @@ function updateModelComboLabel(model: ModelInfo): void {
 }
 
 export function fetchModels(): Promise<void> {
-	return Promise.all([modelStore.fetch(), refreshAcpAgents()]).then(() => {
+	return Promise.all([modelStore.fetch(), refreshAcpAgents()]).then(([didLoadModels, didLoadAgents]) => {
+		modelsLoaded = didLoadModels;
+		externalAgentsLoaded = didLoadAgents;
 		// Dual-write to state.js for backward compat
 		S.setModels(modelStore.models.value);
 		S.setSelectedModelId(modelStore.selectedModelId.value);
@@ -107,16 +171,49 @@ export function fetchModels(): Promise<void> {
 	});
 }
 
-export function selectModel(m: ModelInfo): void {
+function commitModelSelection(m: ModelInfo, sessionKey = S.activeSessionKey): void {
 	modelStore.select(m.id);
 	// Dual-write to state.js for backward compat
 	S.setSelectedModelId(m.id);
 	updateModelComboLabel(m);
 	localStorage.setItem("moltis-model", m.id);
-	setSessionModel(S.activeSessionKey, m.id);
+	setSessionModel(sessionKey, m.id);
 	closeModelDropdown();
 	// Show notice if model doesn't support tools
 	showModelNotice(m);
+}
+
+export function selectModel(m: ModelInfo): void {
+	const externalKind = sessionStore.activeSession.value?.external_agent_kind || "";
+	if (!externalKind) {
+		commitModelSelection(m);
+		return;
+	}
+	if (switchingBackend) return;
+	const sessionKey = sessionStore.activeSessionKey.value;
+	if (!sessionKey) return;
+	switchingBackend = true;
+	updateModelComboAvailability();
+	void sendRpc("external_agents.unbind", { sessionKey })
+		.then((res) => {
+			if (!res?.ok) {
+				showToast(res?.error?.message || "Failed to switch to the selected model", "error");
+				return;
+			}
+			setExternalAgentKind(sessionKey, null);
+			if (sessionStore.activeSessionKey.value === sessionKey) {
+				commitModelSelection(m, sessionKey);
+			} else {
+				setSessionModel(sessionKey, m.id);
+			}
+		})
+		.catch(() => {
+			showToast("Failed to switch to the selected model", "error");
+		})
+		.finally(() => {
+			switchingBackend = false;
+			if (sessionStore.activeSessionKey.value === sessionKey) updateModelComboAvailability();
+		});
 }
 
 export function openModelDropdown(): void {
@@ -182,11 +279,41 @@ function buildModelItem(m: ModelInfo, currentId: string): HTMLDivElement {
 	return el;
 }
 
+function buildAcpItem(agent: ExternalAgentInfo, currentKind: string): HTMLDivElement {
+	const el = document.createElement("div");
+	el.className = "model-dropdown-item";
+	if (agent.kind === currentKind) el.classList.add("selected");
+	el.title = `${agent.name} (${agent.kind})`;
+
+	const label = document.createElement("span");
+	label.className = "model-item-label";
+	label.textContent = agent.name;
+	label.title = el.title;
+	el.appendChild(label);
+
+	const meta = document.createElement("span");
+	meta.className = "model-item-meta";
+	meta.textContent = "ACP agent";
+	el.appendChild(meta);
+	el.addEventListener("click", () => void bindAcpAgent(agent));
+	return el;
+}
+
+function appendDivider(): void {
+	const divider = document.createElement("div");
+	divider.className = "model-dropdown-divider";
+	S.modelDropdownList?.appendChild(divider);
+}
+
 export function renderModelList(query: string): void {
 	if (!S.modelDropdownList) return;
 	S.modelDropdownList.textContent = "";
 	const q = query.toLowerCase();
 	const allModels = modelStore.models.value;
+	const acpAgents = selectableAcpAgents().filter((agent) => {
+		const name = agent.name.toLowerCase();
+		return !q || name.includes(q) || agent.kind.toLowerCase().includes(q) || "acp agent".includes(q);
+	});
 	const filtered = allModels.filter((m) => {
 		// Hide @reasoning-* virtual variants — the reasoning toggle handles these.
 		if (m.id.indexOf(REASONING_SEP) !== -1) return false;
@@ -194,33 +321,19 @@ export function renderModelList(query: string): void {
 		const provider = (m.provider || "").toLowerCase();
 		return !q || label.indexOf(q) !== -1 || provider.indexOf(q) !== -1 || m.id.toLowerCase().indexOf(q) !== -1;
 	});
-	if (filtered.length === 0) {
+	if (filtered.length === 0 && acpAgents.length === 0) {
 		const empty = document.createElement("div");
 		empty.className = "model-dropdown-empty";
-		const acpAgents = installedAcpAgents();
-		if (allModels.length === 0 && acpAgents.length > 0) {
-			empty.textContent = "No LLM models configured. ACP agents are selected from the session header.";
-			S.modelDropdownList.appendChild(empty);
-			acpAgents.forEach((agent) => {
-				const item = document.createElement("div");
-				item.className = "model-dropdown-item model-dropdown-item-unsupported";
-				const label = document.createElement("span");
-				label.className = "model-item-label";
-				label.textContent = agent.name;
-				item.appendChild(label);
-				const meta = document.createElement("span");
-				meta.className = "model-item-meta";
-				meta.textContent = "ACP agent";
-				item.appendChild(meta);
-				S.modelDropdownList?.appendChild(item);
-			});
-			return;
-		}
 		empty.textContent = t("common:labels.noMatchingModels");
 		S.modelDropdownList.appendChild(empty);
 		return;
 	}
-	const currentId = modelStore.selectedModelId.value;
+	const currentKind = sessionStore.activeSession.value?.external_agent_kind || "";
+	for (const agent of acpAgents) {
+		S.modelDropdownList.appendChild(buildAcpItem(agent, currentKind));
+	}
+	if (acpAgents.length > 0 && filtered.length > 0) appendDivider();
+	const currentId = currentKind ? "" : modelStore.selectedModelId.value;
 	let lastPreferredIdx = -1;
 	for (let i = filtered.length - 1; i >= 0; i--) {
 		if (filtered[i].preferred) {
@@ -232,9 +345,7 @@ export function renderModelList(query: string): void {
 		S.modelDropdownList?.appendChild(buildModelItem(m, currentId));
 
 		if (idx === lastPreferredIdx && lastPreferredIdx < filtered.length - 1) {
-			const divider = document.createElement("div");
-			divider.className = "model-dropdown-divider";
-			S.modelDropdownList?.appendChild(divider);
+			appendDivider();
 		}
 	});
 }

--- a/crates/web/ui/src/models.ts
+++ b/crates/web/ui/src/models.ts
@@ -341,7 +341,10 @@ function buildAcpItem(agent: ExternalAgentInfo, currentKind: string): HTMLDivEle
 
 	const meta = document.createElement("span");
 	meta.className = "model-item-meta";
-	meta.textContent = "ACP agent";
+	const provider = document.createElement("span");
+	provider.className = "model-item-provider";
+	provider.textContent = "ACP agent";
+	meta.appendChild(provider);
 	el.appendChild(meta);
 	el.addEventListener("click", () => void bindAcpAgent(agent));
 	return el;

--- a/crates/web/ui/src/models.ts
+++ b/crates/web/ui/src/models.ts
@@ -12,7 +12,7 @@ import { showToast } from "./ui";
 let externalAgents: ExternalAgentInfo[] = [];
 let externalAgentsLoaded = false;
 let modelsLoaded = false;
-let switchingBackend = false;
+const switchingBackendSessions = new Set<string>();
 const acpAutoBindAttempted = new Set<string>();
 const acpAutoBindInFlight = new Set<string>();
 const acpAutoBindFailures = new Map<string, number>();
@@ -36,6 +36,8 @@ function activeExternalAgent(): ExternalAgentInfo | null {
 
 export function updateModelComboAvailability(): void {
 	if (!(S.modelComboBtn && S.modelComboLabel)) return;
+	const sessionKey = sessionStore.activeSessionKey.value;
+	const switchingBackend = switchingBackendSessions.has(sessionKey);
 	const externalKind = sessionStore.activeSession.value?.external_agent_kind || "";
 	const externalAgent = activeExternalAgent();
 	document
@@ -80,6 +82,10 @@ function setExternalAgentKind(sessionKey: string, kind: string | null): void {
 	if (!session) return;
 	session.external_agent_kind = kind;
 	session.dataVersion.value++;
+}
+
+function refreshSessionMetadata(): void {
+	void import("./sessions").then(({ fetchSessions }) => fetchSessions());
 }
 
 function clearAcpAutoBindRetry(sessionKey: string): void {
@@ -133,14 +139,14 @@ function maybeAutoBindAcp(): void {
 }
 
 async function bindAcpAgent(agent: ExternalAgentInfo, notifyFailure = true): Promise<boolean> {
-	if (switchingBackend) return false;
 	const sessionKey = sessionStore.activeSessionKey.value;
 	if (!sessionKey || sessionKey.startsWith("cron:")) return false;
+	if (switchingBackendSessions.has(sessionKey)) return false;
 	if (sessionStore.activeSession.value?.external_agent_kind === agent.kind) {
 		closeModelDropdown();
 		return true;
 	}
-	switchingBackend = true;
+	switchingBackendSessions.add(sessionKey);
 	updateModelComboAvailability();
 	try {
 		const res = await sendRpc("external_agents.bind", { sessionKey, kind: agent.kind });
@@ -149,14 +155,15 @@ async function bindAcpAgent(agent: ExternalAgentInfo, notifyFailure = true): Pro
 			return false;
 		}
 		setExternalAgentKind(sessionKey, agent.kind);
+		refreshSessionMetadata();
 		closeModelDropdown();
 		return true;
 	} catch {
 		if (notifyFailure) showToast("Failed to select ACP agent", "error");
 		return false;
 	} finally {
-		switchingBackend = false;
-		if (sessionStore.activeSessionKey.value === sessionKey) updateModelComboAvailability();
+		switchingBackendSessions.delete(sessionKey);
+		updateModelComboAvailability();
 	}
 }
 
@@ -226,10 +233,10 @@ export function selectModel(m: ModelInfo): void {
 		commitModelSelection(m);
 		return;
 	}
-	if (switchingBackend) return;
 	const sessionKey = sessionStore.activeSessionKey.value;
 	if (!sessionKey) return;
-	switchingBackend = true;
+	if (switchingBackendSessions.has(sessionKey)) return;
+	switchingBackendSessions.add(sessionKey);
 	updateModelComboAvailability();
 	void sendRpc("external_agents.unbind", { sessionKey })
 		.then((res) => {
@@ -238,6 +245,7 @@ export function selectModel(m: ModelInfo): void {
 				return;
 			}
 			setExternalAgentKind(sessionKey, null);
+			refreshSessionMetadata();
 			if (sessionStore.activeSessionKey.value === sessionKey) {
 				commitModelSelection(m, sessionKey);
 			} else {
@@ -248,8 +256,8 @@ export function selectModel(m: ModelInfo): void {
 			showToast("Failed to switch to the selected model", "error");
 		})
 		.finally(() => {
-			switchingBackend = false;
-			if (sessionStore.activeSessionKey.value === sessionKey) updateModelComboAvailability();
+			switchingBackendSessions.delete(sessionKey);
+			updateModelComboAvailability();
 		});
 }
 

--- a/crates/web/ui/src/models.ts
+++ b/crates/web/ui/src/models.ts
@@ -14,6 +14,7 @@ let externalAgentsLoaded = false;
 let modelsLoaded = false;
 let switchingBackend = false;
 const acpAutoBindAttempted = new Set<string>();
+const acpAutoBindInFlight = new Set<string>();
 
 function installedAcpAgents(): ExternalAgentInfo[] {
 	return externalAgents.filter((agent) => agent.installed && agent.isAcp);
@@ -87,23 +88,28 @@ function maybeAutoBindAcp(): void {
 		!externalAgentsLoaded ||
 		modelStore.models.value.length > 0 ||
 		session.external_agent_kind ||
-		acpAutoBindAttempted.has(sessionKey)
+		acpAutoBindAttempted.has(sessionKey) ||
+		acpAutoBindInFlight.has(sessionKey)
 	) {
 		return;
 	}
 	const agent = installedAcpAgents()[0];
 	if (!agent) return;
-	acpAutoBindAttempted.add(sessionKey);
-	void bindAcpAgent(agent);
+	acpAutoBindInFlight.add(sessionKey);
+	void bindAcpAgent(agent)
+		.then((bound) => {
+			if (bound) acpAutoBindAttempted.add(sessionKey);
+		})
+		.finally(() => acpAutoBindInFlight.delete(sessionKey));
 }
 
-async function bindAcpAgent(agent: ExternalAgentInfo): Promise<void> {
-	if (switchingBackend) return;
+async function bindAcpAgent(agent: ExternalAgentInfo): Promise<boolean> {
+	if (switchingBackend) return false;
 	const sessionKey = sessionStore.activeSessionKey.value;
-	if (!sessionKey || sessionKey.startsWith("cron:")) return;
+	if (!sessionKey || sessionKey.startsWith("cron:")) return false;
 	if (sessionStore.activeSession.value?.external_agent_kind === agent.kind) {
 		closeModelDropdown();
-		return;
+		return true;
 	}
 	switchingBackend = true;
 	updateModelComboAvailability();
@@ -111,12 +117,14 @@ async function bindAcpAgent(agent: ExternalAgentInfo): Promise<void> {
 		const res = await sendRpc("external_agents.bind", { sessionKey, kind: agent.kind });
 		if (!res?.ok) {
 			showToast(res?.error?.message || "Failed to select ACP agent", "error");
-			return;
+			return false;
 		}
 		setExternalAgentKind(sessionKey, agent.kind);
 		closeModelDropdown();
+		return true;
 	} catch {
 		showToast("Failed to select ACP agent", "error");
+		return false;
 	} finally {
 		switchingBackend = false;
 		if (sessionStore.activeSessionKey.value === sessionKey) updateModelComboAvailability();

--- a/crates/web/ui/src/onboarding-view.tsx
+++ b/crates/web/ui/src/onboarding-view.tsx
@@ -352,7 +352,7 @@ function SummaryStep({ onBack, onFinish }: { onBack: () => void; onFinish: () =>
 									</span>
 								))}
 							</div>
-							<div>Available in each chat session's external-agent selector.</div>
+							<div>Available alongside models in each chat composer.</div>
 						</div>
 					) : (
 						<>No ACP agents detected on PATH</>

--- a/crates/web/ui/src/onboarding/types.ts
+++ b/crates/web/ui/src/onboarding/types.ts
@@ -1,5 +1,7 @@
 // ── Shared types for onboarding sub-modules ──────────────────
 
+export type { ExternalAgentInfo } from "../types";
+
 export interface ProviderInfo {
 	name: string;
 	displayName: string;
@@ -12,14 +14,6 @@ export interface ProviderInfo {
 	models?: string[];
 	uiOrder?: number;
 	[key: string]: unknown;
-}
-
-export interface ExternalAgentInfo {
-	kind: string;
-	name: string;
-	installed: boolean;
-	isAcp: boolean;
-	version?: string | null;
 }
 
 export interface ModelSelectorRow {

--- a/crates/web/ui/src/pages/ChatPage.tsx
+++ b/crates/web/ui/src/pages/ChatPage.tsx
@@ -19,7 +19,7 @@ import {
 import { SessionHeader } from "../components/SessionHeader";
 import { formatTokens, sendRpc } from "../helpers";
 import { initMediaDrop, teardownMediaDrop } from "../media-drop";
-import { bindModelComboEvents, modelDisplayLabel, modelTitle } from "../models";
+import { bindModelComboEvents, fetchModels, modelDisplayLabel, modelTitle } from "../models";
 import { bindNodeComboEvents, fetchNodes, unbindNodeEvents } from "../nodes-selector";
 import { bindProjectComboEvents } from "../project-combo";
 import { fetchProjects } from "../projects";
@@ -731,8 +731,10 @@ function initializeChatControls(): void {
 	S.setModelComboLabel(S.$("modelComboLabel"));
 	S.setModelDropdown(S.$("modelDropdown"));
 	S.setModelSearchInput(S.$("modelSearchInput"));
+	S.modelSearchInput?.setAttribute("placeholder", "Search models or ACP agents...");
 	S.setModelDropdownList(S.$("modelDropdownList"));
 	bindModelComboEvents();
+	void fetchModels();
 	bindReasoningToggle();
 	S.setNodeCombo(S.$("nodeCombo"));
 	S.setNodeComboBtn(S.$("nodeComboBtn"));

--- a/crates/web/ui/src/reasoning-toggle.ts
+++ b/crates/web/ui/src/reasoning-toggle.ts
@@ -9,6 +9,7 @@
 import { effect } from "@preact/signals";
 import { t } from "./i18n";
 import { modelStore } from "./stores/model-store";
+import { sessionStore } from "./stores/session-store";
 
 const EFFORT_VALUES: string[] = ["", "minimal", "low", "medium", "high", "xhigh"];
 
@@ -91,10 +92,15 @@ export function bindReasoningToggle(): void {
 
 	// Reactively show/hide the combo based on model reasoning support
 	disposeVisibility = effect(() => {
-		const show = modelStore.supportsReasoning.value;
+		const session = sessionStore.activeSession.value;
+		const sessionState = session
+			? { externalAgentKind: session.external_agent_kind, version: session.dataVersion.value }
+			: null;
+		const supportsReasoning = modelStore.supportsReasoning.value;
+		const show = supportsReasoning && !sessionState?.externalAgentKind;
 		reasoningCombo?.classList.toggle("hidden", !show);
 		// Reset effort when switching to a non-reasoning model
-		if (!show && modelStore.reasoningEffort.value) {
+		if (!supportsReasoning && modelStore.reasoningEffort.value) {
 			modelStore.setReasoningEffort("");
 		}
 		if (reasoningComboLabel) {

--- a/crates/web/ui/src/stores/model-store.ts
+++ b/crates/web/ui/src/stores/model-store.ts
@@ -57,13 +57,13 @@ export function setAll(arr: ModelInfo[]): void {
 	models.value = arr || [];
 }
 
-/** Fetch models from the server via RPC. */
-export function fetch(): Promise<void> {
+/** Fetch models from the server via RPC. Returns whether the response succeeded. */
+export function fetch(): Promise<boolean> {
 	return sendRpc("models.list", {}).then((r) => {
 		const res = r as RpcResponse<ModelInfo[]>;
-		if (!res?.ok) return;
+		if (!res?.ok) return false;
 		setAll(res.payload || []);
-		if (models.value.length === 0) return;
+		if (models.value.length === 0) return true;
 		let saved = localStorage.getItem("moltis-model") || "";
 		// If the saved model has a reasoning suffix, strip it and restore the effort
 		const parsed = parseReasoningSuffix(saved);
@@ -76,6 +76,7 @@ export function fetch(): Promise<void> {
 		const model = found || models.value[0];
 		select(model.id);
 		if (!found) localStorage.setItem("moltis-model", model.id);
+		return true;
 	});
 }
 

--- a/crates/web/ui/src/stores/model-store.ts
+++ b/crates/web/ui/src/stores/model-store.ts
@@ -13,6 +13,7 @@ export const REASONING_SEP = "@reasoning-";
 export const models = signal<ModelInfo[]>([]);
 export const selectedModelId = signal<string>(localStorage.getItem("moltis-model") || "");
 export const reasoningEffort = signal<string>(localStorage.getItem("moltis-reasoning-effort") || "");
+let modelListGeneration = 0;
 
 export const selectedModel = computed<ModelInfo | null>(() => {
 	const id = selectedModelId.value;
@@ -54,15 +55,18 @@ export function isReasoningVariant(modelId: string): boolean {
 
 /** Replace the full model list (e.g. after fetch or bootstrap). */
 export function setAll(arr: ModelInfo[]): void {
+	modelListGeneration++;
 	models.value = arr || [];
 }
 
 /** Fetch models from the server via RPC. Returns whether the response succeeded. */
 export function fetch(): Promise<boolean> {
+	const generation = ++modelListGeneration;
 	return sendRpc("models.list", {}).then((r) => {
 		const res = r as RpcResponse<ModelInfo[]>;
 		if (!res?.ok) return false;
-		setAll(res.payload || []);
+		if (generation !== modelListGeneration) return true;
+		models.value = res.payload || [];
 		if (models.value.length === 0) return true;
 		let saved = localStorage.getItem("moltis-model") || "";
 		// If the saved model has a reasoning suffix, strip it and restore the effort

--- a/crates/web/ui/src/types/external-agent.ts
+++ b/crates/web/ui/src/types/external-agent.ts
@@ -1,0 +1,8 @@
+/** External chat agent discovered by the gateway. */
+export interface ExternalAgentInfo {
+	kind: string;
+	name: string;
+	installed: boolean;
+	isAcp: boolean;
+	version?: string | null;
+}

--- a/crates/web/ui/src/types/index.ts
+++ b/crates/web/ui/src/types/index.ts
@@ -11,6 +11,8 @@ export type {
 // ChannelType is both a type and a runtime const object, so use plain re-export.
 export { ChannelType } from "./channel";
 
+export type { ExternalAgentInfo } from "./external-agent";
+
 export type {
 	ActiveHoursConfig,
 	CronJob,

--- a/crates/web/ui/src/types/rpc-methods.ts
+++ b/crates/web/ui/src/types/rpc-methods.ts
@@ -6,6 +6,7 @@
 // typed use `unknown` as a placeholder -- callers can narrow with
 // `as` casts until we refine the type here.
 
+import type { ExternalAgentInfo } from "./external-agent";
 import type { ModelInfo } from "./model";
 import type { SessionMeta } from "./session";
 
@@ -60,7 +61,7 @@ export interface RpcMethodMap {
 	// ── Exec ────────────────────────────────────────────────────
 	"exec.approval.resolve": unknown;
 	"external_agents.bind": unknown;
-	"external_agents.list": unknown;
+	"external_agents.list": ExternalAgentInfo[];
 	"external_agents.status": unknown;
 	"external_agents.unbind": unknown;
 

--- a/docs/src/external-agents.md
+++ b/docs/src/external-agents.md
@@ -2,7 +2,7 @@
 
 Moltis can bind a chat session to an external CLI coding agent. When a session is bound, `chat.send` persists the user turn in Moltis, sends the prompt and recent session context to the external process, streams the CLI output back to the web UI, and persists the assistant response.
 
-ACP, the Agent Client Protocol, is a JSON-RPC protocol for connecting editor or coding agents to a host application. Moltis can run ACP-compatible command-line agents as external agents, route their permission prompts through Moltis approvals, and show them in the session header selector as `ACP: <agent>`. The canonical ACP agent catalog is https://agentclientprotocol.com/get-started/agents.
+ACP, the Agent Client Protocol, is a JSON-RPC protocol for connecting editor or coding agents to a host application. Moltis can run ACP-compatible command-line agents as external agents, route their permission prompts through Moltis approvals, and show them alongside provider-backed models in the chat composer selector as `ACP: <agent>`. The canonical ACP agent catalog is https://agentclientprotocol.com/get-started/agents.
 
 Supported agent kinds:
 
@@ -11,12 +11,12 @@ Supported agent kinds:
 | `claude-code` | `claude -p --output-format json` | Print mode with `session_id` capture; later turns add `--resume <id>`. |
 | `codex` | `codex app-server` | Persistent app-server process; Moltis reuses the Codex `threadId` across turns. |
 | `acp` | `acp` | Persistent ACP JSON-RPC stdio session configured by `[external_agents.agents.acp]`. |
-| `acp-copilot` | `copilot --acp` | Named ACP session shown as `ACP: Copilot` in the session header. |
+| `acp-copilot` | `copilot --acp` | Named ACP session shown as `ACP: Copilot` in the chat model selector. |
 | `acp-codex` | `codex-acp` | Codex via Zed's ACP adapter, shown as `ACP: Codex`. |
 | `acp-claude` | `claude-agent-acp` | Claude Agent SDK via https://github.com/agentclientprotocol/claude-agent-acp, shown as `ACP: Claude`. |
 | `acp-pi` | `pi-acp` | Pi via the `pi-acp` adapter, shown as `ACP: Pi`. |
-| `acp-opencode` | `opencode acp` | Named ACP session shown as `ACP: opencode` in the session header. |
-| `acp-gemini` | `gemini --experimental-acp` | Named ACP session shown as `ACP: Gemini` in the session header. |
+| `acp-opencode` | `opencode acp` | Named ACP session shown as `ACP: opencode` in the chat model selector. |
+| `acp-gemini` | `gemini --experimental-acp` | Named ACP session shown as `ACP: Gemini` in the chat model selector. |
 | `acp-augment` | `auggie --acp` | Augment/Auggie ACP mode. |
 | `acp-kiro` | `kiro-cli acp` | Kiro CLI ACP mode. |
 | `acp-openclaw` | `openclaw acp` | OpenClaw ACP bridge. |
@@ -45,7 +45,7 @@ External agent discovery is enabled by default. On startup, Moltis checks for th
 | `ACP: Stakpak` | `acp-stakpak` | `stakpak acp` |
 | `ACP: fast-agent` | `acp-fast-agent` | `fast-agent-acp` |
 
-Installed ACP agents appear automatically in each chat session's external-agent selector. Missing commands are hidden from the selector, so a fresh install with no ACP agents available continues to show only the normal Moltis agent.
+Installed ACP agents appear automatically alongside normal models in each chat session's composer selector. Missing commands are hidden, so a fresh install with no ACP agents available continues to show only provider-backed models.
 
 Default detection only checks whether the named command exists on Moltis' `$PATH`; it does not verify the binary publisher or installation source. Only install ACP agents from trusted sources, keep untrusted directories out of the service `$PATH`, and use explicit `binary = "/absolute/path/to/agent"` overrides when you want to pin the executable Moltis may launch after a user selects that agent for a session.
 
@@ -164,7 +164,7 @@ binary = "codex"
 
 ## Select an ACP agent for a session
 
-The session header in the web UI exposes an external-agent selector when agents are configured. ACP entries are labeled with the protocol and agent name, such as `ACP: Copilot`. Select `Moltis agent` to unbind and return the session to the normal provider-backed Moltis agent.
+The model selector below the chat text field includes installed ACP agents, labeled with the protocol and agent name, such as `ACP: Copilot`. Selecting an ACP entry binds that chat session to the external agent. Select any normal model in the same menu to unbind the ACP agent and return the session to the provider-backed Moltis agent.
 
 Binding is per session. You can bind one chat session to `ACP: Copilot`, another to `ACP: Claude`, and leave other sessions on the normal Moltis agent.
 
@@ -180,7 +180,7 @@ Moltis advertises ACP file-system and terminal capabilities to agents. File read
 
 - If an ACP agent does not appear in the selector, confirm `[external_agents] enabled = true`, restart Moltis, and verify the configured `binary` exists on `$PATH` or is an absolute path.
 - If an ACP entry appears as unavailable, run the configured command manually from the same shell or service environment that starts Moltis.
-- If the wrong ACP agent is bound, use the session header selector and choose the desired `ACP: <agent>` entry; choose `Moltis agent` to unbind.
+- If the wrong ACP agent is bound, use the selector below the chat text field and choose the desired `ACP: <agent>` entry; choose a normal model to unbind.
 - If the agent needs project-local context, set `working_dir` in that agent's config entry.
 
 Current limitations:


### PR DESCRIPTION
## Summary

- Move installed ACP clients into the composer model selector alongside provider-backed models.
- Remove the historical header ACP selector and redundant `Built-in LLM agent` option.
- Preserve per-session binding, ACP-only auto-binding, unavailable-client handling, and reasoning-control behavior.
- Keep backend transitions isolated per session and refresh authoritative metadata after successful bind/unbind operations.
- Ignore stale model and ACP discovery responses so concurrent refreshes cannot replace newer selector state.
- Update onboarding copy, external-agent documentation, shared types, and E2E coverage.

## Validation

### Completed

- [x] `npx biome check --write` on changed TypeScript, TSX, and E2E files
- [x] `cd crates/web/ui && npm run build`
- [x] `cd crates/web/ui && npx tsc --noEmit`
- [x] `CI=1 MOLTIS_E2E_ONLY_PROJECT=agents npx playwright test e2e/specs/agents.spec.js` (20 passed)
- [x] `CI=1 MOLTIS_E2E_ONLY_PROJECT=agents npx playwright test e2e/specs/agents.spec.js --grep "composer selector lists and binds named ACP agents" --repeat-each=5` (5 passed)
- [x] `CI=1 MOLTIS_E2E_ONLY_PROJECT=default npx playwright test e2e/specs/chat-input.spec.js --grep "model selector exposes long gateway model names"` (1 passed)
- [x] `CI=1 MOLTIS_E2E_ONLY_PROJECT=default npx playwright test e2e/specs/chat-input.spec.js e2e/specs/reasoning-toggle.spec.js` (35 passed)
- [x] `CI=1 MOLTIS_E2E_ONLY_PROJECT=onboarding npx playwright test e2e/specs/onboarding.spec.js --grep "summary shows installed ACP agents"` (1 passed)
- [x] `cargo fmt --all -- --check`
- [x] `just lint`
- [x] `just release-preflight`
- [x] `just test` (6,214 passed)
- [x] `./scripts/local-validate.sh 1171` (all local validation statuses published successfully)

### Remaining

- [x] None

## Manual QA

1. Open a chat with at least one provider model and one installed ACP client.
2. Open the selector below the chat field and verify ACP clients appear above normal models while no ACP selector appears in the header.
3. Select an ACP client and verify the composer label changes, the picker remains enabled, and reasoning controls hide.
4. Reopen the picker, select a normal model, and verify the ACP binding is removed and reasoning controls return when supported.
5. With no provider models configured, verify the first installed ACP client is automatically selected once for a non-cron session.
6. Start an ACP switch, move to another session before it completes, and verify the new session selector remains enabled.