### PR TITLE
fix(whatsapp): stop hardcoding the push name to "Moltis"

### DIFF
--- a/crates/config/src/loader/tests/core.rs
+++ b/crates/config/src/loader/tests/core.rs
@@ -205,6 +205,10 @@ fn write_default_config_writes_template_to_requested_path() {
         raw.contains("YOUR overrides only"),
         "generated template should explain it is override-only"
     );
+    assert!(
+        raw.contains("# push_name = \"Moltis\""),
+        "generated template should document the WhatsApp push name override"
+    );
 
     let parsed: MoltisConfig = parse_config(&raw, &path).expect("parse generated config");
     assert_eq!(

--- a/crates/config/src/template.rs
+++ b/crates/config/src/template.rs
@@ -881,6 +881,12 @@ port = {port}                           # Port number (auto-generated for this i
 # [channels]
 # offered = ["telegram", "whatsapp", "msteams", "discord", "slack", "matrix", "nostr", "signal"]
 
+# Example WhatsApp account. Pair the account by scanning the QR code after startup.
+# [channels.whatsapp.my-bot]
+# push_name = "Moltis"        # Falls back to [identity] name, then "Moltis".
+# dm_policy = "allowlist"
+# allowlist = []
+
 # Example Slack account. api_base_url defaults to Slack; set it only for
 # Slack-compatible proxies, mock servers, or gateways.
 # [channels.slack.my-bot]

--- a/crates/gateway/src/server/init_channels.rs
+++ b/crates/gateway/src/server/init_channels.rs
@@ -147,6 +147,7 @@ pub(crate) async fn init_channels(
         }
         let whatsapp_plugin = Arc::new(tokio::sync::RwLock::new(
             moltis_whatsapp::WhatsAppPlugin::new(wa_data_dir)
+                .with_identity_name(config.identity.name.clone())
                 .with_message_log(Arc::clone(&message_log))
                 .with_event_sink(Arc::clone(&channel_sink)),
         ));

--- a/crates/whatsapp/src/config.rs
+++ b/crates/whatsapp/src/config.rs
@@ -74,6 +74,12 @@ pub struct WhatsAppAccountConfig {
     /// Group JID allowlist.
     pub group_allowlist: Vec<String>,
 
+    /// Name this client asserts for itself on WhatsApp.
+    ///
+    /// Overrides `[identity] name`. Unset on both falls back to `Moltis`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub push_name: Option<String>,
+
     /// Enable OTP self-approval for non-allowlisted DM users (default: true).
     pub otp_self_approval: bool,
 
@@ -189,6 +195,7 @@ impl Default for WhatsAppAccountConfig {
             allowlist: Vec::new(),
             operators: Vec::new(),
             group_allowlist: Vec::new(),
+            push_name: None,
             otp_self_approval: true,
             otp_cooldown_secs: 300,
             channel_overrides: HashMap::new(),

--- a/crates/whatsapp/src/connection.rs
+++ b/crates/whatsapp/src/connection.rs
@@ -10,6 +10,23 @@ use crate::{
     state::{AccountState, AccountStateMap, ShutdownState},
 };
 
+/// Name asserted when neither the account nor the agent identity sets one.
+const DEFAULT_PUSH_NAME: &str = "Moltis";
+
+/// Account override, then agent identity, then the default.
+///
+/// Blank entries fall through rather than being honoured: an empty push name
+/// makes the client refuse to send presence at all.
+fn resolve_push_name(account: Option<&str>, identity: Option<&str>) -> String {
+    [account, identity]
+        .into_iter()
+        .flatten()
+        .map(str::trim)
+        .find(|value| !value.is_empty())
+        .unwrap_or(DEFAULT_PUSH_NAME)
+        .to_string()
+}
+
 /// Start a WhatsApp connection for the given account.
 ///
 /// Builds the `Bot` with a persistent sled store, registers the event handler,
@@ -22,6 +39,7 @@ pub async fn start_connection(
     data_dir: std::path::PathBuf,
     message_log: Option<Arc<dyn MessageLog>>,
     event_sink: Option<Arc<dyn ChannelEventSink>>,
+    identity_name: Option<String>,
 ) -> crate::Result<()> {
     // Use persistent sled store at <data_dir>/whatsapp/<account_id>/.
     let store_path = config
@@ -54,6 +72,13 @@ pub async fn start_connection(
     let state_ref_handler = Arc::clone(&state_ref);
     let accounts_handler = Arc::clone(&accounts);
 
+    // Only changes what this client asserts about itself. The account profile is
+    // left alone on purpose: `Client::set_push_name` rewrites it server side,
+    // which on a number paired from someone's personal phone would rename their
+    // real WhatsApp profile.
+    let push_name = resolve_push_name(config.push_name.as_deref(), identity_name.as_deref());
+    info!(account_id = %account_id, push_name = %push_name, "resolved WhatsApp push name");
+
     let bot = whatsapp_rust::bot::Bot::builder()
         .with_backend_arc(backend)
         .with_transport_factory(
@@ -67,7 +92,7 @@ pub async fn start_connection(
                 .with_os("Moltis")
                 .with_platform_type(waproto::whatsapp::device_props::PlatformType::Desktop),
         )
-        .with_push_name("Moltis")
+        .with_push_name(push_name)
         .on_event(move |event, client| {
             let state_ref = Arc::clone(&state_ref_handler);
             let accounts = Arc::clone(&accounts_handler);
@@ -139,4 +164,23 @@ pub async fn start_connection(
     });
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{DEFAULT_PUSH_NAME, resolve_push_name};
+
+    #[test]
+    fn account_wins_then_identity_then_the_default() {
+        assert_eq!(resolve_push_name(Some("Support"), Some("Ada")), "Support");
+        assert_eq!(resolve_push_name(None, Some("Ada")), "Ada");
+        assert_eq!(resolve_push_name(None, None), DEFAULT_PUSH_NAME);
+    }
+
+    #[test]
+    fn blank_entries_fall_through_instead_of_disabling_presence() {
+        assert_eq!(resolve_push_name(Some("   "), Some("Ada")), "Ada");
+        assert_eq!(resolve_push_name(Some(""), None), DEFAULT_PUSH_NAME);
+        assert_eq!(resolve_push_name(Some("  Ada  "), None), "Ada");
+    }
 }

--- a/crates/whatsapp/src/plugin.rs
+++ b/crates/whatsapp/src/plugin.rs
@@ -35,6 +35,7 @@ pub struct WhatsAppPlugin {
     message_log: Option<Arc<dyn MessageLog>>,
     event_sink: Option<Arc<dyn ChannelEventSink>>,
     data_dir: PathBuf,
+    identity_name: Option<String>,
     probe_cache: RwLock<HashMap<String, (ChannelHealthSnapshot, Instant)>>,
 }
 
@@ -50,8 +51,16 @@ impl WhatsAppPlugin {
             message_log: None,
             event_sink: None,
             data_dir,
+            identity_name: None,
             probe_cache: RwLock::new(HashMap::new()),
         }
+    }
+
+    /// Agent identity name, used as the WhatsApp push name unless an account
+    /// sets its own.
+    pub fn with_identity_name(mut self, name: Option<String>) -> Self {
+        self.identity_name = name;
+        self
     }
 
     pub fn with_message_log(mut self, log: Arc<dyn MessageLog>) -> Self {
@@ -176,6 +185,7 @@ impl ChannelPlugin for WhatsAppPlugin {
             self.data_dir.clone(),
             self.message_log.clone(),
             self.event_sink.clone(),
+            self.identity_name.clone(),
         )
         .await
         .map_err(|e| moltis_channels::Error::unavailable(format!("whatsapp start: {e}")))?;

--- a/docs/src/whatsapp.md
+++ b/docs/src/whatsapp.md
@@ -138,6 +138,7 @@ Each WhatsApp account is a named entry under `[channels.whatsapp]`:
 | `group_allowlist` | array | `[]` | Group JIDs allowed for bot responses |
 | `otp_self_approval` | bool | `true` | Allow non-allowlisted users to self-approve via OTP |
 | `otp_cooldown_secs` | int | `300` | Cooldown seconds after 3 failed OTP attempts |
+| `push_name` | string | — | Name this client asserts on WhatsApp, shown to anyone without the number saved. Falls back to `[identity] name`, then `"Moltis"` |
 
 ### Full Example
 


### PR DESCRIPTION
The WhatsApp client asserted a hardcoded push name. That name rides the
presence stanza, so it is what shows to anyone who does not have the number
saved as a contact: a bot configured as "Ada" appears in group chats as
"Moltis".

The builder hook it used is not meant for this. Its own doc comment says the
value exists so a mock server can assign phone numbers deterministically
during multi-device testing.

Resolution order is now account override, then agent identity, then the old
constant:

  [identity]
  name = "Ada"

  [channels.whatsapp.support]
  push_name = "Support"   # optional, overrides identity for this account

The account level exists because one instance can run several numbers.
Falling back to [identity] name means a configured bot is not called
something else on WhatsApp without anyone asking for it, and an instance
that sets neither is unchanged.

Blank values fall through rather than being honoured. An empty push name
makes send_presence refuse to send at all, so a stray name = "" would
otherwise disable presence silently.

Only the name this client sends changes. The account profile is untouched:
Client::set_push_name would rewrite it server side, and on a number paired
from a personal phone that would rename the owner's real WhatsApp profile.

with_os("Moltis") is left alone. That is the Linked Devices entry, where
naming the client software is correct.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
