### PR TITLE
Preserve Responses routing for explicit OpenAI endpoints

### DIFF
--- a/crates/providers/src/registry/registration.rs
+++ b/crates/providers/src/registry/registration.rs
@@ -39,20 +39,18 @@ const OPENAI_DEFAULT_BASE_URL: &str = "https://api.openai.com/v1";
 fn resolve_openai_base_url(
     config: &ProvidersConfig,
     env_overrides: &HashMap<String, String>,
-) -> (String, bool) {
+) -> String {
     if let Some(base_url) = config.get("openai").and_then(|e| e.base_url.clone()) {
-        return (base_url, true);
+        return base_url;
     }
     if let Some(base_url) = env_value(env_overrides, "OPENAI_BASE_URL") {
-        return (base_url, true);
+        return base_url;
     }
-    (OPENAI_DEFAULT_BASE_URL.into(), false)
+    OPENAI_DEFAULT_BASE_URL.into()
 }
 
-pub(crate) fn openai_builtin_capabilities(
-    base_url_overridden: bool,
-) -> openai::OpenAiProviderCapabilities {
-    if base_url_overridden {
+pub(crate) fn openai_builtin_capabilities(base_url: &str) -> openai::OpenAiProviderCapabilities {
+    if base_url.trim().trim_end_matches('/') != OPENAI_DEFAULT_BASE_URL {
         return openai::OpenAiProviderCapabilities::DEFAULT;
     }
     openai::OpenAiProviderCapabilities {
@@ -116,8 +114,8 @@ impl ProviderRegistry {
             && config.is_enabled("openai")
             && let Some(key) = resolve_api_key(config, "openai", "OPENAI_API_KEY", env_overrides)
         {
-            let (base_url, base_url_overridden) = resolve_openai_base_url(config, env_overrides);
-            let capabilities = openai_builtin_capabilities(base_url_overridden);
+            let base_url = resolve_openai_base_url(config, env_overrides);
+            let capabilities = openai_builtin_capabilities(&base_url);
             let alias = config.get("openai").and_then(|e| e.alias.clone());
             let provider_label = alias.unwrap_or_else(|| "openai".into());
             let stream_transport = config
@@ -493,7 +491,7 @@ impl ProviderRegistry {
             return;
         };
 
-        let (base_url, _) = resolve_openai_base_url(config, env_overrides);
+        let base_url = resolve_openai_base_url(config, env_overrides);
 
         let model_id = configured_models_for_provider(config, "openai")
             .into_iter()
@@ -825,8 +823,8 @@ impl ProviderRegistry {
         if config.is_enabled("openai")
             && let Some(key) = resolve_api_key(config, "openai", "OPENAI_API_KEY", env_overrides)
         {
-            let (base_url, base_url_overridden) = resolve_openai_base_url(config, env_overrides);
-            let capabilities = openai_builtin_capabilities(base_url_overridden);
+            let base_url = resolve_openai_base_url(config, env_overrides);
+            let capabilities = openai_builtin_capabilities(&base_url);
 
             // Get alias if configured (for metrics differentiation).
             let alias = config.get("openai").and_then(|e| e.alias.clone());

--- a/crates/providers/src/registry/registration.rs
+++ b/crates/providers/src/registry/registration.rs
@@ -50,7 +50,15 @@ fn resolve_openai_base_url(
 }
 
 pub(crate) fn openai_builtin_capabilities(base_url: &str) -> openai::OpenAiProviderCapabilities {
-    if base_url.trim().trim_end_matches('/') != OPENAI_DEFAULT_BASE_URL {
+    let is_openai_platform = reqwest::Url::parse(base_url.trim()).is_ok_and(|url| {
+        url.scheme() == "https"
+            && url.host_str() == Some("api.openai.com")
+            && url.port_or_known_default() == Some(443)
+            && url.path().trim_end_matches('/') == "/v1"
+            && url.query().is_none()
+            && url.fragment().is_none()
+    });
+    if !is_openai_platform {
         return openai::OpenAiProviderCapabilities::DEFAULT;
     }
     openai::OpenAiProviderCapabilities {

--- a/crates/providers/src/registry/tests.rs
+++ b/crates/providers/src/registry/tests.rs
@@ -18,7 +18,17 @@ const FIREWORKS_KIMI_ROUTER: &str = "accounts/fireworks/routers/kimi-k2p5-turbo"
 
 #[test]
 fn openai_default_base_url_enables_responses_websocket() {
-    let capabilities = openai_builtin_capabilities(false);
+    let capabilities = openai_builtin_capabilities("https://api.openai.com/v1");
+    assert_eq!(
+        capabilities.responses_websocket_policy,
+        ResponsesWebSocketPolicy::OpenAiPlatform,
+    );
+    assert!(capabilities.responses_required_for_reasoning_tools);
+}
+
+#[test]
+fn openai_explicit_default_base_url_enables_responses_routing() {
+    let capabilities = openai_builtin_capabilities(" https://api.openai.com/v1/ ");
     assert_eq!(
         capabilities.responses_websocket_policy,
         ResponsesWebSocketPolicy::OpenAiPlatform,
@@ -28,7 +38,7 @@ fn openai_default_base_url_enables_responses_websocket() {
 
 #[test]
 fn openai_custom_base_url_disables_responses_websocket() {
-    let capabilities = openai_builtin_capabilities(true);
+    let capabilities = openai_builtin_capabilities("https://openai-compatible.example/v1");
     assert_eq!(
         capabilities.responses_websocket_policy,
         ResponsesWebSocketPolicy::Unsupported,

--- a/crates/providers/src/registry/tests.rs
+++ b/crates/providers/src/registry/tests.rs
@@ -28,22 +28,42 @@ fn openai_default_base_url_enables_responses_websocket() {
 
 #[test]
 fn openai_explicit_default_base_url_enables_responses_routing() {
-    let capabilities = openai_builtin_capabilities(" https://api.openai.com/v1/ ");
-    assert_eq!(
-        capabilities.responses_websocket_policy,
-        ResponsesWebSocketPolicy::OpenAiPlatform,
-    );
-    assert!(capabilities.responses_required_for_reasoning_tools);
+    for base_url in [
+        " https://api.openai.com/v1/ ",
+        "https://API.OPENAI.COM/v1",
+        "https://api.openai.com:443/v1",
+    ] {
+        let capabilities = openai_builtin_capabilities(base_url);
+        assert_eq!(
+            capabilities.responses_websocket_policy,
+            ResponsesWebSocketPolicy::OpenAiPlatform,
+            "{base_url}",
+        );
+        assert!(
+            capabilities.responses_required_for_reasoning_tools,
+            "{base_url}"
+        );
+    }
 }
 
 #[test]
 fn openai_custom_base_url_disables_responses_websocket() {
-    let capabilities = openai_builtin_capabilities("https://openai-compatible.example/v1");
-    assert_eq!(
-        capabilities.responses_websocket_policy,
-        ResponsesWebSocketPolicy::Unsupported,
-    );
-    assert!(!capabilities.responses_required_for_reasoning_tools);
+    for base_url in [
+        "https://openai-compatible.example/v1",
+        "http://api.openai.com/v1",
+        "https://api.openai.com/v1?proxy=true",
+    ] {
+        let capabilities = openai_builtin_capabilities(base_url);
+        assert_eq!(
+            capabilities.responses_websocket_policy,
+            ResponsesWebSocketPolicy::Unsupported,
+            "{base_url}",
+        );
+        assert!(
+            !capabilities.responses_required_for_reasoning_tools,
+            "{base_url}"
+        );
+    }
 }
 
 fn capture_one_json_request() -> anyhow::Result<(String, mpsc::Receiver<anyhow::Result<Value>>)> {


### PR DESCRIPTION
## Summary

- classify the built-in OpenAI endpoint by its normalized URL instead of whether it was explicitly configured
- preserve Responses routing for reasoning plus function tools when `OPENAI_BASE_URL` or saved provider config contains the official OpenAI URL
- keep custom OpenAI-compatible endpoints on their existing Chat Completions behavior

Fixes the regression reported in https://github.com/moltis-org/moltis/pull/1198#issuecomment-5336148769.

## Validation

### Completed

- [x] `cargo test -p moltis-providers registry::tests::openai_`
- [x] `cargo test -p moltis-providers openai::provider::core::tests`
- [x] `cargo test -p moltis-providers responses_sse_body_combines_reasoning_and_function_tools`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p moltis-providers --all-targets -- -D warnings`
- [x] `just lint`
- [x] `just release-preflight`
- [x] `git diff --check`

### Remaining

- [ ] `./scripts/local-validate.sh <PR_NUMBER>`

## Manual QA

1. Configure OpenAI with `base_url = "https://api.openai.com/v1"` or set the equivalent `OPENAI_BASE_URL`.
2. Select `gpt-5.6-sol` with a non-`none` reasoning effort and function tools enabled.
3. Confirm the request uses `/v1/responses` and completes tool calls without the Chat Completions `reasoning_effort` error.
4. Confirm a genuinely custom OpenAI-compatible endpoint keeps using its configured wire API.