### PR TITLE
fix(cron): honor heartbeat active hours when the scheduler fires

### DIFF
--- a/crates/cron/src/heartbeat.rs
+++ b/crates/cron/src/heartbeat.rs
@@ -158,6 +158,39 @@ pub fn is_within_active_hours(start: &str, end: &str, timezone: &str) -> bool {
     }
 }
 
+/// Milliseconds until the active-hours window next opens.
+///
+/// Only meaningful when [`is_within_active_hours`] has just returned `false`;
+/// it answers "how long until it would return `true`". `None` means the window
+/// never opens, either because a bound does not parse or because an equal
+/// start and end leaves no minute in it.
+///
+/// The result is never zero, so a caller using it as a next-run time always
+/// moves the schedule forward.
+#[must_use]
+pub fn ms_until_active_hours(start: &str, end: &str, timezone: &str) -> Option<u64> {
+    let start_time = parse_hhmm(start)?;
+    let end_time = parse_hhmm(end)?;
+    let start_minutes = start_time.hour() * 60 + start_time.minute();
+    let end_minutes = end_time.hour() * 60 + end_time.minute();
+    if start_minutes == end_minutes {
+        return None;
+    }
+    Some(minutes_until(start_minutes, current_minutes(timezone)) * 60_000)
+}
+
+/// Minutes from `now_minutes` forward to `target_minutes`, wrapping past
+/// midnight. Never zero: landing exactly on the target means a whole day.
+fn minutes_until(target_minutes: u32, now_minutes: u32) -> u64 {
+    const DAY: u32 = 24 * 60;
+    let delta = (target_minutes + DAY - now_minutes % DAY) % DAY;
+    u64::from(if delta == 0 {
+        DAY
+    } else {
+        delta
+    })
+}
+
 /// Resolve the heartbeat prompt with precedence:
 ///
 /// 1. Explicit config prompt (`custom`)
@@ -384,6 +417,49 @@ mod tests {
         // which is what the config validator already warns about.
         assert!(!is_within_active_hours("12:00", "12:00", "local"));
         assert!(!is_within_active_hours("00:00", "00:00", "UTC"));
+    }
+
+    // ── minutes_until / ms_until_active_hours ────────────────────────────
+
+    #[test]
+    fn minutes_until_counts_forward_within_the_day() {
+        // 02:00 → 08:00 is six hours.
+        assert_eq!(minutes_until(8 * 60, 2 * 60), 360);
+    }
+
+    #[test]
+    fn minutes_until_wraps_past_midnight() {
+        // 23:00 → 08:00 is nine hours, not a negative number of them.
+        assert_eq!(minutes_until(8 * 60, 23 * 60), 540);
+    }
+
+    #[test]
+    fn minutes_until_never_returns_zero() {
+        // A next-run time of `now` stays due, and `ms_until_next_wake` turns a
+        // due job into a zero-length sleep — so returning zero here would spin
+        // the timer loop instead of deferring anything.
+        assert_eq!(minutes_until(8 * 60, 8 * 60), 24 * 60);
+    }
+
+    #[test]
+    fn an_empty_window_never_opens() {
+        assert!(ms_until_active_hours("12:00", "12:00", "UTC").is_none());
+    }
+
+    #[test]
+    fn an_unparseable_bound_never_opens() {
+        // Matches `is_within_active_hours`, which treats an unparseable bound
+        // as "always active" and so never reaches this function.
+        assert!(ms_until_active_hours("08:00", "not-a-time", "UTC").is_none());
+    }
+
+    #[test]
+    fn a_real_window_opens_within_a_day() {
+        let ms = ms_until_active_hours("08:00", "22:00", "UTC");
+        assert!(
+            ms.is_some_and(|ms| ms > 0 && ms <= 24 * 60 * 60_000),
+            "expected an opening within a day, got {ms:?}"
+        );
     }
 
     // ── resolve_heartbeat_prompt ─────────────────────────────────────────

--- a/crates/cron/src/heartbeat.rs
+++ b/crates/cron/src/heartbeat.rs
@@ -371,6 +371,21 @@ mod tests {
         let _ = is_within_active_hours("22:00", "06:00", "local");
     }
 
+    #[test]
+    fn full_day_window_is_always_active() {
+        // 00:00–24:00 covers every minute, so this holds whatever the clock says.
+        assert!(is_within_active_hours("00:00", "24:00", "local"));
+        assert!(is_within_active_hours("00:00", "24:00", "UTC"));
+    }
+
+    #[test]
+    fn empty_window_is_never_active() {
+        // An equal start and end leaves no minute in `now >= start && now < end`,
+        // which is what the config validator already warns about.
+        assert!(!is_within_active_hours("12:00", "12:00", "local"));
+        assert!(!is_within_active_hours("00:00", "00:00", "UTC"));
+    }
+
     // ── resolve_heartbeat_prompt ─────────────────────────────────────────
 
     #[test]

--- a/crates/cron/src/service.rs
+++ b/crates/cron/src/service.rs
@@ -4,7 +4,10 @@ use std::{
     collections::VecDeque,
     future::Future,
     pin::Pin,
-    sync::Arc,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
@@ -22,8 +25,12 @@ use moltis_metrics::{counter, cron as cron_metrics, gauge, histogram};
 use moltis_config::schema::ActiveHoursConfig;
 
 use crate::{
-    Error, Result, heartbeat::is_within_active_hours, schedule::compute_next_run, store::CronStore,
-    system_events::SystemEventsQueue, types::*,
+    Error, Result,
+    heartbeat::{is_within_active_hours, ms_until_active_hours},
+    schedule::compute_next_run,
+    store::CronStore,
+    system_events::SystemEventsQueue,
+    types::*,
 };
 
 /// Result of an agent turn, including optional token usage.
@@ -138,6 +145,12 @@ pub struct CronService {
     /// unrestricted, which is what callers that do not carry heartbeat config
     /// (tests, embedders) get.
     heartbeat_active_hours: Option<ActiveHoursConfig>,
+    /// Raised by [`CronService::wake`] and lowered by the run it asks for.
+    ///
+    /// A wake and a scheduled firing are indistinguishable by the time
+    /// `process_due_jobs` sees them -- both are just a due `next_run_at_ms` --
+    /// so the distinction has to be carried separately.
+    heartbeat_wake_pending: AtomicBool,
 }
 
 /// Max time a job can be in "running" state before we consider it stuck (2 hours).
@@ -248,13 +261,15 @@ impl CronService {
             events_queue,
             wake_cooldown_ms,
             heartbeat_active_hours,
+            heartbeat_wake_pending: AtomicBool::new(false),
         })
     }
 
-    /// Whether the scheduled heartbeat may run right now.
+    /// Whether a *scheduled* heartbeat firing may run right now.
     ///
-    /// Only the timer path consults this. An explicit [`CronService::wake`] is
-    /// a response to something that already happened, so it is not gated.
+    /// An explicit [`CronService::wake`] answers something that already
+    /// happened and is not gated by this; see `heartbeat_wake_pending`, which
+    /// is what keeps the two apart.
     fn heartbeat_may_run_now(&self) -> bool {
         self.heartbeat_active_hours
             .as_ref()
@@ -304,6 +319,9 @@ impl CronService {
 
             debug!(reason, "waking heartbeat");
             job.state.next_run_at_ms = Some(now);
+            // Without this the active-hours gate below would not merely defer
+            // the wake, it would overwrite the due time and lose it.
+            self.heartbeat_wake_pending.store(true, Ordering::Relaxed);
         }
         drop(jobs);
         self.wake_notify.notify_one();
@@ -581,14 +599,28 @@ impl CronService {
                     && job.state.next_run_at_ms.is_some_and(|t| t <= now)
                     && job.state.running_at_ms.is_none()
                 {
-                    if job.id == "__heartbeat__" && !heartbeat_may_run {
-                        // Outside the configured window. Roll the schedule
-                        // forward instead of running, so the job stops being
-                        // due and picks back up once the window reopens.
-                        debug!("skipping heartbeat — outside active hours");
-                        job.state.next_run_at_ms =
-                            compute_next_run(&job.schedule, now).unwrap_or(None);
-                        continue;
+                    if job.id == "__heartbeat__" {
+                        // Consume any pending wake here rather than at the gate,
+                        // so it is spent by the run it asked for whether or not
+                        // the window would have allowed that run anyway.
+                        let woken = self.heartbeat_wake_pending.swap(false, Ordering::Relaxed);
+                        if !woken && !heartbeat_may_run {
+                            // Outside the window. Defer to when it reopens, so
+                            // the job stops being due without being dropped: an
+                            // interval that is a whole number of days would
+                            // otherwise land on the same excluded time forever.
+                            let next = self
+                                .heartbeat_active_hours
+                                .as_ref()
+                                .and_then(|hours| {
+                                    ms_until_active_hours(&hours.start, &hours.end, &hours.timezone)
+                                })
+                                .map(|ms| now.saturating_add(ms))
+                                .or_else(|| compute_next_run(&job.schedule, now).unwrap_or(None));
+                            debug!(?next, "skipping heartbeat — outside active hours");
+                            job.state.next_run_at_ms = next;
+                            continue;
+                        }
                     }
                     // Mark as running under the write lock BEFORE spawning,
                     // so the next timer tick won't pick up the same job again.

--- a/crates/cron/src/service.rs
+++ b/crates/cron/src/service.rs
@@ -19,9 +19,11 @@ use {
 #[cfg(feature = "metrics")]
 use moltis_metrics::{counter, cron as cron_metrics, gauge, histogram};
 
+use moltis_config::schema::ActiveHoursConfig;
+
 use crate::{
-    Error, Result, schedule::compute_next_run, store::CronStore, system_events::SystemEventsQueue,
-    types::*,
+    Error, Result, heartbeat::is_within_active_hours, schedule::compute_next_run, store::CronStore,
+    system_events::SystemEventsQueue, types::*,
 };
 
 /// Result of an agent turn, including optional token usage.
@@ -132,6 +134,10 @@ pub struct CronService {
     events_queue: Arc<SystemEventsQueue>,
     /// Minimum ms between exec-triggered heartbeat wakes. Zero disables cooldown.
     wake_cooldown_ms: u64,
+    /// Window the scheduled heartbeat is allowed to run in. `None` leaves it
+    /// unrestricted, which is what callers that do not carry heartbeat config
+    /// (tests, embedders) get.
+    heartbeat_active_hours: Option<ActiveHoursConfig>,
 }
 
 /// Max time a job can be in "running" state before we consider it stuck (2 hours).
@@ -211,6 +217,7 @@ impl CronService {
             rate_limit_config,
             wake_cooldown_ms,
             SystemEventsQueue::new(),
+            None,
         )
     }
 
@@ -226,6 +233,7 @@ impl CronService {
         rate_limit_config: RateLimitConfig,
         wake_cooldown_ms: u64,
         events_queue: Arc<SystemEventsQueue>,
+        heartbeat_active_hours: Option<ActiveHoursConfig>,
     ) -> Arc<Self> {
         Arc::new(Self {
             store,
@@ -239,7 +247,18 @@ impl CronService {
             rate_limiter: Mutex::new(RateLimiter::new(rate_limit_config)),
             events_queue,
             wake_cooldown_ms,
+            heartbeat_active_hours,
         })
+    }
+
+    /// Whether the scheduled heartbeat may run right now.
+    ///
+    /// Only the timer path consults this. An explicit [`CronService::wake`] is
+    /// a response to something that already happened, so it is not gated.
+    fn heartbeat_may_run_now(&self) -> bool {
+        self.heartbeat_active_hours
+            .as_ref()
+            .is_none_or(|hours| is_within_active_hours(&hours.start, &hours.end, &hours.timezone))
     }
 
     /// Access the shared events queue for enqueueing system events.
@@ -553,6 +572,7 @@ impl CronService {
 
     async fn process_due_jobs(self: &Arc<Self>) {
         let now = now_ms();
+        let heartbeat_may_run = self.heartbeat_may_run_now();
         let due_jobs: Vec<CronJob> = {
             let mut jobs = self.jobs.write().await;
             let mut due = Vec::new();
@@ -561,6 +581,15 @@ impl CronService {
                     && job.state.next_run_at_ms.is_some_and(|t| t <= now)
                     && job.state.running_at_ms.is_none()
                 {
+                    if job.id == "__heartbeat__" && !heartbeat_may_run {
+                        // Outside the configured window. Roll the schedule
+                        // forward instead of running, so the job stops being
+                        // due and picks back up once the window reopens.
+                        debug!("skipping heartbeat — outside active hours");
+                        job.state.next_run_at_ms =
+                            compute_next_run(&job.schedule, now).unwrap_or(None);
+                        continue;
+                    }
                     // Mark as running under the write lock BEFORE spawning,
                     // so the next timer tick won't pick up the same job again.
                     job.state.running_at_ms = Some(now);

--- a/crates/cron/src/service/tests.rs
+++ b/crates/cron/src/service/tests.rs
@@ -1088,13 +1088,13 @@ fn make_svc_with_active_hours(
     )
 }
 
-/// Add a heartbeat job and make it due right now.
-async fn add_due_heartbeat(svc: &Arc<CronService>) {
+/// Add a heartbeat job on an `every_ms` interval and make it due right now.
+async fn add_due_heartbeat_every(svc: &Arc<CronService>, every_ms: u64) {
     svc.add(CronJobCreate {
         id: Some("__heartbeat__".into()),
         name: "__heartbeat__".into(),
         schedule: CronSchedule::Every {
-            every_ms: 30_000,
+            every_ms,
             anchor_ms: None,
         },
         payload: CronPayload::AgentTurn {
@@ -1119,6 +1119,24 @@ async fn add_due_heartbeat(svc: &Arc<CronService>) {
 
     let mut jobs = svc.jobs.write().await;
     jobs[0].state.next_run_at_ms = Some(now_ms());
+}
+
+/// Add a heartbeat due right now on the usual short interval.
+async fn add_due_heartbeat(svc: &Arc<CronService>) {
+    add_due_heartbeat_every(svc, 30_000).await;
+}
+
+/// A window that is shut right now and opens `hours` from now, local time.
+///
+/// Derived from the clock rather than hard-coded so the test means the same
+/// thing whenever it runs.
+fn window_shut_now_opening_in(hours: u32) -> (String, String) {
+    use chrono::Timelike;
+    let start = (chrono::Local::now().hour() + hours) % 24;
+    (
+        format!("{start:02}:00"),
+        format!("{:02}:00", (start + 1) % 24),
+    )
 }
 
 #[tokio::test]
@@ -1149,7 +1167,10 @@ async fn heartbeat_outside_active_hours_is_skipped_and_rescheduled() {
 
 #[tokio::test]
 async fn heartbeat_inside_active_hours_still_runs() {
-    // The control for the test above: 00:00–24:00 covers every minute.
+    // The control for the test above. Note *why* this is always active:
+    // "24:00" is not a valid `%H:%M` time, so `is_within_active_hours` takes
+    // its invalid-config branch and reports active. It is not that the window
+    // is parsed as covering the whole day.
     let svc = make_svc_with_active_hours(
         Arc::new(InMemoryStore::new()),
         noop_agent_turn(),
@@ -1181,4 +1202,88 @@ async fn heartbeat_without_configured_hours_runs() {
 
     let jobs = svc.jobs.read().await;
     assert!(jobs[0].state.running_at_ms.is_some());
+}
+
+#[tokio::test]
+async fn an_explicit_wake_is_not_swallowed_by_the_active_hours_gate() {
+    // `wake` only marks the heartbeat due; the run itself happens in
+    // `process_due_jobs`, which is also where the gate is. Without the pending
+    // flag the gate does not merely defer the wake, it overwrites the due time
+    // and the wake is gone.
+    let svc = make_svc_with_active_hours(
+        Arc::new(InMemoryStore::new()),
+        noop_agent_turn(),
+        "12:00",
+        "12:00",
+    );
+    add_due_heartbeat(&svc).await;
+
+    svc.wake(WAKE_REASON_CRON_EVENT).await;
+    svc.process_due_jobs().await;
+
+    let jobs = svc.jobs.read().await;
+    assert!(
+        jobs[0].state.running_at_ms.is_some(),
+        "an explicit wake was suppressed by the active-hours window"
+    );
+}
+
+#[tokio::test]
+async fn a_wake_is_spent_by_the_run_it_asks_for() {
+    // The flag must not stay raised, or the next scheduled firing rides in on
+    // a wake that was already served.
+    let svc = make_svc_with_active_hours(
+        Arc::new(InMemoryStore::new()),
+        noop_agent_turn(),
+        "12:00",
+        "12:00",
+    );
+    add_due_heartbeat(&svc).await;
+
+    svc.wake(WAKE_REASON_CRON_EVENT).await;
+    svc.process_due_jobs().await;
+    {
+        // Clear the run so the job is eligible again, as completion would.
+        let mut jobs = svc.jobs.write().await;
+        jobs[0].state.running_at_ms = None;
+        jobs[0].state.next_run_at_ms = Some(now_ms());
+    }
+    svc.process_due_jobs().await;
+
+    let jobs = svc.jobs.read().await;
+    assert!(
+        jobs[0].state.running_at_ms.is_none(),
+        "a spent wake let a scheduled firing through the window"
+    );
+}
+
+#[tokio::test]
+async fn a_daily_heartbeat_outside_the_window_is_deferred_to_it_not_past_it() {
+    // Rolling the schedule forward by its own interval lands a whole-day
+    // interval on the same excluded wall-clock time every day, so it never
+    // runs again. The skip has to aim at the window instead.
+    const DAY_MS: u64 = 24 * 60 * 60 * 1000;
+    let (start, end) = window_shut_now_opening_in(2);
+    let svc = make_svc_with_active_hours(
+        Arc::new(InMemoryStore::new()),
+        noop_agent_turn(),
+        &start,
+        &end,
+    );
+    add_due_heartbeat_every(&svc, DAY_MS).await;
+
+    let before = now_ms();
+    svc.process_due_jobs().await;
+
+    let jobs = svc.jobs.read().await;
+    assert!(
+        jobs[0].state.running_at_ms.is_none(),
+        "ran outside {start}-{end}"
+    );
+    let next = jobs[0].state.next_run_at_ms.expect("still scheduled");
+    assert!(next > before, "skipped heartbeat stayed due");
+    assert!(
+        next < before + DAY_MS,
+        "deferred a full day to {next} instead of to the window opening"
+    );
 }

--- a/crates/cron/src/service/tests.rs
+++ b/crates/cron/src/service/tests.rs
@@ -1062,3 +1062,123 @@ async fn test_zero_wake_cooldown_disables_guard() {
         "wake should proceed when cooldown is zero (disabled)"
     );
 }
+
+// ── heartbeat active hours ───────────────────────────────────────────────
+
+/// A service whose scheduled heartbeat is confined to `start`–`end` local time.
+fn make_svc_with_active_hours(
+    store: Arc<InMemoryStore>,
+    agent: AgentTurnFn,
+    start: &str,
+    end: &str,
+) -> Arc<CronService> {
+    CronService::with_events_queue(
+        store,
+        noop_system_event(),
+        agent,
+        None,
+        RateLimitConfig::default(),
+        DEFAULT_WAKE_COOLDOWN_MS,
+        SystemEventsQueue::new(),
+        Some(ActiveHoursConfig {
+            start: start.into(),
+            end: end.into(),
+            timezone: "local".into(),
+        }),
+    )
+}
+
+/// Add a heartbeat job and make it due right now.
+async fn add_due_heartbeat(svc: &Arc<CronService>) {
+    svc.add(CronJobCreate {
+        id: Some("__heartbeat__".into()),
+        name: "__heartbeat__".into(),
+        schedule: CronSchedule::Every {
+            every_ms: 30_000,
+            anchor_ms: None,
+        },
+        payload: CronPayload::AgentTurn {
+            message: "tick".into(),
+            model: None,
+            agent_id: None,
+            timeout_secs: None,
+            tool_controls: Default::default(),
+            deliver: false,
+            channel: None,
+            to: None,
+        },
+        session_target: SessionTarget::Named("heartbeat".into()),
+        delete_after_run: false,
+        enabled: true,
+        system: true,
+        sandbox: CronSandboxConfig::default(),
+        wake_mode: CronWakeMode::default(),
+    })
+    .await
+    .unwrap();
+
+    let mut jobs = svc.jobs.write().await;
+    jobs[0].state.next_run_at_ms = Some(now_ms());
+}
+
+#[tokio::test]
+async fn heartbeat_outside_active_hours_is_skipped_and_rescheduled() {
+    // An equal start and end leaves no minute inside the window, so this is
+    // outside it whatever the clock says.
+    let svc = make_svc_with_active_hours(
+        Arc::new(InMemoryStore::new()),
+        noop_agent_turn(),
+        "12:00",
+        "12:00",
+    );
+    add_due_heartbeat(&svc).await;
+
+    let before = now_ms();
+    svc.process_due_jobs().await;
+
+    let jobs = svc.jobs.read().await;
+    assert!(
+        jobs[0].state.running_at_ms.is_none(),
+        "heartbeat ran outside its active hours"
+    );
+    assert!(
+        jobs[0].state.next_run_at_ms.is_some_and(|t| t > before),
+        "skipped heartbeat stayed due instead of rolling forward"
+    );
+}
+
+#[tokio::test]
+async fn heartbeat_inside_active_hours_still_runs() {
+    // The control for the test above: 00:00–24:00 covers every minute.
+    let svc = make_svc_with_active_hours(
+        Arc::new(InMemoryStore::new()),
+        noop_agent_turn(),
+        "00:00",
+        "24:00",
+    );
+    add_due_heartbeat(&svc).await;
+
+    svc.process_due_jobs().await;
+
+    let jobs = svc.jobs.read().await;
+    assert!(
+        jobs[0].state.running_at_ms.is_some(),
+        "heartbeat did not run inside its active hours"
+    );
+}
+
+#[tokio::test]
+async fn heartbeat_without_configured_hours_runs() {
+    // Callers that do not carry heartbeat config must not be gated.
+    let svc = make_svc(
+        Arc::new(InMemoryStore::new()),
+        noop_system_event(),
+        noop_agent_turn(),
+    );
+    add_due_heartbeat(&svc).await;
+
+    svc.process_due_jobs().await;
+
+    let jobs = svc.jobs.read().await;
+    assert!(jobs[0].state.running_at_ms.is_some());
+}

--- a/crates/gateway/src/server/prepare_core.rs
+++ b/crates/gateway/src/server/prepare_core.rs
@@ -941,6 +941,7 @@ pub async fn prepare_gateway_core_with_profile(
         rate_limit_config,
         wake_cooldown_ms,
         events_queue,
+        Some(config.heartbeat.active_hours.clone()),
     );
 
     let live_cron = Arc::new(crate::cron::LiveCronService::new(Arc::clone(&cron_service)));


### PR DESCRIPTION
Closes #1205.

## Summary

`heartbeat.active_hours` never had any effect. `is_within_active_hours` is written, documented and tested in `crates/cron/src/heartbeat.rs`, but nothing in the crate calls it — the heartbeat is a plain `Every { every_ms }` cron job, and `process_due_jobs` runs whatever is due without consulting the window. A server configured for 07:00–23:00 kept taking heartbeat turns through the night, which is what @IlyaBizyaev observed.

`CronService` now carries the window next to the wake cooldown it already holds, threaded from `config.heartbeat` in `prepare_core.rs` the same way. When the heartbeat comes up due outside the window, `process_due_jobs` rolls its schedule forward instead of running it. Rolling forward rather than leaving it due matters — a skipped job that stayed due would be retried on every tick.

Explicit `wake()` calls are not gated. Those respond to something that already happened, and the cooldown there is a separate concern.

**User-facing impact worth calling out.** `ActiveHoursConfig::default()` is `08:00`–`24:00`, so anyone who never configured `[heartbeat.active_hours]` has effectively been running 24/7 and will now stop between 00:00 and 08:00. That is the default the config template ships and the reference documents ("heartbeats only run during this window"), so this brings the code in line with the docs rather than changing the contract — but it is a behaviour change on upgrade for those users. `start = "00:00"` with `end = "24:00"` covers every minute if someone wants the old behaviour back.

The three existing `is_within_active_hours` tests say "We can't assert exact behavior without controlling time", which is why this went unnoticed — two of them discard the result and only check for the absence of a panic. Two windows are in fact clock-independent: an equal start and end leaves no minute in `now >= start && now < end`, and `00:00`–`24:00` covers all of them. The new tests use those, so nothing here depends on when CI runs.

## Validation

### Completed

- [x] `cargo test -p moltis-cron --lib` — 140 passed, including 5 new tests
- [x] `cargo test -p moltis-gateway --lib` — 640 passed
- [x] `cargo check --workspace --lib --tests`
- [x] `cargo fmt --all -- --check`
- [x] `just lint`

Two closed-loop rounds on identical file hashes. Disabling the gate alone fails only `heartbeat_outside_active_hours_is_skipped_and_rescheduled`; the in-window and no-config-window tests keep passing, so the new test is specific to the fix rather than to the surrounding scaffolding.

The service-level tests call `process_due_jobs` directly and assert on state set synchronously under the write lock, so they need no timer and no sleep.

### Remaining

- [ ] `./scripts/local-validate.sh <PR>`
- [ ] Overnight behaviour against a real clock — the unit tests cover the decision, not a live night

## Manual QA

Not exercised against a running server. The observable change is that a heartbeat coming up due outside the window logs `skipping heartbeat — outside active hours` at debug level and its `next_run_at_ms` advances by one interval instead of a turn being taken; `__heartbeat__` run history should show no entries inside the excluded hours.
