### PR TITLE
Add GPT-5.6 Luna routing coverage

### DIFF
--- a/crates/providers/src/openai/provider/core.rs
+++ b/crates/providers/src/openai/provider/core.rs
@@ -674,19 +674,26 @@ mod tests {
     }
 
     #[test]
-    fn openai_reasoning_with_tools_uses_responses_api() {
-        let mut provider = OpenAiProvider::new(
-            secrecy::Secret::new("test-key".to_string()),
-            "gpt-5.6-luna".to_string(),
-            "https://api.openai.com/v1".to_string(),
-        );
-        provider.reasoning_effort = Some(ReasoningEffort::High);
+    fn openai_gpt_5_6_reasoning_with_tools_uses_responses_api() {
+        for model in ["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"] {
+            let mut provider = OpenAiProvider::new(
+                secrecy::Secret::new("test-key".to_string()),
+                model.to_string(),
+                "https://api.openai.com/v1".to_string(),
+            );
+            provider.reasoning_effort = Some(ReasoningEffort::High);
 
-        assert_eq!(provider.wire_api_for_request(true), WireApi::Responses);
-        assert_eq!(
-            provider.wire_api_for_request(false),
-            WireApi::ChatCompletions
-        );
+            assert_eq!(
+                provider.wire_api_for_request(true),
+                WireApi::Responses,
+                "{model}",
+            );
+            assert_eq!(
+                provider.wire_api_for_request(false),
+                WireApi::ChatCompletions,
+                "{model}",
+            );
+        }
     }
 
     #[test]

--- a/crates/providers/src/openai/provider/core.rs
+++ b/crates/providers/src/openai/provider/core.rs
@@ -677,7 +677,7 @@ mod tests {
     fn openai_reasoning_with_tools_uses_responses_api() {
         let mut provider = OpenAiProvider::new(
             secrecy::Secret::new("test-key".to_string()),
-            "gpt-5.6-sol".to_string(),
+            "gpt-5.6-luna".to_string(),
             "https://api.openai.com/v1".to_string(),
         );
         provider.reasoning_effort = Some(ReasoningEffort::High);

--- a/crates/providers/tests/openai_integration.rs
+++ b/crates/providers/tests/openai_integration.rs
@@ -8,21 +8,29 @@
 
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
-use std::collections::HashSet;
+use std::{collections::HashSet, sync::Arc};
 
 use {
     futures::StreamExt,
-    moltis_agents::model::{ChatMessage, LlmProvider, StreamEvent, ToolCall},
+    moltis_agents::model::{ChatMessage, LlmProvider, ReasoningEffort, StreamEvent, ToolCall},
     moltis_providers::openai::OpenAiProvider,
     secrecy::{ExposeSecret, Secret},
 };
 
 const OPENAI_BASE_URL: &str = "https://api.openai.com/v1";
 const TEST_MODEL: &str = "gpt-5-mini";
+const LUNA_MODEL: &str = "gpt-5.6-luna";
 
 /// Known OpenAI models we catalog. Keep in sync with `DEFAULT_OPENAI_MODELS`
-/// in `crates/providers/src/openai.rs`.
-const KNOWN_MODELS: &[&str] = &["gpt-5.2", "gpt-5.2-chat-latest", "gpt-5-mini"];
+/// in `crates/providers/src/openai/catalog.rs`.
+const KNOWN_MODELS: &[&str] = &[
+    "gpt-5.6-sol",
+    "gpt-5.6-terra",
+    LUNA_MODEL,
+    "gpt-5.2",
+    "gpt-5.2-chat-latest",
+    TEST_MODEL,
+];
 
 fn api_key() -> Secret<String> {
     let key =
@@ -32,6 +40,12 @@ fn api_key() -> Secret<String> {
 
 fn make_provider(model: &str) -> OpenAiProvider {
     OpenAiProvider::new(api_key(), model.to_string(), OPENAI_BASE_URL.to_string())
+}
+
+fn make_provider_with_reasoning(model: &str, effort: ReasoningEffort) -> Arc<dyn LlmProvider> {
+    Arc::new(make_provider(model))
+        .with_reasoning_effort(effort)
+        .expect("OpenAI provider should support reasoning_effort")
 }
 
 fn weather_tool() -> serde_json::Value {
@@ -172,6 +186,37 @@ async fn tool_call_round_trip_streaming() {
 
 #[tokio::test]
 #[ignore]
+async fn luna_reasoning_tool_call_uses_responses_api() {
+    let p = make_provider_with_reasoning(LUNA_MODEL, ReasoningEffort::High);
+    let messages = vec![ChatMessage::user(
+        "What's the weather in Paris? Use the get_weather tool.",
+    )];
+
+    let mut stream = p.stream_with_tools(messages, vec![weather_tool()]);
+    let mut saw_tool_start = false;
+    let mut saw_done = false;
+
+    while let Some(event) = stream.next().await {
+        match event {
+            StreamEvent::ToolCallStart { name, .. } => {
+                assert_eq!(name, "get_weather");
+                saw_tool_start = true;
+            },
+            StreamEvent::Done(_) => {
+                saw_done = true;
+                break;
+            },
+            StreamEvent::Error(err) => panic!("stream error: {err}"),
+            _ => {},
+        }
+    }
+
+    assert!(saw_done, "Luna reasoning tool stream must emit Done");
+    assert!(saw_tool_start, "Luna should call get_weather");
+}
+
+#[tokio::test]
+#[ignore]
 async fn multi_turn_tool_use() {
     let p = make_provider(TEST_MODEL);
     let tools = vec![weather_tool()];
@@ -261,6 +306,7 @@ async fn catalog_models_are_live() {
     eprintln!("==================================\n");
 
     assert!(alive.contains(&TEST_MODEL), "{TEST_MODEL} should be live");
+    assert!(alive.contains(&LUNA_MODEL), "{LUNA_MODEL} should be live");
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- exercise GPT-5.6 Sol, Terra, and Luna in the deterministic reasoning-plus-tools Responses routing test
- keep the live OpenAI model-health list synchronized with all cataloged GPT-5.6 variants and require Luna to remain available
- add a credentialed Luna streaming regression that combines high reasoning effort with a function tool, covering the failure reported in #1181

The routing implementation landed in #1198, and #1212 preserved that routing when setup persists the official OpenAI base URL. This follow-up adds the model-specific CI coverage that was not included before #1212 merged.

Closes #1181

## Validation

### Completed

- [x] `cargo test -p moltis-providers openai_gpt_5_6_reasoning_with_tools_uses_responses_api`
- [x] `cargo test -p moltis-providers --lib`
- [x] `cargo test -p moltis-providers --test openai_integration --no-run`
- [x] `cargo fmt --all -- --check`
- [x] `just release-preflight`

### Remaining

- [ ] `./scripts/local-validate.sh 1213` (startup currently blocked by repeated GitHub GraphQL timeouts)
- [ ] `OPENAI_API_KEY=... cargo test -p moltis-providers --test openai_integration luna_reasoning_tool_call_uses_responses_api -- --ignored --exact` (runs in credentialed provider CI)

## Manual QA

1. Export an OpenAI API key with access to `gpt-5.6-luna`.
2. Run the remaining credentialed test command above.
3. Verify the stream emits a `get_weather` tool call and a terminal `Done` event without a Chat Completions reasoning/tool compatibility error.