### PR TITLE
Route OpenAI reasoning tool calls through Responses

### DIFF
--- a/crates/providers/src/openai/mod.rs
+++ b/crates/providers/src/openai/mod.rs
@@ -72,6 +72,7 @@ pub(crate) struct OpenAiProviderCapabilities {
     pub(crate) probe_fallback_policy: ProbeFallbackPolicy,
     pub(crate) probe_output_cap_policy: ProbeOutputCapPolicy,
     pub(crate) responses_websocket_policy: ResponsesWebSocketPolicy,
+    pub(crate) responses_required_for_reasoning_tools: bool,
 }
 
 impl OpenAiProviderCapabilities {
@@ -92,6 +93,7 @@ impl OpenAiProviderCapabilities {
         probe_fallback_policy: ProbeFallbackPolicy::None,
         probe_output_cap_policy: ProbeOutputCapPolicy::ReasoningModelsUseMaxCompletionTokens,
         responses_websocket_policy: ResponsesWebSocketPolicy::Unsupported,
+        responses_required_for_reasoning_tools: false,
     };
 }
 

--- a/crates/providers/src/openai/provider/completion.rs
+++ b/crates/providers/src/openai/provider/completion.rs
@@ -10,7 +10,6 @@ use crate::{
     openai_compat::{
         normalize_tool_call_arguments_from_schemas, parse_openai_compat_usage_from_payload,
         parse_tool_calls, split_responses_instructions_and_input, strip_think_tags,
-        to_responses_api_tools,
     },
 };
 
@@ -415,19 +414,7 @@ impl OpenAiProvider {
         tools: &[serde_json::Value],
         options: &AgentToolControls,
     ) -> anyhow::Result<CompletionResponse> {
-        let (instructions, input) = split_responses_instructions_and_input(messages.to_vec());
-        let mut body = serde_json::json!({
-            "model": self.model,
-            "input": input,
-            "stream": true,
-        });
-        if let Some(instructions) = instructions {
-            body["instructions"] = serde_json::Value::String(instructions);
-        }
-        if !tools.is_empty() {
-            body["tools"] = serde_json::Value::Array(to_responses_api_tools(tools));
-        }
-        super::core::apply_openai_responses_tool_choice(&mut body, options)?;
+        let body = self.prepare_responses_sse_body(messages.to_vec(), tools, options)?;
 
         debug!(
             model = %self.model,

--- a/crates/providers/src/openai/provider/core.rs
+++ b/crates/providers/src/openai/provider/core.rs
@@ -25,6 +25,7 @@ impl OpenAiProvider {
         Self::new_with_name(api_key, model, base_url, "openai".into()).with_capabilities(
             OpenAiProviderCapabilities {
                 responses_websocket_policy: super::super::ResponsesWebSocketPolicy::OpenAiPlatform,
+                responses_required_for_reasoning_tools: true,
                 ..OpenAiProviderCapabilities::DEFAULT
             },
         )
@@ -331,6 +332,18 @@ impl OpenAiProvider {
             format!("{base}/v1/responses")
         }
     }
+
+    fn wire_api_for_request(&self, has_tools: bool) -> WireApi {
+        if matches!(self.wire_api, WireApi::Responses)
+            || (self.capabilities.responses_required_for_reasoning_tools
+                && self.reasoning_effort.is_some()
+                && has_tools)
+        {
+            WireApi::Responses
+        } else {
+            WireApi::ChatCompletions
+        }
+    }
 }
 
 fn default_capabilities_for_provider(provider_name: &str) -> OpenAiProviderCapabilities {
@@ -461,7 +474,10 @@ impl LlmProvider for OpenAiProvider {
         tools: &[serde_json::Value],
         options: &AgentToolControls,
     ) -> anyhow::Result<CompletionResponse> {
-        if matches!(self.wire_api, WireApi::Responses) {
+        if matches!(
+            self.wire_api_for_request(!tools.is_empty()),
+            WireApi::Responses
+        ) {
             return self.complete_responses(messages, tools, options).await;
         }
         self.complete_chat(messages, tools, options).await
@@ -505,7 +521,10 @@ impl LlmProvider for OpenAiProvider {
         tools: Vec<serde_json::Value>,
         options: AgentToolControls,
     ) -> Pin<Box<dyn Stream<Item = StreamEvent> + Send + '_>> {
-        match (self.wire_api, self.stream_transport) {
+        match (
+            self.wire_api_for_request(!tools.is_empty()),
+            self.stream_transport,
+        ) {
             (WireApi::Responses, ProviderStreamTransport::Sse) => {
                 self.stream_responses_sse(messages, tools, options)
             },
@@ -651,6 +670,52 @@ mod tests {
                 .with_reasoning_effort(ReasoningEffort::High)
                 .is_some(),
             "provider URLs must not enable provider-specific reasoning behavior"
+        );
+    }
+
+    #[test]
+    fn openai_reasoning_with_tools_uses_responses_api() {
+        let mut provider = OpenAiProvider::new(
+            secrecy::Secret::new("test-key".to_string()),
+            "gpt-5.6-sol".to_string(),
+            "https://api.openai.com/v1".to_string(),
+        );
+        provider.reasoning_effort = Some(ReasoningEffort::High);
+
+        assert_eq!(provider.wire_api_for_request(true), WireApi::Responses);
+        assert_eq!(
+            provider.wire_api_for_request(false),
+            WireApi::ChatCompletions
+        );
+    }
+
+    #[test]
+    fn openai_tools_without_reasoning_keep_configured_chat_api() {
+        let provider = OpenAiProvider::new(
+            secrecy::Secret::new("test-key".to_string()),
+            "gpt-5.6-sol".to_string(),
+            "https://api.openai.com/v1".to_string(),
+        );
+
+        assert_eq!(
+            provider.wire_api_for_request(true),
+            WireApi::ChatCompletions
+        );
+    }
+
+    #[test]
+    fn compatible_provider_does_not_switch_wire_api_implicitly() {
+        let mut provider = OpenAiProvider::new_with_name(
+            secrecy::Secret::new("test-key".to_string()),
+            "gpt-5.6-sol".to_string(),
+            "https://example.com/v1".to_string(),
+            "custom-openai".to_string(),
+        );
+        provider.reasoning_effort = Some(ReasoningEffort::High);
+
+        assert_eq!(
+            provider.wire_api_for_request(true),
+            WireApi::ChatCompletions
         );
     }
 

--- a/crates/providers/src/openai/provider/request.rs
+++ b/crates/providers/src/openai/provider/request.rs
@@ -2,7 +2,10 @@ use std::collections::{HashMap, HashSet};
 
 use tracing::warn;
 
-use {crate::raw_model_id, moltis_agents::model::ChatMessage};
+use {
+    crate::{openai_compat::split_responses_instructions_and_input, raw_model_id},
+    moltis_agents::model::{AgentToolControls, ChatMessage},
+};
 
 use {
     super::OpenAiProvider,
@@ -10,6 +13,30 @@ use {
 };
 
 impl OpenAiProvider {
+    pub(super) fn prepare_responses_sse_body(
+        &self,
+        messages: Vec<ChatMessage>,
+        tools: &[serde_json::Value],
+        options: &AgentToolControls,
+    ) -> anyhow::Result<serde_json::Value> {
+        let (instructions, input) = split_responses_instructions_and_input(messages);
+        let mut body = serde_json::json!({
+            "model": self.model,
+            "input": input,
+            "stream": true,
+        });
+        if let Some(instructions) = instructions {
+            body["instructions"] = serde_json::Value::String(instructions);
+        }
+        if !tools.is_empty() {
+            body["tools"] =
+                serde_json::Value::Array(crate::openai_compat::to_responses_api_tools(tools));
+        }
+        super::core::apply_openai_responses_tool_choice(&mut body, options)?;
+        self.apply_reasoning_effort_responses(&mut body);
+        Ok(body)
+    }
+
     /// For OpenRouter Anthropic models, inject `cache_control` breakpoints
     /// on the system message and the last user message to enable prompt
     /// caching passthrough to Anthropic.
@@ -494,6 +521,38 @@ mod tests {
             panic!("messages should be an array");
         };
         messages
+    }
+
+    #[test]
+    fn responses_sse_body_combines_reasoning_and_function_tools() {
+        let mut provider = provider("gpt-5.6-sol", "openai", "https://api.openai.com/v1");
+        provider.reasoning_effort = Some(moltis_agents::model::ReasoningEffort::High);
+        let tools = [serde_json::json!({
+            "name": "get_weather",
+            "description": "Get weather",
+            "parameters": {
+                "type": "object",
+                "properties": { "location": { "type": "string" } },
+                "required": ["location"]
+            }
+        })];
+
+        let Ok(body) = provider.prepare_responses_sse_body(
+            vec![
+                ChatMessage::system("Be concise"),
+                ChatMessage::user("Weather?"),
+            ],
+            &tools,
+            &AgentToolControls::default(),
+        ) else {
+            panic!("responses request body should be valid");
+        };
+
+        assert_eq!(body["reasoning"]["effort"], "high");
+        assert_eq!(body["tools"][0]["type"], "function");
+        assert_eq!(body["tools"][0]["name"], "get_weather");
+        assert_eq!(body["tool_choice"], "auto");
+        assert_eq!(body["instructions"], "Be concise");
     }
 
     #[test]

--- a/crates/providers/src/openai/provider/streaming.rs
+++ b/crates/providers/src/openai/provider/streaming.rs
@@ -9,7 +9,6 @@ use crate::{
     openai_compat::{
         ResponsesStreamState, SseLineResult, StreamingToolState, finalize_responses_stream,
         finalize_stream, process_openai_sse_line, process_responses_sse_line,
-        split_responses_instructions_and_input, to_responses_api_tools,
     },
 };
 
@@ -27,26 +26,13 @@ impl OpenAiProvider {
         options: AgentToolControls,
     ) -> Pin<Box<dyn Stream<Item = StreamEvent> + Send + '_>> {
         Box::pin(async_stream::stream! {
-            let (instructions, input) = split_responses_instructions_and_input(messages);
-            let mut body = serde_json::json!({
-                "model": self.model,
-                "input": input,
-                "stream": true,
-            });
-
-            if let Some(instructions) = instructions {
-                body["instructions"] = serde_json::Value::String(instructions);
-            }
-
-            if !tools.is_empty() {
-                body["tools"] = serde_json::Value::Array(to_responses_api_tools(&tools));
-            }
-            if let Err(error) = super::core::apply_openai_responses_tool_choice(&mut body, &options) {
-                yield StreamEvent::Error(error.to_string());
-                return;
-            }
-
-            self.apply_reasoning_effort_responses(&mut body);
+            let body = match self.prepare_responses_sse_body(messages, &tools, &options) {
+                Ok(body) => body,
+                Err(error) => {
+                    yield StreamEvent::Error(error.to_string());
+                    return;
+                },
+            };
 
             debug!(
                 model = %self.model,

--- a/crates/providers/src/registry/registration.rs
+++ b/crates/providers/src/registry/registration.rs
@@ -57,6 +57,7 @@ pub(crate) fn openai_builtin_capabilities(
     }
     openai::OpenAiProviderCapabilities {
         responses_websocket_policy: openai::ResponsesWebSocketPolicy::OpenAiPlatform,
+        responses_required_for_reasoning_tools: true,
         ..openai::OpenAiProviderCapabilities::DEFAULT
     }
 }

--- a/crates/providers/src/registry/tests.rs
+++ b/crates/providers/src/registry/tests.rs
@@ -18,18 +18,22 @@ const FIREWORKS_KIMI_ROUTER: &str = "accounts/fireworks/routers/kimi-k2p5-turbo"
 
 #[test]
 fn openai_default_base_url_enables_responses_websocket() {
+    let capabilities = openai_builtin_capabilities(false);
     assert_eq!(
-        openai_builtin_capabilities(false).responses_websocket_policy,
+        capabilities.responses_websocket_policy,
         ResponsesWebSocketPolicy::OpenAiPlatform,
     );
+    assert!(capabilities.responses_required_for_reasoning_tools);
 }
 
 #[test]
 fn openai_custom_base_url_disables_responses_websocket() {
+    let capabilities = openai_builtin_capabilities(true);
     assert_eq!(
-        openai_builtin_capabilities(true).responses_websocket_policy,
+        capabilities.responses_websocket_policy,
         ResponsesWebSocketPolicy::Unsupported,
     );
+    assert!(!capabilities.responses_required_for_reasoning_tools);
 }
 
 fn capture_one_json_request() -> anyhow::Result<(String, mpsc::Receiver<anyhow::Result<Value>>)> {


### PR DESCRIPTION
## Summary

- route built-in OpenAI requests that combine function tools with `reasoning_effort` through the Responses API
- preserve Chat Completions behavior when tools or reasoning are absent and for OpenAI-compatible providers
- share Responses request construction across streaming and non-streaming calls so reasoning fields stay consistent

## Validation

### Completed

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p moltis-providers --all-targets -- -D warnings`
- [x] `cargo test -p moltis-providers openai::provider::core::tests`
- [x] `cargo test -p moltis-providers responses_sse_body_combines_reasoning_and_function_tools`
- [x] `cargo test -p moltis-providers openai_default_base_url_enables_responses_websocket`
- [x] `cargo test -p moltis-providers openai_custom_base_url_disables_responses_websocket`
- [x] `./scripts/check-file-size.sh`
- [x] `git diff --check`

### Remaining

- [ ] `./scripts/local-validate.sh 1198` - provider checks passed, but the unrelated iOS build fails because `apps/ios/Sources/GraphQL/Generated/MoltisAPI/MoltisAPI.graphql.swift` is missing after Apollo generation

## Manual QA

1. Configure the built-in OpenAI provider with `gpt-5.6-sol` and a non-`none` reasoning effort.
2. Start an agent run with function tools enabled.
3. Confirm the request succeeds through `/v1/responses` instead of returning the Chat Completions HTTP 400.
4. Confirm an OpenAI request without reasoning or without tools continues to use Chat Completions.