### PR TITLE
fix(skills): point wacrawl install metadata at the openclaw org

### DIFF
--- a/crates/skills/src/assets/messaging/wacrawl/SKILL.md
+++ b/crates/skills/src/assets/messaging/wacrawl/SKILL.md
@@ -2,16 +2,16 @@
 name: wacrawl
 description: Read-only local archive and full-text search of WhatsApp Desktop messages via the wacrawl CLI. Use for searching chat history, exporting conversations, and creating encrypted backups. macOS only (reads local WhatsApp Desktop SQLite databases).
 platforms: [darwin]
-homepage: https://github.com/steipete/wacrawl
+homepage: https://github.com/openclaw/wacrawl
 requires:
   bins: [wacrawl]
   install:
     - kind: brew
-      formula: steipete/tap/wacrawl
+      formula: openclaw/tap/wacrawl
       bins: [wacrawl]
       os: [darwin]
     - kind: go
-      module: "github.com/steipete/wacrawl/cmd/wacrawl@latest"
+      module: "github.com/openclaw/wacrawl/cmd/wacrawl@latest"
       bins: [wacrawl]
 origin:
   source: moltis

--- a/crates/skills/src/bundled.rs
+++ b/crates/skills/src/bundled.rs
@@ -810,6 +810,55 @@ mod tests {
     }
 
     #[test]
+    fn wacrawl_install_metadata_uses_openclaw_sources() {
+        let skills = store().discover();
+        let wacrawl = skills
+            .iter()
+            .find(|s| s.name == "wacrawl")
+            .expect("wacrawl should be bundled");
+
+        let modules: Vec<&str> = wacrawl
+            .requires
+            .install
+            .iter()
+            .filter_map(|install| install.module.as_deref())
+            .collect();
+
+        assert_eq!(
+            wacrawl.homepage.as_deref(),
+            Some("https://github.com/openclaw/wacrawl")
+        );
+        assert!(
+            wacrawl
+                .requires
+                .install
+                .iter()
+                .any(|install| install.formula.as_deref() == Some("openclaw/tap/wacrawl"))
+        );
+        assert!(modules.contains(&"github.com/openclaw/wacrawl/cmd/wacrawl@latest"));
+        assert!(
+            !wacrawl
+                .homepage
+                .as_deref()
+                .is_some_and(|homepage| { homepage.contains("github.com/steipete/wacrawl") })
+        );
+        assert!(!wacrawl.requires.install.iter().any(|install| {
+            install
+                .formula
+                .as_deref()
+                .is_some_and(|formula| formula.contains("steipete/tap/wacrawl"))
+        }));
+        // Load-bearing: `go install` compares the declared module path against the
+        // required one, so the pre-rename path fails outright — the repo was renamed
+        // into the openclaw org and its go.mod declares `github.com/openclaw/wacrawl`.
+        assert!(
+            !modules
+                .iter()
+                .any(|module| module.contains("github.com/steipete/wacrawl"))
+        );
+    }
+
+    #[test]
     fn webhook_subscriptions_is_moltis_native() {
         let s = store();
         let body = s.read_skill("webhook-subscriptions").expect("should exist");


### PR DESCRIPTION
## Summary

The `wacrawl` skill's Go install fallback is broken. Its `requires.install` entry asks for
`github.com/steipete/wacrawl/cmd/wacrawl@latest`, but wacrawl was renamed into the `openclaw`
organization and its `go.mod` now declares `module github.com/openclaw/wacrawl`. GitHub serves an
HTTP redirect for the old owner, so the URL still opens in a browser and `git clone` still works —
but the Go module resolver compares the declared module path against the required one and refuses
the mismatch:

```
go: github.com/steipete/wacrawl/cmd/wacrawl@latest:
    module declares its path as: github.com/openclaw/wacrawl
            but was required as: github.com/steipete/wacrawl
```

This is the same failure mode as #1189 (gogcli, fixed in #1191), applied to a skill asset rather
than the sandbox image.

The other two stale references in the same frontmatter are migrated alongside it, which makes this
file match how the sibling `slacrawl` skill already reads:

| Field | Before | After | Why |
|---|---|---|---|
| `module` | `github.com/steipete/wacrawl/...` | `github.com/openclaw/wacrawl/...` | **The bug** — `go install` hard-fails on the path mismatch |
| `homepage` | `github.com/steipete/wacrawl` | `github.com/openclaw/wacrawl` | Names the canonical URL instead of relying on GitHub's owner redirect |
| `formula` | `steipete/tap/wacrawl` | `openclaw/tap/wacrawl` | `wacrawl.rb` no longer exists in `steipete/homebrew-tap`; it lives in `openclaw/homebrew-tap` |

The brew change is worth spelling out: the old coordinate still resolves **today**, but only because
`steipete/homebrew-tap`'s `tap_migrations.json` maps `wacrawl` to `openclaw/tap`. Naming the real
tap directly drops a dependency on a compatibility shim this repo does not control.

`songsee` was checked and deliberately left alone — `openclaw/songsee`'s `go.mod` still declares
`module github.com/steipete/songsee`, so `crates/skills/src/assets/media/songsee/SKILL.md` is
correct as written.

### Test coverage

Adds `wacrawl_install_metadata_uses_openclaw_sources`, mirroring the existing
`slacrawl_install_metadata_uses_openclaw_sources`: it asserts the literal post-rename homepage,
formula, and module path, plus a negative assertion against each pre-rename value. The module
negative is the load-bearing one, since that is the only field `go install` hard-fails on.

The test was written first and confirmed to fail against the unfixed asset before the fix was
applied, so it genuinely catches this regression rather than merely restating the constant.

## Validation

### Completed

- [x] `cargo fmt --all -- --check`
- [x] `just lint`
- [x] `cargo test -p moltis-skills --features bundled-skills crawl_install_metadata` — new test red before the fix, green after
- [x] `cargo nextest run --workspace --no-fail-fast` — 7017 passed, 126 skipped
- [x] `./scripts/check-file-size.sh`
- [x] `bash scripts/check-changelog-guard.sh origin/main HEAD` — no manual `CHANGELOG.md` edits
- [x] `./scripts/local-validate.sh` static checks — biome, tsc, i18n, zizmor, lockfile, install-names, install-docs, file-size
- [x] `./scripts/local-validate.sh` build — `cargo build --workspace --all-features --all-targets`
- [x] `./scripts/local-validate.sh` macOS app build — Swift bridge, project gen, swift lint, `xcodebuild`
- [x] `./scripts/local-validate.sh` iOS app build — schema export, project gen, GraphQL gen, `xcodebuild`

### Remaining

- [ ] CI on this PR
- [ ] Local Playwright E2E is not fully green on this machine — 416 passed, 6 failed. See below; none
      are believed related to this change, but one was not conclusively isolated locally.

#### Pre-existing local failures (not introduced here)

This PR changes no TypeScript, TSX, or Swift, so nothing here feeds the web UI or the app builds.
The local failures were still investigated rather than assumed:

**Rust —** an earlier full-suite run hit
`moltis-gateway push::tests::fanout_is_bounded_and_times_out_a_hung_endpoint`
(`assert_eq!(stats.sent, 11)` observed 10). `crates/gateway/src/push.rs` is byte-identical to `main`
on this branch. It passes 5/5 as a single test, 6/6 as a whole module, and passed a complete
`--no-fail-fast` run of all 7017 tests; it only fails under full-workspace load. The deadlines are
30ms total / 5ms per endpoint across 12 subscriptions with one deliberately hung, so a second
endpoint tips over its deadline when the machine is saturated. No test was skipped or retried away
to hide this.

**E2E —** the 6 failures were re-run in isolation; 3 passed immediately. The remaining 3 were
re-checked with `crates/skills` reverted to `main` and the binary rebuilt:

| Spec | On this branch | On `main` |
|---|---|---|
| `pwa-push.spec.js:875` revival through presence | fails | fails |
| `sessions.spec.js:874` toggling sandbox | fails | fails |
| `sessions.spec.js:81` date buckets after midnight | fails | passes |

The first two reproduce on `main`, so they are pre-existing. `sessions.spec.js:874` is purely
environmental: the toggle renders as `<button disabled id="sandboxToggle" title="Sandboxes are
disabled on cloud deploys without a container runtime…">` because this machine has no Docker or
Apple Container.

`sessions.spec.js:81` is the one that was not conclusively isolated. The two runs used different
test selections (6 tests vs 3), which matters because this test depends on gateway state accumulated
by earlier specs — its own comment notes that a background `/api/sessions` refresh replaces the list
wholesale and the server page is capped at 40 by recency, so injected fixtures cannot come back once
enough sessions exist. That makes it order- and state-dependent rather than a controlled comparison.
There is no mechanism by which three URL strings in a skill's YAML frontmatter could affect whether
the session list renders its `main` entry, but that is reasoning, not a measurement, and it is
recorded here as such. CI runs E2E from a clean state and is the authority.

## Manual QA

Verifying the actual failure and the fix requires a Go toolchain:

```bash
# Reproduce the bug (fails on the pre-rename path):
go install github.com/steipete/wacrawl/cmd/wacrawl@latest

# Confirm the fixed path installs:
go install github.com/openclaw/wacrawl/cmd/wacrawl@latest
wacrawl --version
```

Confirm the brew coordinate resolves without leaning on the tap migration shim:

```bash
brew info openclaw/tap/wacrawl
```

Confirm the skill metadata the runtime actually sees:

```bash
cargo test -p moltis-skills --features bundled-skills wacrawl_install_metadata_uses_openclaw_sources
```

Upstream facts this rests on, re-checkable with `gh`:

```bash
gh api repos/steipete/wacrawl --jq '.full_name'                    # => openclaw/wacrawl (redirect)
gh api repos/openclaw/wacrawl/contents/go.mod --jq '.content' | base64 -d | head -1
                                                                    # => module github.com/openclaw/wacrawl
gh api repos/steipete/homebrew-tap/contents/Formula --jq '.[].name' | grep -c wacrawl   # => 0
gh api repos/openclaw/homebrew-tap/contents/Formula --jq '.[].name' | grep -c wacrawl   # => 1
```
