### PR TITLE
fix(sandbox): point gogcli module path at the openclaw org

### DIFF
--- a/crates/tools/src/sandbox/tests/docker_router.rs
+++ b/crates/tools/src/sandbox/tests/docker_router.rs
@@ -631,6 +631,11 @@ fn test_sandbox_image_dockerfile_creates_home_in_install_layer() {
 fn test_sandbox_image_dockerfile_installs_gogcli() {
     let dockerfile = sandbox_image_dockerfile("ubuntu:25.10", &["curl".into()]);
     assert!(dockerfile.contains(&format!("go install {GOGCLI_MODULE_PATH}@{GOGCLI_VERSION}")));
+    // Assert the literal module path: interpolating the constant alone cannot catch a
+    // wrong constant, and `go install` rejects the pre-rename path because gogcli's
+    // go.mod declares `module github.com/openclaw/gogcli`.
+    assert!(dockerfile.contains("go install github.com/openclaw/gogcli/cmd/gog@latest"));
+    assert!(!dockerfile.contains("github.com/steipete/gogcli"));
     assert!(dockerfile.contains("ln -sf /usr/local/bin/gog /usr/local/bin/gogcli"));
 }
 

--- a/crates/tools/src/sandbox/types.rs
+++ b/crates/tools/src/sandbox/types.rs
@@ -562,7 +562,7 @@ pub(crate) fn canonical_sandbox_packages(packages: &[String]) -> Vec<String> {
 }
 
 pub(crate) const SANDBOX_HOME_DIR: &str = "/home/sandbox";
-pub(crate) const GOGCLI_MODULE_PATH: &str = "github.com/steipete/gogcli/cmd/gog";
+pub(crate) const GOGCLI_MODULE_PATH: &str = "github.com/openclaw/gogcli/cmd/gog";
 pub(crate) const GOGCLI_VERSION: &str = "latest";
 
 /// Additional Go-based CLI tools installed via `go install` in the sandbox image.


### PR DESCRIPTION
## Summary

`moltis sandbox build` fails on every pre-built image. The generated Dockerfile runs

```
GOBIN=/usr/local/bin go install github.com/steipete/gogcli/cmd/gog@latest
```

but gogcli moved into the `openclaw` org and its `go.mod` now declares
`module github.com/openclaw/gogcli`. GitHub redirects the old owner, so the URL still opens in a
browser and `git clone` still works — but the Go resolver compares the declared module path against
the required one and refuses:

```
go: github.com/steipete/gogcli/cmd/gog@latest: version constraints conflict:
	github.com/steipete/gogcli@v0.35.0: parsing go.mod:
	module declares its path as: github.com/openclaw/gogcli
	        but was required as: github.com/steipete/gogcli
```

That kills the `go install` layer, and with it the whole image build.

`GOGCLI_MODULE_PATH` now points at `github.com/openclaw/gogcli/cmd/gog`. It was the last pre-rename
Go module path left in the sandbox image — `discrawl` and `slacrawl` were already moved in #989 and
#1021.

The existing regression test could never have caught this: it interpolated `GOGCLI_MODULE_PATH` into
its own expectation, so it passed for any value of the constant. It now asserts the literal path plus
a negative assertion on the old one, which is what `test_sandbox_image_dockerfile_installs_crawl_tools`
right below it already does.

`CHANGELOG.md` untouched — git-cliff generates it.

Fixes #1189

## Validation

- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy -p moltis-tools --all-targets -- -D warnings` — clean
- [x] `cargo test -p moltis-tools test_sandbox_image_dockerfile_installs_gogcli` — 1 passed
- [x] `cargo test -p moltis-tools sandbox::tests::docker_router::test_sandbox_image_dockerfile_install` — 2 passed
- [x] `./scripts/check-file-size.sh`, `./scripts/i18n-check.sh`, `./scripts/check-changelog-guard.sh origin/main HEAD` — all clean
- [x] Reverted the constant to its old value and re-ran the test: fails with
      `assertion failed: dockerfile.contains("go install github.com/openclaw/gogcli/cmd/gog@latest")`.
      So the new assertion actually guards the constant instead of restating it.
- [x] `./scripts/local-validate.sh 1191` — exit 0, all 16 statuses green, including
      `local/macos-app` (951s) and `local/ios-app` (422s) as real Xcode builds rather than skips.
- [ ] Full `moltis sandbox clean && moltis sandbox build` — didn't run it, the default package set
      pulls several GB. Verified the resolver behaviour directly instead, below.

No Playwright specs: this doesn't touch the web UI.

## Manual QA

Ran the exact command the Dockerfile emits, on go1.24.3 darwin/amd64 (it auto-switches to go1.26.5,
which the module requires):

```
$ go install github.com/steipete/gogcli/cmd/gog@latest
go: downloading github.com/steipete/gogcli v0.35.0
go: github.com/steipete/gogcli@v0.35.0 requires go >= 1.26.5; switching to go1.26.5
go: downloading go1.26.5 (darwin/amd64)
go: github.com/steipete/gogcli/cmd/gog@latest: version constraints conflict:
	github.com/steipete/gogcli@v0.35.0: parsing go.mod:
	module declares its path as: github.com/openclaw/gogcli
	        but was required as: github.com/steipete/gogcli
exit status 1
```

Same error as the build log in #1189, down to the version and the indentation. The new path installs
and produces the binary:

```
$ GOBIN=/tmp/gogbin go install github.com/openclaw/gogcli/cmd/gog@latest
go: github.com/openclaw/gogcli@v0.35.0 requires go >= 1.26.5; switching to go1.26.5
[... dependency downloads ...]
exit status 0

$ ls -l /tmp/gogbin/gog
-rwxr-xr-x  1  62191840  gog
```

Both owners resolve to the same repository (`gh api repos/steipete/gogcli --jq .full_name` →
`openclaw/gogcli`) and the proxy serves the same commit hash for either path, which is exactly why
the redirect hides this from everything except the module resolver.

## One I left alone

The same failure mode exists in `crates/skills/src/assets/messaging/wacrawl/SKILL.md`, which declares
`module: github.com/steipete/wacrawl/cmd/wacrawl@latest` while `openclaw/wacrawl` declares
`module github.com/openclaw/wacrawl`. That's a host-install path rather than the sandbox image, so I
kept it out — happy to send it separately or fold it in here, whichever you prefer.

Worth knowing the rename isn't uniform: `songsee`'s go.mod still declares
`github.com/steipete/songsee`, so its SKILL.md entry is correct as-is. A blanket steipete→openclaw
sweep would break that one.

---

I used a local AI assistant for the repo spelunking and to draft this write-up. Every command above
is one I ran myself, and I checked the rename against the module proxy rather than taking the issue's
word for it.
