### PR TITLE
fix(web): hide archived cron sessions by default

### DIFF
--- a/crates/web/ui/e2e/specs/sessions.spec.js
+++ b/crates/web/ui/e2e/specs/sessions.spec.js
@@ -484,6 +484,41 @@ test.describe("Session management", () => {
 		expect(pageErrors).toEqual([]);
 	});
 
+	test("cron tab hides archived sessions until the shared archive toggle is enabled", async ({ page }) => {
+		const pageErrors = await navigateAndWait(page, "/");
+		await waitForWsConnected(page);
+
+		const keys = await page.evaluate(() => {
+			const store = window.__moltis_stores?.sessionStore;
+			if (!store) throw new Error("session store unavailable");
+
+			const suffix = Date.now();
+			const activeKey = `cron:e2e-archive-filter-active-${suffix}`;
+			const archivedKey = `cron:e2e-archive-filter-archived-${suffix}`;
+			store.setShowArchivedSessions(false);
+			store.upsert({ key: activeKey, label: "Active cron run", archived: false });
+			store.upsert({ key: archivedKey, label: "Archived cron run", archived: true });
+			return { activeKey, archivedKey };
+		});
+
+		await page.locator('#sessionTabBar .session-tab[data-tab="cron"]').click();
+
+		const activeItem = page.locator(`#sessionList .session-item[data-session-key="${keys.activeKey}"]`);
+		const archivedItem = page.locator(`#sessionList .session-item[data-session-key="${keys.archivedKey}"]`);
+		const archivedToggle = page.locator("#showArchivedSessions");
+		await expect(activeItem).toBeVisible();
+		await expect(archivedItem).toHaveCount(0);
+		await expect(archivedToggle).toBeVisible();
+
+		await archivedToggle.check();
+		await expect(archivedItem).toBeVisible();
+
+		await archivedToggle.uncheck();
+		await expect(archivedItem).toHaveCount(0);
+
+		expect(pageErrors).toEqual([]);
+	});
+
 	test("stop action appears for active run and clears after abort", async ({ page }) => {
 		const pageErrors = watchPageErrors(page);
 		await page.goto("/");

--- a/crates/web/ui/src/app.tsx
+++ b/crates/web/ui/src/app.tsx
@@ -666,7 +666,7 @@ function initSessionTabBar(): void {
 			btn.classList.toggle("active", btn.dataset.tab === current);
 		}
 		if (archivedRow) {
-			archivedRow.classList.toggle("hidden", current !== "sessions");
+			archivedRow.classList.toggle("hidden", current !== "sessions" && current !== "cron");
 		}
 	}
 

--- a/crates/web/ui/src/components/SessionList.tsx
+++ b/crates/web/ui/src/components/SessionList.tsx
@@ -326,7 +326,7 @@ export function SessionList(): VNode {
 	if (tab === "sessions") {
 		filtered = filtered.filter((s) => !(s.key || "").startsWith("cron:") && (showArchived || !s.archived));
 	} else if (tab === "cron") {
-		filtered = filtered.filter((s) => (s.key || "").startsWith("cron:"));
+		filtered = filtered.filter((s) => (s.key || "").startsWith("cron:") && (showArchived || !s.archived));
 	}
 
 	// Build parent→children map for tree rendering


### PR DESCRIPTION
## Summary

- apply the shared archived-session preference to the Cron tab so archived runs are hidden by default
- keep the Show archived sessions control available while viewing Cron sessions
- add a Playwright regression for hiding, showing, and re-hiding an archived Cron session

## Validation Completed

- `npm --prefix crates/web/ui run typecheck`
- `npm --prefix crates/web/ui run build`
- `crates/web/ui/node_modules/.bin/biome check crates/web/ui/src/app.tsx crates/web/ui/src/components/SessionList.tsx crates/web/ui/e2e/specs/sessions.spec.js`
- `cargo +nightly-2026-06-20 fmt --all -- --check`
- release-preflight Clippy across the workspace, providers, and gateway with the macOS Metal feature path
- `cargo +nightly-2026-06-20 test --workspace --exclude moltis-qmd`
- `cargo +nightly-2026-06-20 test -p moltis-qmd -- --test-threads=1`
- focused Playwright session/archive scenarios (3 passed)

## Validation Remaining

- GitHub Actions CI

## Manual QA

- The Playwright regression covers the default-hidden, toggle-visible, and re-hidden behavior on the Cron tab.
- No chat-session export is attached because issue #1111 reports no associated chat session; the reproducible UI regression is covered by the automated test.

Closes https://github.com/moltis-org/moltis/issues/1111