### PR TITLE
Fix ClawHub skill search results

### DIFF
--- a/crates/gateway/src/services/skills/service.rs
+++ b/crates/gateway/src/services/skills/service.rs
@@ -1045,81 +1045,64 @@ impl SkillsService for NoopSkillsService {
             .and_then(|v| v.as_str())
             .ok_or_else(|| "missing 'query' parameter".to_string())?;
         let client = moltis_skills::clawhub::ClawHubClient::new();
-        let response = client.search(query).await.map_err(ServiceError::message)?;
-
-        // Enrich results with stats from skill info. Use a semaphore to limit
-        // concurrent requests (avoid hitting ClawHub's 180 req/min rate limit).
-        let semaphore = Arc::new(tokio::sync::Semaphore::new(5));
-        let futs: Vec<_> = response
-            .results
-            .iter()
-            .map(|r| {
-                let slug = r.slug.clone();
-                let client = moltis_skills::clawhub::ClawHubClient::new();
-                let sem = Arc::clone(&semaphore);
-                async move {
-                    let _permit = sem.acquire().await;
-                    (slug.clone(), client.skill_info(&slug).await.ok())
-                }
-            })
-            .collect();
-        let infos = futures::future::join_all(futs).await;
-
-        let enriched: Vec<EnrichedSearchResult> = response
-            .results
-            .into_iter()
-            .map(|r| {
-                let mut e = EnrichedSearchResult::from(r.clone());
-                if let Some((_, Some(info))) = infos.iter().find(|(s, _)| *s == r.slug) {
-                    if let Some(stats) = &info.skill.stats {
-                        e.downloads = stats.downloads;
-                        e.stars = stats.stars;
-                    }
-                    if let Some(owner) = &info.owner {
-                        e.owner_handle = owner.handle.clone();
-                        e.owner_image = owner.image.clone();
-                    }
-                }
-                e
-            })
-            .collect();
+        let response = match client.search(query).await {
+            Ok(response) => response,
+            Err(error) => {
+                tracing::warn!(%error, "ClawHub search failed");
+                return Err(ServiceError::message(error));
+            },
+        };
+        tracing::debug!(
+            result_count = response.results.len(),
+            "ClawHub search completed"
+        );
+        let enriched: Vec<EnrichedSearchResult> =
+            response.results.into_iter().map(Into::into).collect();
 
         Ok(serde_json::json!({ "results": enriched }))
     }
 
     async fn clawhub_scan(&self, params: Value) -> ServiceResult {
-        let slug = params
-            .get("slug")
+        let reference = params
+            .get("reference")
+            .or_else(|| params.get("slug"))
             .and_then(|v| v.as_str())
-            .ok_or_else(|| "missing 'slug' parameter".to_string())?;
-        moltis_skills::clawhub::validate_slug(slug).map_err(ServiceError::message)?;
+            .ok_or_else(|| "missing 'reference' parameter".to_string())?;
+        let skill_ref = moltis_skills::clawhub::parse_skill_reference(reference)
+            .map_err(ServiceError::message)?;
         let client = moltis_skills::clawhub::ClawHubClient::new();
-        let scan = client.scan(slug).await.map_err(ServiceError::message)?;
+        let scan = client
+            .scan(skill_ref.slug, skill_ref.owner_handle)
+            .await
+            .map_err(ServiceError::message)?;
         Ok(serde_json::to_value(scan).unwrap_or_default())
     }
 
     async fn clawhub_info(&self, params: Value) -> ServiceResult {
-        let slug = params
-            .get("slug")
+        let reference = params
+            .get("reference")
+            .or_else(|| params.get("slug"))
             .and_then(|v| v.as_str())
-            .ok_or_else(|| "missing 'slug' parameter".to_string())?;
-        moltis_skills::clawhub::validate_slug(slug).map_err(ServiceError::message)?;
+            .ok_or_else(|| "missing 'reference' parameter".to_string())?;
+        let skill_ref = moltis_skills::clawhub::parse_skill_reference(reference)
+            .map_err(ServiceError::message)?;
         let client = moltis_skills::clawhub::ClawHubClient::new();
         let info = client
-            .skill_info(slug)
+            .skill_info(skill_ref.slug, skill_ref.owner_handle)
             .await
             .map_err(ServiceError::message)?;
         Ok(serde_json::to_value(info).unwrap_or_default())
     }
 
     async fn clawhub_install(&self, params: Value) -> ServiceResult {
-        let slug = params
-            .get("slug")
+        let reference = params
+            .get("reference")
+            .or_else(|| params.get("slug"))
             .and_then(|v| v.as_str())
-            .ok_or_else(|| "missing 'slug' parameter".to_string())?;
+            .ok_or_else(|| "missing 'reference' parameter".to_string())?;
         let install_dir =
             moltis_skills::install::default_install_dir().map_err(ServiceError::message)?;
-        let skills = moltis_skills::clawhub::install_from_clawhub(slug, &install_dir)
+        let skills = moltis_skills::clawhub::install_from_clawhub(reference, &install_dir)
             .await
             .map_err(ServiceError::message)?;
         let installed: Vec<_> = skills
@@ -1134,7 +1117,7 @@ impl SkillsService for NoopSkillsService {
             .collect();
         security_audit(
             "skills.clawhub.install",
-            serde_json::json!({ "slug": slug, "installed_count": installed.len() }),
+            serde_json::json!({ "reference": reference, "installed_count": installed.len() }),
         );
         Ok(serde_json::json!({ "installed": installed }))
     }

--- a/crates/skills/src/clawhub.rs
+++ b/crates/skills/src/clawhub.rs
@@ -405,6 +405,21 @@ pub fn parse_skill_reference(reference: &str) -> Result<SkillReference<'_>> {
     })
 }
 
+fn resolve_install_owner<'a>(
+    requested_owner: Option<&'a str>,
+    info: &'a SkillInfoResponse,
+) -> Result<&'a str> {
+    let owner = requested_owner
+        .or_else(|| {
+            info.owner
+                .as_ref()
+                .and_then(|owner| owner.handle.as_deref())
+        })
+        .ok_or_else(|| Error::Install("ClawHub skill response has no owner handle".into()))?;
+    validate_slug(owner)?;
+    Ok(owner)
+}
+
 struct LegacyCleanup {
     source: String,
     target: PathBuf,
@@ -469,23 +484,25 @@ pub async fn install_from_clawhub(
     reference: &str,
     install_dir: &Path,
 ) -> Result<Vec<SkillMetadata>> {
-    let skill_ref = parse_skill_reference(reference)?;
-    let slug = skill_ref.slug;
-    let owner_handle = skill_ref.owner_handle;
+    let requested_ref = parse_skill_reference(reference)?;
+    let slug = requested_ref.slug;
 
     let client = ClawHubClient::new();
 
     // Get skill metadata and version.
-    let info = client.skill_info(slug, owner_handle).await?;
+    let info = client.skill_info(slug, requested_ref.owner_handle).await?;
+    let owner_handle = resolve_install_owner(requested_ref.owner_handle, &info)?;
+    let skill_ref = SkillReference {
+        slug,
+        owner_handle: Some(owner_handle),
+    };
     let version = info
         .latest_version
         .as_ref()
         .map(|v| v.version.clone())
         .ok_or_else(|| Error::Install(format!("skill '{slug}' has no published version")))?;
 
-    let dir_name = owner_handle
-        .map(|owner| format!("clawhub-{owner}-{slug}"))
-        .unwrap_or_else(|| format!("clawhub-{slug}"));
+    let dir_name = format!("clawhub-{owner_handle}-{slug}");
     let target = install_dir.join(&dir_name);
 
     // Remove existing if re-installing.
@@ -495,7 +512,9 @@ pub async fn install_from_clawhub(
     tokio::fs::create_dir_all(&target).await?;
 
     // Download zip archive.
-    let zip_bytes = client.download_zip(slug, owner_handle, &version).await?;
+    let zip_bytes = client
+        .download_zip(slug, Some(owner_handle), &version)
+        .await?;
 
     // Extract zip on a blocking thread (zip I/O is synchronous).
     let target_owned = target.clone();
@@ -528,7 +547,7 @@ pub async fn install_from_clawhub(
     // Remove existing entry if re-installing.
     let legacy_cleanup =
         mark_legacy_bare_install_for_cleanup(&mut manifest, skill_ref, install_dir);
-    let source_key = clawhub_source_key(reference);
+    let source_key = clawhub_source_key(&format!("@{owner_handle}/{slug}"));
     manifest.remove_repo(&source_key);
 
     let now = std::time::SystemTime::now()
@@ -765,6 +784,36 @@ mod tests {
         );
         assert!(parse_skill_reference("@owner").is_err());
         assert!(parse_skill_reference("@../csv").is_err());
+    }
+
+    #[test]
+    fn bare_install_resolves_to_owner_qualified_identity() {
+        let info: SkillInfoResponse =
+            serde_json::from_str(r#"{"skill":{"slug":"csv"},"owner":{"handle":"ivangdavila"}}"#)
+                .unwrap();
+
+        let owner = resolve_install_owner(None, &info).unwrap();
+        assert_eq!(owner, "ivangdavila");
+        assert_eq!(
+            clawhub_source_key(&format!("@{owner}/{}", info.skill.slug)),
+            "clawhub:@ivangdavila/csv"
+        );
+        assert_eq!(
+            resolve_install_owner(Some("requested-owner"), &info).unwrap(),
+            "requested-owner"
+        );
+    }
+
+    #[test]
+    fn bare_install_rejects_missing_or_invalid_owner() {
+        let missing: SkillInfoResponse =
+            serde_json::from_str(r#"{"skill":{"slug":"csv"}}"#).unwrap();
+        assert!(resolve_install_owner(None, &missing).is_err());
+
+        let invalid: SkillInfoResponse =
+            serde_json::from_str(r#"{"skill":{"slug":"csv"},"owner":{"handle":"../publisher"}}"#)
+                .unwrap();
+        assert!(resolve_install_owner(None, &invalid).is_err());
     }
 
     #[tokio::test]

--- a/crates/skills/src/clawhub.rs
+++ b/crates/skills/src/clawhub.rs
@@ -11,7 +11,7 @@ use crate::{
     error::{Error, Result},
     manifest::ManifestStore,
     parse,
-    types::{RepoEntry, SkillMetadata, SkillState},
+    types::{RepoEntry, SkillMetadata, SkillState, SkillsManifest},
 };
 
 const BASE_URL: &str = "https://clawhub.ai";
@@ -405,6 +405,32 @@ pub fn parse_skill_reference(reference: &str) -> Result<SkillReference<'_>> {
     })
 }
 
+async fn remove_legacy_bare_install(
+    manifest: &mut SkillsManifest,
+    skill_ref: SkillReference<'_>,
+    install_dir: &Path,
+) -> Result<bool> {
+    if skill_ref.owner_handle.is_none() {
+        return Ok(false);
+    }
+
+    let legacy_source = clawhub_source_key(skill_ref.slug);
+    let legacy_dir_name = format!("clawhub-{}", skill_ref.slug);
+    let is_legacy_install = manifest
+        .find_repo(&legacy_source)
+        .is_some_and(|repo| repo.repo_name == legacy_dir_name);
+    if !is_legacy_install {
+        return Ok(false);
+    }
+
+    let legacy_target = install_dir.join(&legacy_dir_name);
+    if legacy_target.exists() {
+        tokio::fs::remove_dir_all(legacy_target).await?;
+    }
+    manifest.remove_repo(&legacy_source);
+    Ok(true)
+}
+
 // ── Install from ClawHub ────────────────────────────────────────────────────
 
 /// Install a single skill from ClawHub by owner-qualified reference or bare slug.
@@ -473,6 +499,7 @@ pub async fn install_from_clawhub(
     let mut manifest = store.load()?;
 
     // Remove existing entry if re-installing.
+    remove_legacy_bare_install(&mut manifest, skill_ref, install_dir).await?;
     let source_key = clawhub_source_key(reference);
     manifest.remove_repo(&source_key);
 
@@ -576,7 +603,7 @@ fn extract_zip(zip_bytes: &[u8], target: &Path) -> Result<()> {
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use {super::*, crate::formats::PluginFormat};
 
     #[test]
     fn clawhub_source_key_format() {
@@ -710,6 +737,67 @@ mod tests {
         );
         assert!(parse_skill_reference("@owner").is_err());
         assert!(parse_skill_reference("@../csv").is_err());
+    }
+
+    #[tokio::test]
+    async fn qualified_reinstall_removes_legacy_bare_install() {
+        let tmp = tempfile::tempdir().unwrap();
+        let legacy_dir = tmp.path().join("clawhub-csv");
+        std::fs::create_dir_all(&legacy_dir).unwrap();
+        std::fs::write(legacy_dir.join("SKILL.md"), "legacy").unwrap();
+
+        let mut manifest = SkillsManifest::default();
+        manifest.add_repo(RepoEntry {
+            source: "clawhub:csv".into(),
+            repo_name: "clawhub-csv".into(),
+            installed_at_ms: 0,
+            commit_sha: None,
+            format: PluginFormat::default(),
+            quarantined: false,
+            quarantine_reason: None,
+            provenance: None,
+            skills: Vec::new(),
+        });
+
+        let removed = remove_legacy_bare_install(
+            &mut manifest,
+            parse_skill_reference("@ivangdavila/csv").unwrap(),
+            tmp.path(),
+        )
+        .await
+        .unwrap();
+
+        assert!(removed);
+        assert!(manifest.find_repo("clawhub:csv").is_none());
+        assert!(!legacy_dir.exists());
+    }
+
+    #[tokio::test]
+    async fn qualified_reinstall_preserves_nonstandard_manifest_path() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut manifest = SkillsManifest::default();
+        manifest.add_repo(RepoEntry {
+            source: "clawhub:csv".into(),
+            repo_name: "custom-location".into(),
+            installed_at_ms: 0,
+            commit_sha: None,
+            format: PluginFormat::default(),
+            quarantined: false,
+            quarantine_reason: None,
+            provenance: None,
+            skills: Vec::new(),
+        });
+
+        let removed = remove_legacy_bare_install(
+            &mut manifest,
+            parse_skill_reference("@ivangdavila/csv").unwrap(),
+            tmp.path(),
+        )
+        .await
+        .unwrap();
+
+        assert!(!removed);
+        assert!(manifest.find_repo("clawhub:csv").is_some());
     }
 
     /// Integration test: hit the real ClawHub search API.

--- a/crates/skills/src/clawhub.rs
+++ b/crates/skills/src/clawhub.rs
@@ -16,6 +16,7 @@ use crate::{
 
 const BASE_URL: &str = "https://clawhub.ai";
 const USER_AGENT: &str = "moltis-skills";
+const REQUEST_TIMEOUT_SECS: u64 = 15;
 
 // ── API response types ──────────────────────────────────────────────────────
 
@@ -39,6 +40,26 @@ pub struct SearchResult {
     pub updated_at: Option<u64>,
     #[serde(default)]
     pub version: Option<String>,
+    #[serde(default)]
+    pub downloads: u64,
+    #[serde(default)]
+    pub owner_handle: Option<String>,
+    #[serde(default)]
+    pub owner: Option<OwnerInfo>,
+    #[serde(default)]
+    pub native: Option<NativeSearchMetadata>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NativeSearchMetadata {
+    #[serde(default)]
+    pub skill: Option<NativeSearchSkill>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NativeSearchSkill {
+    #[serde(default)]
+    pub stats: Option<SkillStats>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -187,6 +208,7 @@ impl ClawHubClient {
                 .get(url)
                 .query(query)
                 .header("User-Agent", USER_AGENT)
+                .timeout(std::time::Duration::from_secs(REQUEST_TIMEOUT_SECS))
                 .send()
                 .await?;
 
@@ -231,9 +253,16 @@ impl ClawHubClient {
     }
 
     /// Get metadata for a specific skill.
-    pub async fn skill_info(&self, slug: &str) -> Result<SkillInfoResponse> {
+    pub async fn skill_info(
+        &self,
+        slug: &str,
+        owner_handle: Option<&str>,
+    ) -> Result<SkillInfoResponse> {
         let url = format!("{}/api/v1/skills/{}", self.base_url, slug);
-        let resp = self.get_with_retry(&url, &[]).await?;
+        let query = owner_handle
+            .map(|owner| vec![("ownerHandle", owner)])
+            .unwrap_or_default();
+        let resp = self.get_with_retry(&url, &query).await?;
 
         if !resp.status().is_success() {
             return Err(Error::Install(format!(
@@ -247,9 +276,12 @@ impl ClawHubClient {
     }
 
     /// Get security scan results for a skill.
-    pub async fn scan(&self, slug: &str) -> Result<ScanResponse> {
+    pub async fn scan(&self, slug: &str, owner_handle: Option<&str>) -> Result<ScanResponse> {
         let url = format!("{}/api/v1/skills/{}/scan", self.base_url, slug);
-        let resp = self.get_with_retry(&url, &[]).await?;
+        let query = owner_handle
+            .map(|owner| vec![("ownerHandle", owner)])
+            .unwrap_or_default();
+        let resp = self.get_with_retry(&url, &query).await?;
 
         if !resp.status().is_success() {
             return Err(Error::Install(format!(
@@ -263,11 +295,18 @@ impl ClawHubClient {
     }
 
     /// Download a skill as a zip archive.
-    pub async fn download_zip(&self, slug: &str, version: &str) -> Result<Vec<u8>> {
+    pub async fn download_zip(
+        &self,
+        slug: &str,
+        owner_handle: Option<&str>,
+        version: &str,
+    ) -> Result<Vec<u8>> {
         let url = format!("{}/api/v1/download", self.base_url);
-        let resp = self
-            .get_with_retry(&url, &[("slug", slug), ("version", version)])
-            .await?;
+        let mut query = vec![("slug", slug), ("version", version)];
+        if let Some(owner) = owner_handle {
+            query.push(("ownerHandle", owner));
+        }
+        let resp = self.get_with_retry(&url, &query).await?;
 
         if !resp.status().is_success() {
             return Err(Error::Install(format!(
@@ -283,8 +322,7 @@ impl ClawHubClient {
 
 // ── Enriched search results ─────────────────────────────────────────────────
 
-/// Enriched search result with additional metadata from skill info lookups.
-/// This is what we return to the frontend.
+/// Search result shaped for the frontend, using metadata returned by search.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct EnrichedSearchResult {
@@ -304,12 +342,28 @@ pub struct EnrichedSearchResult {
     pub owner_handle: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub owner_image: Option<String>,
+    pub install_ref: String,
     #[serde(default)]
     pub stars: u64,
 }
 
 impl From<SearchResult> for EnrichedSearchResult {
     fn from(r: SearchResult) -> Self {
+        let owner_handle = r
+            .owner_handle
+            .or_else(|| r.owner.as_ref().and_then(|owner| owner.handle.clone()));
+        let install_ref = owner_handle
+            .as_ref()
+            .map(|owner| format!("@{owner}/{}", r.slug))
+            .unwrap_or_else(|| r.slug.clone());
+        let owner_image = r.owner.and_then(|owner| owner.image);
+        let native_stats = r.native.and_then(|native| native.skill?.stats);
+        let downloads = if r.downloads == 0 {
+            native_stats.as_ref().map_or(0, |stats| stats.downloads)
+        } else {
+            r.downloads
+        };
+        let stars = native_stats.map_or(0, |stats| stats.stars);
         Self {
             score: r.score,
             slug: r.slug,
@@ -317,35 +371,68 @@ impl From<SearchResult> for EnrichedSearchResult {
             summary: r.summary,
             updated_at: r.updated_at,
             version: r.version,
-            downloads: 0,
-            owner_handle: None,
-            owner_image: None,
-            stars: 0,
+            downloads,
+            owner_handle,
+            owner_image,
+            install_ref,
+            stars,
         }
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SkillReference<'a> {
+    pub slug: &'a str,
+    pub owner_handle: Option<&'a str>,
+}
+
+pub fn parse_skill_reference(reference: &str) -> Result<SkillReference<'_>> {
+    let Some(qualified) = reference.strip_prefix('@') else {
+        validate_slug(reference)?;
+        return Ok(SkillReference {
+            slug: reference,
+            owner_handle: None,
+        });
+    };
+    let (owner_handle, slug) = qualified
+        .split_once('/')
+        .ok_or_else(|| Error::Install("invalid ClawHub reference: expected @owner/slug".into()))?;
+    validate_slug(owner_handle)?;
+    validate_slug(slug)?;
+    Ok(SkillReference {
+        slug,
+        owner_handle: Some(owner_handle),
+    })
+}
+
 // ── Install from ClawHub ────────────────────────────────────────────────────
 
-/// Install a single skill from ClawHub by slug.
+/// Install a single skill from ClawHub by owner-qualified reference or bare slug.
 ///
 /// Downloads the skill zip archive, extracts all files (SKILL.md, scripts,
-/// templates, references, etc.) to `install_dir/clawhub-<slug>/`, and
+/// templates, references, etc.) to an owner-qualified directory, and
 /// records the skill in the manifest.
-pub async fn install_from_clawhub(slug: &str, install_dir: &Path) -> Result<Vec<SkillMetadata>> {
-    validate_slug(slug)?;
+pub async fn install_from_clawhub(
+    reference: &str,
+    install_dir: &Path,
+) -> Result<Vec<SkillMetadata>> {
+    let skill_ref = parse_skill_reference(reference)?;
+    let slug = skill_ref.slug;
+    let owner_handle = skill_ref.owner_handle;
 
     let client = ClawHubClient::new();
 
     // Get skill metadata and version.
-    let info = client.skill_info(slug).await?;
+    let info = client.skill_info(slug, owner_handle).await?;
     let version = info
         .latest_version
         .as_ref()
         .map(|v| v.version.clone())
         .ok_or_else(|| Error::Install(format!("skill '{slug}' has no published version")))?;
 
-    let dir_name = format!("clawhub-{slug}");
+    let dir_name = owner_handle
+        .map(|owner| format!("clawhub-{owner}-{slug}"))
+        .unwrap_or_else(|| format!("clawhub-{slug}"));
     let target = install_dir.join(&dir_name);
 
     // Remove existing if re-installing.
@@ -355,7 +442,7 @@ pub async fn install_from_clawhub(slug: &str, install_dir: &Path) -> Result<Vec<
     tokio::fs::create_dir_all(&target).await?;
 
     // Download zip archive.
-    let zip_bytes = client.download_zip(slug, &version).await?;
+    let zip_bytes = client.download_zip(slug, owner_handle, &version).await?;
 
     // Extract zip on a blocking thread (zip I/O is synchronous).
     let target_owned = target.clone();
@@ -386,7 +473,7 @@ pub async fn install_from_clawhub(slug: &str, install_dir: &Path) -> Result<Vec<
     let mut manifest = store.load()?;
 
     // Remove existing entry if re-installing.
-    let source_key = clawhub_source_key(slug);
+    let source_key = clawhub_source_key(reference);
     manifest.remove_repo(&source_key);
 
     let now = std::time::SystemTime::now()
@@ -521,13 +608,24 @@ mod tests {
     /// Test with the actual JSON shape returned by the ClawHub /api/v1/search endpoint.
     #[test]
     fn search_response_deserialises_real_format() {
-        let json = r#"{"results":[{"score":3.54,"slug":"csv-handler","displayName":"Csv Handler","summary":"Handle CSV files","version":null,"updatedAt":1772056835938}]}"#;
+        let json = r#"{"results":[{"score":6120,"slug":"csv","displayName":"CSV","summary":"Handle CSV files","version":null,"updatedAt":1772056835938,"downloads":5395,"ownerHandle":"ivangdavila","owner":{"handle":"ivangdavila","displayName":"Ivan","image":"https://example.com/avatar.png"},"native":{"skill":{"stats":{"downloads":5395,"installs":188,"stars":4,"versions":1}}}}]}"#;
         let resp: SearchResponse = serde_json::from_str(json).unwrap();
         assert_eq!(resp.results.len(), 1);
-        assert_eq!(resp.results[0].slug, "csv-handler");
-        assert_eq!(resp.results[0].display_name.as_deref(), Some("Csv Handler"));
+        assert_eq!(resp.results[0].slug, "csv");
+        assert_eq!(resp.results[0].display_name.as_deref(), Some("CSV"));
         assert_eq!(resp.results[0].updated_at, Some(1772056835938));
         assert!(resp.results[0].version.is_none());
+        assert_eq!(resp.results[0].downloads, 5395);
+        assert_eq!(resp.results[0].owner_handle.as_deref(), Some("ivangdavila"));
+        assert_eq!(
+            resp.results[0]
+                .native
+                .as_ref()
+                .and_then(|native| native.skill.as_ref())
+                .and_then(|skill| skill.stats.as_ref())
+                .map(|stats| stats.stars),
+            Some(4)
+        );
     }
 
     /// Test with the actual JSON shape returned by the ClawHub /api/v1/skills/<slug> endpoint.
@@ -565,11 +663,53 @@ mod tests {
             summary: Some("A test".into()),
             updated_at: Some(1234567890000),
             version: None,
+            downloads: 42,
+            owner_handle: Some("publisher".into()),
+            owner: Some(OwnerInfo {
+                handle: Some("publisher".into()),
+                display_name: None,
+                image: Some("https://example.com/avatar.png".into()),
+            }),
+            native: Some(NativeSearchMetadata {
+                skill: Some(NativeSearchSkill {
+                    stats: Some(SkillStats {
+                        downloads: 42,
+                        installs_all_time: 3,
+                        stars: 7,
+                    }),
+                }),
+            }),
         };
         let enriched: EnrichedSearchResult = sr.into();
         assert_eq!(enriched.slug, "test");
-        assert_eq!(enriched.downloads, 0);
-        assert!(enriched.owner_handle.is_none());
+        assert_eq!(enriched.downloads, 42);
+        assert_eq!(enriched.owner_handle.as_deref(), Some("publisher"));
+        assert_eq!(enriched.install_ref, "@publisher/test");
+        assert_eq!(enriched.stars, 7);
+        assert_eq!(
+            enriched.owner_image.as_deref(),
+            Some("https://example.com/avatar.png")
+        );
+    }
+
+    #[test]
+    fn parses_owner_qualified_skill_reference() {
+        assert_eq!(
+            parse_skill_reference("@ivangdavila/csv").unwrap(),
+            SkillReference {
+                slug: "csv",
+                owner_handle: Some("ivangdavila"),
+            }
+        );
+        assert_eq!(
+            parse_skill_reference("csv-handler").unwrap(),
+            SkillReference {
+                slug: "csv-handler",
+                owner_handle: None,
+            }
+        );
+        assert!(parse_skill_reference("@owner").is_err());
+        assert!(parse_skill_reference("@../csv").is_err());
     }
 
     /// Integration test: hit the real ClawHub search API.
@@ -598,7 +738,7 @@ mod tests {
     #[tokio::test]
     async fn live_scan_returns_security_data() {
         let client = ClawHubClient::new();
-        let resp = client.scan("csv-handler").await;
+        let resp = client.scan("csv", Some("ivangdavila")).await;
         match resp {
             Ok(scan) => {
                 let sec = scan.security.expect("should have security data");
@@ -620,10 +760,10 @@ mod tests {
     #[tokio::test]
     async fn live_skill_info_returns_metadata() {
         let client = ClawHubClient::new();
-        let resp = client.skill_info("csv-handler").await;
+        let resp = client.skill_info("csv", Some("ivangdavila")).await;
         match resp {
             Ok(info) => {
-                assert_eq!(info.skill.slug, "csv-handler");
+                assert_eq!(info.skill.slug, "csv");
                 assert!(info.latest_version.is_some());
                 assert!(info.owner.is_some());
             },

--- a/crates/skills/src/clawhub.rs
+++ b/crates/skills/src/clawhub.rs
@@ -3,7 +3,7 @@
 //! Uses the public ClawHub REST API at `https://clawhub.ai/api/v1/`.
 //! No authentication required for read operations. Rate limit: 180 req/min.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
 
@@ -405,14 +405,12 @@ pub fn parse_skill_reference(reference: &str) -> Result<SkillReference<'_>> {
     })
 }
 
-async fn remove_legacy_bare_install(
+fn remove_legacy_bare_manifest_entry(
     manifest: &mut SkillsManifest,
     skill_ref: SkillReference<'_>,
     install_dir: &Path,
-) -> Result<bool> {
-    if skill_ref.owner_handle.is_none() {
-        return Ok(false);
-    }
+) -> Option<PathBuf> {
+    skill_ref.owner_handle?;
 
     let legacy_source = clawhub_source_key(skill_ref.slug);
     let legacy_dir_name = format!("clawhub-{}", skill_ref.slug);
@@ -420,15 +418,26 @@ async fn remove_legacy_bare_install(
         .find_repo(&legacy_source)
         .is_some_and(|repo| repo.repo_name == legacy_dir_name);
     if !is_legacy_install {
-        return Ok(false);
+        return None;
     }
 
     let legacy_target = install_dir.join(&legacy_dir_name);
-    if legacy_target.exists() {
-        tokio::fs::remove_dir_all(legacy_target).await?;
-    }
     manifest.remove_repo(&legacy_source);
-    Ok(true)
+    Some(legacy_target)
+}
+
+async fn save_manifest_then_remove_legacy(
+    store: &ManifestStore,
+    manifest: &SkillsManifest,
+    legacy_target: Option<PathBuf>,
+) -> Result<()> {
+    store.save(manifest)?;
+    if let Some(target) = legacy_target
+        && target.exists()
+    {
+        tokio::fs::remove_dir_all(target).await?;
+    }
+    Ok(())
 }
 
 // ── Install from ClawHub ────────────────────────────────────────────────────
@@ -499,7 +508,7 @@ pub async fn install_from_clawhub(
     let mut manifest = store.load()?;
 
     // Remove existing entry if re-installing.
-    remove_legacy_bare_install(&mut manifest, skill_ref, install_dir).await?;
+    let legacy_target = remove_legacy_bare_manifest_entry(&mut manifest, skill_ref, install_dir);
     let source_key = clawhub_source_key(reference);
     manifest.remove_repo(&source_key);
 
@@ -519,7 +528,7 @@ pub async fn install_from_clawhub(
         provenance: None,
         skills: skill_states,
     });
-    store.save(&manifest)?;
+    save_manifest_then_remove_legacy(&store, &manifest, legacy_target).await?;
 
     tracing::info!(%slug, name = %metadata.name, "installed skill from ClawHub");
     Ok(vec![metadata])
@@ -759,16 +768,18 @@ mod tests {
             skills: Vec::new(),
         });
 
-        let removed = remove_legacy_bare_install(
+        let legacy_target = remove_legacy_bare_manifest_entry(
             &mut manifest,
             parse_skill_reference("@ivangdavila/csv").unwrap(),
             tmp.path(),
-        )
-        .await
-        .unwrap();
+        );
+        let store = ManifestStore::new(tmp.path().join("manifest.json"));
+        save_manifest_then_remove_legacy(&store, &manifest, legacy_target)
+            .await
+            .unwrap();
 
-        assert!(removed);
         assert!(manifest.find_repo("clawhub:csv").is_none());
+        assert!(store.load().unwrap().find_repo("clawhub:csv").is_none());
         assert!(!legacy_dir.exists());
     }
 
@@ -788,16 +799,53 @@ mod tests {
             skills: Vec::new(),
         });
 
-        let removed = remove_legacy_bare_install(
+        let legacy_target = remove_legacy_bare_manifest_entry(
             &mut manifest,
             parse_skill_reference("@ivangdavila/csv").unwrap(),
             tmp.path(),
-        )
-        .await
-        .unwrap();
+        );
 
-        assert!(!removed);
+        assert!(legacy_target.is_none());
         assert!(manifest.find_repo("clawhub:csv").is_some());
+    }
+
+    #[tokio::test]
+    async fn failed_manifest_save_preserves_legacy_install() {
+        let tmp = tempfile::tempdir().unwrap();
+        let legacy_dir = tmp.path().join("clawhub-csv");
+        std::fs::create_dir_all(&legacy_dir).unwrap();
+        std::fs::write(legacy_dir.join("SKILL.md"), "legacy").unwrap();
+
+        let mut manifest = SkillsManifest::default();
+        manifest.add_repo(RepoEntry {
+            source: "clawhub:csv".into(),
+            repo_name: "clawhub-csv".into(),
+            installed_at_ms: 0,
+            commit_sha: None,
+            format: PluginFormat::default(),
+            quarantined: false,
+            quarantine_reason: None,
+            provenance: None,
+            skills: Vec::new(),
+        });
+        let manifest_path = tmp.path().join("manifest.json");
+        let store = ManifestStore::new(manifest_path.clone());
+        store.save(&manifest).unwrap();
+
+        let legacy_target = remove_legacy_bare_manifest_entry(
+            &mut manifest,
+            parse_skill_reference("@ivangdavila/csv").unwrap(),
+            tmp.path(),
+        );
+
+        std::fs::create_dir(manifest_path.with_extension("json.tmp")).unwrap();
+        assert!(
+            save_manifest_then_remove_legacy(&store, &manifest, legacy_target)
+                .await
+                .is_err()
+        );
+        assert!(store.load().unwrap().find_repo("clawhub:csv").is_some());
+        assert!(legacy_dir.join("SKILL.md").is_file());
     }
 
     /// Integration test: hit the real ClawHub search API.

--- a/crates/skills/src/clawhub.rs
+++ b/crates/skills/src/clawhub.rs
@@ -405,37 +405,55 @@ pub fn parse_skill_reference(reference: &str) -> Result<SkillReference<'_>> {
     })
 }
 
-fn remove_legacy_bare_manifest_entry(
+struct LegacyCleanup {
+    source: String,
+    target: PathBuf,
+}
+
+fn mark_legacy_bare_install_for_cleanup(
     manifest: &mut SkillsManifest,
     skill_ref: SkillReference<'_>,
     install_dir: &Path,
-) -> Option<PathBuf> {
+) -> Option<LegacyCleanup> {
     skill_ref.owner_handle?;
 
     let legacy_source = clawhub_source_key(skill_ref.slug);
     let legacy_dir_name = format!("clawhub-{}", skill_ref.slug);
-    let is_legacy_install = manifest
-        .find_repo(&legacy_source)
-        .is_some_and(|repo| repo.repo_name == legacy_dir_name);
-    if !is_legacy_install {
+    let legacy_repo = manifest.find_repo_mut(&legacy_source)?;
+    if legacy_repo.repo_name != legacy_dir_name {
         return None;
     }
 
-    let legacy_target = install_dir.join(&legacy_dir_name);
-    manifest.remove_repo(&legacy_source);
-    Some(legacy_target)
+    // Keep a non-discoverable tombstone until directory cleanup succeeds so a
+    // later reinstall can retry after a transient filesystem failure.
+    legacy_repo.skills.clear();
+    Some(LegacyCleanup {
+        source: legacy_source,
+        target: install_dir.join(legacy_dir_name),
+    })
 }
 
 async fn save_manifest_then_remove_legacy(
     store: &ManifestStore,
     manifest: &SkillsManifest,
-    legacy_target: Option<PathBuf>,
+    legacy_cleanup: Option<LegacyCleanup>,
 ) -> Result<()> {
     store.save(manifest)?;
-    if let Some(target) = legacy_target
-        && target.exists()
+    let Some(cleanup) = legacy_cleanup else {
+        return Ok(());
+    };
+
+    if cleanup.target.exists()
+        && let Err(error) = tokio::fs::remove_dir_all(&cleanup.target).await
     {
-        tokio::fs::remove_dir_all(target).await?;
+        tracing::warn!(path = %cleanup.target.display(), %error, "failed to remove legacy ClawHub install; will retry on reinstall");
+        return Ok(());
+    }
+
+    let mut cleaned_manifest = manifest.clone();
+    cleaned_manifest.remove_repo(&cleanup.source);
+    if let Err(error) = store.save(&cleaned_manifest) {
+        tracing::warn!(%error, "failed to remove legacy ClawHub cleanup marker; will retry on reinstall");
     }
     Ok(())
 }
@@ -508,7 +526,8 @@ pub async fn install_from_clawhub(
     let mut manifest = store.load()?;
 
     // Remove existing entry if re-installing.
-    let legacy_target = remove_legacy_bare_manifest_entry(&mut manifest, skill_ref, install_dir);
+    let legacy_cleanup =
+        mark_legacy_bare_install_for_cleanup(&mut manifest, skill_ref, install_dir);
     let source_key = clawhub_source_key(reference);
     manifest.remove_repo(&source_key);
 
@@ -528,7 +547,7 @@ pub async fn install_from_clawhub(
         provenance: None,
         skills: skill_states,
     });
-    save_manifest_then_remove_legacy(&store, &manifest, legacy_target).await?;
+    save_manifest_then_remove_legacy(&store, &manifest, legacy_cleanup).await?;
 
     tracing::info!(%slug, name = %metadata.name, "installed skill from ClawHub");
     Ok(vec![metadata])
@@ -768,17 +787,17 @@ mod tests {
             skills: Vec::new(),
         });
 
-        let legacy_target = remove_legacy_bare_manifest_entry(
+        let legacy_cleanup = mark_legacy_bare_install_for_cleanup(
             &mut manifest,
             parse_skill_reference("@ivangdavila/csv").unwrap(),
             tmp.path(),
         );
         let store = ManifestStore::new(tmp.path().join("manifest.json"));
-        save_manifest_then_remove_legacy(&store, &manifest, legacy_target)
+        save_manifest_then_remove_legacy(&store, &manifest, legacy_cleanup)
             .await
             .unwrap();
 
-        assert!(manifest.find_repo("clawhub:csv").is_none());
+        assert!(manifest.find_repo("clawhub:csv").unwrap().skills.is_empty());
         assert!(store.load().unwrap().find_repo("clawhub:csv").is_none());
         assert!(!legacy_dir.exists());
     }
@@ -799,13 +818,13 @@ mod tests {
             skills: Vec::new(),
         });
 
-        let legacy_target = remove_legacy_bare_manifest_entry(
+        let legacy_cleanup = mark_legacy_bare_install_for_cleanup(
             &mut manifest,
             parse_skill_reference("@ivangdavila/csv").unwrap(),
             tmp.path(),
         );
 
-        assert!(legacy_target.is_none());
+        assert!(legacy_cleanup.is_none());
         assert!(manifest.find_repo("clawhub:csv").is_some());
     }
 
@@ -826,13 +845,18 @@ mod tests {
             quarantined: false,
             quarantine_reason: None,
             provenance: None,
-            skills: Vec::new(),
+            skills: vec![SkillState {
+                name: "csv".into(),
+                relative_path: "clawhub-csv".into(),
+                trusted: true,
+                enabled: true,
+            }],
         });
         let manifest_path = tmp.path().join("manifest.json");
         let store = ManifestStore::new(manifest_path.clone());
         store.save(&manifest).unwrap();
 
-        let legacy_target = remove_legacy_bare_manifest_entry(
+        let legacy_cleanup = mark_legacy_bare_install_for_cleanup(
             &mut manifest,
             parse_skill_reference("@ivangdavila/csv").unwrap(),
             tmp.path(),
@@ -840,12 +864,91 @@ mod tests {
 
         std::fs::create_dir(manifest_path.with_extension("json.tmp")).unwrap();
         assert!(
-            save_manifest_then_remove_legacy(&store, &manifest, legacy_target)
+            save_manifest_then_remove_legacy(&store, &manifest, legacy_cleanup)
                 .await
                 .is_err()
         );
-        assert!(store.load().unwrap().find_repo("clawhub:csv").is_some());
+        assert_eq!(
+            store
+                .load()
+                .unwrap()
+                .find_repo("clawhub:csv")
+                .unwrap()
+                .skills
+                .len(),
+            1
+        );
         assert!(legacy_dir.join("SKILL.md").is_file());
+    }
+
+    #[tokio::test]
+    async fn failed_legacy_cleanup_is_successful_and_retryable() {
+        let tmp = tempfile::tempdir().unwrap();
+        let legacy_target = tmp.path().join("clawhub-csv");
+        std::fs::write(&legacy_target, "not a directory").unwrap();
+
+        let mut manifest = SkillsManifest::default();
+        manifest.add_repo(RepoEntry {
+            source: "clawhub:csv".into(),
+            repo_name: "clawhub-csv".into(),
+            installed_at_ms: 0,
+            commit_sha: None,
+            format: PluginFormat::default(),
+            quarantined: false,
+            quarantine_reason: None,
+            provenance: None,
+            skills: vec![SkillState {
+                name: "csv".into(),
+                relative_path: "clawhub-csv".into(),
+                trusted: true,
+                enabled: true,
+            }],
+        });
+        manifest.add_repo(RepoEntry {
+            source: "clawhub:@ivangdavila/csv".into(),
+            repo_name: "clawhub-ivangdavila-csv".into(),
+            installed_at_ms: 1,
+            commit_sha: None,
+            format: PluginFormat::default(),
+            quarantined: false,
+            quarantine_reason: None,
+            provenance: None,
+            skills: Vec::new(),
+        });
+        let cleanup = mark_legacy_bare_install_for_cleanup(
+            &mut manifest,
+            parse_skill_reference("@ivangdavila/csv").unwrap(),
+            tmp.path(),
+        );
+        let store = ManifestStore::new(tmp.path().join("manifest.json"));
+
+        save_manifest_then_remove_legacy(&store, &manifest, cleanup)
+            .await
+            .unwrap();
+        let persisted = store.load().unwrap();
+        assert!(
+            persisted
+                .find_repo("clawhub:csv")
+                .unwrap()
+                .skills
+                .is_empty()
+        );
+        assert!(persisted.find_repo("clawhub:@ivangdavila/csv").is_some());
+
+        std::fs::remove_file(&legacy_target).unwrap();
+        let mut retry_manifest = store.load().unwrap();
+        let retry_cleanup = mark_legacy_bare_install_for_cleanup(
+            &mut retry_manifest,
+            parse_skill_reference("@ivangdavila/csv").unwrap(),
+            tmp.path(),
+        );
+        save_manifest_then_remove_legacy(&store, &retry_manifest, retry_cleanup)
+            .await
+            .unwrap();
+
+        let persisted = store.load().unwrap();
+        assert!(persisted.find_repo("clawhub:csv").is_none());
+        assert!(persisted.find_repo("clawhub:@ivangdavila/csv").is_some());
     }
 
     /// Integration test: hit the real ClawHub search API.

--- a/crates/web/ui/e2e/specs/skills.spec.js
+++ b/crates/web/ui/e2e/specs/skills.spec.js
@@ -3,17 +3,24 @@ const { navigateAndWait, watchPageErrors } = require("../helpers");
 
 async function mockClawHubSearch(page, response) {
 	await page.addInitScript((searchResponse) => {
+		const plannedResponses = Array.isArray(searchResponse) ? searchResponse : [{ response: searchResponse }];
+		window.__clawHubSearchRequests = [];
+		window.__clawHubSearchResponseCount = 0;
 		const originalSend = WebSocket.prototype.send;
 		WebSocket.prototype.send = function (payload) {
 			try {
 				const parsed = JSON.parse(payload);
 				if (parsed?.method === "skills.clawhub.search") {
-					queueMicrotask(() => {
+					const query = parsed.params?.query;
+					window.__clawHubSearchRequests.push(query);
+					const plan = plannedResponses.find((candidate) => candidate.query === query) || plannedResponses[0];
+					setTimeout(() => {
 						const event = new MessageEvent("message", {
-							data: JSON.stringify({ type: "res", id: parsed.id, ...searchResponse }),
+							data: JSON.stringify({ type: "res", id: parsed.id, ...plan.response }),
 						});
+						window.__clawHubSearchResponseCount += 1;
 						if (typeof this.onmessage === "function") this.onmessage(event);
-					});
+					}, plan.delayMs || 0);
 					return;
 				}
 			} catch {
@@ -112,6 +119,55 @@ test.describe("Skills page", () => {
 		await expect(page.getByRole("alert")).toContainText("The request timed out. Please try again.");
 		await expect(page.getByText("The request timed out. Please try again.", { exact: true })).toBeVisible();
 		expect(consoleErrors.some((message) => message.includes("ClawHub search failed"))).toBeTruthy();
+		expect(pageErrors).toEqual([]);
+	});
+
+	test("ClawHub search ignores stale responses", async ({ page }) => {
+		await mockClawHubSearch(page, [
+			{
+				query: "csv",
+				delayMs: 1000,
+				response: {
+					ok: false,
+					error: { code: "TIMEOUT", message: "Old CSV search timed out" },
+				},
+			},
+			{
+				query: "weather",
+				response: {
+					ok: true,
+					payload: {
+						results: [
+							{
+								score: 100,
+								slug: "weather",
+								installRef: "@forecast/weather",
+								displayName: "Current Weather",
+								ownerHandle: "forecast",
+							},
+						],
+					},
+				},
+			},
+		]);
+		const consoleErrors = [];
+		page.on("console", (message) => {
+			if (message.type() === "error") consoleErrors.push(message.text());
+		});
+		const pageErrors = watchPageErrors(page);
+		await navigateAndWait(page, "/skills");
+		await page.getByRole("tab", { name: "ClawHub", exact: true }).click();
+		const searchInput = page.getByPlaceholder("Search ClawHub skills (e.g. csv, weather, github)...");
+
+		await searchInput.fill("csv");
+		await page.waitForFunction(() => window.__clawHubSearchRequests?.includes("csv"));
+		await searchInput.fill("weather");
+
+		await expect(page.getByText("Current Weather", { exact: true })).toBeVisible();
+		await page.waitForFunction(() => window.__clawHubSearchResponseCount === 2);
+		await expect(page.getByText("Current Weather", { exact: true })).toBeVisible();
+		await expect(page.getByRole("alert")).not.toBeVisible();
+		expect(consoleErrors.some((message) => message.includes("Old CSV search timed out"))).toBeFalsy();
 		expect(pageErrors).toEqual([]);
 	});
 

--- a/crates/web/ui/e2e/specs/skills.spec.js
+++ b/crates/web/ui/e2e/specs/skills.spec.js
@@ -31,6 +31,27 @@ async function mockClawHubSearch(page, response) {
 	}, response);
 }
 
+async function deferClawHubDebounceTimers(page) {
+	await page.evaluate(() => {
+		const deferred = [];
+		const originalSetTimeout = window.setTimeout.bind(window);
+		const originalClearTimeout = window.clearTimeout.bind(window);
+		window.__runDeferredClawHubSearchTimer = (index) => deferred[index]?.callback();
+		window.setTimeout = (callback, delay, ...args) => {
+			if (delay === 300 && typeof callback === "function") {
+				const id = 1_000_000 + deferred.length;
+				deferred.push({ id, callback: () => callback(...args) });
+				return id;
+			}
+			return originalSetTimeout(callback, delay, ...args);
+		};
+		window.clearTimeout = (id) => {
+			if (deferred.some((timer) => timer.id === id)) return;
+			originalClearTimeout(id);
+		};
+	});
+}
+
 test.describe("Skills page", () => {
 	test("skills page loads", async ({ page }) => {
 		const pageErrors = watchPageErrors(page);
@@ -168,6 +189,41 @@ test.describe("Skills page", () => {
 		await expect(page.getByText("Current Weather", { exact: true })).toBeVisible();
 		await expect(page.getByRole("alert")).not.toBeVisible();
 		expect(consoleErrors.some((message) => message.includes("Old CSV search timed out"))).toBeFalsy();
+		expect(pageErrors).toEqual([]);
+	});
+
+	test("ClawHub search ignores a queued stale debounce callback", async ({ page }) => {
+		await mockClawHubSearch(page, [
+			{
+				query: "csv",
+				response: {
+					ok: true,
+					payload: { results: [{ score: 10, slug: "csv", displayName: "Old CSV Result" }] },
+				},
+			},
+			{
+				query: "weather",
+				response: {
+					ok: true,
+					payload: { results: [{ score: 100, slug: "weather", displayName: "Current Weather" }] },
+				},
+			},
+		]);
+		const pageErrors = watchPageErrors(page);
+		await navigateAndWait(page, "/skills");
+		await page.getByRole("tab", { name: "ClawHub", exact: true }).click();
+		await deferClawHubDebounceTimers(page);
+		const searchInput = page.getByPlaceholder("Search ClawHub skills (e.g. csv, weather, github)...");
+
+		await searchInput.fill("csv");
+		await searchInput.fill("weather");
+		await searchInput.press("Enter");
+		await expect(page.getByText("Current Weather", { exact: true })).toBeVisible();
+		await page.evaluate(() => window.__runDeferredClawHubSearchTimer(0));
+
+		expect(await page.evaluate(() => window.__clawHubSearchRequests)).toEqual(["weather"]);
+		await expect(page.getByText("Current Weather", { exact: true })).toBeVisible();
+		await expect(page.getByText("Old CSV Result", { exact: true })).not.toBeVisible();
 		expect(pageErrors).toEqual([]);
 	});
 

--- a/crates/web/ui/e2e/specs/skills.spec.js
+++ b/crates/web/ui/e2e/specs/skills.spec.js
@@ -1,6 +1,29 @@
 const { expect, test } = require("../base-test");
 const { navigateAndWait, watchPageErrors } = require("../helpers");
 
+async function mockClawHubSearch(page, response) {
+	await page.addInitScript((searchResponse) => {
+		const originalSend = WebSocket.prototype.send;
+		WebSocket.prototype.send = function (payload) {
+			try {
+				const parsed = JSON.parse(payload);
+				if (parsed?.method === "skills.clawhub.search") {
+					queueMicrotask(() => {
+						const event = new MessageEvent("message", {
+							data: JSON.stringify({ type: "res", id: parsed.id, ...searchResponse }),
+						});
+						if (typeof this.onmessage === "function") this.onmessage(event);
+					});
+					return;
+				}
+			} catch {
+				// Let non-JSON WebSocket traffic pass through unchanged.
+			}
+			return originalSend.call(this, payload);
+		};
+	}, response);
+}
+
 test.describe("Skills page", () => {
 	test("skills page loads", async ({ page }) => {
 		const pageErrors = watchPageErrors(page);
@@ -31,6 +54,64 @@ test.describe("Skills page", () => {
 	test("page has no JS errors", async ({ page }) => {
 		const pageErrors = watchPageErrors(page);
 		await navigateAndWait(page, "/skills");
+		expect(pageErrors).toEqual([]);
+	});
+
+	test("ClawHub search shows owner-qualified results", async ({ page }) => {
+		await mockClawHubSearch(page, {
+			ok: true,
+			payload: {
+				results: [
+					{
+						score: 6120,
+						slug: "csv",
+						installRef: "@ivangdavila/csv",
+						displayName: "CSV by Ivan",
+						summary: "Parse RFC 4180 CSV files",
+						downloads: 5395,
+						ownerHandle: "ivangdavila",
+					},
+					{
+						score: 6120,
+						slug: "csv",
+						installRef: "@thcjp/csv",
+						displayName: "CSV by THCJP",
+						summary: "Parse and generate CSV files",
+						downloads: 17,
+						ownerHandle: "thcjp",
+					},
+				],
+			},
+		});
+		const pageErrors = watchPageErrors(page);
+		await navigateAndWait(page, "/skills");
+		await page.getByRole("tab", { name: "ClawHub", exact: true }).click();
+		await page.getByPlaceholder("Search ClawHub skills (e.g. csv, weather, github)...").fill("csv");
+
+		await expect(page.getByText("CSV by Ivan", { exact: true })).toBeVisible();
+		await expect(page.getByText("CSV by THCJP", { exact: true })).toBeVisible();
+		await expect(page.getByText("@ivangdavila /", { exact: true })).toBeVisible();
+		await expect(page.getByText("@thcjp /", { exact: true })).toBeVisible();
+		expect(pageErrors).toEqual([]);
+	});
+
+	test("ClawHub search reports RPC errors in the page, toast, and console", async ({ page }) => {
+		await mockClawHubSearch(page, {
+			ok: false,
+			error: { code: "TIMEOUT", message: "ClawHub search timed out after 15 seconds" },
+		});
+		const consoleErrors = [];
+		page.on("console", (message) => {
+			if (message.type() === "error") consoleErrors.push(message.text());
+		});
+		const pageErrors = watchPageErrors(page);
+		await navigateAndWait(page, "/skills");
+		await page.getByRole("tab", { name: "ClawHub", exact: true }).click();
+		await page.getByPlaceholder("Search ClawHub skills (e.g. csv, weather, github)...").fill("csv");
+
+		await expect(page.getByRole("alert")).toContainText("The request timed out. Please try again.");
+		await expect(page.getByText("The request timed out. Please try again.", { exact: true })).toBeVisible();
+		expect(consoleErrors.some((message) => message.includes("ClawHub search failed"))).toBeTruthy();
 		expect(pageErrors).toEqual([]);
 	});
 

--- a/crates/web/ui/src/helpers.ts
+++ b/crates/web/ui/src/helpers.ts
@@ -284,7 +284,7 @@ export function renderMarkdown(raw: string): string {
 	return result.trimEnd();
 }
 
-export function sendRpc<T = unknown>(method: string, params: unknown): Promise<RpcResponse<T>> {
+export function sendRpc<T = unknown>(method: string, params: unknown, timeoutMs?: number): Promise<RpcResponse<T>> {
 	return new Promise((resolve) => {
 		if (!S.ws || S.ws.readyState !== WebSocket.OPEN) {
 			resolve({
@@ -300,12 +300,12 @@ export function sendRpc<T = unknown>(method: string, params: unknown): Promise<R
 			return;
 		}
 		const id = nextId();
-		const timeoutMs = rpcTimeoutMs();
+		const requestTimeoutMs = timeoutMs ?? rpcTimeoutMs();
 		const timer = setTimeout(() => {
 			if (S.pending[id]) {
 				delete S.pending[id];
 				const message = `${localizedRpcErrorMessage({ code: "TIMEOUT", message: "RPC request timed out" })} (${method})`;
-				console.warn("RPC request timed out", { method, timeoutMs });
+				console.warn("RPC request timed out", { method, timeoutMs: requestTimeoutMs });
 				resolve({
 					ok: false,
 					error: {
@@ -314,7 +314,7 @@ export function sendRpc<T = unknown>(method: string, params: unknown): Promise<R
 					},
 				} as unknown as RpcResponse<T>);
 			}
-		}, timeoutMs);
+		}, requestTimeoutMs);
 		S.pending[id] = ((res: RpcResponse) => {
 			clearTimeout(timer);
 			resolve(res as RpcResponse<T>);

--- a/crates/web/ui/src/pages/skills/ClawHubSection.tsx
+++ b/crates/web/ui/src/pages/skills/ClawHubSection.tsx
@@ -17,6 +17,7 @@ interface ClawHubResult {
 	downloads?: number;
 	ownerHandle?: string;
 	ownerImage?: string;
+	installRef?: string;
 	stars?: number;
 }
 
@@ -45,6 +46,7 @@ interface ClawHubSkillInfo {
 // ── Helpers ──────────────────────────────────────────────────
 
 let searchTimer: ReturnType<typeof setTimeout> | null = null;
+const CLAWHUB_SEARCH_TIMEOUT_MS = 20_000;
 
 function relativeTime(ms: number): string {
 	const diff = Date.now() - ms;
@@ -124,10 +126,12 @@ function SecurityScanPanel({ scan }: { scan: ScanData | null }): VNode | null {
 
 function DetailPanel({
 	slug,
+	reference,
 	onClose,
 	onInstalled,
 }: {
 	slug: string;
+	reference: string;
 	onClose: () => void;
 	onInstalled: () => void;
 }): VNode {
@@ -143,11 +147,11 @@ function DetailPanel({
 	useEffect(() => {
 		if (fetched.current) return;
 		fetched.current = true;
-		Promise.all([sendRpc("skills.clawhub.info", { slug }), sendRpc("skills.clawhub.scan", { slug })])
+		Promise.all([sendRpc("skills.clawhub.info", { reference }), sendRpc("skills.clawhub.scan", { reference })])
 			.then(([infoRes, scanRes]) => {
 				loading.value = false;
 				if (infoRes?.ok) info.value = infoRes.payload as ClawHubSkillInfo;
-				else error.value = String(infoRes?.error || "Failed to load skill info");
+				else error.value = infoRes?.error?.message || "Failed to load skill info";
 				if (scanRes?.ok) {
 					const p = scanRes.payload as { security?: ScanData } | undefined;
 					if (p?.security) scan.value = p.security;
@@ -157,12 +161,12 @@ function DetailPanel({
 				loading.value = false;
 				error.value = "Failed to load skill info";
 			});
-	}, [slug]);
+	}, [reference]);
 
 	async function doInstall(): Promise<void> {
 		installing.value = true;
 		try {
-			const res = await sendRpc("skills.clawhub.install", { slug });
+			const res = await sendRpc("skills.clawhub.install", { reference });
 			if (res?.ok) {
 				installed.value = true;
 				showToast("Installed — review and enable the skill in the Skills tab.", "success");
@@ -375,6 +379,7 @@ function ResultCard({ result, onInstalled }: { result: ClawHubResult; onInstalle
 			{expanded.value && (
 				<DetailPanel
 					slug={result.slug}
+					reference={result.installRef || result.slug}
 					onInstalled={onInstalled}
 					onClose={() => {
 						expanded.value = false;
@@ -392,26 +397,42 @@ export function ClawHubSection({ onChanged }: { onChanged: () => void }): VNode 
 	const results = useSignal<ClawHubResult[]>([]);
 	const searching = useSignal(false);
 	const searched = useSignal(false);
+	const error = useSignal<string | null>(null);
 	const inputRef = useRef<HTMLInputElement>(null);
 
 	function doSearch(q: string): void {
 		if (!q.trim()) {
 			results.value = [];
 			searched.value = false;
+			error.value = null;
 			return;
 		}
 		searching.value = true;
-		sendRpc("skills.clawhub.search", { query: q.trim() })
+		error.value = null;
+		sendRpc("skills.clawhub.search", { query: q.trim() }, CLAWHUB_SEARCH_TIMEOUT_MS)
 			.then((res) => {
 				searching.value = false;
 				searched.value = true;
 				if (res?.ok) {
 					const payload = res.payload as { results?: ClawHubResult[] } | undefined;
 					results.value = payload?.results || [];
+					console.info("ClawHub search completed", { query: q.trim(), resultCount: results.value.length });
+					return;
 				}
+				const message = res?.error?.message || "ClawHub search failed";
+				results.value = [];
+				error.value = message;
+				console.error("ClawHub search failed", { query: q.trim(), error: res?.error });
+				showToast(message, "error");
 			})
-			.catch(() => {
+			.catch((cause: unknown) => {
 				searching.value = false;
+				searched.value = true;
+				results.value = [];
+				const message = cause instanceof Error ? cause.message : "ClawHub search failed";
+				error.value = message;
+				console.error("ClawHub search failed", { query: q.trim(), cause });
+				showToast(message, "error");
 			});
 	}
 
@@ -422,6 +443,7 @@ export function ClawHubSection({ onChanged }: { onChanged: () => void }): VNode 
 		if (!v.trim()) {
 			results.value = [];
 			searched.value = false;
+			error.value = null;
 			return;
 		}
 		searchTimer = setTimeout(() => doSearch(v), 300);
@@ -470,14 +492,22 @@ export function ClawHubSection({ onChanged }: { onChanged: () => void }): VNode 
 					{searching.value ? "Searching\u2026" : "Search"}
 				</button>
 			</div>
+			{error.value && (
+				<div
+					role="alert"
+					className="mt-2 rounded border border-[var(--danger)]/40 bg-[var(--danger)]/10 px-3 py-2 text-sm text-[var(--danger)]"
+				>
+					ClawHub search failed: {error.value}
+				</div>
+			)}
 			{results.value.length > 0 && (
 				<div style={{ display: "flex", flexDirection: "column", gap: "4px", marginTop: "8px" }}>
 					{results.value.map((r) => (
-						<ResultCard key={r.slug} result={r} onInstalled={onChanged} />
+						<ResultCard key={r.installRef || `${r.ownerHandle || ""}/${r.slug}`} result={r} onInstalled={onChanged} />
 					))}
 				</div>
 			)}
-			{searched.value && results.value.length === 0 && !searching.value && (
+			{searched.value && !error.value && results.value.length === 0 && !searching.value && (
 				<div
 					style={{
 						fontSize: ".78rem",

--- a/crates/web/ui/src/pages/skills/ClawHubSection.tsx
+++ b/crates/web/ui/src/pages/skills/ClawHubSection.tsx
@@ -45,7 +45,6 @@ interface ClawHubSkillInfo {
 
 // ── Helpers ──────────────────────────────────────────────────
 
-let searchTimer: ReturnType<typeof setTimeout> | null = null;
 const CLAWHUB_SEARCH_TIMEOUT_MS = 20_000;
 
 function relativeTime(ms: number): string {
@@ -399,9 +398,21 @@ export function ClawHubSection({ onChanged }: { onChanged: () => void }): VNode 
 	const searched = useSignal(false);
 	const error = useSignal<string | null>(null);
 	const inputRef = useRef<HTMLInputElement>(null);
+	const searchTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+	const searchGeneration = useRef(0);
+
+	useEffect(
+		() => () => {
+			searchGeneration.current += 1;
+			if (searchTimer.current) clearTimeout(searchTimer.current);
+		},
+		[],
+	);
 
 	function doSearch(q: string): void {
-		if (!q.trim()) {
+		const trimmedQuery = q.trim();
+		const generation = ++searchGeneration.current;
+		if (!trimmedQuery) {
 			results.value = [];
 			searched.value = false;
 			error.value = null;
@@ -409,29 +420,31 @@ export function ClawHubSection({ onChanged }: { onChanged: () => void }): VNode 
 		}
 		searching.value = true;
 		error.value = null;
-		sendRpc("skills.clawhub.search", { query: q.trim() }, CLAWHUB_SEARCH_TIMEOUT_MS)
+		sendRpc("skills.clawhub.search", { query: trimmedQuery }, CLAWHUB_SEARCH_TIMEOUT_MS)
 			.then((res) => {
+				if (generation !== searchGeneration.current) return;
 				searching.value = false;
 				searched.value = true;
 				if (res?.ok) {
 					const payload = res.payload as { results?: ClawHubResult[] } | undefined;
 					results.value = payload?.results || [];
-					console.info("ClawHub search completed", { query: q.trim(), resultCount: results.value.length });
+					console.info("ClawHub search completed", { query: trimmedQuery, resultCount: results.value.length });
 					return;
 				}
 				const message = res?.error?.message || "ClawHub search failed";
 				results.value = [];
 				error.value = message;
-				console.error("ClawHub search failed", { query: q.trim(), error: res?.error });
+				console.error("ClawHub search failed", { query: trimmedQuery, error: res?.error });
 				showToast(message, "error");
 			})
 			.catch((cause: unknown) => {
+				if (generation !== searchGeneration.current) return;
 				searching.value = false;
 				searched.value = true;
 				results.value = [];
 				const message = cause instanceof Error ? cause.message : "ClawHub search failed";
 				error.value = message;
-				console.error("ClawHub search failed", { query: q.trim(), cause });
+				console.error("ClawHub search failed", { query: trimmedQuery, cause });
 				showToast(message, "error");
 			});
 	}
@@ -439,19 +452,21 @@ export function ClawHubSection({ onChanged }: { onChanged: () => void }): VNode 
 	function onInput(e: Event): void {
 		const v = (e.target as HTMLInputElement).value;
 		query.value = v;
-		if (searchTimer) clearTimeout(searchTimer);
+		searchGeneration.current += 1;
+		searching.value = false;
+		searched.value = false;
+		results.value = [];
+		error.value = null;
+		if (searchTimer.current) clearTimeout(searchTimer.current);
 		if (!v.trim()) {
-			results.value = [];
-			searched.value = false;
-			error.value = null;
 			return;
 		}
-		searchTimer = setTimeout(() => doSearch(v), 300);
+		searchTimer.current = setTimeout(() => doSearch(v), 300);
 	}
 
 	function onKeyDown(e: Event): void {
 		if ((e as KeyboardEvent).key === "Enter") {
-			if (searchTimer) clearTimeout(searchTimer);
+			if (searchTimer.current) clearTimeout(searchTimer.current);
 			doSearch(query.value);
 		}
 	}

--- a/crates/web/ui/src/pages/skills/ClawHubSection.tsx
+++ b/crates/web/ui/src/pages/skills/ClawHubSection.tsx
@@ -409,9 +409,9 @@ export function ClawHubSection({ onChanged }: { onChanged: () => void }): VNode 
 		[],
 	);
 
-	function doSearch(q: string): void {
+	function doSearch(q: string, generation: number): void {
+		if (generation !== searchGeneration.current) return;
 		const trimmedQuery = q.trim();
-		const generation = ++searchGeneration.current;
 		if (!trimmedQuery) {
 			results.value = [];
 			searched.value = false;
@@ -449,10 +449,14 @@ export function ClawHubSection({ onChanged }: { onChanged: () => void }): VNode 
 			});
 	}
 
+	function searchNow(q: string): void {
+		doSearch(q, ++searchGeneration.current);
+	}
+
 	function onInput(e: Event): void {
 		const v = (e.target as HTMLInputElement).value;
 		query.value = v;
-		searchGeneration.current += 1;
+		const generation = ++searchGeneration.current;
 		searching.value = false;
 		searched.value = false;
 		results.value = [];
@@ -461,13 +465,13 @@ export function ClawHubSection({ onChanged }: { onChanged: () => void }): VNode 
 		if (!v.trim()) {
 			return;
 		}
-		searchTimer.current = setTimeout(() => doSearch(v), 300);
+		searchTimer.current = setTimeout(() => doSearch(v, generation), 300);
 	}
 
 	function onKeyDown(e: Event): void {
 		if ((e as KeyboardEvent).key === "Enter") {
 			if (searchTimer.current) clearTimeout(searchTimer.current);
-			doSearch(query.value);
+			searchNow(query.value);
 		}
 	}
 
@@ -502,7 +506,7 @@ export function ClawHubSection({ onChanged }: { onChanged: () => void }): VNode 
 				<button
 					className="provider-btn"
 					disabled={searching.value || !query.value.trim()}
-					onClick={() => doSearch(query.value)}
+					onClick={() => searchNow(query.value)}
 				>
 					{searching.value ? "Searching\u2026" : "Search"}
 				</button>


### PR DESCRIPTION
## Summary

- stop per-result ClawHub metadata requests from pushing skill search beyond the RPC timeout
- consume search metadata directly and carry owner-qualified references through detail, scan, download, and install flows
- reconcile owner-qualified reinstalls with controlled legacy bare-slug manifest entries and directories
- prevent obsolete overlapping search responses from replacing the active query state
- add bounded external request timeouts plus gateway/browser diagnostics, an inline error alert, and an error toast
- cover duplicate publisher slugs, visible RPC timeout failures, legacy reinstall cleanup, and stale responses

## Validation

### Completed

- [x] `./scripts/local-validate.sh 1196`
- [x] `just release-preflight`
- [x] `cargo fmt --all -- --check`
- [x] `cargo build --bin moltis`
- [x] `cargo test -p moltis-skills clawhub::tests -- --nocapture`
- [x] `cargo test -p moltis-skills qualified_reinstall -- --nocapture`
- [x] `cd crates/web/ui && npx biome check --write src/helpers.ts src/pages/skills/ClawHubSection.tsx e2e/specs/skills.spec.js`
- [x] `cd crates/web/ui && npm run build`
- [x] `cd crates/web/ui && npm run build:all`
- [x] `cd crates/web/ui && npx tsc --noEmit`
- [x] `cd crates/web/ui && npx playwright test e2e/specs/skills.spec.js`
- [x] `git diff --check`

### Remaining

- None.

## Manual QA

1. Open Settings > Skills > ClawHub.
2. Search for `csv`.
3. Confirm results appear and duplicate slugs are distinguished by publisher.
4. Open a result and confirm detail/scan requests resolve the selected publisher.
5. Start a second search before the first completes and confirm only the newest results or errors are shown.
6. Reinstall a legacy bare-slug skill from an owner-qualified result and confirm the old installation is removed.
7. Simulate an unavailable or slow ClawHub response and confirm the inline alert, toast, browser console error, and gateway warning identify the failure.