### PR TITLE
feat(web): add Markdown copy and session export

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Verify releases with `gh attestation verify <artifact> -R moltis-org/moltis` or 
 ## Features
 
 - **AI Gateway** — Multi-provider LLM support (OpenAI Codex, GitHub Copilot, Local), streaming responses, agent loop with sub-agent delegation, session modes, parallel tool execution
-- **Communication** — Web UI, Telegram, Signal, Microsoft Teams, Discord, API access, voice I/O (8 TTS + 7 STT providers), mobile PWA with push notifications
+- **Communication** — Web UI with Markdown copy/export, Telegram, Signal, Microsoft Teams, Discord, API access, voice I/O (8 TTS + 7 STT providers), mobile PWA with push notifications
 - **Memory & Recall** — Per-agent memory workspaces, embeddings-powered long-term memory, hybrid vector + full-text search, session persistence with auto-compaction, cross-session recall, Cursor-compatible project context, context-file safety scanning
 - **Safer Agent Editing** — Automatic checkpoints before built-in skill and memory mutations, restore tooling, session branching
 - **Extensibility** — MCP servers (stdio + HTTP/SSE), skill system, 15 lifecycle hook events with circuit breaker, destructive command guard

--- a/crates/web/ui/e2e/specs/chat-markdown-export.spec.js
+++ b/crates/web/ui/e2e/specs/chat-markdown-export.spec.js
@@ -1,0 +1,183 @@
+const { expect, test } = require("../base-test");
+const { createSession, expectRpcOk, navigateAndWait, waitForWsConnected } = require("../helpers");
+
+function readClipboardMarkdown(page) {
+	return page.evaluate(async () => (await navigator.clipboard.readText()).replace(/\r\n/g, "\n"));
+}
+
+test.describe("Chat Markdown export", () => {
+	test("assistant copy action preserves the original Markdown", async ({ page, context }) => {
+		await context.grantPermissions(["clipboard-read", "clipboard-write"]);
+		const pageErrors = await navigateAndWait(page, "/");
+		await waitForWsConnected(page);
+		await createSession(page);
+		const sessionKey = new URL(page.url()).pathname.replace(/^\/chats\//, "").replace(/\//g, ":");
+
+		const markdown = "**Bold** with [a link](https://example.com)\n\n```ts\nconst answer = 42;\n```";
+		await expectRpcOk(page, "system-event", {
+			event: "chat",
+			payload: {
+				sessionKey,
+				state: "final",
+				text: markdown,
+				messageIndex: 0,
+				replyMedium: "text",
+				runId: "run-copy-markdown",
+			},
+		});
+
+		const assistant = page.locator("#messages .msg.assistant").filter({ hasText: "Bold with a link" });
+		await expect(assistant).toBeVisible();
+		const footerOrder = await assistant
+			.locator(":scope > .msg-model-footer, :scope > .msg-action-bar")
+			.evaluateAll((elements) =>
+				elements.map((element) => (element.classList.contains("msg-model-footer") ? "footer" : "actions")),
+			);
+		expect(footerOrder).toEqual(["footer", "actions"]);
+		await assistant.getByRole("button", { name: "Copy as Markdown", exact: true }).click();
+
+		await expect.poll(() => readClipboardMarkdown(page)).toBe(markdown);
+		expect(pageErrors).toEqual([]);
+	});
+
+	test("persisted assistant response without model metadata can be copied as Markdown", async ({ page, context }) => {
+		await context.grantPermissions(["clipboard-read", "clipboard-write"]);
+		const pageErrors = await navigateAndWait(page, "/");
+		await waitForWsConnected(page);
+		await createSession(page);
+		const sessionKey = new URL(page.url()).pathname.replace(/^\/chats\//, "").replace(/\//g, ":");
+		const markdown = "Persisted **Markdown** with `code`.";
+
+		await page.evaluate(
+			({ key, content }) => {
+				const cache = window.__moltis_modules?.["stores/session-history-cache"];
+				const sessions = window.__moltis_modules?.sessions;
+				if (!(cache?.replaceSessionHistory && sessions?.switchSession)) {
+					throw new Error("session history E2E modules unavailable");
+				}
+				cache.replaceSessionHistory(key, [
+					{
+						role: "assistant",
+						content,
+						historyIndex: 0,
+						created_at: Date.now(),
+					},
+				]);
+				sessions.switchSession(key);
+			},
+			{ key: sessionKey, content: markdown },
+		);
+
+		const assistant = page.locator("#messages .msg.assistant").filter({ hasText: "Persisted Markdown" });
+		await expect(assistant).toBeVisible();
+		const footerOrder = await assistant
+			.locator(":scope > .msg-model-footer, :scope > .msg-action-bar")
+			.evaluateAll((elements) =>
+				elements.map((element) => (element.classList.contains("msg-model-footer") ? "footer" : "actions")),
+			);
+		expect(footerOrder).toEqual(["footer", "actions"]);
+		await assistant.getByRole("button", { name: "Copy as Markdown", exact: true }).click();
+
+		await expect.poll(() => readClipboardMarkdown(page)).toBe(markdown);
+		expect(pageErrors).toEqual([]);
+	});
+
+	test("session save downloads all history pages as Markdown", async ({ page }) => {
+		const pageErrors = await navigateAndWait(page, "/");
+		await waitForWsConnected(page);
+
+		const requestedPages = [];
+		await page.route("**/api/sessions/main/history**", (route) => {
+			const url = new URL(route.request().url());
+			const cursor = url.searchParams.get("cursor");
+			requestedPages.push({ cursor, limit: url.searchParams.get("limit") });
+			const body =
+				cursor === null
+					? {
+							history: [
+								{
+									role: "assistant",
+									content: "Latest answer with **bold text**.",
+									historyIndex: 2,
+								},
+							],
+							hasMore: true,
+							nextCursor: 2,
+							totalMessages: 3,
+						}
+					: {
+							history: [
+								{
+									role: "user",
+									content: [
+										{ type: "text", text: "Question with `inline code`." },
+										{
+											type: "image_url",
+											image_url: { url: "https://example.com/a folder/image(1).png" },
+										},
+									],
+									historyIndex: 0,
+								},
+								{ role: "assistant", content: "Earlier answer.", historyIndex: 1 },
+							],
+							hasMore: false,
+							nextCursor: null,
+							totalMessages: 3,
+						};
+			return route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(body) });
+		});
+
+		const downloadPromise = page.waitForEvent("download");
+		await page.getByRole("button", { name: "Save as Markdown", exact: true }).click();
+		const download = await downloadPromise;
+		expect(download.suggestedFilename()).toMatch(/\.md$/);
+
+		const content = await (await download.createReadStream()).toArray();
+		const text = Buffer.concat(content).toString("utf-8");
+		expect(text).toContain("## User\n\nQuestion with `inline code`.");
+		expect(text).toContain("![Image](https://example.com/a%20folder/image%281%29.png)");
+		expect(text).toContain("## Assistant\n\nEarlier answer.");
+		expect(text).toContain("## Assistant\n\nLatest answer with **bold text**.");
+		expect(text.indexOf("Question with")).toBeLessThan(text.indexOf("Earlier answer"));
+		expect(text.indexOf("Earlier answer")).toBeLessThan(text.indexOf("Latest answer"));
+		expect(requestedPages).toEqual([
+			{ cursor: null, limit: "500" },
+			{ cursor: "2", limit: "500" },
+		]);
+		expect(pageErrors).toEqual([]);
+	});
+
+	test("session save does not download a partial history", async ({ page }) => {
+		const pageErrors = await navigateAndWait(page, "/");
+		await waitForWsConnected(page);
+
+		await page.route("**/api/sessions/main/history**", (route) => {
+			const cursor = new URL(route.request().url()).searchParams.get("cursor");
+			const body =
+				cursor === null
+					? {
+							history: [{ role: "assistant", content: "Latest answer.", historyIndex: 1 }],
+							hasMore: true,
+							nextCursor: 1,
+							totalMessages: 3,
+						}
+					: {
+							history: [{ role: "assistant", content: "Earlier answer.", historyIndex: 0 }],
+							hasMore: false,
+							nextCursor: null,
+							totalMessages: 3,
+						};
+			return route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(body) });
+		});
+
+		const downloads = [];
+		page.on("download", (download) => downloads.push(download));
+		const saveButton = page.getByRole("button", { name: "Save as Markdown", exact: true });
+		await saveButton.click();
+
+		await expect(page.getByText("Failed to load complete session history", { exact: true })).toBeVisible();
+		await expect(saveButton).toBeEnabled();
+		expect(downloads).toHaveLength(0);
+		expect(pageErrors).toEqual([]);
+	});
+});

--- a/crates/web/ui/src/components/SessionHeader.tsx
+++ b/crates/web/ui/src/components/SessionHeader.tsx
@@ -18,6 +18,7 @@ import {
 	setSessionReplying,
 	switchSession,
 } from "../sessions";
+import { saveSessionAsMarkdown } from "../sessions/session-markdown";
 import { sessionStore } from "../stores/session-store";
 import { ComboSelect, confirmDialog, shareLinkDialog, shareVisibilityDialog, showToast } from "../ui";
 
@@ -52,6 +53,7 @@ export interface SessionHeaderProps {
 	showSelectors?: boolean;
 	showName?: boolean;
 	showShare?: boolean;
+	showSaveMarkdown?: boolean;
 	showFork?: boolean;
 	showStop?: boolean;
 	showClear?: boolean;
@@ -118,6 +120,7 @@ export function SessionHeader({
 	showSelectors = true,
 	showName = true,
 	showShare = true,
+	showSaveMarkdown = false,
 	showFork = true,
 	showStop = true,
 	showClear = true,
@@ -141,6 +144,7 @@ export function SessionHeader({
 
 	const [renaming, setRenaming] = useState(false);
 	const [clearing, setClearing] = useState(false);
+	const [savingMarkdown, setSavingMarkdown] = useState(false);
 	const [stopping, setStopping] = useState(false);
 	const [switchingAgent, setSwitchingAgent] = useState(false);
 	const [agentOptions, setAgentOptions] = useState<AgentOption[]>(initialAgentOptions);
@@ -374,6 +378,18 @@ export function SessionHeader({
 		});
 	}, [onBeforeShare, shareSnapshot]);
 
+	const onSaveMarkdown = useCallback(() => {
+		if (savingMarkdown) return;
+		setSavingMarkdown(true);
+		saveSessionAsMarkdown(currentKey, fullName)
+			.then(() => showToast("Session saved as Markdown", "success"))
+			.catch((error: unknown) => {
+				const message = error instanceof Error ? error.message : "Failed to save session as Markdown";
+				showToast(message, "error");
+			})
+			.finally(() => setSavingMarkdown(false));
+	}, [currentKey, fullName, savingMarkdown]);
+
 	const onArchive = useCallback(() => {
 		if (!(session && canArchive)) return;
 		if (typeof onBeforeArchive === "function") {
@@ -599,6 +615,20 @@ export function SessionHeader({
 					>
 						<span className="icon icon-sm icon-share shrink-0" />
 						Share
+					</button>
+				)}
+				{showSaveMarkdown && (
+					<button
+						type="button"
+						className={`${actionButtonClass} inline-flex items-center gap-1.5`}
+						onClick={onSaveMarkdown}
+						title="Save as Markdown"
+						aria-label="Save as Markdown"
+						aria-busy={savingMarkdown}
+						disabled={savingMarkdown}
+					>
+						<span className="icon icon-sm icon-document shrink-0" />
+						<span className="hidden md:inline">Save .md</span>
 					</button>
 				)}
 				{showDelete && !isMain && (

--- a/crates/web/ui/src/message-actions.ts
+++ b/crates/web/ui/src/message-actions.ts
@@ -1,6 +1,6 @@
 // ── Message action bar (copy, voice, retry, fork) ────────────
 //
-// Appended below each finalized assistant message footer.
+// Appended to each finalized assistant message.
 // The retry button opens a popover with "Try again", "Add details",
 // and "More concise" options.
 // Icons use CSS mask-image classes (icon-*) backed by SVG files on disk.
@@ -68,16 +68,17 @@ export function appendMessageActions(ctx: MessageActionContext): void {
 	bar.className = "msg-action-bar";
 
 	// ── Copy button ──────────────────────────────────────────
-	const copyBtn = actionButton("icon-copy", "Copy");
+	const copyTitle = "Copy as Markdown";
+	const copyBtn = actionButton("icon-copy", copyTitle);
 	copyBtn.addEventListener("click", () => {
-		const text = extractPlainText(messageEl);
+		const text = ctx.text?.trim() ? ctx.text : extractPlainText(messageEl);
 		copyToClipboard(text, "", "Failed to copy to clipboard").then((ok) => {
 			if (!ok) return;
 			copyBtn.replaceChildren(iconSpan("icon-checkmark"));
-			copyBtn.title = "Copied";
+			copyBtn.title = "Copied as Markdown";
 			setTimeout(() => {
 				copyBtn.replaceChildren(iconSpan("icon-copy"));
-				copyBtn.title = "Copy";
+				copyBtn.title = copyTitle;
 			}, 1500);
 		});
 	});

--- a/crates/web/ui/src/pages/ChatPage.tsx
+++ b/crates/web/ui/src/pages/ChatPage.tsx
@@ -670,6 +670,7 @@ function mountSessionHeaderControls(): void {
 			<SessionHeader
 				showSelectors={false}
 				showName={false}
+				showSaveMarkdown={true}
 				showStop={false}
 				actionButtonClass={
 					"text-xs border border-[var(--border)] px-2 py-1 rounded-md transition-colors cursor-pointer bg-transparent font-[var(--font-body)] text-[var(--muted)]"

--- a/crates/web/ui/src/sessions/session-markdown.ts
+++ b/crates/web/ui/src/sessions/session-markdown.ts
@@ -1,0 +1,179 @@
+import type { HistoryMessage } from "../types";
+import type { HistoryPayload } from "./session-history";
+import { fetchSessionHistoryViaHttp, mergeHistoryPages } from "./session-history";
+
+const SESSION_EXPORT_PAGE_LIMIT = 500;
+
+interface ContentBlock {
+	type?: unknown;
+	text?: unknown;
+	image_url?: { url?: unknown };
+}
+
+interface ValidatedHistoryPage {
+	history: HistoryMessage[];
+	hasMore: boolean;
+	nextCursor?: number;
+	totalMessages: number;
+}
+
+function markdownLinkDestination(url: string): string {
+	return Array.from(url)
+		.map((character) => {
+			if (character === "(") return "%28";
+			if (character === ")") return "%29";
+			const codePoint = character.codePointAt(0) ?? 0;
+			return codePoint <= 0x20 || codePoint === 0x7f || "<>\\".includes(character)
+				? encodeURIComponent(character)
+				: character;
+		})
+		.join("");
+}
+
+function contentBlockToMarkdown(block: unknown): string {
+	if (typeof block === "string") return block;
+	if (!(block && typeof block === "object")) return "";
+	const typedBlock = block as ContentBlock;
+	if (typedBlock.type === "text" && typeof typedBlock.text === "string") {
+		return typedBlock.text;
+	}
+	if (typedBlock.type === "image_url" && typeof typedBlock.image_url?.url === "string") {
+		return `![Image](${markdownLinkDestination(typedBlock.image_url.url)})`;
+	}
+	return "";
+}
+
+function messageContentToMarkdown(content: unknown): string {
+	if (typeof content === "string") return content.trim() ? content : "";
+	if (!Array.isArray(content)) return "";
+	return content
+		.map(contentBlockToMarkdown)
+		.filter((block) => block.trim())
+		.join("\n\n");
+}
+
+function inlineTitle(title: string): string {
+	return title.replace(/\s+/g, " ").trim() || "Moltis session";
+}
+
+export function sessionHistoryToMarkdown(title: string, history: HistoryMessage[]): string {
+	const sections = history.flatMap((message) => {
+		const role = message.role === "user" ? "User" : message.role === "assistant" ? "Assistant" : null;
+		if (!role) return [];
+		const content = messageContentToMarkdown(message.content);
+		if (!content) return [];
+		return [`## ${role}\n\n${content}`];
+	});
+	return `${[`# ${inlineTitle(title)}`, ...sections].join("\n\n")}\n`;
+}
+
+export function sessionMarkdownFilename(title: string): string {
+	let stem = Array.from(inlineTitle(title))
+		.map((character) => {
+			const codePoint = character.codePointAt(0) ?? 0;
+			const isBidiControl =
+				codePoint === 0x200e ||
+				codePoint === 0x200f ||
+				(codePoint >= 0x202a && codePoint <= 0x202e) ||
+				(codePoint >= 0x2066 && codePoint <= 0x2069);
+			return codePoint < 32 || isBidiControl || '<>:"/\\|?*'.includes(character) ? "-" : character;
+		})
+		.join("")
+		.replace(/\s+/g, " ")
+		.trim();
+	stem = Array.from(stem)
+		.slice(0, 100)
+		.join("")
+		.replace(/[. ]+$/g, "");
+	if (!stem) stem = "moltis-session";
+	if (/^(aux|con|nul|prn|com[1-9]|lpt[1-9])(?:\.|$)/i.test(stem)) stem = `moltis-${stem}`;
+	return `${stem}.md`;
+}
+
+function invalidHistoryResponse(): never {
+	throw new Error("Failed to load complete session history");
+}
+
+function validateHistoryPage(payload: HistoryPayload, expectedTotalMessages: number | null): ValidatedHistoryPage {
+	if (!(Array.isArray(payload.history) && payload.history.every((message) => message && typeof message === "object"))) {
+		return invalidHistoryResponse();
+	}
+	if (typeof payload.hasMore !== "boolean") return invalidHistoryResponse();
+	if (
+		!(typeof payload.totalMessages === "number" && Number.isInteger(payload.totalMessages)) ||
+		payload.totalMessages < 0 ||
+		(expectedTotalMessages !== null && payload.totalMessages !== expectedTotalMessages)
+	) {
+		return invalidHistoryResponse();
+	}
+	return {
+		history: payload.history,
+		hasMore: payload.hasMore,
+		nextCursor: payload.nextCursor,
+		totalMessages: payload.totalMessages,
+	};
+}
+
+function validateNextCursor(nextCursor: number | undefined, currentCursor: number | undefined): number {
+	if (
+		typeof nextCursor !== "number" ||
+		!Number.isInteger(nextCursor) ||
+		nextCursor < 0 ||
+		(currentCursor !== undefined && nextCursor >= currentCursor)
+	) {
+		return invalidHistoryResponse();
+	}
+	return nextCursor;
+}
+
+function flattenHistoryPages(pages: HistoryMessage[][]): HistoryMessage[] {
+	const olderHistory: HistoryMessage[] = [];
+	for (let pageIndex = pages.length - 1; pageIndex > 0; pageIndex -= 1) {
+		for (const message of pages[pageIndex]) olderHistory.push(message);
+	}
+	return mergeHistoryPages(pages[0] || [], olderHistory);
+}
+
+export async function fetchCompleteSessionHistory(sessionKey: string): Promise<HistoryMessage[]> {
+	const pages: HistoryMessage[][] = [];
+	let cursor: number | undefined;
+	let expectedTotalMessages: number | null = null;
+
+	for (;;) {
+		const payload = validateHistoryPage(
+			await fetchSessionHistoryViaHttp(sessionKey, {
+				...(cursor === undefined ? {} : { cursor }),
+				limit: SESSION_EXPORT_PAGE_LIMIT,
+			}),
+			expectedTotalMessages,
+		);
+		expectedTotalMessages ??= payload.totalMessages;
+		pages.push(payload.history);
+		if (payload.hasMore && payload.history.length === 0) return invalidHistoryResponse();
+		if (!payload.hasMore) {
+			const history = flattenHistoryPages(pages);
+			if (history.length !== expectedTotalMessages) return invalidHistoryResponse();
+			return history;
+		}
+
+		cursor = validateNextCursor(payload.nextCursor, cursor);
+	}
+}
+
+function downloadMarkdown(markdown: string, filename: string): void {
+	const blob = new Blob([markdown], { type: "text/markdown;charset=utf-8" });
+	const url = URL.createObjectURL(blob);
+	const link = document.createElement("a");
+	link.href = url;
+	link.download = filename;
+	link.hidden = true;
+	document.body.appendChild(link);
+	link.click();
+	link.remove();
+	setTimeout(() => URL.revokeObjectURL(url), 0);
+}
+
+export async function saveSessionAsMarkdown(sessionKey: string, title: string): Promise<void> {
+	const history = await fetchCompleteSessionHistory(sessionKey);
+	downloadMarkdown(sessionHistoryToMarkdown(title, history), sessionMarkdownFilename(title));
+}

--- a/crates/web/ui/src/sessions/session-render.ts
+++ b/crates/web/ui/src/sessions/session-render.ts
@@ -269,6 +269,8 @@ function renderHistoryAssistantMessage(msg: AssistantMsg): HTMLElement | null {
 		const footer = createModelFooter(msg);
 		el.appendChild(footer);
 		upsertTtsProviderFooter(el, msg.tts_provider);
+	}
+	if (el) {
 		appendMessageActions({
 			messageEl: el,
 			sessionKey: S.activeSessionKey,
@@ -371,7 +373,8 @@ export function appendLastMessageTimestamp(epochMs: number): void {
 	if (!footer) {
 		footer = document.createElement("div");
 		footer.className = "msg-model-footer";
-		lastMsg.appendChild(footer);
+		const actionBar = lastMsg.querySelector(".msg-action-bar");
+		lastMsg.insertBefore(footer, actionBar || null);
 	}
 	const timeEl = document.createElement("time");
 	timeEl.className = "msg-footer-time";

--- a/crates/web/ui/src/types/index.ts
+++ b/crates/web/ui/src/types/index.ts
@@ -144,7 +144,7 @@ export interface McpServerInfo {
 /** A history message stored in the session history cache. */
 export interface HistoryMessage {
 	role?: string;
-	content?: string;
+	content?: string | unknown[];
 	historyIndex?: number;
 	messageIndex?: number;
 	tool_call_id?: string;

--- a/crates/web/ui/src/ws/tool-helpers.ts
+++ b/crates/web/ui/src/ws/tool-helpers.ts
@@ -295,8 +295,8 @@ export function resolveFinalMessageEl(p: ChatPayload): HTMLElement | null {
 
 // ── Final footer ──────────────────────────────────────────────
 
-export function appendFinalFooter(msgEl: HTMLElement | null, p: ChatPayload, eventSession: string): void {
-	if (!(msgEl && p.model)) return;
+function createFinalModelFooter(p: ChatPayload): HTMLElement | null {
+	if (!p.model) return null;
 	const footer = document.createElement("div");
 	footer.className = "msg-model-footer";
 	let footerText = p.provider ? `${p.provider} / ${p.model}` : p.model;
@@ -323,7 +323,13 @@ export function appendFinalFooter(msgEl: HTMLElement | null, p: ChatPayload, eve
 		badge.textContent = p.replyMedium;
 		footer.appendChild(badge);
 	}
-	msgEl.appendChild(footer);
+	return footer;
+}
+
+export function appendFinalFooter(msgEl: HTMLElement | null, p: ChatPayload, eventSession: string): void {
+	if (!msgEl) return;
+	const footer = createFinalModelFooter(p);
+	if (footer) msgEl.appendChild(footer);
 
 	appendMessageActions({
 		messageEl: msgEl,

--- a/docs/src/quickstart.md
+++ b/docs/src/quickstart.md
@@ -75,6 +75,8 @@ def is_prime(n):
     return True
 ```
 
+Use **Copy as Markdown** on an assistant response to preserve its formatting, or **Save as Markdown** in the session toolbar to download the full conversation.
+
 ## What's Next?
 
 ### Enable Tool Use


### PR DESCRIPTION
## Summary

- Preserve the original Markdown when copying assistant replies, including live and persisted replies without model metadata.
- Add a session-level **Save as Markdown** action that loads the complete paginated history and exports user/assistant text plus image references with Markdown-safe URLs and filenames.
- Document both actions and add focused Playwright coverage for copy, pagination, download ordering, and partial-history failures.

Closes #1131

## Validation

### Completed

- `npm.cmd ci`
- `npm.cmd run build`
- `npx.cmd tsc --noEmit`
- `npx.cmd biome check src/sessions/session-markdown.ts e2e/specs/chat-markdown-export.spec.js`
- `node --check e2e/specs/chat-markdown-export.spec.js`
- `just format-check`
- `cargo +nightly-2026-06-20 build --locked -p moltis --bin moltis --no-default-features --features lightweight`
- `npx.cmd playwright test e2e/specs/chat-markdown-export.spec.js --project=default` (4 passed, Chromium on Windows)
- `git diff --check`

### Remaining

- `just release-preflight` was attempted but cannot complete on this Windows host because `VULKAN_SDK` is unset; installing the SDK requires accepting its external license.
- A full session transcript is not attached because it contains local filesystem and environment context; the relevant implementation decisions and validation results are included here.

## Manual QA

- Verified the copy action returns the source Markdown rather than rendered text, with Windows clipboard line-ending normalization accounted for in the test.
- Verified the session export requests every history page, preserves chronological order, safely encodes image destinations, and downloads a `.md` file.
- Verified an inconsistent message total shows an error and does not download a partial export.