### PR TITLE
Fix Apple Container sandbox resource limits

### DIFF
--- a/crates/tools/src/sandbox/apple.rs
+++ b/crates/tools/src/sandbox/apple.rs
@@ -33,8 +33,9 @@ use super::paths::{
 };
 #[cfg(target_os = "macos")]
 use super::types::{
-    BuildImageResult, DEFAULT_SANDBOX_IMAGE, ManagedFilesMount, NetworkPolicy, SANDBOX_FILES_DIR,
-    SANDBOX_HOME_DIR, Sandbox, SandboxConfig, SandboxId, truncate_output_for_display,
+    BuildImageResult, DEFAULT_SANDBOX_IMAGE, ManagedFilesMount, NetworkPolicy, ResourceLimits,
+    SANDBOX_FILES_DIR, SANDBOX_HOME_DIR, Sandbox, SandboxConfig, SandboxId,
+    truncate_output_for_display,
 };
 #[cfg(target_os = "macos")]
 use crate::error::{Error, Result};
@@ -466,8 +467,10 @@ impl AppleContainerSandbox {
         image: &str,
         tz: Option<&str>,
         volumes: &[String],
+        resource_limits: &ResourceLimits,
     ) -> std::result::Result<(), CreateError> {
-        let args = apple_container_run_args(name, image, tz, volumes);
+        let args = apple_container_run_args(name, image, tz, volumes, resource_limits)
+            .map_err(|error| CreateError::Other(error.to_string()))?;
 
         let output = tokio::process::Command::new("container")
             .args(&args)
@@ -865,7 +868,9 @@ impl Sandbox for AppleContainerSandbox {
 
             // Phase 2: Create a new container.
             info!(name, image = %image, attempt, "creating apple container");
-            match Self::run_container(&name, &image, tz, &volumes).await {
+            match Self::run_container(&name, &image, tz, &volumes, &self.config.resource_limits)
+                .await
+            {
                 Ok(()) => {},
                 Err(CreateError::AlreadyExists) => {
                     warn!(

--- a/crates/tools/src/sandbox/apple.rs
+++ b/crates/tools/src/sandbox/apple.rs
@@ -1,7 +1,7 @@
 //! Apple Container sandbox backend (macOS 26+, Apple Silicon).
 
 #[cfg(target_os = "macos")]
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 #[cfg(target_os = "macos")]
 use std::process::Command;
 #[cfg(target_os = "macos")]
@@ -22,6 +22,7 @@ use super::containers::{
     apple_container_run_state_from_inspect, is_apple_container_daemon_stale_error,
     is_apple_container_exists_error, is_apple_container_service_error,
     rebuildable_sandbox_image_tag, sandbox_image_exists, unmark_zombie,
+    validate_apple_container_resource_limits,
 };
 #[cfg(target_os = "macos")]
 use super::host::provision_packages;
@@ -53,7 +54,7 @@ use crate::sandbox::file_system::{
 pub struct AppleContainerSandbox {
     pub config: SandboxConfig,
     name_generations: RwLock<HashMap<String, u32>>,
-    mount_policy_validated: Mutex<HashSet<String>>,
+    container_policy_fingerprints: Mutex<HashMap<String, String>>,
     /// Cached host gateway IP for proxy routing in Trusted mode.
     host_gateway_cache: RwLock<Option<String>>,
 }
@@ -64,7 +65,7 @@ impl AppleContainerSandbox {
         Self {
             config,
             name_generations: RwLock::new(HashMap::new()),
-            mount_policy_validated: Mutex::new(HashSet::new()),
+            container_policy_fingerprints: Mutex::new(HashMap::new()),
             host_gateway_cache: RwLock::new(None),
         }
     }
@@ -125,6 +126,13 @@ impl AppleContainerSandbox {
             .container_prefix
             .as_deref()
             .unwrap_or("moltis-sandbox")
+    }
+
+    pub(crate) fn container_policy_fingerprint(&self) -> String {
+        format!(
+            "{:?}\0{:?}",
+            self.config.managed_files_mount, self.config.resource_limits
+        )
     }
 
     fn base_container_name(&self, id: &SandboxId) -> String {
@@ -782,25 +790,28 @@ impl Sandbox for AppleContainerSandbox {
     }
 
     async fn ensure_ready(&self, id: &SandboxId, image_override: Option<&str>) -> Result<()> {
+        validate_apple_container_resource_limits(&self.config.resource_limits)?;
+
         let mut name = self.container_name(id).await;
         // This state lock also serializes Apple Container creation. The CLI has
         // no atomic create-or-inspect primitive, so releasing it after policy
         // validation would let a concurrent caller remove the fresh winner.
-        let mut validated = self.mount_policy_validated.lock().await;
-        if !validated.contains(&name) {
+        let mut fingerprints = self.container_policy_fingerprints.lock().await;
+        let desired_fingerprint = self.container_policy_fingerprint();
+        if fingerprints.get(&name) != Some(&desired_fingerprint) {
             if Self::container_exists(&name).await? {
                 warn!(
                     name,
-                    "recreating existing apple container to apply managed Files mount policy"
+                    "recreating existing apple container to apply sandbox policy"
                 );
                 Self::force_remove_and_wait(&name).await;
                 if Self::container_exists(&name).await? {
                     return Err(Error::message(format!(
-                        "failed to remove apple container '{name}' after managed Files mount policy changed"
+                        "failed to remove apple container '{name}' after sandbox policy changed"
                     )));
                 }
             }
-            validated.insert(name.clone());
+            fingerprints.insert(name.clone(), desired_fingerprint);
         }
         let requested_image = image_override.unwrap_or_else(|| self.image());
         let image = self.resolve_local_image(requested_image).await?;

--- a/crates/tools/src/sandbox/apple.rs
+++ b/crates/tools/src/sandbox/apple.rs
@@ -798,20 +798,19 @@ impl Sandbox for AppleContainerSandbox {
         // validation would let a concurrent caller remove the fresh winner.
         let mut fingerprints = self.container_policy_fingerprints.lock().await;
         let desired_fingerprint = self.container_policy_fingerprint();
-        if fingerprints.get(&name) != Some(&desired_fingerprint) {
+        if fingerprints.get(&name) != Some(&desired_fingerprint)
+            && Self::container_exists(&name).await?
+        {
+            warn!(
+                name,
+                "recreating existing apple container to apply sandbox policy"
+            );
+            Self::force_remove_and_wait(&name).await;
             if Self::container_exists(&name).await? {
-                warn!(
-                    name,
-                    "recreating existing apple container to apply sandbox policy"
-                );
-                Self::force_remove_and_wait(&name).await;
-                if Self::container_exists(&name).await? {
-                    return Err(Error::message(format!(
-                        "failed to remove apple container '{name}' after sandbox policy changed"
-                    )));
-                }
+                return Err(Error::message(format!(
+                    "failed to remove apple container '{name}' after sandbox policy changed"
+                )));
             }
-            fingerprints.insert(name.clone(), desired_fingerprint);
         }
         let requested_image = image_override.unwrap_or_else(|| self.image());
         let image = self.resolve_local_image(requested_image).await?;
@@ -830,6 +829,7 @@ impl Sandbox for AppleContainerSandbox {
                     info!(name, "apple container already running");
                     match Self::wait_for_container_exec_ready(&name).await {
                         Ok(()) => {
+                            fingerprints.insert(name.clone(), desired_fingerprint.clone());
                             unmark_zombie(&name);
                             return Ok(());
                         },
@@ -850,6 +850,7 @@ impl Sandbox for AppleContainerSandbox {
                         info!(name, "apple container restarted");
                         match Self::wait_for_container_exec_ready(&name).await {
                             Ok(()) => {
+                                fingerprints.insert(name.clone(), desired_fingerprint.clone());
                                 unmark_zombie(&name);
                                 return Ok(());
                             },
@@ -945,6 +946,7 @@ impl Sandbox for AppleContainerSandbox {
                         provision_packages("container", &name, &self.config.packages).await?;
                     }
 
+                    fingerprints.insert(name.clone(), desired_fingerprint.clone());
                     return Ok(());
                 },
                 Err(error) => {
@@ -976,6 +978,7 @@ impl Sandbox for AppleContainerSandbox {
                                         )
                                         .await?;
                                     }
+                                    fingerprints.insert(name.clone(), desired_fingerprint.clone());
                                     return Ok(());
                                 },
                                 Err(restart_error) => {

--- a/crates/tools/src/sandbox/containers.rs
+++ b/crates/tools/src/sandbox/containers.rs
@@ -10,6 +10,8 @@ use {
 
 #[cfg(any(target_os = "macos", test))]
 use super::types::APPLE_CONTAINER_SAFE_WORKDIR;
+#[cfg(target_os = "macos")]
+use super::types::ResourceLimits;
 use {
     super::types::{
         GO_TOOL_INSTALLS, GOGCLI_MODULE_PATH, GOGCLI_VERSION, SANDBOX_HOME_DIR,
@@ -119,7 +121,8 @@ pub(crate) fn apple_container_run_args(
     image: &str,
     tz: Option<&str>,
     volumes: &[String],
-) -> Vec<String> {
+    resource_limits: &ResourceLimits,
+) -> Result<Vec<String>> {
     let mut args = vec![
         "run".to_string(),
         "-d".to_string(),
@@ -132,6 +135,25 @@ pub(crate) fn apple_container_run_args(
     if let Some(tz) = tz {
         args.extend(["-e".to_string(), format!("TZ={tz}")]);
     }
+    if let Some(ref memory) = resource_limits.memory_limit {
+        args.extend(["--memory".to_string(), memory.clone()]);
+    }
+    if let Some(cpus) = resource_limits.cpu_quota {
+        let cpus = cpus.to_string().parse::<i64>().map_err(|_| {
+            Error::message(format!(
+                "Apple Container requires cpu_quota to be a positive whole number, got {cpus}"
+            ))
+        })?;
+        if cpus < 1 {
+            return Err(Error::message(format!(
+                "Apple Container requires cpu_quota to be a positive whole number, got {cpus}"
+            )));
+        }
+        args.extend(["--cpus".to_string(), cpus.to_string()]);
+    }
+    if let Some(pids) = resource_limits.pids_max {
+        args.extend(["--ulimit".to_string(), format!("nproc={pids}")]);
+    }
     for volume in volumes {
         args.extend(["--volume".to_string(), volume.to_string()]);
     }
@@ -142,7 +164,7 @@ pub(crate) fn apple_container_run_args(
         "-c".to_string(),
         apple_container_bootstrap_command(),
     ]);
-    args
+    Ok(args)
 }
 
 #[cfg(any(target_os = "macos", test))]

--- a/crates/tools/src/sandbox/containers.rs
+++ b/crates/tools/src/sandbox/containers.rs
@@ -123,6 +123,8 @@ pub(crate) fn apple_container_run_args(
     volumes: &[String],
     resource_limits: &ResourceLimits,
 ) -> Result<Vec<String>> {
+    validate_apple_container_resource_limits(resource_limits)?;
+
     let mut args = vec![
         "run".to_string(),
         "-d".to_string(),
@@ -139,16 +141,6 @@ pub(crate) fn apple_container_run_args(
         args.extend(["--memory".to_string(), memory.clone()]);
     }
     if let Some(cpus) = resource_limits.cpu_quota {
-        let cpus = cpus.to_string().parse::<i64>().map_err(|_| {
-            Error::message(format!(
-                "Apple Container requires cpu_quota to be a positive whole number, got {cpus}"
-            ))
-        })?;
-        if cpus < 1 {
-            return Err(Error::message(format!(
-                "Apple Container requires cpu_quota to be a positive whole number, got {cpus}"
-            )));
-        }
         args.extend(["--cpus".to_string(), cpus.to_string()]);
     }
     if let Some(pids) = resource_limits.pids_max {
@@ -165,6 +157,25 @@ pub(crate) fn apple_container_run_args(
         apple_container_bootstrap_command(),
     ]);
     Ok(args)
+}
+
+#[cfg(target_os = "macos")]
+pub(crate) fn validate_apple_container_resource_limits(
+    resource_limits: &ResourceLimits,
+) -> Result<()> {
+    let Some(cpus) = resource_limits.cpu_quota else {
+        return Ok(());
+    };
+    let valid = cpus.is_finite()
+        && cpus >= 1.0
+        && cpus.fract() == 0.0
+        && cpus.to_string().parse::<i64>().is_ok();
+    if !valid {
+        return Err(Error::message(format!(
+            "Apple Container requires cpu_quota to be a positive whole number, got {cpus}"
+        )));
+    }
+    Ok(())
 }
 
 #[cfg(any(target_os = "macos", test))]

--- a/crates/tools/src/sandbox/tests/apple.rs
+++ b/crates/tools/src/sandbox/tests/apple.rs
@@ -320,6 +320,30 @@ fn test_apple_container_run_args_reject_fractional_cpu_quota() {
 
 #[cfg(target_os = "macos")]
 #[test]
+fn test_apple_container_policy_fingerprint_includes_resource_limits() {
+    let first = AppleContainerSandbox::new(SandboxConfig {
+        resource_limits: ResourceLimits {
+            pids_max: Some(256),
+            ..Default::default()
+        },
+        ..Default::default()
+    });
+    let second = AppleContainerSandbox::new(SandboxConfig {
+        resource_limits: ResourceLimits {
+            pids_max: Some(512),
+            ..Default::default()
+        },
+        ..Default::default()
+    });
+
+    assert_ne!(
+        first.container_policy_fingerprint(),
+        second.container_policy_fingerprint()
+    );
+}
+
+#[cfg(target_os = "macos")]
+#[test]
 fn test_apple_container_managed_files_mount_coexists_with_home_persistence() {
     let temp_dir = tempfile::tempdir().unwrap();
     let host_data_dir = temp_dir.path().join("moltis-data");

--- a/crates/tools/src/sandbox/tests/apple.rs
+++ b/crates/tools/src/sandbox/tests/apple.rs
@@ -185,7 +185,14 @@ fn test_apple_container_bootstrap_command_uses_portable_sleep() {
 
 #[test]
 fn test_apple_container_run_args_pin_workdir_and_bootstrap_home() {
-    let args = apple_container_run_args("moltis-sandbox-test", "ubuntu:25.10", Some("UTC"), &[]);
+    let args = apple_container_run_args(
+        "moltis-sandbox-test",
+        "ubuntu:25.10",
+        Some("UTC"),
+        &[],
+        &ResourceLimits::default(),
+    )
+    .unwrap();
     let expected = vec![
         "run",
         "-d",
@@ -208,9 +215,14 @@ fn test_apple_container_run_args_pin_workdir_and_bootstrap_home() {
 
 #[test]
 fn test_apple_container_run_args_with_home_volume() {
-    let args = apple_container_run_args("moltis-sandbox-test", "ubuntu:25.10", Some("UTC"), &[
-        "/tmp/home:/home/sandbox".to_string(),
-    ]);
+    let args = apple_container_run_args(
+        "moltis-sandbox-test",
+        "ubuntu:25.10",
+        Some("UTC"),
+        &["/tmp/home:/home/sandbox".to_string()],
+        &ResourceLimits::default(),
+    )
+    .unwrap();
     let expected = vec![
         "run",
         "-d",
@@ -239,7 +251,14 @@ fn test_apple_container_run_args_with_multiple_volumes() {
         "/tmp/home:/home/sandbox".to_string(),
         "/tmp/files:/home/sandbox/files:ro".to_string(),
     ];
-    let args = apple_container_run_args("moltis-sandbox-test", "ubuntu:25.10", None, &volumes);
+    let args = apple_container_run_args(
+        "moltis-sandbox-test",
+        "ubuntu:25.10",
+        None,
+        &volumes,
+        &ResourceLimits::default(),
+    )
+    .unwrap();
 
     assert_eq!(
         args.windows(2)
@@ -247,6 +266,55 @@ fn test_apple_container_run_args_with_multiple_volumes() {
             .map(|window| window[1].as_str())
             .collect::<Vec<_>>(),
         volumes.iter().map(String::as_str).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn test_apple_container_run_args_apply_resource_limits() {
+    let args = apple_container_run_args(
+        "moltis-sandbox-test",
+        "ubuntu:25.10",
+        None,
+        &[],
+        &ResourceLimits {
+            memory_limit: Some("1G".into()),
+            cpu_quota: Some(2.0),
+            pids_max: Some(512),
+        },
+    )
+    .unwrap();
+
+    assert_eq!(
+        args.windows(2)
+            .filter(|window| matches!(window[0].as_str(), "--memory" | "--cpus" | "--ulimit"))
+            .map(|window| (window[0].as_str(), window[1].as_str()))
+            .collect::<Vec<_>>(),
+        vec![
+            ("--memory", "1G"),
+            ("--cpus", "2"),
+            ("--ulimit", "nproc=512")
+        ]
+    );
+}
+
+#[test]
+fn test_apple_container_run_args_reject_fractional_cpu_quota() {
+    let error = apple_container_run_args(
+        "moltis-sandbox-test",
+        "ubuntu:25.10",
+        None,
+        &[],
+        &ResourceLimits {
+            cpu_quota: Some(0.5),
+            ..Default::default()
+        },
+    )
+    .unwrap_err();
+
+    assert!(
+        error
+            .to_string()
+            .contains("cpu_quota to be a positive whole number")
     );
 }
 

--- a/docs/src/sandbox.md
+++ b/docs/src/sandbox.md
@@ -448,7 +448,11 @@ How resource limits are applied depends on the backend:
 |-------|--------|-----------------|------|-----------------|----------------|
 | `memory_limit` | `--memory` | `--memory` | Wasmtime reservation | `ulimit -v` | `MemoryMax=` |
 | `cpu_quota` | `--cpus` | `--cpus` | epoch timeout | `ulimit -t` (seconds) | `CPUQuota=` |
-| `pids_max` | `--pids-limit` | `--pids-limit` | n/a | `ulimit -u` | `TasksMax=` |
+| `pids_max` | `--pids-limit` | `--ulimit nproc=` | n/a | `ulimit -u` | `TasksMax=` |
+
+Apple Container requires version 0.9 or newer to apply `pids_max`.
+Its `--cpus` option only accepts positive whole CPU counts, so fractional
+`cpu_quota` values are not supported by that backend.
 
 ## Comparison
 


### PR DESCRIPTION
## Summary

- pass configured sandbox memory and whole-CPU limits to Apple Container using `--memory` and `--cpus`
- apply `pids_max` with Apple Container's native `--ulimit nproc=<limit>` syntax
- reject fractional Apple Container CPU quotas explicitly instead of silently weakening the requested limit
- document Apple Container version and CPU-granularity constraints

Closes #1188

## Validation

### Completed

- [x] `cargo test -p moltis-tools apple_container_run_args`
- [x] `cargo fmt --all -- --check`
- [x] `just lint`
- [x] `container run --rm --cpus 2 --memory 512M ubuntu:25.10 true`

### Remaining

- [ ] `./scripts/local-validate.sh <PR_NUMBER>`
- [ ] Live `pids_max` verification with Apple Container 0.9+; the local CLI is 0.8.0 and predates `--ulimit`

## Manual QA

1. Install Apple Container 0.9 or newer and select `backend = "apple-container"`.
2. Configure `memory_limit = "1G"`, `cpu_quota = 2.0`, and `pids_max = 512` under `[tools.exec.sandbox.resource_limits]`.
3. Restart Moltis and run `ulimit -u` plus a command that forks child processes inside the sandbox.
4. Confirm the process limit is 512 and the command completes without `Resource temporarily unavailable`.
5. Set `cpu_quota = 0.5` and confirm Moltis reports that Apple Container requires a positive whole CPU count.