### PR TITLE
fix(gateway): thread start_background_tasks into the memory runtime builder

### DIFF
--- a/crates/gateway/src/server/init_memory.rs
+++ b/crates/gateway/src/server/init_memory.rs
@@ -206,8 +206,14 @@ pub(crate) async fn init_memory_system(
         match embedding_dimension {
             Some(dim) => match try_init_zvec(mem_cfg, data_dir, dim).await {
                 Ok(store) => {
-                    return build_memory_runtime_from_store(mem_cfg, data_dir, embedder, store)
-                        .await;
+                    return build_memory_runtime_from_store(
+                        mem_cfg,
+                        data_dir,
+                        embedder,
+                        store,
+                        start_background_tasks,
+                    )
+                    .await;
                 },
                 Err(e) => {
                     warn!(
@@ -284,7 +290,8 @@ async fn build_memory_runtime(
     let store: Box<dyn moltis_memory::store::MemoryStore> = Box::new(
         moltis_memory::store_sqlite::SqliteMemoryStore::new(memory_pool),
     );
-    build_memory_runtime_from_store(mem_cfg, data_dir, embedder, store).await
+    build_memory_runtime_from_store(mem_cfg, data_dir, embedder, store, start_background_tasks)
+        .await
 }
 
 /// Validate that the configured memory backend is available with the current
@@ -401,6 +408,7 @@ async fn build_memory_runtime_from_store(
     data_dir: &FsPath,
     embedder: Option<Box<dyn moltis_memory::embeddings::EmbeddingProvider>>,
     store: Box<dyn moltis_memory::store::MemoryStore>,
+    start_background_tasks: bool,
 ) -> Option<moltis_memory::runtime::DynMemoryRuntime> {
     let data_memory_file = data_dir.join("MEMORY.md");
     let data_memory_file_lower = data_dir.join("memory.md");


### PR DESCRIPTION
## Summary

`moltis-gateway` does not compile on `main` (594ffaf1):

```
error[E0425]: cannot find value `start_background_tasks` in this scope
  --> crates/gateway/src/server/init_memory.rs:509:9
```

#1158 factored the runtime setup out into `build_memory_runtime_from_store` and moved the headless branch along with it, but the flag that branch reads stayed behind on `build_memory_runtime`, and neither call site passes it. This adds the parameter and passes it at both.

It also lines the two backends up. `build_memory_runtime_from_store` is now reached from the SQLite path and from the zvec path added in #1158, and only the SQLite path used to carry the flag — so a headless run would have started the sync and watcher tasks on zvec while skipping them on SQLite.

Two things worth flagging that this PR does not cover:

- The `Format` job is red on `main` for a separate reason — `crates/memory-zvec/src/store.rs` (1799 lines) and `crates/gateway/src/methods/services/admin.rs` (1531 lines) are both over the 1500-line limit, and `ALLOW_LIST` in `scripts/check-file-size.sh` is empty. Both trace to 9b47001a. Splitting them is a call for whoever owns that code, so this PR leaves them alone and `Format` stays red.
- On the run that merged it, `Rust CI (clippy + test)` was skipped, along with E2E, iOS, macOS and Sandbox. `Code Coverage` was the only job that compiled the crate and caught this, which is easy to read as a coverage blip rather than a broken build.

## Validation

### Completed

- [x] `cargo check -p moltis-gateway --lib --tests` — fails on `main`, passes here
- [x] `cargo check -p moltis-gateway --lib --features zvec` — covers the `:209` call site, which is behind `#[cfg(feature = "zvec")]`
- [x] `cargo fmt --all -- --check`
- [x] `just lint`
- [x] `cargo test -p moltis-gateway --lib push::tests::fanout_is_bounded_and_times_out_a_hung_endpoint` — the gateway test target could not be built at all before this

Reverting each of the three edits on its own reproduces a distinct failure: dropping the argument at `:209` fails only under `--features zvec`, dropping it at `:290` fails under default features, and dropping the parameter reproduces the original `E0425`.

### Remaining

- [ ] `./scripts/local-validate.sh <PR>`
- [ ] Full workspace suite — left to CI

## Manual QA

Not exercised at runtime. The headless behaviour this restores is the `if !start_background_tasks` branch in `build_memory_runtime_from_store`: with the flag false it runs one initial sync and returns instead of spawning the periodic sync and the file watcher. Before #1158 the SQLite path did that; after it, neither path could, because the code did not compile.
