### PR TITLE
fix(httpd): require authentication for vault unlock and recovery

### DIFF
--- a/crates/httpd/src/auth_routes/vault.rs
+++ b/crates/httpd/src/auth_routes/vault.rs
@@ -90,8 +90,16 @@ pub(super) struct VaultUnlockRequest {
     password: String,
 }
 
+/// Unseal the vault with the vault password.
+///
+/// Requires an authenticated session: unsealing decrypts every stored
+/// secret (provider keys, SSH private keys, env vars, channel tokens), so
+/// an unauthenticated caller must never be able to attempt it. `/api/auth/*`
+/// is allowlisted in `is_public_path()`, so the `AuthSession` extractor is
+/// what enforces auth here.
 #[cfg(feature = "vault")]
 pub(super) async fn vault_unlock_handler(
+    _session: crate::auth_middleware::AuthSession,
     State(state): State<AuthState>,
     Json(body): Json<VaultUnlockRequest>,
 ) -> impl IntoResponse {
@@ -120,8 +128,14 @@ pub(super) struct VaultRecoveryRequest {
     recovery_key: String,
 }
 
+/// Unseal the vault with the recovery key.
+///
+/// Requires an authenticated session for the same reason as
+/// [`vault_unlock_handler`]: a stolen recovery key alone must not be enough
+/// to decrypt stored secrets over the network.
 #[cfg(feature = "vault")]
 pub(super) async fn vault_recovery_handler(
+    _session: crate::auth_middleware::AuthSession,
     State(state): State<AuthState>,
     Json(body): Json<VaultRecoveryRequest>,
 ) -> impl IntoResponse {

--- a/crates/httpd/tests/auth_middleware/more.rs
+++ b/crates/httpd/tests/auth_middleware/more.rs
@@ -873,3 +873,131 @@ pub(super) async fn local_privileged_api_during_onboarding_requires_auth() {
         "privileged API must require auth even during onboarding"
     );
 }
+
+// ── Vault unlock/recovery auth tests (GH #1177, CWE-306) ─────────────────────
+
+/// `/api/auth/*` is allowlisted in `is_public_path()`, so the vault unlock
+/// endpoint must enforce auth itself. An unauthenticated POST must be rejected
+/// before the password is ever checked, and the vault must stay sealed.
+#[cfg(all(feature = "web-ui", feature = "vault"))]
+#[tokio::test]
+pub(super) async fn vault_unlock_requires_authentication() {
+    let (addr, store, _state, vault) = start_localhost_server_with_vault().await;
+    let password = generated_password();
+    store.set_initial_password(&password).await.unwrap();
+    let _rk = vault.initialize(&password).await.unwrap();
+    vault.seal().await;
+
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(format!("http://{addr}/api/auth/vault/unlock"))
+        .header("Content-Type", "application/json")
+        .body(json_password(&password))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(
+        resp.status(),
+        401,
+        "unauthenticated vault unlock must be rejected"
+    );
+    assert_eq!(
+        vault.status().await.unwrap(),
+        moltis_vault::VaultStatus::Sealed,
+        "vault must stay sealed for unauthenticated callers"
+    );
+}
+
+/// A stolen recovery key alone must not unseal the vault over the network.
+#[cfg(all(feature = "web-ui", feature = "vault"))]
+#[tokio::test]
+pub(super) async fn vault_recovery_requires_authentication() {
+    let (addr, store, _state, vault) = start_localhost_server_with_vault().await;
+    let password = generated_password();
+    store.set_initial_password(&password).await.unwrap();
+    let recovery_key = vault.initialize(&password).await.unwrap();
+    let phrase = recovery_key.phrase().to_owned();
+    vault.seal().await;
+
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(format!("http://{addr}/api/auth/vault/recovery"))
+        .header("Content-Type", "application/json")
+        .body(serde_json::json!({ "recovery_key": phrase }).to_string())
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(
+        resp.status(),
+        401,
+        "unauthenticated vault recovery must be rejected"
+    );
+    assert_eq!(
+        vault.status().await.unwrap(),
+        moltis_vault::VaultStatus::Sealed,
+        "vault must stay sealed for unauthenticated callers"
+    );
+}
+
+/// An authenticated session can still unseal the vault with the password.
+#[cfg(all(feature = "web-ui", feature = "vault"))]
+#[tokio::test]
+pub(super) async fn vault_unlock_succeeds_with_session() {
+    let (addr, store, _state, vault) = start_localhost_server_with_vault().await;
+    let password = generated_password();
+    store.set_initial_password(&password).await.unwrap();
+    let _rk = vault.initialize(&password).await.unwrap();
+    vault.seal().await;
+    let token = store.create_session().await.unwrap();
+
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(format!("http://{addr}/api/auth/vault/unlock"))
+        .header("Content-Type", "application/json")
+        .header("Cookie", format!("moltis_session={token}"))
+        .body(json_password(&password))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), 200);
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(body["ok"], true);
+    assert_eq!(
+        vault.status().await.unwrap(),
+        moltis_vault::VaultStatus::Unsealed
+    );
+}
+
+/// An authenticated session can still unseal the vault with the recovery key.
+#[cfg(all(feature = "web-ui", feature = "vault"))]
+#[tokio::test]
+pub(super) async fn vault_recovery_succeeds_with_session() {
+    let (addr, store, _state, vault) = start_localhost_server_with_vault().await;
+    let password = generated_password();
+    store.set_initial_password(&password).await.unwrap();
+    let recovery_key = vault.initialize(&password).await.unwrap();
+    let phrase = recovery_key.phrase().to_owned();
+    vault.seal().await;
+    let token = store.create_session().await.unwrap();
+
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(format!("http://{addr}/api/auth/vault/recovery"))
+        .header("Content-Type", "application/json")
+        .header("Cookie", format!("moltis_session={token}"))
+        .body(serde_json::json!({ "recovery_key": phrase }).to_string())
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), 200);
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(body["ok"], true);
+    assert_eq!(
+        vault.status().await.unwrap(),
+        moltis_vault::VaultStatus::Unsealed
+    );
+}

--- a/docs/src/authentication.md
+++ b/docs/src/authentication.md
@@ -283,8 +283,10 @@ header snippet and passkey migration guidance.
 | Remove passkey | `DELETE /api/auth/passkeys/{id}` | Session |
 | Remove all auth | `POST /api/auth/reset` | Session |
 | Vault status | `GET /api/auth/vault/status` | No |
-| Vault unlock | `POST /api/auth/vault/unlock` | No |
-| Vault recovery | `POST /api/auth/vault/recovery` | No |
+| Vault unlock | `POST /api/auth/vault/unlock` | Session |
+| Vault recovery | `POST /api/auth/vault/recovery` | Session |
+| Vault initialize | `POST /api/auth/vault/initialize` | Session |
+| Vault disable | `POST /api/auth/vault/disable` | Session |
 
 ## Encryption at Rest
 

--- a/docs/src/vault.md
+++ b/docs/src/vault.md
@@ -157,8 +157,10 @@ Use the recovery key to unseal the vault when you've forgotten your
 password:
 
 ```bash
+# Requires an authenticated session (or API key); log in first.
 curl -X POST http://localhost:18789/api/auth/vault/recovery \
   -H "Content-Type: application/json" \
+  -H "Cookie: moltis_session=$MOLTIS_SESSION" \
   -d '{"recovery_key": "ABCD-EFGH-JKLM-NPQR-STUV-WXYZ-2345-6789"}'
 ```
 
@@ -222,15 +224,19 @@ Allowed through regardless of vault state:
 
 ## API Endpoints
 
-Vault unlock endpoints are under `/api/auth/vault/`. Unlock and recovery are
-available before login so a sealed vault can be opened during authentication.
-Disabling the vault requires an authenticated session.
+Vault unlock endpoints are under `/api/auth/vault/`. Every endpoint that can
+change vault state — unlock, recovery, initialize, disable — requires an
+authenticated session, because unsealing decrypts all stored secrets. Only
+`status` is readable without a session. Logging in already unseals the vault
+with your password, so the unlock endpoints are only needed when the vault
+password differs from the login password or when recovering with the key.
 
 | Method | Path | Purpose |
 |--------|------|---------|
 | `GET` | `/api/auth/vault/status` | Returns `{"status": "uninitialized"\|"sealed"\|"unsealed"\|"disabled"}` |
-| `POST` | `/api/auth/vault/unlock` | Unseal with password: `{"password": "..."}` |
-| `POST` | `/api/auth/vault/recovery` | Unseal with recovery key: `{"recovery_key": "..."}` |
+| `POST` | `/api/auth/vault/initialize` | Initialize the vault for the current login password (session required) |
+| `POST` | `/api/auth/vault/unlock` | Unseal with password: `{"password": "..."}` (session required) |
+| `POST` | `/api/auth/vault/recovery` | Unseal with recovery key: `{"recovery_key": "..."}` (session required) |
 | `POST` | `/api/auth/vault/disable` | Decrypt stored secrets and set `auth.vault_enabled = false`; accepts `{"password":"..."}` when sealed. |
 
 ## Disabling The Vault


### PR DESCRIPTION
## Summary

Fixes #1177 (CWE-306). `POST /api/auth/vault/unlock` and `POST /api/auth/vault/recovery` took no `AuthSession` extractor. `is_public_path()` allowlists the whole `/api/auth/` prefix, so `auth_gate` never ran for these routes and **any unauthenticated remote caller could brute-force the vault password or replay a stolen recovery key**. A successful call unseals the vault, decrypting provider API keys, managed SSH private keys, env variables, and channel/webhook secrets.

The sibling handlers `vault_initialize_handler` and `vault_disable_handler` already carried `AuthSession`; unlock and recovery were the two that did not.

```mermaid
flowchart LR
    R["POST /api/auth/vault/unlock"] --> G{"auth_gate"}
    G -->|"is_public_path() matches /api/auth/*<br/>middleware skipped"| H["vault_unlock_handler"]
    H --> E{"AuthSession extractor<br/>(added by this PR)"}
    E -->|"no session cookie / API key"| U["401 — vault stays sealed"]
    E -->|"valid session"| V["vault.unseal(password)"]
    V --> D["secrets decrypted:<br/>provider keys, SSH keys,<br/>env vars, channel tokens"]

    style E fill:#2d6a4f,color:#fff
    style U fill:#2d6a4f,color:#fff
    style D fill:#7f1d1d,color:#fff
```

### Why requiring a session cannot lock anyone out

Password hashes (`auth_password`), sessions, passkeys, and API keys are stored **unencrypted** — only env vars, SSH keys, channel secrets, webhook secrets, and provider keys go through the vault. Login therefore works against a sealed vault, and `auth_routes.rs:394` already unseals it best-effort on successful login. The unlock forms live in Settings > Encryption, which is behind auth in the UI already. The docs previously advertised these endpoints as pre-login; that claim was wrong and is corrected here.

### Changes

- `crates/httpd/src/auth_routes/vault.rs` — add `_session: crate::auth_middleware::AuthSession` to both handlers, ahead of the `Json` body extractor so the body is not consumed first. Doc comments record why the extractor (not the middleware) is what enforces auth on these paths.
- `crates/httpd/tests/auth_middleware/more.rs` — four integration tests.
- `docs/src/authentication.md`, `docs/src/vault.md` — endpoint tables now mark unlock/recovery/initialize/disable as session-required; the recovery `curl` example carries a session cookie.

## Validation

### Completed

- [x] `cargo test -p moltis-httpd --test auth_middleware vault_` — 13 passed, 0 failed
- [x] Reverted the fix and re-ran the two rejection tests to prove they catch the regression: both returned **200 instead of 401** without it, then restored the fix
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p moltis-httpd --tests --all-features` — clean (the one `moltis-gateway` unused-import warning is pre-existing and untouched by this branch)

### Remaining

- [ ] `./scripts/local-validate.sh <PR_NUMBER>` — full branch validation
- [ ] `just lint` — OS-aware clippy across the workspace

No E2E specs were added: the change is server-side only and no web UI behaviour changes (the unlock forms already run inside an authenticated Settings page).

## Manual QA

1. Build with the vault feature and start the server: `cargo run --features vault`.
2. Complete auth setup so a password exists, then initialize the vault from **Settings > Encryption**. Save the recovery key.
3. Restart the server so the vault is sealed. Confirm the **Encryption** badge reads amber "Locked".
4. From a shell with **no session cookie**, attempt an unlock:
   ```bash
   curl -i -X POST http://localhost:18789/api/auth/vault/unlock \
     -H "Content-Type: application/json" -d '{"password":"<vault password>"}'
   ```
   Expect **401 `not authenticated`**. Repeat against `/api/auth/vault/recovery` with the real recovery key — also 401.
5. Confirm `GET /api/auth/vault/status` still reports `sealed` (the attempts did nothing).
6. Log in through the web UI. The vault unseals on login; the badge turns green.
7. Seal it again (restart), log in, then unlock from **Settings > Encryption** using both the password form and the recovery-key form. Both should succeed and flip the badge to green.

## Follow-up (not in this PR)

Neither endpoint goes through `LoginGuard`, so an *authenticated* session can still brute-force the vault password unthrottled. Much lower severity now that a session is required, but worth a separate issue.
