### PR TITLE
fix(scripts): guard empty bash array expansions for macOS bash 3.2

### DIFF
--- a/justfile
+++ b/justfile
@@ -358,9 +358,12 @@ local-validate-full pr_number='':
     if [[ -n {{ quote(pr_number) }} ]]; then
         args+=({{ quote(pr_number) }})
     fi
+    # `"${args[@]+...}"` is required: bash 3.2 (the default /bin/bash on macOS)
+    # treats a plain `"${args[@]}"` on an empty array as an unbound variable
+    # under `set -u`. The array is empty in the supported no-PR local-only mode.
     LOCAL_VALIDATE_TEST_CMD="just test" \
     LOCAL_VALIDATE_E2E_CMD="cd crates/web/ui && npm run e2e:install && npm run e2e" \
-        ./scripts/local-validate.sh "${args[@]}"
+        ./scripts/local-validate.sh "${args[@]+"${args[@]}"}"
 
 # Run all tests (nightly to share build cache with clippy/lint, OS-aware).
 # On macOS: single nextest run using default features (includes Metal, not CUDA).

--- a/scripts/gpg-sign-release.sh
+++ b/scripts/gpg-sign-release.sh
@@ -84,7 +84,11 @@ if ! gh release view "$VERSION" --repo "$REPO" --json tagName >/dev/null 2>&1; t
   exit 1
 fi
 
-# Verify GPG key is available
+# Verify GPG key is available.
+# GPG_SIGN_ARGS stays empty when no --key/GPG_KEY_ID is given (GPG picks its own
+# default key), so every expansion below needs the `"${arr[@]+...}"` guard:
+# bash 3.2 (the default /bin/bash on macOS) treats a plain `"${arr[@]}"` on an
+# empty array as an unbound variable under `set -u`.
 GPG_SIGN_ARGS=()
 if [[ -n "$KEY_ID" ]]; then
   GPG_SIGN_ARGS+=(--local-user "$KEY_ID")
@@ -103,7 +107,7 @@ fi
 # is accessible (prompts for YubiKey PIN/touch if needed early).
 PROBE="$(mktemp)"
 echo "gpg-sign-release probe" > "$PROBE"
-if ! gpg --batch "${GPG_SIGN_ARGS[@]}" --armor --detach-sign "$PROBE" 2>/dev/null; then
+if ! gpg --batch "${GPG_SIGN_ARGS[@]+"${GPG_SIGN_ARGS[@]}"}" --armor --detach-sign "$PROBE" 2>/dev/null; then
   rm -f "$PROBE" "${PROBE}.asc"
   echo "error: GPG signing failed. Is your YubiKey inserted and unlocked?" >&2
   exit 1
@@ -189,7 +193,7 @@ for file in "${ARTIFACTS[@]}"; do
     echo "  WARNING: no SHA256 checksum found for $name — skipping integrity check" >&2
   fi
 
-  gpg --batch "${GPG_SIGN_ARGS[@]}" --armor --detach-sign "$file"
+  gpg --batch "${GPG_SIGN_ARGS[@]+"${GPG_SIGN_ARGS[@]}"}" --armor --detach-sign "$file"
   ASC_FILES+=("${file}.asc")
   echo "  Created: ${name}.asc"
 done

--- a/scripts/local-validate.sh
+++ b/scripts/local-validate.sh
@@ -7,11 +7,15 @@ CURRENT_PID=""
 RUN_CHECK_ASYNC_PID=""
 STATUS_PUBLISH_ENABLED=1
 
+# `"${arr[@]+"${arr[@]}"}"` is required throughout this script: bash 3.2 (the
+# default /bin/bash on macOS) treats a plain `"${arr[@]}"` on an empty array as
+# an unbound variable under `set -u`. ACTIVE_PIDS is empty before the first
+# async check starts and again after the last one is reaped.
 remove_active_pid() {
   local target="$1"
   local -a kept=()
   local pid
-  for pid in "${ACTIVE_PIDS[@]}"; do
+  for pid in "${ACTIVE_PIDS[@]+"${ACTIVE_PIDS[@]}"}"; do
     if [[ "$pid" != "$target" ]]; then
       kept+=("$pid")
     fi
@@ -31,7 +35,7 @@ handle_interrupt() {
   fi
 
   local pid
-  for pid in "${ACTIVE_PIDS[@]}"; do
+  for pid in "${ACTIVE_PIDS[@]+"${ACTIVE_PIDS[@]}"}"; do
     kill -TERM "$pid" 2>/dev/null || true
   done
 
@@ -41,7 +45,7 @@ handle_interrupt() {
     kill -KILL "$CURRENT_PID" 2>/dev/null || true
   fi
 
-  for pid in "${ACTIVE_PIDS[@]}"; do
+  for pid in "${ACTIVE_PIDS[@]+"${ACTIVE_PIDS[@]}"}"; do
     kill -KILL "$pid" 2>/dev/null || true
   done
 

--- a/scripts/test-webhook.sh
+++ b/scripts/test-webhook.sh
@@ -147,6 +147,10 @@ compute_stripe_signature() {
 # ── Send ────────────────────────────────────────────────────────────────
 
 send_webhook() {
+  # extra_headers stays empty for `stripe` without --secret, so both expansions
+  # below need the `"${arr[@]+...}"` guard: bash 3.2 (the default /bin/bash on
+  # macOS) treats a plain `"${arr[@]}"` on an empty array as an unbound variable
+  # under `set -u`.
   local profile="$1" payload="$2" extra_headers=()
 
   echo "────────────────────────────────────────────"
@@ -202,7 +206,7 @@ send_webhook() {
   echo ""
 
   echo "Request headers:"
-  for h in "${extra_headers[@]}"; do
+  for h in "${extra_headers[@]+"${extra_headers[@]}"}"; do
     echo "  $h"
   done
   echo ""
@@ -213,7 +217,7 @@ send_webhook() {
   response=$(curl -sk -w "\n__HTTP_CODE__%{http_code}" \
     -X POST "$URL" \
     -H "Content-Type: application/json" \
-    "${extra_headers[@]}" \
+    "${extra_headers[@]+"${extra_headers[@]}"}" \
     -d "$payload" 2>&1)
 
   http_code="${response##*__HTTP_CODE__}"


### PR DESCRIPTION
## Summary

`just local-validate-full` with no PR number died immediately on macOS:

```
/var/folders/.../just-zwC8Ev/local-validate-full: line 361: args[@]: unbound variable
error: recipe `local-validate-full` failed with exit code 1
```

The recipe runs under `set -euo pipefail` and expands `"${args[@]}"`. On bash 3.2 — the
default `/bin/bash` on macOS — expanding an **empty** array under `set -u` is an
unbound-variable error; bash 4.4+ treats it as empty and works fine. `args` is empty
exactly when no `pr_number` is passed, which is the documented no-PR local-only mode that
`scripts/local-validate.sh` explicitly supports via its `LOCAL_ONLY` branch. The script was
correct all along — only the just wrapper was broken, and it broke the one mode it existed
to enable.

Fixed by expanding as `"${arr[@]+"${arr[@]}"}"`. The `+` alternate-value form skips the
expansion entirely when the array is unset or empty, and otherwise preserves per-element
quoting, so multi-word elements still arrive as single arguments.

I then audited the rest of the repo's shell for the same bug class and fixed every
expansion whose array is reachably empty:

| File | Array | Empty when |
|---|---|---|
| `justfile` | `args` | no `pr_number` (local-only mode) — the reported break |
| `scripts/local-validate.sh` | `ACTIVE_PIDS` | before the first async check starts, and again after the last is reaped — Ctrl-C at those points crashed the interrupt handler instead of terminating children |
| `scripts/gpg-sign-release.sh` | `GPG_SIGN_ARGS` | default-key path (no `--key`, no `GPG_KEY_ID`) — broke release signing outright |
| `scripts/test-webhook.sh` | `extra_headers` | `stripe` profile without `--secret` |

Arrays that are provably non-empty at every expansion are left alone
(`build-swift-bridge.sh` `TARGETS`/`BUILD_ARGS`/`LIPO_INPUTS`, `verify-release.sh`
`DL_ARGS`/`FILES`). Verified on bash 3.2 that `${#arr[@]}` and slices such as
`${arr[@]:1}` are already safe and need no guard.

### Known issue not fixed here

`scripts/ship-pr.sh` declares `local -A` associative arrays, which bash 3.2 rejects, so it
aborts with exit 2 on stock macOS before reaching any array expansion — meaning `just ship`
cannot work there. Fixing it needs a separate decision (require bash 4+ via the shebang, or
rewrite the area-counting without associative arrays), so it is deliberately untouched.

## Validation

### Completed

- [x] `just local-validate-full` (no argument, macOS, bash 3.2) — now reaches and runs the real validation steps instead of dying at the recipe
- [x] `cargo fmt --all -- --check` — passed
- [x] `just lint` — passed (634s)
- [x] full Rust workspace test suite — passed (806s)
- [x] `cargo build` — passed (1642s)
- [x] `biome check` / `npx tsc --noEmit` — passed
- [x] i18n, zizmor, file-size, install-names, install-docs, lockfile, build-web-assets — passed
- [x] macOS app build (3788s) and iOS app build (766s) — passed
- [x] `bash -n` on all three edited scripts under `/bin/bash` 3.2 — clean
- [x] Verified the guard preserves argument quoting on bash 3.2: an `-H "B: two words"` element still arrives as a single argument

### Remaining

- [ ] CI on Linux (bash 5.x) — the guarded form is a no-op difference there, but worth confirming

## Manual QA

On macOS with the stock `/bin/bash` (3.2):

1. `just local-validate-full` — previously died instantly with `args[@]: unbound variable`. Now it enters local-only mode and runs the checks:
   ```
   Local-only validation (b0fdeef) — no statuses will be published
   [local/i18n] passed in 1s
   [local/fmt] passed in 7s
   [local/biome] passed in 8s
   ...
   ```
2. `just local-validate-full 1234` — still passes the PR number through to `scripts/local-validate.sh` (PR mode unchanged).
3. `./scripts/gpg-sign-release.sh` without `--key`/`GPG_KEY_ID` — reaches the GPG liveness probe instead of aborting on `GPG_SIGN_ARGS[@]`.
4. `./scripts/test-webhook.sh --profile stripe` without `--secret` — sends without erroring on `extra_headers[@]`.

## Note on E2E

The E2E step failed in the first full `local-validate-full` run, but not because of this
change. 49 tests passed, then the test server on `127.0.0.1:50252` went away and all 400+
remaining tests failed with `net::ERR_CONNECTION_REFUSED` in ~250ms each — a server-death
cascade, with no panic in the log. That run took 3.0h because it executed straight after
~75 minutes of Xcode builds on a loaded machine.

Re-run on an idle machine: **417 passed in 9.5m**, with 5 failures in `pwa-push.spec.js`,
`sessions.spec.js`, `reasoning-toggle.spec.js`, and `onboarding.spec.js`. Those reproduce
on re-run and are pre-existing on `main`: this branch changes only `justfile` and three
shell scripts (`git diff main...HEAD --name-only`), none of which the E2E suite, the web
server, or the built assets read. The spec that died in the loaded run
(`chat-input.spec.js`) passes 28/28 in isolation.
