### PR TITLE
feat: add MiniMax Code ACP agent

### DIFF
--- a/crates/config/src/template.rs
+++ b/crates/config/src/template.rs
@@ -840,6 +840,10 @@ port = {port}                           # Port number (auto-generated for this i
 # binary = "kimi"
 # args = ["acp"]
 
+# [external_agents.agents.acp-minimax-code]
+# binary = "mcode"
+# args = ["acp"]
+
 # [external_agents.agents.acp-stakpak]
 # binary = "stakpak"
 # args = ["acp"]

--- a/crates/config/src/validate/tests/agents.rs
+++ b/crates/config/src/validate/tests/agents.rs
@@ -396,6 +396,10 @@ args = ["acp"]
 binary = "kimi"
 args = ["acp"]
 
+[external_agents.agents.acp-minimax-code]
+binary = "mcode"
+args = ["acp"]
+
 [external_agents.agents.acp-stakpak]
 binary = "stakpak"
 args = ["acp"]

--- a/crates/gateway/src/external_agents.rs
+++ b/crates/gateway/src/external_agents.rs
@@ -912,6 +912,10 @@ fn session_key_param(params: &Value) -> Option<String> {
 }
 
 #[cfg(test)]
+#[path = "external_agents/registry_tests.rs"]
+mod registry_tests;
+
+#[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use std::{pin::Pin, sync::atomic::Ordering};
@@ -1109,29 +1113,6 @@ mod tests {
             session_store,
             metadata,
         )
-    }
-
-    #[tokio::test]
-    async fn default_registry_includes_minimax_code_acp() {
-        let metadata = Arc::new(SqliteSessionMetadata::new(sqlite_pool().await));
-        let service = GatewayExternalAgentService::new(
-            ExternalAgentsConfig::default(),
-            metadata,
-            Arc::new(ApprovalManager::default()),
-        );
-
-        assert!(
-            service
-                .registry
-                .has_kind(AgentTransportKind::AcpMinimaxCode)
-        );
-        let agents = service.registry.list_agents().await;
-        let minimax_code = agents
-            .iter()
-            .find(|agent| agent.kind == AgentTransportKind::AcpMinimaxCode)
-            .expect("MiniMax Code ACP transport should be registered");
-        assert_eq!(minimax_code.name, "ACP: MiniMax Code");
-        assert!(minimax_code.is_acp);
     }
 
     #[tokio::test]

--- a/crates/gateway/src/external_agents.rs
+++ b/crates/gateway/src/external_agents.rs
@@ -104,6 +104,9 @@ impl GatewayExternalAgentService {
                 "acp".to_string(),
             ]),
             (AgentTransportKind::AcpKimi, "kimi", vec!["acp".to_string()]),
+            (AgentTransportKind::AcpMinimaxCode, "mcode", vec![
+                "acp".to_string(),
+            ]),
             (AgentTransportKind::AcpStakpak, "stakpak", vec![
                 "acp".to_string(),
             ]),
@@ -1106,6 +1109,29 @@ mod tests {
             session_store,
             metadata,
         )
+    }
+
+    #[tokio::test]
+    async fn default_registry_includes_minimax_code_acp() {
+        let metadata = Arc::new(SqliteSessionMetadata::new(sqlite_pool().await));
+        let service = GatewayExternalAgentService::new(
+            ExternalAgentsConfig::default(),
+            metadata,
+            Arc::new(ApprovalManager::default()),
+        );
+
+        assert!(
+            service
+                .registry
+                .has_kind(AgentTransportKind::AcpMinimaxCode)
+        );
+        let agents = service.registry.list_agents().await;
+        let minimax_code = agents
+            .iter()
+            .find(|agent| agent.kind == AgentTransportKind::AcpMinimaxCode)
+            .expect("MiniMax Code ACP transport should be registered");
+        assert_eq!(minimax_code.name, "ACP: MiniMax Code");
+        assert!(minimax_code.is_acp);
     }
 
     #[tokio::test]

--- a/crates/gateway/src/external_agents/registry_tests.rs
+++ b/crates/gateway/src/external_agents/registry_tests.rs
@@ -1,0 +1,29 @@
+#![allow(clippy::expect_used)]
+
+use {super::*, moltis_sessions::metadata::SqliteSessionMetadata, sqlx::sqlite::SqlitePoolOptions};
+
+#[tokio::test]
+async fn default_registry_includes_minimax_code_acp() {
+    let pool = SqlitePoolOptions::new()
+        .connect_lazy("sqlite::memory:")
+        .expect("create in-memory SQLite pool");
+    let metadata = Arc::new(SqliteSessionMetadata::new(pool));
+    let service = GatewayExternalAgentService::new(
+        ExternalAgentsConfig::default(),
+        metadata,
+        Arc::new(ApprovalManager::default()),
+    );
+
+    assert!(
+        service
+            .registry
+            .has_kind(AgentTransportKind::AcpMinimaxCode)
+    );
+    let agents = service.registry.list_agents().await;
+    let minimax_code = agents
+        .iter()
+        .find(|agent| agent.kind == AgentTransportKind::AcpMinimaxCode)
+        .expect("MiniMax Code ACP transport should be registered");
+    assert_eq!(minimax_code.name, "ACP: MiniMax Code");
+    assert!(minimax_code.is_acp);
+}

--- a/crates/sessions/src/metadata.rs
+++ b/crates/sessions/src/metadata.rs
@@ -34,6 +34,7 @@ pub enum ExternalAgentKind {
     AcpOpenclaw,
     AcpOpenhands,
     AcpKimi,
+    AcpMinimaxCode,
     AcpStakpak,
     AcpFastAgent,
 }
@@ -56,6 +57,7 @@ impl ExternalAgentKind {
         Self::AcpOpenclaw,
         Self::AcpOpenhands,
         Self::AcpKimi,
+        Self::AcpMinimaxCode,
         Self::AcpStakpak,
         Self::AcpFastAgent,
     ];
@@ -79,6 +81,7 @@ impl ExternalAgentKind {
             Self::AcpOpenclaw => "acp-openclaw",
             Self::AcpOpenhands => "acp-openhands",
             Self::AcpKimi => "acp-kimi",
+            Self::AcpMinimaxCode => "acp-minimax-code",
             Self::AcpStakpak => "acp-stakpak",
             Self::AcpFastAgent => "acp-fast-agent",
         }
@@ -103,6 +106,7 @@ impl ExternalAgentKind {
             Self::AcpOpenclaw => "ACP: OpenClaw",
             Self::AcpOpenhands => "ACP: OpenHands",
             Self::AcpKimi => "ACP: Kimi",
+            Self::AcpMinimaxCode => "ACP: MiniMax Code",
             Self::AcpStakpak => "ACP: Stakpak",
             Self::AcpFastAgent => "ACP: fast-agent",
         }
@@ -124,6 +128,7 @@ impl ExternalAgentKind {
                 | Self::AcpOpenclaw
                 | Self::AcpOpenhands
                 | Self::AcpKimi
+                | Self::AcpMinimaxCode
                 | Self::AcpStakpak
                 | Self::AcpFastAgent
         )
@@ -157,6 +162,7 @@ impl std::str::FromStr for ExternalAgentKind {
             "acp-openclaw" => Ok(Self::AcpOpenclaw),
             "acp-openhands" => Ok(Self::AcpOpenhands),
             "acp-kimi" => Ok(Self::AcpKimi),
+            "acp-minimax-code" => Ok(Self::AcpMinimaxCode),
             "acp-stakpak" => Ok(Self::AcpStakpak),
             "acp-fast-agent" => Ok(Self::AcpFastAgent),
             other => Err(format!("unknown external agent kind: {other}")),

--- a/crates/sessions/src/metadata/tests.rs
+++ b/crates/sessions/src/metadata/tests.rs
@@ -101,6 +101,11 @@ fn external_agent_kind_parses_named_acp_variants() {
             "ACP: OpenHands",
         ),
         ("acp-kimi", ExternalAgentKind::AcpKimi, "ACP: Kimi"),
+        (
+            "acp-minimax-code",
+            ExternalAgentKind::AcpMinimaxCode,
+            "ACP: MiniMax Code",
+        ),
         ("acp-stakpak", ExternalAgentKind::AcpStakpak, "ACP: Stakpak"),
         (
             "acp-fast-agent",

--- a/crates/web/ui/e2e/specs/agents.spec.js
+++ b/crates/web/ui/e2e/specs/agents.spec.js
@@ -499,6 +499,7 @@ test.describe("Agents settings page", () => {
 				{ kind: "acp-openclaw", name: "ACP: OpenClaw", installed: true, isAcp: true, version: null },
 				{ kind: "acp-openhands", name: "ACP: OpenHands", installed: true, isAcp: true, version: null },
 				{ kind: "acp-kimi", name: "ACP: Kimi", installed: true, isAcp: true, version: null },
+				{ kind: "acp-minimax-code", name: "ACP: MiniMax Code", installed: true, isAcp: true, version: null },
 				{ kind: "acp-stakpak", name: "ACP: Stakpak", installed: true, isAcp: true, version: null },
 				{ kind: "acp-fast-agent", name: "ACP: fast-agent", installed: true, isAcp: true, version: null },
 			],
@@ -538,6 +539,7 @@ test.describe("Agents settings page", () => {
 		await expect(page.getByText("ACP: OpenClaw", { exact: true })).toBeVisible();
 		await expect(page.getByText("ACP: OpenHands", { exact: true })).toBeVisible();
 		await expect(page.getByText("ACP: Kimi", { exact: true })).toBeVisible();
+		await expect(page.getByText("ACP: MiniMax Code", { exact: true })).toBeVisible();
 		await expect(page.getByText("ACP: Stakpak", { exact: true })).toBeVisible();
 		await expect(page.getByText("ACP: fast-agent", { exact: true })).toBeVisible();
 
@@ -610,6 +612,7 @@ test.describe("Agents settings page", () => {
 			{ kind: "acp-openclaw", name: "ACP: OpenClaw", installed: false, isAcp: true, version: null },
 			{ kind: "acp-openhands", name: "ACP: OpenHands", installed: false, isAcp: true, version: null },
 			{ kind: "acp-kimi", name: "ACP: Kimi", installed: false, isAcp: true, version: null },
+			{ kind: "acp-minimax-code", name: "ACP: MiniMax Code", installed: false, isAcp: true, version: null },
 			{ kind: "acp-stakpak", name: "ACP: Stakpak", installed: false, isAcp: true, version: null },
 			{ kind: "acp-fast-agent", name: "ACP: fast-agent", installed: false, isAcp: true, version: null },
 		]);
@@ -640,6 +643,7 @@ test.describe("Agents settings page", () => {
 			"ACP: OpenClaw",
 			"ACP: OpenHands",
 			"ACP: Kimi",
+			"ACP: MiniMax Code",
 			"ACP: Stakpak",
 			"ACP: fast-agent",
 		]) {

--- a/docs/src/external-agents.md
+++ b/docs/src/external-agents.md
@@ -22,6 +22,7 @@ Supported agent kinds:
 | `acp-openclaw` | `openclaw acp` | OpenClaw ACP bridge. |
 | `acp-openhands` | `openhands acp` | OpenHands CLI ACP mode. |
 | `acp-kimi` | `kimi acp` | Kimi CLI ACP mode. |
+| `acp-minimax-code` | `mcode acp` | MiniMax Code ACP mode. |
 | `acp-stakpak` | `stakpak acp` | Stakpak ACP mode. |
 | `acp-fast-agent` | `fast-agent-acp` | fast-agent ACP server. |
 
@@ -42,6 +43,7 @@ External agent discovery is enabled by default. On startup, Moltis checks for th
 | `ACP: OpenClaw` | `acp-openclaw` | `openclaw acp` |
 | `ACP: OpenHands` | `acp-openhands` | `openhands acp` |
 | `ACP: Kimi` | `acp-kimi` | `kimi acp` |
+| `ACP: MiniMax Code` | `acp-minimax-code` | `mcode acp` |
 | `ACP: Stakpak` | `acp-stakpak` | `stakpak acp` |
 | `ACP: fast-agent` | `acp-fast-agent` | `fast-agent-acp` |
 
@@ -110,6 +112,10 @@ args = ["acp"]
 binary = "kimi"
 args = ["acp"]
 
+[external_agents.agents.acp-minimax-code]
+binary = "mcode"
+args = ["acp"]
+
 [external_agents.agents.acp-stakpak]
 binary = "stakpak"
 args = ["acp"]
@@ -120,6 +126,8 @@ args = []
 ```
 
 Claude ACP support is not provided by plain `claude`; Moltis detects the separate `claude-agent-acp` adapter binary. Install it from the upstream package/repository and ensure that binary is on the Moltis service `$PATH`, or set `binary = "/absolute/path/to/claude-agent-acp"`.
+
+MiniMax Code is available as the `@minimax-ai/code` npm package. Once its `mcode` binary is on the Moltis service `$PATH`, Moltis detects it automatically and launches `mcode acp` when selected.
 
 Cursor CLI supports ACP with `agent acp`, but Moltis does not auto-detect it because `agent` is a generic executable name that can collide with unrelated tools. Configure Cursor manually with the generic `acp` entry and an absolute `binary` path if you want to use it.
 


### PR DESCRIPTION
## Summary

- add a named `acp-minimax-code` external-agent kind backed by `mcode acp`
- include MiniMax Code in Moltis' default executable detection and agent registry
- document automatic discovery and manual TOML configuration
- keep config validation and the Agents settings UI fixtures in sync with the new kind

## Why

MiniMax Code exposes a native ACP stdio server through `mcode acp`. Moltis already has the generic ACP transport and named entries for Kimi, OpenCode, Gemini, and other agents, so this change only adds the product-specific discovery and metadata needed for a one-click selection.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p moltis-sessions external_agent_kind_parses_named_acp_variants -- --nocapture`
- `cargo test -p moltis-config external_agents_known_kinds_not_warned -- --nocapture`
- `cargo test -p moltis-gateway default_registry_includes_minimax_code_acp -- --nocapture`
- `node --check crates/web/ui/e2e/specs/agents.spec.js`

The focused Cargo runs used a temporary local dependency-resolution stub for the unrelated optional `zvec-rust` workspace package, because Cargo otherwise initializes zvec's large recursive C++ submodules even when testing packages that do not build that backend. The stub was supplied only through command-line Cargo config; it is not part of this branch and `Cargo.lock` is unchanged.

Manual browser QA was not run; the existing Agents settings E2E fixture was updated for both installed and unavailable states.

## Implementation context

This change was developed with AI assistance. The key constraints were to reuse Moltis' existing ACP runtime, use the real `mcode acp` command, preserve the generic ACP escape hatch, and avoid claiming process-restart session resume support that is not part of this host path. I cannot attach the complete session transcript because it also contains unrelated private workspace and release context; the summary, decisions, and validation output relevant to this PR are included above.
