### PR TITLE
fix(sessions): allow deleting and archiving the main session

### DIFF
--- a/crates/gateway/src/session/maintenance.rs
+++ b/crates/gateway/src/session/maintenance.rs
@@ -7,10 +7,6 @@ impl LiveSessionService {
             .and_then(|v| v.as_str())
             .ok_or_else(|| "missing 'key' parameter".to_string())?;
 
-        if key == "main" {
-            return Err("cannot delete the main session".into());
-        }
-
         let force = params
             .get("force")
             .and_then(|v| v.as_bool())

--- a/crates/gateway/src/session/service.rs
+++ b/crates/gateway/src/session/service.rs
@@ -32,7 +32,7 @@ async fn is_archivable_entry(
     metadata: &SqliteSessionMetadata,
     entry: &moltis_sessions::metadata::SessionEntry,
 ) -> bool {
-    entry.key != "main" && !is_current_channel_session(metadata, entry).await
+    !is_current_channel_session(metadata, entry).await
 }
 
 /// Why a session's channel binding cannot be cleared, if it cannot.

--- a/crates/gateway/src/session/tests.rs
+++ b/crates/gateway/src/session/tests.rs
@@ -1300,7 +1300,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn patch_archived_rejects_main_session() {
+    async fn patch_archived_allows_main_session() {
         let dir = tempfile::tempdir().unwrap();
         let store = Arc::new(SessionStore::new(dir.path().to_path_buf()));
         let pool = sqlite_pool().await;
@@ -1312,12 +1312,30 @@ mod tests {
 
         let svc = LiveSessionService::new(Arc::clone(&store), Arc::clone(&metadata));
 
-        let error = svc
+        let result = svc
             .patch(serde_json::json!({ "key": "main", "archived": true }))
             .await
-            .unwrap_err();
-        assert!(error.to_string().contains("cannot be archived"));
-        assert!(!metadata.get("main").await.unwrap().archived);
+            .unwrap();
+        assert_eq!(result.get("archived").and_then(|v| v.as_bool()), Some(true));
+        assert!(metadata.get("main").await.unwrap().archived);
+    }
+
+    #[tokio::test]
+    async fn delete_allows_main_session() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Arc::new(SessionStore::new(dir.path().to_path_buf()));
+        let pool = sqlite_pool().await;
+        let metadata = Arc::new(SqliteSessionMetadata::new(pool));
+        metadata
+            .upsert("main", Some("Main".to_string()))
+            .await
+            .unwrap();
+
+        let svc = LiveSessionService::new(Arc::clone(&store), Arc::clone(&metadata));
+
+        let result = svc.delete(serde_json::json!({ "key": "main" })).await;
+        assert!(result.is_ok());
+        assert!(metadata.get("main").await.is_none());
     }
 
     #[tokio::test]

--- a/crates/gateway/src/session/tests/tests/archive_search_tests.rs
+++ b/crates/gateway/src/session/tests/tests/archive_search_tests.rs
@@ -35,19 +35,23 @@ async fn patch_archived_rejection_does_not_partially_mutate_session() {
     let store = Arc::new(SessionStore::new(dir.path().to_path_buf()));
     let pool = sqlite_pool().await;
     let metadata = Arc::new(SqliteSessionMetadata::new(pool));
+    let binding = r#"{"channel_type":"telegram","account_id":"bot1","chat_id":"123"}"#.to_string();
     metadata
-        .upsert("main", Some("Main".to_string()))
+        .upsert("telegram:bot1:123", Some("Telegram current".to_string()))
         .await
         .unwrap();
     metadata
-        .set_model("main", Some("claude-sonnet".to_string()))
+        .set_channel_binding("telegram:bot1:123", Some(binding))
+        .await;
+    metadata
+        .set_model("telegram:bot1:123", Some("claude-sonnet".to_string()))
         .await;
 
     let svc = LiveSessionService::new(Arc::clone(&store), Arc::clone(&metadata));
 
     let error = svc
         .patch(serde_json::json!({
-            "key": "main",
+            "key": "telegram:bot1:123",
             "label": "Mutated?",
             "model": "gpt-5",
             "archived": true
@@ -57,8 +61,8 @@ async fn patch_archived_rejection_does_not_partially_mutate_session() {
 
     assert!(error.to_string().contains("cannot be archived"));
 
-    let entry = metadata.get("main").await.unwrap();
-    assert_eq!(entry.label.as_deref(), Some("Main"));
+    let entry = metadata.get("telegram:bot1:123").await.unwrap();
+    assert_eq!(entry.label.as_deref(), Some("Telegram current"));
     assert_eq!(entry.model.as_deref(), Some("claude-sonnet"));
     assert!(!entry.archived);
 }

--- a/crates/tools/src/sessions_manage.rs
+++ b/crates/tools/src/sessions_manage.rs
@@ -147,7 +147,7 @@ impl AgentTool for SessionsDeleteTool {
 
     fn description(&self) -> &str {
         "Delete a chat session and its history by key. \
-         Deleting the main session is not allowed."
+         The main session is recreated empty on its next message."
     }
 
     fn parameters_schema(&self) -> Value {
@@ -170,10 +170,6 @@ impl AgentTool for SessionsDeleteTool {
     async fn execute(&self, params: Value) -> anyhow::Result<Value> {
         let key = require_str(&params, "key")?;
         let force = bool_param(&params, "force", false);
-
-        if key == "main" {
-            return Err(Error::message("cannot delete the main session").into());
-        }
 
         if self.metadata.get(key).await.is_none() {
             return Err(Error::message(format!("session not found: {key}")).into());
@@ -327,24 +323,31 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn sessions_delete_rejects_main_session() -> TestResult<()> {
+    async fn sessions_delete_allows_main_session() -> TestResult<()> {
         let metadata = Arc::new(SqliteSessionMetadata::new(test_pool().await?));
         metadata.upsert("main", Some("Main".to_string())).await?;
 
-        let delete_fn: DeleteSessionFn =
-            Arc::new(move |_req| Box::pin(async move { Ok(serde_json::json!({ "ok": true })) }));
+        let deleted = Arc::new(AtomicBool::new(false));
+        let deleted_flag = Arc::clone(&deleted);
+        let delete_fn: DeleteSessionFn = Arc::new(move |req| {
+            let deleted_flag = Arc::clone(&deleted_flag);
+            Box::pin(async move {
+                assert_eq!(req.key, "main");
+                deleted_flag.store(true, Ordering::SeqCst);
+                Ok(serde_json::json!({ "ok": true }))
+            })
+        });
 
         let tool = SessionsDeleteTool::new(metadata, delete_fn);
-        let result = tool
+        let value = tool
             .execute(serde_json::json!({
                 "key": "main"
             }))
-            .await;
+            .await
+            .map_err(|e| std::io::Error::other(format!("main-session delete failed: {e}")))?;
 
-        let err = result
-            .err()
-            .ok_or_else(|| std::io::Error::other("expected main-session delete to fail"))?;
-        assert!(err.to_string().contains("cannot delete the main session"));
+        assert_eq!(value.get("deleted").and_then(|v| v.as_bool()), Some(true));
+        assert!(deleted.load(Ordering::SeqCst));
         Ok(())
     }
 }

--- a/crates/web/ui/e2e/specs/sessions.spec.js
+++ b/crates/web/ui/e2e/specs/sessions.spec.js
@@ -447,14 +447,15 @@ test.describe("Session management", () => {
 		expect(pageErrors).toEqual([]);
 	});
 
-	test("main session shows clear but hides delete, non-main shows delete but hides clear", async ({ page }) => {
+	test("main session shows clear, delete, and archive; non-main shows delete but hides clear", async ({ page }) => {
 		const pageErrors = watchPageErrors(page);
 		await page.goto("/");
 		await waitForWsConnected(page);
 		await expectPageContentMounted(page);
 
 		await expect(page.locator('button[title="Clear session"]')).toBeVisible();
-		await expect(page.locator('button[title="Delete session"]')).toHaveCount(0);
+		await expect(page.locator('button[title="Delete session"]')).toBeVisible();
+		await expect(page.locator('button[title="Archive session"]')).toBeVisible();
 
 		await createSession(page);
 
@@ -496,6 +497,60 @@ test.describe("Session management", () => {
 
 		await archivedToggle.uncheck();
 		await expect(sessionItem).toBeVisible({ timeout: 10_000 });
+
+		expect(pageErrors).toEqual([]);
+	});
+
+	test("main session can be archived and restored from the sidebar toggle", async ({ page }) => {
+		const pageErrors = watchPageErrors(page);
+		await navigateAndWait(page, "/");
+		await waitForWsConnected(page);
+
+		const mainItem = page.locator('#sessionList .session-item[data-session-key="main"]');
+		await expect(mainItem).toBeVisible({ timeout: 10_000 });
+
+		await page.locator('button[title="Archive session"]').click();
+		await expect(mainItem).toHaveCount(0);
+
+		const archivedToggle = page.locator("#showArchivedSessions");
+		await expect(archivedToggle).toBeVisible();
+		await archivedToggle.check();
+		await expect(mainItem).toBeVisible({ timeout: 10_000 });
+
+		await page.locator('button[title="Unarchive session"]').click();
+		await expect(page.locator('button[title="Archive session"]')).toBeVisible({ timeout: 10_000 });
+
+		await archivedToggle.uncheck();
+		await expect(mainItem).toBeVisible({ timeout: 10_000 });
+
+		expect(pageErrors).toEqual([]);
+	});
+
+	test("main session can be deleted and comes back empty", async ({ page }) => {
+		const pageErrors = await navigateAndWait(page, "/");
+		await waitForWsConnected(page);
+
+		// Keep another session around so the delete has somewhere to land.
+		await createSession(page);
+		const createdUrl = page.url();
+
+		const mainItem = page.locator('#sessionList .session-item[data-session-key="main"]');
+		await mainItem.click();
+		await expect.poll(() => page.url(), { timeout: 10_000 }).not.toBe(createdUrl);
+
+		const deleteBtn = page.locator('button[title="Delete session"]');
+		await expect(deleteBtn).toBeVisible({ timeout: 10_000 });
+		await deleteBtn.click();
+
+		// An empty main deletes without the confirmation dialog and hands the
+		// view to another session.
+		await expect.poll(() => page.url(), { timeout: 10_000 }).not.toMatch(/\/chats\/main$/);
+		await expect(mainItem).toHaveCount(0);
+
+		// Opening main again recreates it lazily rather than erroring.
+		await navigateAndWait(page, "/chats/main");
+		await waitForWsConnected(page);
+		await expect(mainItem).toBeVisible({ timeout: 10_000 });
 
 		expect(pageErrors).toEqual([]);
 	});

--- a/crates/web/ui/src/components/SessionHeader.tsx
+++ b/crates/web/ui/src/components/SessionHeader.tsx
@@ -679,7 +679,7 @@ export function SessionHeader({
 						<span className="hidden md:inline">Save .md</span>
 					</button>
 				)}
-				{showDelete && !isMain && (
+				{showDelete && (
 					<button
 						className={`${actionButtonClass} chat-session-btn-danger inline-flex items-center gap-1.5`}
 						onClick={onDelete}

--- a/crates/web/ui/src/sessions.ts
+++ b/crates/web/ui/src/sessions.ts
@@ -439,10 +439,7 @@ newSessionBtn.addEventListener("click", () => {
 });
 
 export function isArchivableSession(session: SessionMeta): boolean {
-	return (
-		session.key !== "main" &&
-		((session as SessionMeta & { activeChannel?: boolean }).activeChannel !== true || session.archived === true)
-	);
+	return (session as SessionMeta & { activeChannel?: boolean }).activeChannel !== true || session.archived === true;
 }
 
 /** The reply target stored in `SessionMeta.channelBinding`, JSON or already parsed. */

--- a/docs/src/session-branching.md
+++ b/docs/src/session-branching.md
@@ -108,10 +108,13 @@ leaving them in the main sidebar list.
 - Archived sessions are hidden from the default sidebar list.
 - Enable **Show archived sessions** in the sidebar to reveal and restore them.
 
-Archive is available for any non-`main` session, including cron and
-channel-bound chats, except when the session is the current active session for
+Archive is available for any session — including `main`, cron, and
+channel-bound chats — except when the session is the current active session for
 its bound channel chat. That prevents hiding the live Telegram, Discord, or
-similar chat out from under the channel router.
+similar chat out from under the channel router. Deleting `main` is safe: an
+empty `main` session is recreated as soon as it is opened or receives a
+message. Archiving `main` just hides it from the default sidebar list like any
+other archived session — restore it with the **Show archived sessions** toggle.
 
 ```admonish info title="Independence"
 A forked session is fully independent after creation. Changes to the parent


### PR DESCRIPTION
## Summary

Fixes #1132: the `main` session can now be deleted and archived like any other session.

- **gateway**: drop the `main` guard in `delete_impl` and in `is_archivable_entry`. The current-active-channel-session archive restriction stays, and `sessions.clear_all` still keeps main/channel-bound/cron sessions.
- **tools**: `sessions_delete` no longer rejects `main`; tool description updated.
- **web UI**: the Delete button now shows for `main`; `isArchivableSession` includes `main`. Clear stays main-only.
- **docs**: `session-branching.md` archive section updated with the delete/archive semantics for `main`.

**Why this is safe** — the "old reason" no longer holds because sessions are created lazily:
- session resolve (`sessions.switch`) and chat send both `upsert` the metadata row (`crates/chat/src/service/chat_impl/send.rs`), so a deleted `main` is recreated empty as soon as it is opened or receives a message;
- onboarding re-ensures `main` after imports (`onboarding.rs` — its comment already notes main "only gets created when the user sends their first message");
- fresh installs already run before any `main` row exists, so no startup path requires it.

Two behavioral notes reviewers may care about:
- Archiving `main` while it is the active session keeps you on it (the archive fallback `switchSession("main")` is a self-switch); the sidebar hides it until **Show archived sessions** is enabled. Same escape hatches as any archived session (header Unarchive button, sidebar toggle).
- A cron job with `sessionTarget: "main"` keeps delivering into an archived `main` without unarchiving it — consistent with how archived cron sessions already behave since #1172.

## Validation

### Completed
- [x] `cargo test -p moltis-gateway --lib session::` — 62 passed / 0 failed (includes new `delete_allows_main_session`, flipped `patch_archived_allows_main_session`, and the atomicity test re-anchored to the still-guarded current-channel case)
- [x] `cargo test -p moltis-tools --lib sessions_` — 17 passed / 0 failed (flipped `sessions_delete_allows_main_session` verifies the delete_fn is invoked)
- [x] `cargo fmt --all -- --check` — clean (pinned nightly)
- [x] clippy `-D warnings` per the justfile lint recipe: `-p moltis-tools --all-targets` and `-p moltis-gateway --all-targets --features local-llm-metal` — clean
- [x] `biome check crates/web/ui/src/`, `npm run build`, `npx tsc --noEmit` — clean
- [x] repo-wide sweep for remaining `main`-guard claims (rs/ts/tsx/js/swift + docs) — only the distinct "main agent persona" guard remains, which is a different feature and intentionally untouched

### Remaining
- [ ] `e2e/specs/sessions.spec.js` execution (updated: button-visibility test flipped; new "main can be archived and restored" test). My environment could not complete the pinned-browser download (repeated CDN stalls), so these were verified by static trace only — CI's e2e job should exercise them.
- [ ] `./scripts/local-validate.sh <PR>` broad pass

## Manual QA

1. Open the web UI on `main` → header shows **Clear**, **Archive**, and **Delete**.
2. Archive `main` → it leaves the default sidebar list; enable **Show archived sessions** → visible; **Unarchive** restores it.
3. With another session existing, delete `main` → UI switches to the next session; opening `main` again (or sending it a message) recreates it empty.
4. Agent tool `sessions_delete` with `{"key": "main"}` deletes and reports `deleted: true`.

## AI assistance

This change was built with AI assistance (Claude). Key decision trail, per the contributing guide's transparency ask: the guard removal was scoped by first verifying the lazy-recreation invariant in code (`send.rs` upserts, resolve-path upsert, onboarding ensure) rather than trusting the issue thread; the atomicity regression test was deliberately re-anchored to the still-guarded channel case instead of deleted; three independent AI review passes (invariant hunt / regression refutation / convention audit) ran over the final diff, and their two minor findings (docs conflating delete vs archive semantics; cron-into-archived-main note) are addressed in the docs wording and the note above.