### PR TITLE
fix(gateway): treat heartbeat.update params as a patch, not a whole config

### DIFF
--- a/crates/gateway/src/methods/services/core.rs
+++ b/crates/gateway/src/methods/services/core.rs
@@ -42,6 +42,39 @@ async fn prepare_chat_send_params(ctx: &MethodContext) -> serde_json::Value {
     params
 }
 
+/// Overlay `patch` onto `base`, recursing into objects so a partial nested
+/// object updates the keys it carries instead of replacing the whole thing.
+fn overlay_json(base: &mut serde_json::Value, patch: &serde_json::Value) {
+    match (base, patch) {
+        (serde_json::Value::Object(base), serde_json::Value::Object(patch)) => {
+            for (key, value) in patch {
+                overlay_json(
+                    base.entry(key.clone()).or_insert(serde_json::Value::Null),
+                    value,
+                );
+            }
+        },
+        (base, patch) => *base = patch.clone(),
+    }
+}
+
+/// Apply a `heartbeat.update` payload to the configuration already in effect.
+///
+/// [`HeartbeatConfig`](moltis_config::schema::HeartbeatConfig) is
+/// `#[serde(default)]`, so deserializing a payload on its own turns every key
+/// the caller left out into that key's default. The settings form only sends
+/// the fields it renders — it has no input for `wake_cooldown` or `agent_id` —
+/// so treating the payload as a whole config quietly rewrites the rest. An
+/// explicit `null` still clears an optional field.
+fn apply_heartbeat_patch(
+    current: &moltis_config::schema::HeartbeatConfig,
+    patch: &serde_json::Value,
+) -> Result<moltis_config::schema::HeartbeatConfig, serde_json::Error> {
+    let mut merged = serde_json::to_value(current)?;
+    overlay_json(&mut merged, patch);
+    serde_json::from_value(merged)
+}
+
 pub(super) fn register(reg: &mut MethodRegistry) {
     // Config
     reg.register(
@@ -376,14 +409,18 @@ pub(super) fn register(reg: &mut MethodRegistry) {
             "heartbeat.update",
             Box::new(|ctx| {
                 Box::pin(async move {
-                    let patch: moltis_config::schema::HeartbeatConfig =
-                        serde_json::from_value(ctx.params.clone()).map_err(|e| {
-                            ErrorShape::new(
-                                error_codes::INVALID_REQUEST,
-                                format!("invalid heartbeat config: {e}"),
-                            )
-                        })?;
-                    ctx.state.inner.write().await.heartbeat_config = patch.clone();
+                    let patch = {
+                        let mut state = ctx.state.inner.write().await;
+                        let patch = apply_heartbeat_patch(&state.heartbeat_config, &ctx.params)
+                            .map_err(|e| {
+                                ErrorShape::new(
+                                    error_codes::INVALID_REQUEST,
+                                    format!("invalid heartbeat config: {e}"),
+                                )
+                            })?;
+                        state.heartbeat_config = patch.clone();
+                        patch
+                    };
 
                     // Persist to moltis.toml so the config survives restarts.
                     if let Err(e) = moltis_config::update_config(|cfg| {
@@ -1408,5 +1445,68 @@ mod tests {
         assert_eq!(params["_tool_audience"], "public");
         assert_eq!(params["_tool_policy"]["deny"][0], "*");
         assert_eq!(params["_private_context"], false);
+    }
+
+    #[test]
+    fn a_heartbeat_update_leaves_fields_the_payload_omits_alone() -> anyhow::Result<()> {
+        let current = moltis_config::schema::HeartbeatConfig {
+            wake_cooldown: "1h".into(),
+            agent_id: Some("night-shift".into()),
+            ..Default::default()
+        };
+
+        // What the settings form sends. It has no input for `wake_cooldown` or
+        // `agent_id`, so neither key is in the payload.
+        let saved = apply_heartbeat_patch(
+            &current,
+            &serde_json::json!({
+                "enabled": true,
+                "every": "15m",
+                "ack_max_chars": 300,
+                "deliver": false,
+                "sandbox_enabled": true,
+                "active_hours": {"start": "07:00", "end": "23:00", "timezone": "local"},
+            }),
+        )?;
+
+        assert_eq!(saved.every, "15m");
+        assert_eq!(saved.wake_cooldown, "1h");
+        assert_eq!(saved.agent_id.as_deref(), Some("night-shift"));
+        Ok(())
+    }
+
+    #[test]
+    fn a_partial_active_hours_moves_only_the_keys_it_carries() -> anyhow::Result<()> {
+        let current = moltis_config::schema::HeartbeatConfig {
+            active_hours: moltis_config::schema::ActiveHoursConfig {
+                start: "09:00".into(),
+                end: "21:00".into(),
+                timezone: "UTC".into(),
+            },
+            ..Default::default()
+        };
+
+        let saved = apply_heartbeat_patch(
+            &current,
+            &serde_json::json!({"active_hours": {"start": "07:00"}}),
+        )?;
+
+        assert_eq!(saved.active_hours.start, "07:00");
+        assert_eq!(saved.active_hours.end, "21:00");
+        assert_eq!(saved.active_hours.timezone, "UTC");
+        Ok(())
+    }
+
+    #[test]
+    fn an_explicit_null_still_clears_an_optional_field() -> anyhow::Result<()> {
+        let current = moltis_config::schema::HeartbeatConfig {
+            model: Some("anthropic/claude-sonnet-4".into()),
+            ..Default::default()
+        };
+
+        let saved = apply_heartbeat_patch(&current, &serde_json::json!({"model": null}))?;
+
+        assert!(saved.model.is_none());
+        Ok(())
     }
 }

--- a/crates/web/ui/src/pages/CronsPage.tsx
+++ b/crates/web/ui/src/pages/CronsPage.tsx
@@ -55,15 +55,15 @@ interface CronStatusInfo {
 interface HeartbeatConfig {
 	enabled?: boolean;
 	every?: string;
-	model?: string;
-	prompt?: string;
+	model?: string | null;
+	prompt?: string | null;
 	ack_max_chars?: number;
 	deliver?: boolean;
-	channel?: string;
-	to?: string;
+	channel?: string | null;
+	to?: string | null;
 	active_hours?: { start?: string; end?: string; timezone?: string };
 	sandbox_enabled?: boolean;
-	sandbox_image?: string;
+	sandbox_image?: string | null;
 }
 
 interface HeartbeatStatusInfo {
@@ -266,23 +266,27 @@ function cronTimezoneHelpText(): string {
 		: "Leave blank to use UTC. Enter a timezone like Europe/Paris to use your local timezone.";
 }
 
+// heartbeat.update merges its payload onto the config already in effect, so a
+// key that is absent means "leave this alone". JSON.stringify drops undefined
+// properties, so an emptied optional field has to go out as an explicit null to
+// clear it.
 function collectHeartbeatForm(form: Element): HeartbeatConfig {
 	return {
 		enabled: (form.querySelector("[data-hb=enabled]") as HTMLInputElement).checked,
 		every: (form.querySelector("[data-hb=every]") as HTMLInputElement).value.trim() || "30m",
-		model: heartbeatModel.value || undefined,
-		prompt: (form.querySelector("[data-hb=prompt]") as HTMLTextAreaElement).value.trim() || undefined,
+		model: heartbeatModel.value || null,
+		prompt: (form.querySelector("[data-hb=prompt]") as HTMLTextAreaElement).value.trim() || null,
 		ack_max_chars: parseInt((form.querySelector("[data-hb=ackMax]") as HTMLInputElement).value, 10) || 300,
 		deliver: (form.querySelector("[data-hb=deliver]") as HTMLInputElement).checked,
-		channel: (form.querySelector("[data-hb=channel]") as HTMLInputElement).value.trim() || undefined,
-		to: (form.querySelector("[data-hb=to]") as HTMLInputElement).value.trim() || undefined,
+		channel: (form.querySelector("[data-hb=channel]") as HTMLInputElement).value.trim() || null,
+		to: (form.querySelector("[data-hb=to]") as HTMLInputElement).value.trim() || null,
 		active_hours: {
 			start: (form.querySelector("[data-hb=ahStart]") as HTMLInputElement).value.trim() || "08:00",
 			end: (form.querySelector("[data-hb=ahEnd]") as HTMLInputElement).value.trim() || "24:00",
 			timezone: (form.querySelector("[data-hb=ahTz]") as HTMLSelectElement).value.trim() || "local",
 		},
 		sandbox_enabled: (form.querySelector("[data-hb=sandboxEnabled]") as HTMLInputElement).checked,
-		sandbox_image: heartbeatSandboxImage.value || undefined,
+		sandbox_image: heartbeatSandboxImage.value || null,
 	};
 }
 


### PR DESCRIPTION
Closes #1187.

## Summary

`heartbeat.update` deserializes its params straight into `HeartbeatConfig` and assigns the result over the whole config, both in state and in `moltis.toml`. The struct is `#[serde(default)]`, so every key the caller leaves out comes back as that key's default rather than being left alone — the payload is treated as a whole config even though the handler calls it a patch.

`collectHeartbeatForm` in `CronsPage.tsx` builds its payload from the inputs the page renders, and there is no input for `wake_cooldown` or `agent_id`. So pressing Save rewrites `wake_cooldown` to `"5m"` and drops `agent_id`. @IlyaBizyaev reported the first; `agent_id` goes the same way.

The payload is now overlaid on the configuration already in effect instead of replacing it. The merge recurses into objects so `active_hours` behaves the same way one level down — sending only `start` no longer resets `end` and `timezone`. An explicit `null` clears an optional field.

That last part needed a companion change in the form. `collectHeartbeatForm` assigned `undefined` to an emptied `model`, `prompt`, `channel`, `to` or `sandbox_image`, and `JSON.stringify` drops undefined properties, so under merge semantics none of those five could be cleared any more. It now sends `null` for them, which the endpoint reads as a clear.

Reading the current config and writing the merged one happen under a single write lock, so two updates can't merge onto the same stale copy.

Fixing this server-side covers every caller rather than just the form, including the enabled toggle, which sends back whatever the last save left in the client's copy.

## Validation

### Completed

- [x] `cargo test -p moltis-gateway --lib` — 643 passed, 3 of them new
- [x] `cargo check --workspace --lib --tests`
- [x] `cargo fmt --all -- --check`
- [x] `just lint`
- [x] `tsc --noEmit`
- [x] `biome ci crates/web/ui/src/ crates/web/ui/e2e/` — same 21 diagnostics on `CronsPage.tsx` as `main`, exit 0

Two closed-loop rounds on an identical file hash. Restoring the old whole-config behaviour fails exactly the two tests that pin the fix — `wake_cooldown` comes back `"5m"` instead of `"1h"`, `active_hours.end` `"24:00"` instead of `"21:00"`, which is the reported symptom. The third test (an explicit `null` still clears an optional field) passes either way and acts as the control.

### Remaining

- [ ] `./scripts/local-validate.sh <PR>`
- [ ] Save on the real Heartbeat page against a `moltis.toml` carrying a non-default `wake_cooldown`

## Manual QA

Not exercised against a running server. By hand: set `wake_cooldown = "1h"` under `[heartbeat]` in `moltis.toml`, press Save on the Heartbeat page, and confirm the file still reads `"1h"`. Before this change it comes back `"5m"`.

The page still has no input for `wake_cooldown` or `agent_id`. This stops Save from clobbering them; it does not add a way to edit them there.