### PR TITLE
test(gateway): run the push fanout test on a paused clock

### DIFF
--- a/crates/gateway/Cargo.toml
+++ b/crates/gateway/Cargo.toml
@@ -254,6 +254,7 @@ zvec = ["dep:moltis-memory-zvec"]
 
 [dev-dependencies]
 serial_test = { workspace = true }
+tokio       = { features = ["test-util"], workspace = true }
 
 [lints]
 workspace = true

--- a/crates/gateway/src/push.rs
+++ b/crates/gateway/src/push.rs
@@ -1367,7 +1367,13 @@ mod tests {
         assert_eq!(service.send_to_all(&payload).await.expect("send"), 0);
     }
 
-    #[tokio::test]
+    // The counts below tell a hung endpoint from a healthy one by whether its
+    // send crosses `send_timeout`, and the mock's delay only sits 6x inside
+    // that deadline. On the real clock a loaded machine can close that gap and
+    // bill a healthy endpoint as timed out. A paused clock only moves when the
+    // runtime is idle, so the delay stays well inside the timeout however long
+    // the test really takes, while the hung endpoint still never completes.
+    #[tokio::test(start_paused = true)]
     async fn fanout_is_bounded_and_times_out_a_hung_endpoint() {
         let (service, client, _dir) =
             mock_service(Duration::from_millis(30), Duration::from_millis(5)).await;

--- a/crates/gateway/src/server/init_memory.rs
+++ b/crates/gateway/src/server/init_memory.rs
@@ -206,8 +206,14 @@ pub(crate) async fn init_memory_system(
         match embedding_dimension {
             Some(dim) => match try_init_zvec(mem_cfg, data_dir, dim).await {
                 Ok(store) => {
-                    return build_memory_runtime_from_store(mem_cfg, data_dir, embedder, store)
-                        .await;
+                    return build_memory_runtime_from_store(
+                        mem_cfg,
+                        data_dir,
+                        embedder,
+                        store,
+                        start_background_tasks,
+                    )
+                    .await;
                 },
                 Err(e) => {
                     warn!(
@@ -284,7 +290,8 @@ async fn build_memory_runtime(
     let store: Box<dyn moltis_memory::store::MemoryStore> = Box::new(
         moltis_memory::store_sqlite::SqliteMemoryStore::new(memory_pool),
     );
-    build_memory_runtime_from_store(mem_cfg, data_dir, embedder, store).await
+    build_memory_runtime_from_store(mem_cfg, data_dir, embedder, store, start_background_tasks)
+        .await
 }
 
 /// Validate that the configured memory backend is available with the current
@@ -401,6 +408,7 @@ async fn build_memory_runtime_from_store(
     data_dir: &FsPath,
     embedder: Option<Box<dyn moltis_memory::embeddings::EmbeddingProvider>>,
     store: Box<dyn moltis_memory::store::MemoryStore>,
+    start_background_tasks: bool,
 ) -> Option<moltis_memory::runtime::DynMemoryRuntime> {
     let data_memory_file = data_dir.join("MEMORY.md");
     let data_memory_file_lower = data_dir.join("memory.md");


### PR DESCRIPTION
Closes #1193.

Stacked on #1201 — that fix is the first commit here because `moltis-gateway` does not compile without it, so this branch could not build or run the test on its own. It drops out once #1201 lands.

## Summary

`fanout_is_bounded_and_times_out_a_hung_endpoint` decides which endpoint is hung by whether its send crosses `send_timeout`, so the counts it asserts depend on how much wall-clock time a healthy send takes. The mock's delay is 5ms against a 30ms timeout, and `#[tokio::test]` runs the fanout on a current-thread runtime, so all eight concurrent sends share one thread. Under a full-workspace nextest run that thread competes with many other processes, and the delay on top of the 5ms sleep is enough to bill a healthy endpoint as timed out — `sent` drops to 10 and the assertion fails.

Starting the test with a paused clock removes the dependency. Time only advances when the runtime is idle, so the mock's delay always lands well inside the timeout however long the test really takes, while the hung endpoint still never completes and still times out. No assertion changes.

`start_paused` is already used in `crates/matrix/src/client.rs`, and four crates already carry the `tokio` `test-util` dev-dependency it needs.

Worth noting for anyone reading the issue: of the three directions I suggested there, the first does not work as written. `mock_service` pins the fanout timeout at 1s, so raising `send_timeout` into seconds trips the fanout deadline first and changes what the stats mean.

## Validation

### Completed

- [x] `cargo test -p moltis-gateway --lib push::tests::` — 20 passed
- [x] `cargo check -p moltis-gateway --lib --tests` and `--features zvec`
- [x] `cargo fmt --all -- --check`
- [x] `just lint`

Reverse-checked by making the flake deterministic rather than waiting for it. Blocking the runtime thread for 100ms once eight sends are in flight — after five of them have parked on their 5ms sleeps — reproduces the reported failure exactly:

```
panicked at crates/gateway/src/push.rs:1396:9:
  left: 10
 right: 11
```

With `start_paused` and the same injected block still in place, the test passes: the blocked thread does not move the virtual clock, so nothing crosses the deadline. Removing the injection, it passes clean. Both closed-loop rounds were run on identical file hashes.

### Remaining

- [ ] `./scripts/local-validate.sh <PR>` — its `file-size` check fails on `main` for an unrelated reason, see #1202
- [ ] Full workspace suite under load — this is the run the flake needs, left to CI

## Manual QA

Not applicable — test-only change, no runtime behaviour touched.
