### PR TITLE
Fix Apple Container status parsing across versions

### DIFF
--- a/crates/tools/src/sandbox/apple.rs
+++ b/crates/tools/src/sandbox/apple.rs
@@ -18,10 +18,10 @@ use tokio::sync::{Mutex, RwLock};
 
 #[cfg(target_os = "macos")]
 use super::containers::{
-    apple_container_exec_args, apple_container_run_args, apple_container_status_from_inspect,
-    is_apple_container_daemon_stale_error, is_apple_container_exists_error,
-    is_apple_container_service_error, rebuildable_sandbox_image_tag, sandbox_image_exists,
-    unmark_zombie,
+    ContainerRunState, apple_container_exec_args, apple_container_run_args,
+    apple_container_run_state_from_inspect, is_apple_container_daemon_stale_error,
+    is_apple_container_exists_error, is_apple_container_service_error,
+    rebuildable_sandbox_image_tag, sandbox_image_exists, unmark_zombie,
 };
 #[cfg(target_os = "macos")]
 use super::host::provision_packages;
@@ -316,9 +316,9 @@ impl AppleContainerSandbox {
             match output {
                 Ok(output) if output.status.success() => {
                     let stdout = String::from_utf8_lossy(&output.stdout);
-                    match apple_container_status_from_inspect(&stdout) {
-                        Some("running") => return Ok(()),
-                        Some("stopped") => {
+                    match apple_container_run_state_from_inspect(&stdout) {
+                        Some(ContainerRunState::Running) => return Ok(()),
+                        Some(ContainerRunState::Stopped | ContainerRunState::Exited) => {
                             return Err(Error::message(format!(
                                 "container {name} failed to stay running after startup"
                             )));
@@ -452,9 +452,9 @@ impl AppleContainerSandbox {
             return ContainerState::NotFound;
         }
 
-        match apple_container_status_from_inspect(&stdout) {
-            Some("running") => ContainerState::Running,
-            Some("stopped") => ContainerState::Stopped,
+        match apple_container_run_state_from_inspect(&stdout) {
+            Some(ContainerRunState::Running) => ContainerState::Running,
+            Some(ContainerRunState::Stopped | ContainerRunState::Exited) => ContainerState::Stopped,
             _ => ContainerState::Unknown,
         }
     }

--- a/crates/tools/src/sandbox/containers.rs
+++ b/crates/tools/src/sandbox/containers.rs
@@ -3,7 +3,7 @@
 use std::collections::HashSet;
 
 use {
-    serde::Serialize,
+    serde::{Deserialize, Serialize},
     sha2::{Digest, Sha256},
     tracing::warn,
 };
@@ -433,6 +433,42 @@ pub enum ContainerRunState {
     Unknown,
 }
 
+#[derive(Debug, Clone, Copy, Deserialize)]
+#[serde(rename_all = "lowercase")]
+enum AppleContainerState {
+    Running,
+    Stopped,
+    Exited,
+    #[serde(other)]
+    Unknown,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum AppleContainerStatus {
+    Legacy(AppleContainerState),
+    Current { state: AppleContainerState },
+}
+
+impl AppleContainerStatus {
+    fn run_state(&self) -> ContainerRunState {
+        match self {
+            Self::Legacy(state) | Self::Current { state } => match state {
+                AppleContainerState::Running => ContainerRunState::Running,
+                AppleContainerState::Stopped => ContainerRunState::Stopped,
+                AppleContainerState::Exited => ContainerRunState::Exited,
+                AppleContainerState::Unknown => ContainerRunState::Unknown,
+            },
+        }
+    }
+}
+
+fn apple_container_run_state(entry: &serde_json::Value) -> Option<ContainerRunState> {
+    let status =
+        serde_json::from_value::<AppleContainerStatus>(entry.get("status")?.clone()).ok()?;
+    Some(status.run_state())
+}
+
 /// Which container backend manages this container.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "kebab-case")]
@@ -524,16 +560,7 @@ pub async fn list_running_containers_for_prefixes(
                 {
                     continue;
                 }
-                let state_str = entry
-                    .pointer("/status/state")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or_default();
-                let state = match state_str {
-                    "running" => ContainerRunState::Running,
-                    "stopped" => ContainerRunState::Stopped,
-                    "exited" => ContainerRunState::Exited,
-                    _ => ContainerRunState::Unknown,
-                };
+                let state = apple_container_run_state(&entry).unwrap_or(ContainerRunState::Unknown);
                 let image = entry
                     .pointer("/configuration/image/reference")
                     .and_then(|v| v.as_str())
@@ -845,8 +872,8 @@ pub async fn remove_container(name: &str) -> Result<()> {
         match inspect {
             Ok(ref ins) if ins.status.success() => {
                 let stdout = String::from_utf8_lossy(&ins.stdout);
-                let status = apple_container_status_from_inspect(&stdout);
-                if status == Some("running") {
+                let status = apple_container_run_state_from_inspect(&stdout);
+                if status == Some(ContainerRunState::Running) {
                     // Container is genuinely running — return the rm error.
                     let stderr = output
                         .as_ref()
@@ -946,21 +973,14 @@ pub async fn restart_container_daemon() -> Result<()> {
     ))
 }
 
-pub(crate) fn apple_container_status_from_inspect(stdout: &str) -> Option<&'static str> {
+pub(crate) fn apple_container_run_state_from_inspect(stdout: &str) -> Option<ContainerRunState> {
     let inspect = stdout.trim();
     if inspect.is_empty() || inspect == "[]" {
         return None;
     }
 
-    if inspect.contains(r#""status":"running""#) {
-        return Some("running");
-    }
-
-    if inspect.contains(r#""status":"stopped""#) || inspect.contains(r#""status":"exited""#) {
-        return Some("stopped");
-    }
-
-    None
+    let entries = serde_json::from_str::<Vec<serde_json::Value>>(inspect).ok()?;
+    entries.first().and_then(apple_container_run_state)
 }
 
 pub(crate) fn is_apple_container_service_error(stderr: &str) -> bool {

--- a/crates/tools/src/sandbox/tests/apple.rs
+++ b/crates/tools/src/sandbox/tests/apple.rs
@@ -327,19 +327,60 @@ fn test_container_exec_shell_args_docker_keeps_standard_exec_shape() {
 }
 
 #[test]
-fn test_apple_container_status_from_inspect() {
+fn test_apple_container_run_state_from_legacy_inspect() {
     assert_eq!(
-        apple_container_status_from_inspect(
+        apple_container_run_state_from_inspect(
             r#"[{"id":"abc","status":"running","configuration":{}}]"#
         ),
-        Some("running")
+        Some(ContainerRunState::Running)
     );
     assert_eq!(
-        apple_container_status_from_inspect(r#"[{"id":"abc","status":"stopped"}]"#),
-        Some("stopped")
+        apple_container_run_state_from_inspect(r#"[{"id":"abc","status":"stopped"}]"#),
+        Some(ContainerRunState::Stopped)
     );
-    assert_eq!(apple_container_status_from_inspect("[]"), None);
-    assert_eq!(apple_container_status_from_inspect(""), None);
+    assert_eq!(
+        apple_container_run_state_from_inspect(r#"[{"id":"abc","status":"exited"}]"#),
+        Some(ContainerRunState::Exited)
+    );
+}
+
+#[test]
+fn test_apple_container_run_state_from_current_inspect() {
+    assert_eq!(
+        apple_container_run_state_from_inspect(
+            r#"[
+                {
+                    "id": "abc",
+                    "status": { "state": "running" },
+                    "configuration": {}
+                }
+            ]"#
+        ),
+        Some(ContainerRunState::Running)
+    );
+    assert_eq!(
+        apple_container_run_state_from_inspect(r#"[{"id":"abc","status":{"state":"stopped"}}]"#),
+        Some(ContainerRunState::Stopped)
+    );
+    assert_eq!(
+        apple_container_run_state_from_inspect(r#"[{"id":"abc","status":{"state":"exited"}}]"#),
+        Some(ContainerRunState::Exited)
+    );
+}
+
+#[test]
+fn test_apple_container_run_state_rejects_missing_or_malformed_inspect() {
+    assert_eq!(
+        apple_container_run_state_from_inspect(r#"[{"id":"abc","status":{"state":"starting"}}]"#),
+        Some(ContainerRunState::Unknown)
+    );
+    assert_eq!(apple_container_run_state_from_inspect("[]"), None);
+    assert_eq!(apple_container_run_state_from_inspect(""), None);
+    assert_eq!(apple_container_run_state_from_inspect("not json"), None);
+    assert_eq!(
+        apple_container_run_state_from_inspect(r#"[{"id":"abc"}]"#),
+        None
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- replace raw JSON substring matching with a typed Apple Container status decoder
- accept both pre-1.x scalar `status` values and 1.x nested `status.state` values
- use the shared decoder for readiness, lifecycle inspection, failed-removal classification, and container listing
- add regression coverage for both schemas, whitespace, stopped/exited states, unknown states, and malformed output

Fixes #1185.

## Validation

### Completed

- [x] `cargo test -p moltis-tools sandbox::tests::apple -- --nocapture`
- [x] `./scripts/check-file-size.sh`
- [x] `just release-preflight`

### Remaining

- [ ] `./scripts/local-validate.sh <PR_NUMBER>`
- [ ] Manual runtime verification with Apple Container pre-1.x and 1.x installations

## Manual QA

1. Configure `[tools.exec.sandbox]` with `backend = "apple-container"` and `mode = "all"`.
2. Run a sandboxed command such as `pwd` using Apple Container 1.x and confirm the container reaches exec-ready state without being removed and recreated.
3. Repeat with a pre-1.x Apple Container installation and confirm scalar `status` output remains supported.
4. Open the sandbox container list and verify running, stopped, and exited states render correctly on either runtime version.