### PR TITLE
fix(channels): make the untrusted-turn tool ceiling configurable

### DIFF
--- a/crates/channels/src/config_view.rs
+++ b/crates/channels/src/config_view.rs
@@ -1,4 +1,33 @@
-use crate::gating::{DmPolicy, GroupPolicy};
+use {
+    crate::gating::{DmPolicy, GroupPolicy},
+    serde::{Deserialize, Serialize},
+};
+
+/// Tool audience ceiling for a turn that is not an operator in a proven direct
+/// chat. Defaults to the fail-closed [`Self::Public`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum UntrustedAudience {
+    /// Only tools registered for the public audience are visible.
+    #[default]
+    Public,
+    /// No audience ceiling. MCP, WASM, and other trusted tools become visible,
+    /// leaving the name policy layers as the only limit on the turn.
+    Trusted,
+}
+
+/// Name policy applied to a turn that is not an operator in a proven direct
+/// chat. Defaults to the fail-closed [`Self::DenyAll`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum UntrustedTools {
+    /// Deny every tool by name, on top of the audience ceiling.
+    #[default]
+    DenyAll,
+    /// Add no name policy of its own and let the configured policy layers
+    /// decide, the same way they decide for an operator direct chat.
+    Policy,
+}
 
 /// Typed read-only view of common channel account config fields.
 ///
@@ -25,6 +54,20 @@ pub trait ChannelConfigView: Send + Sync + std::fmt::Debug {
     /// An empty list grants nobody privileged access.
     fn operators(&self) -> &[String] {
         &[]
+    }
+
+    /// Tool audience ceiling for untrusted turns on this account. Raise it to
+    /// let a known group reach MCP and other trusted tools, then narrow with
+    /// the tool policy layers.
+    fn untrusted_audience(&self) -> UntrustedAudience {
+        UntrustedAudience::default()
+    }
+
+    /// Name policy for untrusted turns on this account. [`UntrustedTools::Policy`]
+    /// removes the blanket denial and leaves the configured policy layers in
+    /// charge.
+    fn untrusted_tools(&self) -> UntrustedTools {
+        UntrustedTools::default()
     }
 
     /// DM access policy.

--- a/crates/gateway/src/channel_events.rs
+++ b/crates/gateway/src/channel_events.rs
@@ -10,6 +10,7 @@ use {
     moltis_channels::{
         ChannelAckOutcome, ChannelAttachment, ChannelEvent, ChannelEventSink, ChannelMessageMeta,
         ChannelReplyTarget, Error as ChannelError, Result as ChannelResult, SavedChannelFile,
+        config_view::{UntrustedAudience, UntrustedTools},
     },
     moltis_sessions::metadata::{SessionEntry, SqliteSessionMetadata},
     moltis_tools::approval::PendingApprovalView,
@@ -155,14 +156,51 @@ async fn resolve_sender_role(
     moltis_channels::operators::resolve_sender_role(sender_id, config.operators())
 }
 
+/// Read the account's untrusted-turn ceiling. A missing registry or an unknown
+/// account falls back to the defaults, which are the unconfigured behaviour.
+async fn resolve_untrusted_ceiling(
+    state: &Arc<GatewayState>,
+    account_id: &str,
+) -> (UntrustedAudience, UntrustedTools) {
+    let Some(ref registry) = state.services.channel_registry else {
+        return Default::default();
+    };
+    let Some(config) = registry.account_config(account_id).await else {
+        return Default::default();
+    };
+    (config.untrusted_audience(), config.untrusted_tools())
+}
+
 /// Apply the fail-closed context used for every untrusted channel turn.
 ///
 /// The audience ceiling excludes trusted tools, while the deny-all name policy
 /// also removes explicitly public tools. Configured policies may narrow this
 /// context further but cannot widen it.
 fn apply_untrusted_channel_context(params: &mut serde_json::Value) {
-    params["_tool_audience"] = serde_json::json!("public");
-    params["_tool_policy"] = serde_json::json!({ "deny": ["*"] });
+    apply_untrusted_channel_context_with(
+        params,
+        UntrustedAudience::default(),
+        UntrustedTools::default(),
+    );
+}
+
+/// Apply the untrusted channel context at the account's configured ceiling. The
+/// defaults reproduce [`apply_untrusted_channel_context`] exactly.
+///
+/// `_private_context` is deliberately not configurable: owner memory, profile
+/// and project context describe the owner rather than the conversation, so a
+/// room with other people in it never receives them.
+fn apply_untrusted_channel_context_with(
+    params: &mut serde_json::Value,
+    audience: UntrustedAudience,
+    tools: UntrustedTools,
+) {
+    if audience == UntrustedAudience::Public {
+        params["_tool_audience"] = serde_json::json!("public");
+    }
+    if tools == UntrustedTools::DenyAll {
+        params["_tool_policy"] = serde_json::json!({ "deny": ["*"] });
+    }
     params["_private_context"] = serde_json::json!(false);
 }
 

--- a/crates/gateway/src/channel_events/dispatch.rs
+++ b/crates/gateway/src/channel_events/dispatch.rs
@@ -26,10 +26,21 @@ pub(in crate::channel_events) async fn dispatch_to_chat(
         let sender_role =
             resolve_sender_role(state, &reply_to.account_id, meta.sender_id.as_deref()).await;
 
+        let trusted_channel_turn = is_trusted_channel_turn(sender_role, &reply_to);
+        let (untrusted_audience, untrusted_tools) =
+            resolve_untrusted_ceiling(state, &reply_to.account_id).await;
+
         // `/sh <cmd>` is deliberately not a registered channel command — it
         // falls through to the agent, which force-executes it. Stop it here
         // for guests, before it reaches the runner.
-        let trusted_channel_turn = is_trusted_channel_turn(sender_role, &reply_to);
+        //
+        // This stays tied to `trusted_channel_turn` rather than to the
+        // configured ceiling. `run_explicit_shell_command` takes `exec`
+        // straight from the request registry, which the `[tools.policy]`
+        // layers never touch: they are applied in `apply_runtime_tool_filters`
+        // on the agent-run path, which `/sh` returns before reaching. So
+        // letting the ceiling widen this guard would hand out an `exec` that
+        // no `deny` can take back.
         if !trusted_channel_turn && moltis_agents::runner::explicit_shell_command(text).is_some() {
             warn!(
                 account_id = %reply_to.account_id,
@@ -180,14 +191,15 @@ pub(in crate::channel_events) async fn dispatch_to_chat(
             "_native_channel_request": true,
         });
 
-        // Only an operator in a proven direct chat receives tools and private
-        // context. This is the single condition on purpose: an earlier version
+        // Only an operator in a proven direct chat is trusted outright; every
+        // other turn gets a ceiling, whose tightness comes from the account
+        // config. This is the single condition on purpose: an earlier version
         // also skipped the ceiling for anything that parsed as `/sh`, on the
         // assumption that the guard above had already rejected every untrusted
         // `/sh`. That made the ceiling depend on a rejection 60 lines away, so
         // narrowing that guard would have silently opened this one.
         if !trusted_channel_turn {
-            apply_untrusted_channel_context(&mut params);
+            apply_untrusted_channel_context_with(&mut params, untrusted_audience, untrusted_tools);
         }
 
         // Carry this message's acknowledgment identity into the run so the

--- a/crates/gateway/src/channel_events/tests.rs
+++ b/crates/gateway/src/channel_events/tests.rs
@@ -276,6 +276,86 @@ fn untrusted_channel_context_denies_every_tool_and_private_context() {
 }
 
 #[test]
+fn untrusted_ceiling_defaults_match_the_unconfigured_behaviour() {
+    let mut configured = serde_json::json!({});
+    let mut unconfigured = serde_json::json!({});
+
+    apply_untrusted_channel_context_with(
+        &mut configured,
+        UntrustedAudience::default(),
+        UntrustedTools::default(),
+    );
+    apply_untrusted_channel_context(&mut unconfigured);
+
+    assert_eq!(
+        configured, unconfigured,
+        "defaults must not change behaviour for an unconfigured account"
+    );
+}
+
+/// The most permissive ceiling leaves the params carrying no tool policy at
+/// all, so nothing on the request side can deny `exec`.
+///
+/// That is why the `/sh` guard in `dispatch_to_chat` stays tied to
+/// `trusted_channel_turn` and not to this ceiling. `run_explicit_shell_command`
+/// takes `exec` straight from the request registry, before the
+/// `[tools.policy]` layers are consulted, so a guard that widened with the
+/// ceiling would hand out an `exec` that no `deny` can take back.
+#[test]
+fn the_lifted_ceiling_cannot_deny_exec_on_the_request() {
+    let mut params = serde_json::json!({});
+
+    apply_untrusted_channel_context_with(
+        &mut params,
+        UntrustedAudience::Trusted,
+        UntrustedTools::Policy,
+    );
+
+    assert!(params.get("_tool_policy").is_none());
+    assert!(params.get("_tool_audience").is_none());
+    assert_eq!(params["_private_context"], false);
+}
+
+#[test]
+fn each_axis_is_lifted_on_its_own() {
+    let mut both = serde_json::json!({ "_private_context": true });
+    apply_untrusted_channel_context_with(
+        &mut both,
+        UntrustedAudience::Trusted,
+        UntrustedTools::Policy,
+    );
+    assert!(both.get("_tool_audience").is_none());
+    assert!(both.get("_tool_policy").is_none());
+    assert_eq!(
+        both["_private_context"], false,
+        "owner-private context is never configurable for a channel turn"
+    );
+
+    let mut audience_only = serde_json::json!({});
+    apply_untrusted_channel_context_with(
+        &mut audience_only,
+        UntrustedAudience::Trusted,
+        UntrustedTools::default(),
+    );
+    assert_eq!(
+        audience_only["_tool_policy"]["deny"],
+        serde_json::json!(["*"]),
+        "lifting the audience alone must still deny every tool by name"
+    );
+
+    let mut tools_only = serde_json::json!({});
+    apply_untrusted_channel_context_with(
+        &mut tools_only,
+        UntrustedAudience::default(),
+        UntrustedTools::Policy,
+    );
+    assert_eq!(
+        tools_only["_tool_audience"], "public",
+        "dropping the name policy alone must still hold the audience ceiling"
+    );
+}
+
+#[test]
 fn public_audience_tools_require_explicit_registration() {
     const REGISTRATION: &str = include_str!("../server/prepare_core/post_state.rs");
 

--- a/crates/whatsapp/src/config.rs
+++ b/crates/whatsapp/src/config.rs
@@ -1,6 +1,6 @@
 use {
     moltis_channels::{
-        config_view::ChannelConfigView,
+        config_view::{ChannelConfigView, UntrustedAudience, UntrustedTools},
         gating::{DmPolicy, GroupPolicy, MentionMode},
     },
     serde::{Deserialize, Serialize},
@@ -74,6 +74,16 @@ pub struct WhatsAppAccountConfig {
     /// Group JID allowlist.
     pub group_allowlist: Vec<String>,
 
+    /// Tool audience ceiling for turns outside an operator direct chat
+    /// (default: `public`).
+    #[serde(default)]
+    pub untrusted_audience: UntrustedAudience,
+
+    /// Name policy for turns outside an operator direct chat
+    /// (default: `deny_all`).
+    #[serde(default)]
+    pub untrusted_tools: UntrustedTools,
+
     /// Enable OTP self-approval for non-allowlisted DM users (default: true).
     pub otp_self_approval: bool,
 
@@ -114,6 +124,14 @@ impl ChannelConfigView for WhatsAppAccountConfig {
 
     fn group_allowlist(&self) -> &[String] {
         &self.group_allowlist
+    }
+
+    fn untrusted_audience(&self) -> UntrustedAudience {
+        self.untrusted_audience
+    }
+
+    fn untrusted_tools(&self) -> UntrustedTools {
+        self.untrusted_tools
     }
 
     fn dm_policy(&self) -> DmPolicy {
@@ -189,6 +207,8 @@ impl Default for WhatsAppAccountConfig {
             allowlist: Vec::new(),
             operators: Vec::new(),
             group_allowlist: Vec::new(),
+            untrusted_audience: UntrustedAudience::default(),
+            untrusted_tools: UntrustedTools::default(),
             otp_self_approval: true,
             otp_cooldown_secs: 300,
             channel_overrides: HashMap::new(),

--- a/docs/src/channels.md
+++ b/docs/src/channels.md
@@ -378,10 +378,16 @@ separately.
 ```
 
 Untrusted tool restrictions stack with the per-channel tool policy
-(`channels.<type>.<account>.tools.groups.<chat_type>`). Those policies can
-further restrict an operator DM, but cannot enable tools for a guest, shared
-room, or unknown chat. Grant eligibility for privileged access by adding the
-sender to `operators`; the sender must still use a proven direct chat.
+(`channels.<type>.<account>.tools.groups.<chat_type>`). By default those
+policies can further restrict an operator DM, but cannot enable tools for a
+guest, shared room, or unknown chat: the untrusted ceiling denies everything
+before they are consulted. An account that raises its ceiling with
+`untrusted_audience` and `untrusted_tools` (WhatsApp only for now) hands the
+decision back to those policies for its own untrusted turns. The `/sh`
+shortcut stays restricted to operator direct chats either way.
+
+Grant eligibility for privileged access by adding the sender to `operators`;
+the sender must still use a proven direct chat.
 
 ### OTP Self-Approval
 

--- a/docs/src/whatsapp.md
+++ b/docs/src/whatsapp.md
@@ -138,6 +138,8 @@ Each WhatsApp account is a named entry under `[channels.whatsapp]`:
 | `group_allowlist` | array | `[]` | Group JIDs allowed for bot responses |
 | `otp_self_approval` | bool | `true` | Allow non-allowlisted users to self-approve via OTP |
 | `otp_cooldown_secs` | int | `300` | Cooldown seconds after 3 failed OTP attempts |
+| `untrusted_audience` | string | `"public"` | Tool audience ceiling for turns outside an operator direct chat: `"public"` or `"trusted"` |
+| `untrusted_tools` | string | `"deny_all"` | Tool name policy for those turns: `"deny_all"`, or `"policy"` to let `[tools.policy]` decide |
 
 ### Full Example
 


### PR DESCRIPTION
#1170 gave every turn that is not an operator in a proven direct chat a
hardcoded deny-all tool policy on top of the public audience ceiling. That
was right for /sh, but it also removed the three tools registered for the
public audience, and it made tool policy layers 4 and 5 unreachable in any
shared chat, which is the case they were added for in #677.

Two new per-account fields carry the ceiling instead of hardcoding it:

  untrusted_audience = "public" | "trusted"    (default "public")
  untrusted_tools    = "deny_all" | "policy"   (default "deny_all")

The defaults reproduce the current behaviour exactly, so an account with no
configuration is unchanged. WhatsApp is the only channel that reads them so
far; the other eight fall back to the defaults, which is the unconfigured
behaviour.

/sh keeps its own gate, tied to the operator-direct-chat test and not to the
ceiling. It cannot follow the tool policy the way the agent's exec call does:
run_explicit_shell_command takes "exec" straight from the request registry,
and the [tools.policy] layers are applied in apply_runtime_tool_filters on
the agent-run path, which /sh returns before reaching. A guard that widened
with the ceiling would hand out an exec that no deny can take back.

_private_context stays off for every untrusted turn and is not configurable.
Owner memory, profile and project context describe the owner rather than the
conversation, so a room with other people in it never receives them.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
