### PR TITLE
fix(cron): deliver scheduled output to the originating chat

### DIFF
--- a/crates/agents/src/prompt/tests.rs
+++ b/crates/agents/src/prompt/tests.rs
@@ -357,6 +357,7 @@ fn test_runtime_context_injected_when_provided() {
             channel_type: None,
             channel_account_id: None,
             channel_chat_id: None,
+            channel_outbound_to: None,
             channel_chat_type: None,
             channel_sender_id: None,
             data_dir: Some("/home/moltis/.moltis".into()),

--- a/crates/agents/src/prompt/types.rs
+++ b/crates/agents/src/prompt/types.rs
@@ -52,6 +52,7 @@ pub struct PromptHostRuntimeContext {
     pub channel_type: Option<String>,
     pub channel_account_id: Option<String>,
     pub channel_chat_id: Option<String>,
+    pub channel_outbound_to: Option<String>,
     pub channel_chat_type: Option<String>,
     pub channel_sender_id: Option<String>,
     pub data_dir: Option<String>,

--- a/crates/agents/src/runner/instrumentation.rs
+++ b/crates/agents/src/runner/instrumentation.rs
@@ -377,6 +377,7 @@ mod tests {
             channel_type: Some("telegram".into()),
             account_id: Some("acct-1".into()),
             chat_id: Some("chat-1".into()),
+            outbound_to: Some("chat-1".into()),
             chat_type: Some("dm".into()),
             sender_id: Some("42".into()),
         }

--- a/crates/channels/src/plugin.rs
+++ b/crates/channels/src/plugin.rs
@@ -415,6 +415,7 @@ impl From<&ChannelReplyTarget> for ChannelBinding {
             channel_type: Some(channel_type),
             account_id: Some(target.account_id.clone()),
             chat_id: Some(target.chat_id.clone()),
+            outbound_to: Some(target.outbound_to().into_owned()),
             chat_type: target.channel_type.classify_chat(&target.chat_id),
             sender_id: None,
         }
@@ -1358,6 +1359,7 @@ mod tests {
         assert_eq!(binding.channel_type.as_deref(), Some("telegram"));
         assert_eq!(binding.account_id.as_deref(), Some("bot1"));
         assert_eq!(binding.chat_id.as_deref(), Some("-100999"));
+        assert_eq!(binding.outbound_to.as_deref(), Some("-100999:42"));
         assert_eq!(binding.chat_type.as_deref(), Some("channel_or_supergroup"));
         assert!(binding.sender_id.is_none());
     }

--- a/crates/chat/src/prompt.rs
+++ b/crates/chat/src/prompt.rs
@@ -381,6 +381,7 @@ pub(crate) fn channel_binding_from_runtime_context(
         channel_type: host.channel_type.clone(),
         account_id: host.channel_account_id.clone(),
         chat_id: host.channel_chat_id.clone(),
+        outbound_to: host.channel_outbound_to.clone(),
         chat_type: host.channel_chat_type.clone(),
         sender_id: host.channel_sender_id.clone(),
     };
@@ -498,6 +499,7 @@ pub(crate) async fn build_prompt_runtime_context(
         channel_type: channel_context.channel_type,
         channel_account_id: channel_context.account_id,
         channel_chat_id: channel_context.chat_id,
+        channel_outbound_to: channel_context.outbound_to,
         channel_chat_type: channel_context.chat_type,
         data_dir: Some(data_dir_display),
         files_dir: Some(moltis_config::managed_files_dir().display().to_string()),
@@ -782,5 +784,20 @@ mod tests {
             Some("/workspace/project")
         );
         assert!(context.get("working_dir").is_none());
+    }
+
+    #[test]
+    fn tool_context_preserves_canonical_channel_destination() {
+        let mut runtime = PromptRuntimeContext::default();
+        runtime.host.channel_type = Some("telegram".into());
+        runtime.host.channel_account_id = Some("main".into());
+        runtime.host.channel_chat_id = Some("-100123".into());
+        runtime.host.channel_outbound_to = Some("-100123:42".into());
+
+        let context = build_tool_context("telegram:main:-100123:42", None, None, Some(&runtime));
+
+        assert_eq!(context["_channel"]["account_id"], "main");
+        assert_eq!(context["_channel"]["chat_id"], "-100123");
+        assert_eq!(context["_channel"]["outbound_to"], "-100123:42");
     }
 }

--- a/crates/common/src/hooks.rs
+++ b/crates/common/src/hooks.rs
@@ -140,6 +140,10 @@ pub struct ChannelBinding {
     pub account_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub chat_id: Option<String>,
+    /// Canonical outbound address for the current conversation. This may
+    /// include channel-specific routing data (for example a Telegram topic).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub outbound_to: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub chat_type: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -154,6 +158,7 @@ impl ChannelBinding {
             && self.channel_type.is_none()
             && self.account_id.is_none()
             && self.chat_id.is_none()
+            && self.outbound_to.is_none()
             && self.chat_type.is_none()
             && self.sender_id.is_none()
     }
@@ -791,6 +796,7 @@ mod tests {
             channel_type: Some("telegram".into()),
             account_id: Some("bot-main".into()),
             chat_id: Some("-100123".into()),
+            outbound_to: Some("-100123".into()),
             chat_type: Some("channel_or_supergroup".into()),
             sender_id: None,
         }

--- a/crates/cron/src/schedule.rs
+++ b/crates/cron/src/schedule.rs
@@ -168,6 +168,28 @@ mod tests {
     }
 
     #[test]
+    fn test_cron_named_weekdays_with_timezone() {
+        let schedule = CronSchedule::Cron {
+            expr: "0 17 * * MON-FRI".into(),
+            tz: Some("America/Sao_Paulo".into()),
+        };
+        // Friday 2024-02-02 at 18:00 in São Paulo.
+        let now_ms = Utc
+            .with_ymd_and_hms(2024, 2, 2, 21, 0, 0)
+            .single()
+            .unwrap()
+            .timestamp_millis() as u64;
+
+        let next = compute_next_run(&schedule, now_ms).unwrap().unwrap();
+        let expected = Utc
+            .with_ymd_and_hms(2024, 2, 5, 20, 0, 0)
+            .single()
+            .unwrap()
+            .timestamp_millis() as u64;
+        assert_eq!(next, expected, "next run should be Monday at 17:00 BRT");
+    }
+
+    #[test]
     fn test_cron_invalid_expr() {
         let s = CronSchedule::Cron {
             expr: "not valid".into(),

--- a/crates/cron/src/schedule.rs
+++ b/crates/cron/src/schedule.rs
@@ -154,6 +154,37 @@ mod tests {
     }
 
     #[test]
+    fn test_cron_six_field_with_seconds() {
+        let schedule = CronSchedule::Cron {
+            expr: "30 0 9 * * *".into(),
+            tz: None,
+        };
+        let now_ms = 1_706_745_600_000; // 2024-02-01T00:00:00Z
+
+        let next = compute_next_run(&schedule, now_ms).unwrap().unwrap();
+        let dt = DateTime::from_timestamp_millis(next as i64).unwrap();
+
+        assert_eq!(dt.format("%H:%M:%S").to_string(), "09:00:30");
+    }
+
+    #[test]
+    fn test_cron_seven_field_with_year() {
+        let schedule = CronSchedule::Cron {
+            expr: "0 0 9 1 2 * 2025".into(),
+            tz: None,
+        };
+        let now_ms = 1_706_745_600_000; // 2024-02-01T00:00:00Z
+
+        let next = compute_next_run(&schedule, now_ms).unwrap().unwrap();
+        let dt = DateTime::from_timestamp_millis(next as i64).unwrap();
+
+        assert_eq!(
+            dt.format("%Y-%m-%d %H:%M:%S").to_string(),
+            "2025-02-01 09:00:00"
+        );
+    }
+
+    #[test]
     fn test_cron_with_timezone() {
         let s = CronSchedule::Cron {
             expr: "0 9 * * *".into(),

--- a/crates/cron/src/service.rs
+++ b/crates/cron/src/service.rs
@@ -32,6 +32,8 @@ pub struct AgentTurnResult {
     pub output_tokens: Option<u64>,
     /// The session key used for this turn (links to the session store).
     pub session_key: Option<String>,
+    /// Failure that occurred after the agent turn completed while delivering its output.
+    pub delivery_error: Option<String>,
 }
 
 /// Callback for running an isolated agent turn.
@@ -598,6 +600,7 @@ impl CronService {
                     input_tokens: None,
                     output_tokens: None,
                     session_key: None,
+                    delivery_error: None,
                 })
             },
             CronPayload::AgentTurn {
@@ -639,9 +642,22 @@ impl CronService {
                         counter!(cron_metrics::OUTPUT_TOKENS_TOTAL).increment(output);
                     }
                 }
+                let (status, error_msg) = match &r.delivery_error {
+                    Some(delivery_error) => {
+                        error!(
+                            id = %job.id,
+                            error = %delivery_error,
+                            "cron output delivery failed"
+                        );
+                        #[cfg(feature = "metrics")]
+                        counter!(cron_metrics::ERRORS_TOTAL).increment(1);
+                        (RunStatus::Error, Some(delivery_error.clone()))
+                    },
+                    None => (RunStatus::Ok, None),
+                };
                 (
-                    RunStatus::Ok,
-                    None,
+                    status,
+                    error_msg,
                     Some(r.output.clone()),
                     r.input_tokens,
                     r.output_tokens,

--- a/crates/cron/src/service.rs
+++ b/crates/cron/src/service.rs
@@ -456,7 +456,7 @@ impl CronService {
     }
 
     /// Force-run a job immediately.
-    pub async fn run(self: &Arc<Self>, id: &str, force: bool) -> Result<()> {
+    pub async fn run(self: &Arc<Self>, id: &str, force: bool) -> Result<CronRunRecord> {
         let job = {
             let jobs = self.jobs.read().await;
             jobs.iter()
@@ -478,8 +478,7 @@ impl CronService {
         })
         .await;
 
-        self.execute_job(&job).await;
-        Ok(())
+        Ok(self.execute_job(&job).await)
     }
 
     /// Get run history for a job.
@@ -577,12 +576,12 @@ impl CronService {
             let svc = Arc::clone(self);
             let job_clone = job.clone();
             tokio::spawn(async move {
-                svc.execute_job(&job_clone).await;
+                let _run = svc.execute_job(&job_clone).await;
             });
         }
     }
 
-    async fn execute_job(self: &Arc<Self>, job: &CronJob) {
+    async fn execute_job(self: &Arc<Self>, job: &CronJob) -> CronRunRecord {
         let started = now_ms();
         info!(id = %job.id, name = %job.name, "executing cron job");
 
@@ -730,6 +729,7 @@ impl CronService {
             duration_ms,
             "cron job finished"
         );
+        run
     }
 
     async fn update_job_state<F: FnOnce(&mut CronJobState)>(&self, id: &str, f: F) {

--- a/crates/cron/src/service/tests.rs
+++ b/crates/cron/src/service/tests.rs
@@ -16,6 +16,7 @@ fn noop_agent_turn() -> AgentTurnFn {
                 input_tokens: None,
                 output_tokens: None,
                 session_key: None,
+                delivery_error: None,
             })
         })
     })
@@ -37,6 +38,7 @@ fn counting_agent_turn(counter: Arc<AtomicUsize>) -> AgentTurnFn {
                 input_tokens: None,
                 output_tokens: None,
                 session_key: None,
+                delivery_error: None,
             })
         })
     })
@@ -258,7 +260,7 @@ async fn test_force_run() {
 #[tokio::test]
 async fn test_run_returns_recorded_agent_failure() {
     let agent_turn: AgentTurnFn =
-        Arc::new(|_| Box::pin(async { Err(Error::message("delivery failed")) }));
+        Arc::new(|_| Box::pin(async { Err(Error::message("agent turn failed")) }));
     let svc = make_svc(
         Arc::new(InMemoryStore::new()),
         noop_system_event(),
@@ -295,7 +297,70 @@ async fn test_run_returns_recorded_agent_failure() {
     let run = svc.run(&job.id, false).await.unwrap();
 
     assert_eq!(run.status, RunStatus::Error);
-    assert_eq!(run.error.as_deref(), Some("delivery failed"));
+    assert_eq!(run.error.as_deref(), Some("agent turn failed"));
+    assert!(run.output.is_none());
+    assert!(run.input_tokens.is_none());
+    assert!(run.output_tokens.is_none());
+    assert!(run.session_key.is_none());
+}
+
+#[tokio::test]
+async fn test_run_preserves_agent_result_when_delivery_fails() {
+    let agent_turn: AgentTurnFn = Arc::new(|_| {
+        Box::pin(async {
+            Ok(AgentTurnResult {
+                output: "completed report".into(),
+                input_tokens: Some(42),
+                output_tokens: Some(17),
+                session_key: Some("cron:delivery-test".into()),
+                delivery_error: Some("channel unavailable".into()),
+            })
+        })
+    });
+    let svc = make_svc(
+        Arc::new(InMemoryStore::new()),
+        noop_system_event(),
+        agent_turn,
+    );
+    let job = svc
+        .add(CronJobCreate {
+            id: None,
+            name: "delivery failure".into(),
+            schedule: CronSchedule::Every {
+                every_ms: 60_000,
+                anchor_ms: None,
+            },
+            payload: CronPayload::AgentTurn {
+                message: "go".into(),
+                model: None,
+                agent_id: None,
+                timeout_secs: None,
+                tool_controls: Default::default(),
+                deliver: true,
+                channel: Some("main".into()),
+                to: Some("recipient".into()),
+            },
+            session_target: SessionTarget::Isolated,
+            delete_after_run: false,
+            enabled: true,
+            system: false,
+            sandbox: CronSandboxConfig::default(),
+            wake_mode: CronWakeMode::default(),
+        })
+        .await
+        .unwrap();
+
+    let run = svc.run(&job.id, false).await.unwrap();
+
+    assert_eq!(run.status, RunStatus::Error);
+    assert_eq!(run.error.as_deref(), Some("channel unavailable"));
+    assert_eq!(run.output.as_deref(), Some("completed report"));
+    assert_eq!(run.input_tokens, Some(42));
+    assert_eq!(run.output_tokens, Some(17));
+    assert_eq!(run.session_key.as_deref(), Some("cron:delivery-test"));
+
+    let stored_runs = svc.runs(&job.id, 1).await.unwrap();
+    assert_eq!(stored_runs, vec![run]);
 }
 
 #[tokio::test]

--- a/crates/cron/src/service/tests.rs
+++ b/crates/cron/src/service/tests.rs
@@ -249,10 +249,53 @@ async fn test_force_run() {
         .await
         .unwrap();
 
-    svc.run(&job.id, false).await.unwrap();
-    // Give the spawned task a moment.
-    tokio::time::sleep(Duration::from_millis(50)).await;
+    let run = svc.run(&job.id, false).await.unwrap();
+    assert_eq!(run.status, RunStatus::Ok);
+    assert_eq!(run.output.as_deref(), Some("done"));
     assert_eq!(counter.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
+async fn test_run_returns_recorded_agent_failure() {
+    let agent_turn: AgentTurnFn =
+        Arc::new(|_| Box::pin(async { Err(Error::message("delivery failed")) }));
+    let svc = make_svc(
+        Arc::new(InMemoryStore::new()),
+        noop_system_event(),
+        agent_turn,
+    );
+    let job = svc
+        .add(CronJobCreate {
+            id: None,
+            name: "failing".into(),
+            schedule: CronSchedule::Every {
+                every_ms: 60_000,
+                anchor_ms: None,
+            },
+            payload: CronPayload::AgentTurn {
+                message: "go".into(),
+                model: None,
+                agent_id: None,
+                timeout_secs: None,
+                tool_controls: Default::default(),
+                deliver: true,
+                channel: Some("main".into()),
+                to: Some("recipient".into()),
+            },
+            session_target: SessionTarget::Isolated,
+            delete_after_run: false,
+            enabled: true,
+            system: false,
+            sandbox: CronSandboxConfig::default(),
+            wake_mode: CronWakeMode::default(),
+        })
+        .await
+        .unwrap();
+
+    let run = svc.run(&job.id, false).await.unwrap();
+
+    assert_eq!(run.status, RunStatus::Error);
+    assert_eq!(run.error.as_deref(), Some("delivery failed"));
 }
 
 #[tokio::test]

--- a/crates/cron/src/types.rs
+++ b/crates/cron/src/types.rs
@@ -25,7 +25,7 @@ pub enum CronSchedule {
         #[serde(skip_serializing_if = "Option::is_none")]
         anchor_ms: Option<u64>,
     },
-    /// Cron expression (5 fields, or the extended form accepted by the parser).
+    /// Cron expression with 5 fields, or 6/7 fields with leading seconds and an optional year.
     Cron {
         expr: String,
         #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/cron/src/types.rs
+++ b/crates/cron/src/types.rs
@@ -25,7 +25,7 @@ pub enum CronSchedule {
         #[serde(skip_serializing_if = "Option::is_none")]
         anchor_ms: Option<u64>,
     },
-    /// Cron expression (5-field standard or 6-field with seconds).
+    /// Cron expression (5 fields, or the extended form accepted by the parser).
     Cron {
         expr: String,
         #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/gateway/src/cron.rs
+++ b/crates/gateway/src/cron.rs
@@ -86,11 +86,13 @@ impl CronServiceTrait for LiveCronService {
             .get("force")
             .and_then(|v| v.as_bool())
             .unwrap_or(false);
-        self.inner
+        let run = self
+            .inner
             .run(id, force)
             .await
             .map_err(ServiceError::message)?;
-        Ok(serde_json::json!({ "ran": id }))
+        let ok = run.status == moltis_cron::types::RunStatus::Ok;
+        Ok(serde_json::json!({ "ran": id, "ok": ok, "run": run }))
     }
 
     async fn runs(&self, params: Value) -> ServiceResult {

--- a/crates/gateway/src/server/helpers.rs
+++ b/crates/gateway/src/server/helpers.rs
@@ -581,30 +581,28 @@ pub(crate) async fn maybe_deliver_cron_output(
     outbound: Option<Arc<dyn moltis_channels::ChannelOutbound>>,
     req: &moltis_cron::service::AgentTurnRequest,
     delivery_text: &str,
-) {
+) -> moltis_cron::Result<()> {
     if !req.deliver || delivery_text.trim().is_empty() {
-        return;
+        return Ok(());
     }
 
     let (Some(channel_account), Some(chat_id)) = (&req.channel, &req.to) else {
-        return;
+        return Err(moltis_cron::Error::message(
+            "cron delivery requires both channel and destination",
+        ));
     };
 
-    if let Some(outbound) = outbound {
-        if let Err(error) = outbound
-            .send_text(channel_account, chat_id, delivery_text, None)
-            .await
-        {
-            tracing::warn!(
-                channel = %channel_account,
-                to = %chat_id,
-                error = %error,
-                "cron job channel delivery failed"
-            );
-        }
-    } else {
-        tracing::debug!("cron job delivery requested but no channel outbound configured");
-    }
+    let outbound = outbound.ok_or_else(|| {
+        moltis_cron::Error::message("cron delivery requested but channel outbound is unavailable")
+    })?;
+    outbound
+        .send_text(channel_account, chat_id, delivery_text, None)
+        .await
+        .map_err(|error| {
+            moltis_cron::Error::message(format!(
+                "failed to deliver cron output to {channel_account}: {error}"
+            ))
+        })
 }
 
 // ── Skill hot-reload watcher ─────────────────────────────────────────────────

--- a/crates/gateway/src/server/prepare_core.rs
+++ b/crates/gateway/src/server/prepare_core.rs
@@ -762,6 +762,7 @@ pub async fn prepare_gateway_core_with_profile(
                         input_tokens: None,
                         output_tokens: None,
                         session_key: None,
+                        delivery_error: None,
                     });
                 }
             }
@@ -875,19 +876,26 @@ pub async fn prepare_gateway_core_with_profile(
                 text.clone()
             };
 
-            if req.deliver && !is_heartbeat_turn && delivery_text.trim().is_empty() {
-                return Err(moltis_cron::Error::message(
-                    "cron agent produced an empty response; nothing was delivered",
-                ));
-            }
-            maybe_deliver_cron_output(state.services.channel_outbound_arc(), &req, &delivery_text)
-                .await?;
+            let delivery_error =
+                if req.deliver && !is_heartbeat_turn && delivery_text.trim().is_empty() {
+                    Some("cron agent produced an empty response; nothing was delivered".to_string())
+                } else {
+                    maybe_deliver_cron_output(
+                        state.services.channel_outbound_arc(),
+                        &req,
+                        &delivery_text,
+                    )
+                    .await
+                    .err()
+                    .map(|error| error.to_string())
+                };
 
             Ok(moltis_cron::service::AgentTurnResult {
                 output: text,
                 input_tokens,
                 output_tokens,
                 session_key: Some(session_key),
+                delivery_error,
             })
         })
     });

--- a/crates/gateway/src/server/prepare_core.rs
+++ b/crates/gateway/src/server/prepare_core.rs
@@ -875,8 +875,13 @@ pub async fn prepare_gateway_core_with_profile(
                 text.clone()
             };
 
+            if req.deliver && !is_heartbeat_turn && delivery_text.trim().is_empty() {
+                return Err(moltis_cron::Error::message(
+                    "cron agent produced an empty response; nothing was delivered",
+                ));
+            }
             maybe_deliver_cron_output(state.services.channel_outbound_arc(), &req, &delivery_text)
-                .await;
+                .await?;
 
             Ok(moltis_cron::service::AgentTurnResult {
                 output: text,

--- a/crates/gateway/src/server/tests_legacy/cron.rs
+++ b/crates/gateway/src/server/tests_legacy/cron.rs
@@ -1,6 +1,35 @@
 use std::sync::Arc;
 
-use super::common::{DeliveredMessage, RecordingChannelOutbound, cron_delivery_request};
+use {
+    super::common::{DeliveredMessage, RecordingChannelOutbound, cron_delivery_request},
+    async_trait::async_trait,
+    moltis_common::types::ReplyPayload,
+};
+
+struct FailingChannelOutbound;
+
+#[async_trait]
+impl moltis_channels::ChannelOutbound for FailingChannelOutbound {
+    async fn send_text(
+        &self,
+        _account_id: &str,
+        _to: &str,
+        _text: &str,
+        _reply_to: Option<&str>,
+    ) -> moltis_channels::Result<()> {
+        Err(moltis_channels::Error::unavailable("test delivery failure"))
+    }
+
+    async fn send_media(
+        &self,
+        _account_id: &str,
+        _to: &str,
+        _payload: &ReplyPayload,
+        _reply_to: Option<&str>,
+    ) -> moltis_channels::Result<()> {
+        Ok(())
+    }
+}
 
 #[tokio::test]
 async fn maybe_deliver_cron_output_sends_to_configured_channel() {
@@ -12,7 +41,8 @@ async fn maybe_deliver_cron_output_sends_to_configured_channel() {
         &req,
         "Daily digest ready",
     )
-    .await;
+    .await
+    .unwrap();
 
     let delivered = outbound.delivered.lock().await.clone();
     assert_eq!(delivered, vec![DeliveredMessage {
@@ -33,7 +63,8 @@ async fn maybe_deliver_cron_output_skips_blank_messages() {
         &req,
         "   ",
     )
-    .await;
+    .await
+    .unwrap();
 
     assert!(outbound.delivered.lock().await.is_empty());
 }
@@ -49,14 +80,33 @@ async fn maybe_deliver_cron_output_skips_when_deliver_is_false() {
         &req,
         "should not be sent",
     )
-    .await;
+    .await
+    .unwrap();
 
     assert!(outbound.delivered.lock().await.is_empty());
 }
 
 #[tokio::test]
-async fn maybe_deliver_cron_output_skips_when_no_outbound_configured() {
+async fn maybe_deliver_cron_output_fails_when_no_outbound_is_configured() {
     let req = cron_delivery_request();
 
-    crate::server::helpers::maybe_deliver_cron_output(None, &req, "Daily digest ready").await;
+    let error = crate::server::helpers::maybe_deliver_cron_output(None, &req, "Daily digest ready")
+        .await
+        .unwrap_err();
+    assert!(error.to_string().contains("outbound is unavailable"));
+}
+
+#[tokio::test]
+async fn maybe_deliver_cron_output_propagates_channel_failure() {
+    let req = cron_delivery_request();
+    let outbound: Arc<dyn moltis_channels::ChannelOutbound> = Arc::new(FailingChannelOutbound);
+
+    let error = crate::server::helpers::maybe_deliver_cron_output(
+        Some(outbound),
+        &req,
+        "Daily digest ready",
+    )
+    .await
+    .unwrap_err();
+    assert!(error.to_string().contains("test delivery failure"));
 }

--- a/crates/graphql/src/error.rs
+++ b/crates/graphql/src/error.rs
@@ -24,6 +24,14 @@ pub fn from_service<T: serde::de::DeserializeOwned>(
     serde_json::from_value(value).map_err(parse_err)
 }
 
+/// Convert any successful service response into the conventional mutation
+/// result. Use this when the backing service returns the created/updated value
+/// instead of an `{ "ok": true }` envelope.
+pub fn from_service_ok(result: ServiceResult) -> async_graphql::Result<crate::types::BoolResult> {
+    result.map_err(gql_err)?;
+    Ok(crate::types::BoolResult { ok: true })
+}
+
 /// Convert a `ServiceResult` into a raw JSON GraphQL result.
 ///
 /// Returns the JSON value as-is, wrapped in the `Json` scalar. Use this for

--- a/crates/graphql/src/mutations/resolvers.rs
+++ b/crates/graphql/src/mutations/resolvers.rs
@@ -6,7 +6,7 @@
 use async_graphql::{Context, Object, Result};
 
 use crate::{
-    error::{from_service, from_service_json, gql_err, parse_err},
+    error::{from_service, from_service_json, from_service_ok, gql_err, parse_err},
     scalars::Json,
     services,
     types::{
@@ -457,17 +457,17 @@ pub struct CronMutation;
 impl CronMutation {
     async fn add(&self, ctx: &Context<'_>, input: Json) -> Result<BoolResult> {
         let s = services!(ctx);
-        from_service(s.cron.add(input.0).await)
+        from_service_ok(s.cron.add(input.0).await)
     }
 
     async fn update(&self, ctx: &Context<'_>, input: Json) -> Result<BoolResult> {
         let s = services!(ctx);
-        from_service(s.cron.update(input.0).await)
+        from_service_ok(s.cron.update(input.0).await)
     }
 
     async fn remove(&self, ctx: &Context<'_>, id: String) -> Result<BoolResult> {
         let s = services!(ctx);
-        from_service(s.cron.remove(serde_json::json!({ "id": id })).await)
+        from_service_ok(s.cron.remove(serde_json::json!({ "id": id })).await)
     }
 
     /// Trigger a cron job immediately.

--- a/crates/graphql/src/queries/resolvers.rs
+++ b/crates/graphql/src/queries/resolvers.rs
@@ -405,7 +405,7 @@ impl CronQuery {
     /// Get run history for a cron job.
     async fn runs(&self, ctx: &Context<'_>, job_id: String) -> Result<Vec<CronRunRecord>> {
         let s = services!(ctx);
-        from_service(s.cron.runs(serde_json::json!({ "jobId": job_id })).await)
+        from_service(s.cron.runs(serde_json::json!({ "id": job_id })).await)
     }
 }
 

--- a/crates/graphql/tests/integration/mutation_tests.rs
+++ b/crates/graphql/tests/integration/mutation_tests.rs
@@ -179,7 +179,16 @@ async fn providers_oauth_start_mutation_returns_typed_shape() {
 #[tokio::test]
 async fn cron_add_mutation() {
     let mock = MockDispatch::new();
-    mock.set_response("cron.add", json!({"ok": true}));
+    mock.set_response(
+        "cron.add",
+        json!({
+            "id": "job-1",
+            "name": "backup",
+            "enabled": true,
+            "schedule": { "kind": "every", "every_ms": 60000 },
+            "payload": { "kind": "agentTurn", "message": "backup" }
+        }),
+    );
     let (schema, _) = build_test_schema(mock.clone());
 
     let res = schema
@@ -192,4 +201,32 @@ async fn cron_add_mutation() {
     let (method, params) = mock.last_call().expect("should have called");
     assert_eq!(method, "cron.add");
     assert_eq!(params["name"], "backup");
+}
+
+#[tokio::test]
+async fn cron_run_reports_recorded_failure() {
+    let mock = MockDispatch::new();
+    mock.set_response(
+        "cron.run",
+        json!({
+            "ran": "job-1",
+            "ok": false,
+            "run": {
+                "jobId": "job-1",
+                "status": "error",
+                "error": "channel delivery failed"
+            }
+        }),
+    );
+    let (schema, _) = build_test_schema(mock);
+
+    let response = schema
+        .execute(Request::new(
+            r#"mutation { cron { run(id: "job-1") { ok } } }"#,
+        ))
+        .await;
+
+    assert!(response.errors.is_empty(), "errors: {:?}", response.errors);
+    let data = response.data.into_json().expect("json");
+    assert_eq!(data["cron"]["run"]["ok"], false);
 }

--- a/crates/graphql/tests/integration/query_tests.rs
+++ b/crates/graphql/tests/integration/query_tests.rs
@@ -60,6 +60,24 @@ async fn cron_list_query() {
 }
 
 #[tokio::test]
+async fn cron_runs_query_forwards_job_id() {
+    let mock = MockDispatch::new();
+    mock.set_response("cron.runs", json!([]));
+    let (schema, _) = build_test_schema(mock.clone());
+
+    let res = schema
+        .execute(Request::new(
+            r#"{ cron { runs(jobId: "job-1") { status } } }"#,
+        ))
+        .await;
+
+    assert!(res.errors.is_empty(), "errors: {:?}", res.errors);
+    let (method, params) = mock.last_call().expect("should have called");
+    assert_eq!(method, "cron.runs");
+    assert_eq!(params["id"], "job-1");
+}
+
+#[tokio::test]
 async fn sessions_list_query() {
     let mock = MockDispatch::new();
     mock.set_response(

--- a/crates/tools/src/cron_tool.rs
+++ b/crates/tools/src/cron_tool.rs
@@ -18,6 +18,9 @@ use {
     },
 };
 
+mod current_channel;
+mod schema;
+
 /// The cron tool exposed to LLM agents.
 pub struct CronTool {
     service: Arc<CronService>,
@@ -589,7 +592,7 @@ fn rescue_stringified_object(v: &mut Value) {
     }
 }
 
-fn normalize_job_value(job: &Value) -> Result<Value> {
+fn normalize_job_value(job: &Value, channel_context: Option<&Value>) -> Result<Value> {
     let mut normalized = job.clone();
     rescue_stringified_object(&mut normalized);
     prune_null_fields(&mut normalized);
@@ -597,6 +600,10 @@ fn normalize_job_value(job: &Value) -> Result<Value> {
         .as_object_mut()
         .ok_or_else(|| Error::message("job must be an object"))?;
     normalize_session_target_field(obj);
+    if let Some(payload) = obj.get_mut("payload") {
+        rescue_stringified_object(payload);
+    }
+    current_channel::apply(obj, channel_context)?;
     normalize_sandbox_field(obj)?;
     normalize_wake_mode_field(obj)?;
 
@@ -618,7 +625,7 @@ fn normalize_job_value(job: &Value) -> Result<Value> {
     Ok(normalized)
 }
 
-fn normalize_patch_value(patch: &Value) -> Result<Value> {
+fn normalize_patch_value(patch: &Value, channel_context: Option<&Value>) -> Result<Value> {
     let mut normalized = patch.clone();
     rescue_stringified_object(&mut normalized);
     prune_null_fields(&mut normalized);
@@ -626,6 +633,10 @@ fn normalize_patch_value(patch: &Value) -> Result<Value> {
         .as_object_mut()
         .ok_or_else(|| Error::message("patch must be an object"))?;
     normalize_session_target_field(obj);
+    if let Some(payload) = obj.get_mut("payload") {
+        rescue_stringified_object(payload);
+    }
+    current_channel::apply(obj, channel_context)?;
     normalize_sandbox_field(obj)?;
     normalize_wake_mode_field(obj)?;
 
@@ -666,7 +677,13 @@ impl AgentTool for CronTool {
          - payload.kind: \"agentTurn\"\n\
          - payload.message: the prompt for the isolated agent run\n\
          \n\
-         To deliver the agent output to a channel (e.g. Telegram) after the run:\n\
+         When the request comes from a messaging channel and the user wants the \
+         scheduled result sent back to that same conversation, set:\n\
+         - payload.deliver_to_current_chat: true\n\
+         The host securely resolves the exact account and destination and forces \
+         an isolated agentTurn; do not ask the user for channel IDs.\n\
+         \n\
+         To deliver to a different channel or recipient after the run:\n\
          - payload.deliver: true\n\
          - payload.channel: the channel account identifier (e.g. the Telegram \
            bot username like \"my_telegram_bot\")\n\
@@ -678,7 +695,11 @@ impl AgentTool for CronTool {
          - sessionTarget \"main\" requires payload kind \"systemEvent\"\n\
          - sessionTarget \"isolated\" requires payload kind \"agentTurn\"\n\
          - When the user asks to send output to a channel, always use \
-           sessionTarget \"isolated\" + kind \"agentTurn\" + deliver fields\n\
+           deliver_to_current_chat for the current conversation, or explicit \
+           sessionTarget \"isolated\" + kind \"agentTurn\" + deliver fields for a \
+           different destination\n\
+         - In cron expressions, prefer named weekdays such as MON-FRI because \
+           numeric weekday mappings differ across cron implementations\n\
          \n\
          Optional execution controls for agent turns:\n\
          - payload.model: model id for this job\n\
@@ -687,113 +708,7 @@ impl AgentTool for CronTool {
     }
 
     fn parameters_schema(&self) -> Value {
-        let time_field = |description: &str| {
-            json!({
-                "type": ["integer", "string"],
-                "description": description
-            })
-        };
-        json!({
-            "type": "object",
-            "properties": {
-                "action": {
-                    "type": "string",
-                    "enum": ["status", "list", "add", "update", "remove", "run", "runs"],
-                    "description": "The action to perform"
-                },
-                "job": {
-                    "type": "object",
-                    "description": "Job specification (for 'add' action)",
-                    "properties": {
-                        "name": { "type": "string", "description": "Human-readable job name" },
-                        "schedule": {
-                            "type": ["object", "string", "integer"],
-                            "description": "Schedule object. For one-off jobs use {kind:'at', delay_ms} where delay_ms is milliseconds from now (e.g. 600000 for 10 min) — never compute at_ms yourself. For recurring use {kind:'every', every_ms} or {kind:'cron', expr, tz?}.",
-                            "properties": {
-                                "kind": { "type": "string", "enum": ["at", "every", "cron"] },
-                                "delay_ms": time_field("Milliseconds from now to run the job. Accepts integer milliseconds or a duration string like '10m'. Preferred over at_ms."),
-                                "at_ms": time_field("Absolute epoch milliseconds or ISO-8601 timestamp. Use delay_ms instead unless you have an exact timestamp."),
-                                "every_ms": time_field("Recurring interval when kind='every'. Accepts integer milliseconds or a duration string like '15m'."),
-                                "anchor_ms": time_field("Optional anchor when kind='every'. Accepts epoch milliseconds or ISO-8601 timestamp."),
-                                "expr": { "type": "string", "description": "Cron expression used when kind='cron'" },
-                                "tz": { "type": "string", "description": "Optional timezone used when kind='cron'" }
-                            },
-                            "required": ["kind"]
-                        },
-                        "payload": {
-                            "type": ["object", "string"],
-                            "description": "What to do. Use {kind:'systemEvent', text} for main-session reminders or {kind:'agentTurn', message, model?, timeout_secs?, active_tools?, tool_choice?, deliver?, channel?, to?}. `payload.model` selects the LLM for that job. This tool also accepts a shorthand message string at runtime.",
-                            "properties": {
-                                "kind": { "type": "string", "enum": ["systemEvent", "agentTurn"] },
-                                "text": { "type": "string" },
-                                "message": { "type": "string" },
-                                "model": { "type": "string" },
-                                "timeout_secs": {
-                                    "type": ["integer", "string"],
-                                    "description": "Optional timeout in seconds. Accepts an integer number of seconds or a duration string like '2m'."
-                                },
-                                "active_tools": {
-                                    "type": "array",
-                                    "items": { "type": "string" },
-                                    "description": "Optional per-turn whitelist of tools visible to the scheduled agent."
-                                },
-                                "tool_choice": {
-                                    "type": "object",
-                                    "description": "Optional provider tool choice, e.g. {type:'tool', name:'classify_destination'}.",
-                                    "properties": {
-                                        "type": { "type": "string", "enum": ["auto", "any", "none", "tool"] },
-                                        "name": { "type": "string" }
-                                    },
-                                    "required": ["type"]
-                                },
-                                "deliver": { "type": "boolean", "description": "Set to true to deliver the agent output to a channel (e.g. Telegram) after the run. Requires channel and to." },
-                                "channel": { "type": "string", "description": "Channel account identifier for delivery (e.g. the Telegram bot username like 'my_telegram_bot'). Required when deliver=true." },
-                                "to": { "type": "string", "description": "Recipient chat ID for delivery (e.g. '123456789' for Telegram). Required when deliver=true." }
-                            },
-                            "required": ["kind"]
-                        },
-                        "sessionTarget": { "type": "string", "enum": ["main", "isolated"], "default": "isolated" },
-                        "sandbox": {
-                            "type": "object",
-                            "description": "Execution environment for agent turns. Use {enabled:false} for host execution, or {enabled:true, image?} for sandbox execution.",
-                            "properties": {
-                                "enabled": { "type": "boolean", "description": "true = sandbox execution, false = host execution" },
-                                "image": { "type": "string", "description": "Optional sandbox image tag when sandbox is enabled" }
-                            }
-                        },
-                        "execution": {
-                            "type": "object",
-                            "description": "Alias for sandbox settings. Use {target:'host'|'sandbox', image?}.",
-                            "properties": {
-                                "target": { "type": "string", "enum": ["host", "sandbox"] },
-                                "image": { "type": "string" }
-                            }
-                        },
-                        "deleteAfterRun": { "type": "boolean", "default": false },
-                        "enabled": { "type": "boolean", "default": true },
-                        "wakeMode": { "type": "string", "enum": ["now", "nextHeartbeat"], "default": "nextHeartbeat", "description": "Whether to trigger an immediate heartbeat after this job fires" }
-                    },
-                    "required": ["name", "schedule", "payload"]
-                },
-                "patch": {
-                    "type": "object",
-                    "description": "Fields to update (for 'update' action)"
-                },
-                "id": {
-                    "type": "string",
-                    "description": "Job ID (for update/remove/run/runs)"
-                },
-                "force": {
-                    "type": "boolean",
-                    "description": "Force-run even if disabled (for 'run' action)"
-                },
-                "limit": {
-                    "type": "integer",
-                    "description": "Max run records to return (for 'runs' action, default 20)"
-                }
-            },
-            "required": ["action"]
-        })
+        schema::parameters()
     }
 
     async fn execute(&self, params: Value) -> anyhow::Result<Value> {
@@ -835,7 +750,7 @@ impl AgentTool for CronTool {
                         }
                     },
                 };
-                let normalized = normalize_job_value(&job_val)?;
+                let normalized = normalize_job_value(&job_val, params.get("_channel"))?;
                 let create: CronJobCreate = serde_json::from_value(normalized)
                     .map_err(|e| Error::message(format!("invalid job spec: {e}")))?;
                 let job = self.service.add(create).await?;
@@ -849,7 +764,7 @@ impl AgentTool for CronTool {
                 let patch_val = params
                     .get("patch")
                     .ok_or_else(|| Error::message("missing 'patch' for update"))?;
-                let normalized = normalize_patch_value(patch_val)?;
+                let normalized = normalize_patch_value(patch_val, params.get("_channel"))?;
                 let patch: CronJobPatch = serde_json::from_value(normalized)
                     .map_err(|e| Error::message(format!("invalid patch: {e}")))?;
                 let job = self.service.update(id, patch).await?;
@@ -872,8 +787,8 @@ impl AgentTool for CronTool {
                     .get("force")
                     .and_then(|v| v.as_bool())
                     .unwrap_or(false);
-                self.service.run(id, force).await?;
-                Ok(json!({ "ran": id }))
+                let run = self.service.run(id, force).await?;
+                Ok(json!({ "ran": id, "run": run }))
             },
             "runs" => {
                 let id = params

--- a/crates/tools/src/cron_tool/current_channel.rs
+++ b/crates/tools/src/cron_tool/current_channel.rs
@@ -122,6 +122,7 @@ mod tests {
                     input_tokens: None,
                     output_tokens: None,
                     session_key: None,
+                    delivery_error: None,
                 })
             })
         });

--- a/crates/tools/src/cron_tool/current_channel.rs
+++ b/crates/tools/src/cron_tool/current_channel.rs
@@ -1,0 +1,295 @@
+use {
+    moltis_common::hooks::ChannelBinding,
+    serde_json::{Map, Value, json},
+};
+
+use crate::{Result, error::Error};
+
+struct DeliveryTarget {
+    account_id: String,
+    to: String,
+}
+
+fn shortcut_enabled(payload: &mut Map<String, Value>) -> Result<bool> {
+    if !payload.contains_key("deliver_to_current_chat")
+        && let Some(value) = payload.remove("deliverToCurrentChat")
+    {
+        payload.insert("deliver_to_current_chat".to_string(), value);
+    }
+
+    let Some(value) = payload.remove("deliver_to_current_chat") else {
+        return Ok(false);
+    };
+    value
+        .as_bool()
+        .ok_or_else(|| Error::message("payload.deliver_to_current_chat must be a boolean"))
+}
+
+fn delivery_target(channel_context: Option<&Value>) -> Result<DeliveryTarget> {
+    let value = channel_context.ok_or_else(|| {
+        Error::message(
+            "payload.deliver_to_current_chat requires a current messaging channel; use explicit payload.channel and payload.to outside a channel conversation",
+        )
+    })?;
+    let binding: ChannelBinding = serde_json::from_value(value.clone())
+        .map_err(|error| Error::message(format!("invalid current channel context: {error}")))?;
+    let account_id = required_text(
+        binding.account_id,
+        "current channel has no delivery account",
+    )?;
+    let to = required_text(
+        binding.outbound_to.or(binding.chat_id),
+        "current channel has no delivery destination",
+    )?;
+    Ok(DeliveryTarget { account_id, to })
+}
+
+fn required_text(value: Option<String>, error: &str) -> Result<String> {
+    value
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| Error::message(error))
+}
+
+fn reject_conflicting_destination(
+    payload: &Map<String, Value>,
+    target: &DeliveryTarget,
+) -> Result<()> {
+    for (field, expected) in [
+        ("channel", target.account_id.as_str()),
+        ("to", target.to.as_str()),
+    ] {
+        if let Some(actual) = payload
+            .get(field)
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            && actual != expected
+        {
+            return Err(Error::message(format!(
+                "payload.{field} conflicts with the current channel destination"
+            )));
+        }
+    }
+    Ok(())
+}
+
+pub(super) fn apply(job: &mut Map<String, Value>, channel_context: Option<&Value>) -> Result<()> {
+    let Some(Value::Object(payload)) = job.get_mut("payload") else {
+        return Ok(());
+    };
+    if !shortcut_enabled(payload)? {
+        return Ok(());
+    }
+
+    let target = delivery_target(channel_context)?;
+    reject_conflicting_destination(payload, &target)?;
+    if !payload.contains_key("message")
+        && let Some(text) = payload.get("text").cloned()
+    {
+        payload.insert("message".to_string(), text);
+    }
+    payload.insert("kind".to_string(), json!("agentTurn"));
+    payload.insert("deliver".to_string(), json!(true));
+    payload.insert("channel".to_string(), json!(target.account_id));
+    payload.insert("to".to_string(), json!(target.to));
+    job.insert("sessionTarget".to_string(), json!("isolated"));
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used)]
+
+    use std::sync::Arc;
+
+    use {
+        moltis_agents::tool_registry::AgentTool,
+        moltis_cron::{
+            service::{AgentTurnFn, CronService, SystemEventFn},
+            store_memory::InMemoryStore,
+        },
+    };
+
+    use super::*;
+
+    fn cron_tool() -> super::super::CronTool {
+        let system_event: SystemEventFn = Arc::new(|_| {});
+        let agent_turn: AgentTurnFn = Arc::new(|_| {
+            Box::pin(async {
+                Ok(moltis_cron::service::AgentTurnResult {
+                    output: "ok".into(),
+                    input_tokens: None,
+                    output_tokens: None,
+                    session_key: None,
+                })
+            })
+        });
+        let service = CronService::new(Arc::new(InMemoryStore::new()), system_event, agent_turn);
+        super::super::CronTool::new(service)
+    }
+
+    fn channel(outbound_to: Option<&str>) -> Value {
+        json!({
+            "channel_type": "whatsapp",
+            "account_id": "main",
+            "chat_id": "5511999999999",
+            "outbound_to": outbound_to
+        })
+    }
+
+    #[test]
+    fn resolves_current_chat_and_forces_agent_turn() {
+        let mut job = json!({
+            "sessionTarget": "main",
+            "payload": {
+                "kind": "systemEvent",
+                "text": "Send the report",
+                "deliver_to_current_chat": true
+            }
+        });
+
+        apply(job.as_object_mut().unwrap(), Some(&channel(None))).unwrap();
+
+        assert_eq!(job["sessionTarget"], "isolated");
+        assert_eq!(job["payload"]["kind"], "agentTurn");
+        assert_eq!(job["payload"]["message"], "Send the report");
+        assert_eq!(job["payload"]["deliver"], true);
+        assert_eq!(job["payload"]["channel"], "main");
+        assert_eq!(job["payload"]["to"], "5511999999999");
+        assert!(job["payload"].get("deliver_to_current_chat").is_none());
+    }
+
+    #[test]
+    fn preserves_threaded_outbound_destination() {
+        let mut job = json!({
+            "payload": {
+                "message": "Send the report",
+                "deliverToCurrentChat": true
+            }
+        });
+
+        apply(
+            job.as_object_mut().unwrap(),
+            Some(&channel(Some("-100123:42"))),
+        )
+        .unwrap();
+
+        assert_eq!(job["payload"]["to"], "-100123:42");
+    }
+
+    #[test]
+    fn rejects_missing_or_conflicting_destination() {
+        let original = json!({
+            "payload": {
+                "message": "Send the report",
+                "deliver_to_current_chat": true,
+                "to": "someone-else"
+            }
+        });
+        let mut no_context = original.clone();
+        let error = apply(no_context.as_object_mut().unwrap(), None).unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("requires a current messaging channel")
+        );
+
+        let mut conflict = original;
+        let error = apply(conflict.as_object_mut().unwrap(), Some(&channel(None))).unwrap_err();
+        assert!(error.to_string().contains("conflicts"));
+    }
+
+    #[test]
+    fn false_shortcut_is_removed_without_changing_routing() {
+        let mut job = json!({
+            "sessionTarget": "main",
+            "payload": {
+                "kind": "systemEvent",
+                "text": "Keep local",
+                "deliver_to_current_chat": false
+            }
+        });
+
+        apply(job.as_object_mut().unwrap(), None).unwrap();
+
+        assert_eq!(job["sessionTarget"], "main");
+        assert!(job["payload"].get("deliver_to_current_chat").is_none());
+        assert!(job["payload"].get("deliver").is_none());
+    }
+
+    #[tokio::test]
+    async fn tool_run_and_strict_update_return_expected_results() {
+        let tool = cron_tool();
+        let added = tool
+            .execute(json!({
+                "action": "add",
+                "_channel": channel(Some("5511999999999")),
+                "job": {
+                    "name": "daily report",
+                    "schedule": { "kind": "every", "every_ms": 60000 },
+                    "payload": {
+                        "kind": "systemEvent",
+                        "text": "Old report",
+                        "deliver_to_current_chat": true
+                    },
+                    "sessionTarget": "main"
+                }
+            }))
+            .await
+            .unwrap();
+
+        assert_eq!(added["sessionTarget"], "isolated");
+        assert_eq!(added["payload"]["kind"], "agentTurn");
+        assert_eq!(added["payload"]["message"], "Old report");
+        assert_eq!(added["payload"]["deliver"], true);
+        assert_eq!(added["payload"]["channel"], "main");
+        assert_eq!(added["payload"]["to"], "5511999999999");
+
+        let run = tool
+            .execute(json!({ "action": "run", "id": added["id"] }))
+            .await
+            .unwrap();
+        assert_eq!(run["run"]["status"], "ok");
+        assert_eq!(run["run"]["output"], "ok");
+
+        let updated = tool
+            .execute(json!({
+                "action": "update",
+                "id": added["id"],
+                "_channel": channel(Some("5511999999999")),
+                "patch": {
+                    "name": null,
+                    "schedule": null,
+                    "payload": {
+                        "kind": "systemEvent",
+                        "text": "Send the new report",
+                        "message": null,
+                        "model": null,
+                        "timeout_secs": null,
+                        "active_tools": null,
+                        "tool_choice": null,
+                        "deliver_to_current_chat": true,
+                        "deliver": null,
+                        "channel": null,
+                        "to": null
+                    },
+                    "sessionTarget": "main",
+                    "sandbox": null,
+                    "execution": null,
+                    "deleteAfterRun": null,
+                    "enabled": null,
+                    "wakeMode": null
+                }
+            }))
+            .await
+            .unwrap();
+
+        assert_eq!(updated["sessionTarget"], "isolated");
+        assert_eq!(updated["payload"]["kind"], "agentTurn");
+        assert_eq!(updated["payload"]["message"], "Send the new report");
+        assert_eq!(updated["payload"]["deliver"], true);
+        assert_eq!(updated["payload"]["channel"], "main");
+        assert_eq!(updated["payload"]["to"], "5511999999999");
+    }
+}

--- a/crates/tools/src/cron_tool/schema.rs
+++ b/crates/tools/src/cron_tool/schema.rs
@@ -1,0 +1,186 @@
+use serde_json::{Value, json};
+
+fn time_field(description: &str) -> Value {
+    json!({
+        "type": ["integer", "string"],
+        "description": description
+    })
+}
+
+fn job_schema() -> Value {
+    json!({
+        "type": "object",
+        "description": "Job specification for the add action",
+        "properties": {
+            "name": { "type": "string", "description": "Human-readable job name" },
+            "schedule": {
+                "type": ["object", "string", "integer"],
+                "description": "For one-off jobs use {kind:'at', delay_ms}; never compute at_ms yourself. For recurring jobs use {kind:'every', every_ms} or {kind:'cron', expr, tz?}. Prefer weekday names such as MON-FRI because numeric mappings differ across cron implementations.",
+                "properties": {
+                    "kind": { "type": "string", "enum": ["at", "every", "cron"] },
+                    "delay_ms": time_field("Milliseconds from now. Accepts an integer or duration such as '10m'. Preferred over at_ms."),
+                    "at_ms": time_field("Absolute epoch milliseconds or ISO-8601 timestamp. Prefer delay_ms unless the timestamp is exact."),
+                    "every_ms": time_field("Recurring interval. Accepts an integer or duration such as '15m'."),
+                    "anchor_ms": time_field("Optional interval anchor as epoch milliseconds or ISO-8601 timestamp."),
+                    "expr": { "type": "string", "description": "Cron expression. Prefer weekday names such as MON-FRI over numbers." },
+                    "tz": { "type": "string", "description": "Optional timezone for a cron expression." }
+                },
+                "required": ["kind"]
+            },
+            "payload": {
+                "type": ["object", "string"],
+                "description": "Use {kind:'systemEvent', text} for main-session reminders or {kind:'agentTurn', message}. In a messaging conversation, deliver_to_current_chat:true routes the agentTurn back to that exact conversation without copying identifiers.",
+                "properties": {
+                    "kind": { "type": "string", "enum": ["systemEvent", "agentTurn"] },
+                    "text": { "type": "string" },
+                    "message": { "type": "string" },
+                    "model": { "type": "string" },
+                    "timeout_secs": {
+                        "type": ["integer", "string"],
+                        "description": "Optional timeout in seconds or duration such as '2m'."
+                    },
+                    "active_tools": {
+                        "type": "array",
+                        "items": { "type": "string" },
+                        "description": "Optional tool whitelist for the scheduled agent."
+                    },
+                    "tool_choice": {
+                        "type": "object",
+                        "description": "Optional provider tool choice.",
+                        "properties": {
+                            "type": { "type": "string", "enum": ["auto", "any", "none", "tool"] },
+                            "name": { "type": "string" }
+                        },
+                        "required": ["type"]
+                    },
+                    "deliver_to_current_chat": {
+                        "type": "boolean",
+                        "description": "Deliver to the current messaging conversation. The host resolves the trusted destination and forces isolated agent execution."
+                    },
+                    "deliver": {
+                        "type": "boolean",
+                        "description": "Deliver after the run. Requires channel and to unless deliver_to_current_chat is true."
+                    },
+                    "channel": {
+                        "type": "string",
+                        "description": "Channel account for explicit delivery."
+                    },
+                    "to": {
+                        "type": "string",
+                        "description": "Recipient address for explicit delivery."
+                    }
+                },
+                "required": ["kind"]
+            },
+            "sessionTarget": {
+                "type": "string",
+                "enum": ["main", "isolated"],
+                "default": "isolated"
+            },
+            "sandbox": {
+                "type": "object",
+                "description": "Execution environment. Use {enabled:false} for host or {enabled:true, image?} for sandbox.",
+                "properties": {
+                    "enabled": { "type": "boolean" },
+                    "image": { "type": "string" }
+                }
+            },
+            "execution": {
+                "type": ["object", "string"],
+                "description": "Alias for sandbox settings. Accepts 'host', 'sandbox', or {target, image?}.",
+                "properties": {
+                    "target": { "type": "string", "enum": ["host", "sandbox"] },
+                    "image": { "type": "string" }
+                }
+            },
+            "deleteAfterRun": { "type": "boolean", "default": false },
+            "enabled": { "type": "boolean", "default": true },
+            "wakeMode": {
+                "type": "string",
+                "enum": ["now", "nextHeartbeat"],
+                "default": "nextHeartbeat"
+            }
+        },
+        "required": ["name", "schedule", "payload"]
+    })
+}
+
+pub(super) fn parameters() -> Value {
+    let job = job_schema();
+    let mut patch = job.clone();
+    if let Some(schema) = patch.as_object_mut() {
+        schema.insert(
+            "description".to_string(),
+            json!("Fields to update for the update action"),
+        );
+        schema.remove("required");
+    }
+
+    json!({
+        "type": "object",
+        "properties": {
+            "action": {
+                "type": "string",
+                "enum": ["status", "list", "add", "update", "remove", "run", "runs"],
+                "description": "The action to perform"
+            },
+            "job": job,
+            "patch": patch,
+            "id": {
+                "type": "string",
+                "description": "Job ID for update, remove, run, or runs"
+            },
+            "force": {
+                "type": "boolean",
+                "description": "Force-run a disabled job"
+            },
+            "limit": {
+                "type": "integer",
+                "description": "Maximum run records to return; defaults to 20"
+            }
+        },
+        "required": ["action"]
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used)]
+
+    use super::*;
+
+    #[test]
+    fn update_patch_exposes_mutable_job_fields() {
+        let schema = parameters();
+        let patch = &schema["properties"]["patch"];
+
+        assert!(patch["required"].is_null());
+        for field in ["name", "schedule", "payload", "sessionTarget", "enabled"] {
+            assert!(
+                patch["properties"].get(field).is_some(),
+                "missing patch field {field}"
+            );
+        }
+    }
+
+    #[test]
+    fn strict_mode_keeps_patch_fields_usable() {
+        let mut schema = parameters();
+        moltis_providers::openai_compat::patch_schema_for_strict_mode(&mut schema);
+        let patch = &schema["properties"]["patch"];
+
+        assert_eq!(patch["additionalProperties"], false);
+        assert!(
+            patch["required"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .any(|field| field == "payload")
+        );
+        assert!(
+            patch["properties"]["payload"]["properties"]
+                .get("deliver_to_current_chat")
+                .is_some()
+        );
+    }
+}

--- a/crates/tools/src/cron_tool/tests.rs
+++ b/crates/tools/src/cron_tool/tests.rs
@@ -21,6 +21,7 @@ fn noop_agent() -> AgentTurnFn {
                 input_tokens: None,
                 output_tokens: None,
                 session_key: None,
+                delivery_error: None,
             })
         })
     })

--- a/docs/src/scheduling.md
+++ b/docs/src/scheduling.md
@@ -98,6 +98,10 @@ Jobs support several schedule kinds:
 | `cron` | `expr`, optional `tz` | Standard cron expression (e.g. `"0 */6 * * *"`) |
 | `at` | `at_ms` | Run once at a specific Unix timestamp (ms) |
 
+Prefer named weekdays such as `MON-FRI` in cron expressions. Numeric weekday
+values are not portable across cron implementations because some number Sunday
+as zero while others number it as one.
+
 ## Cron Tool
 
 The agent manages jobs through the built-in `cron` tool. Available actions:
@@ -120,7 +124,25 @@ one-time tasks (reminders, follow-ups).
 Background agent turns can deliver their final output to a configured channel
 account/chat after the run completes.
 
-Use all of the following together:
+When asking the agent from WhatsApp, Telegram, or another messaging channel to
+send a scheduled result back to the same conversation, the agent can use the
+transient tool shortcut:
+
+```json
+{
+  "payload": {
+    "message": "Prepare and send the daily summary.",
+    "deliver_to_current_chat": true
+  }
+}
+```
+
+Moltis resolves the account and destination from trusted session context,
+converts the payload to an isolated `agentTurn`, and stores the normal
+`deliver`, `channel`, and `to` fields. The shortcut itself is not persisted.
+It returns an error outside a messaging-channel conversation.
+
+For a different or explicitly selected destination, use all of the following:
 
 - `sessionTarget: "isolated"`
 - `payload.kind: "agentTurn"`
@@ -150,7 +172,9 @@ Example:
 
 Channel delivery is separate from session targeting. The cron job still runs in
 an isolated cron session, then Moltis forwards the finished output to the
-requested channel destination.
+requested channel destination. Delivery failures and empty non-heartbeat
+outputs are recorded as failed cron runs. The `run` action returns that run
+record so callers can distinguish execution from successful delivery.
 
 ## Session Targeting
 

--- a/docs/src/scheduling.md
+++ b/docs/src/scheduling.md
@@ -95,7 +95,7 @@ Jobs support several schedule kinds:
 | Kind | Fields | Description |
 |------|--------|-------------|
 | `every` | `every_ms` | Repeat at a fixed interval (milliseconds) |
-| `cron` | `expr`, optional `tz` | Standard cron expression (e.g. `"0 */6 * * *"`) |
+| `cron` | `expr`, optional `tz` | A standard 5-field cron expression, or 6/7 fields with leading seconds and an optional trailing year |
 | `at` | `at_ms` | Run once at a specific Unix timestamp (ms) |
 
 Prefer named weekdays such as `MON-FRI` in cron expressions. Numeric weekday
@@ -174,7 +174,12 @@ Channel delivery is separate from session targeting. The cron job still runs in
 an isolated cron session, then Moltis forwards the finished output to the
 requested channel destination. Delivery failures and empty non-heartbeat
 outputs are recorded as failed cron runs. The `run` action returns that run
-record so callers can distinguish execution from successful delivery.
+record with the completed output, token usage, and session key intact so callers
+can distinguish agent execution from successful delivery.
+
+Existing jobs with `deliver: true` but without both `channel` and `to` are
+recorded as failed runs. Earlier versions silently skipped delivery for these
+incomplete destinations.
 
 ## Session Targeting
 


### PR DESCRIPTION
## Summary

- add a transient `payload.deliver_to_current_chat` shortcut that resolves the originating messaging destination from gateway-owned channel context and persists the normal explicit delivery fields
- preserve canonical outbound addresses, including thread/topic routing, while rejecting missing or conflicting destinations
- keep cron update fields usable after OpenAI strict-schema normalization by deriving the patch schema from the complete job schema
- record empty output and outbound delivery failures without discarding completed agent output, token usage, token metrics, or the session key, and return those manual run results to callers
- align the GraphQL cron adapters with the live service response shapes
- document same-conversation delivery, supported 5/6/7-field cron forms, and named weekdays that avoid implementation-specific numeric mappings
- treat existing stored jobs with `deliver: true` but without both `channel` and `to` as failed runs; earlier versions silently skipped delivery for these incomplete destinations

```mermaid
flowchart LR
    A[Inbound channel message] --> B[Trusted channel binding]
    B --> C[Cron tool context]
    C --> D[deliver_to_current_chat resolution]
    D --> E[Persist explicit account and destination]
    E --> F[Isolated cron run]
    F --> G[Channel delivery]
    G --> H[Recorded success or delivery error]
```

## Validation

### Completed

- [x] `cargo fetch --locked`
- [x] `cargo +nightly-2026-06-20 fmt --all -- --check`
- [x] `cargo test -p moltis-tools cron_tool --lib` (36 passed)
- [x] `cargo test -p moltis-cron` (140 passed)
- [x] `cargo test -p moltis-gateway maybe_deliver_cron_output` (5 passed)
- [x] `cargo test -p moltis-graphql --test integration cron_`
- [x] focused channel binding, prompt context, and agent prompt regression tests
- [x] regression coverage proving delivery errors retain completed output, input/output tokens, and session key in the persisted run record
- [x] regression coverage for 6-field cron expressions with leading seconds and 7-field expressions with a trailing year
- [x] `cargo clippy -p moltis-common -p moltis-channels -p moltis-agents -p moltis-chat -p moltis-tools -p moltis-cron -p moltis-gateway -p moltis-graphql --all-targets -- -D warnings`
- [x] `cargo clippy -p moltis-cron -p moltis-tools -p moltis-gateway --all-targets -- -D warnings` after review feedback
- [x] `cargo build -p moltis-cron -p moltis-tools -p moltis-gateway --all-targets` after review feedback
- [x] `CARGO_TARGET_DIR=/build/target MOLTIS_VERSION=20260821.01-local-cronfix ./scripts/cargo-build-moltis.sh --release`
- [x] `./scripts/local-validate.sh 1226` with Docker-backed Rust/Node commands and affected-crate lint/test overrides; all applicable local contexts passed and statuses were published for `c31676df`

### Remaining

- [ ] `cargo +nightly-2026-06-20 clippy -Z unstable-options --workspace --all-features --all-targets --timings -- -D warnings` — the optional CUDA backend stops in `llama-cpp-sys-2` because this builder has no `nvcc`/CUDA Toolkit; the affected non-CUDA crates pass Clippy above

## Manual QA

1. Started a production-feature build with an authenticated WhatsApp account and the cron service enabled.
2. Created a temporary isolated `agentTurn` cron job targeting the trusted current WhatsApp conversation.
3. Updated the job through the live GraphQL adapter and verified that its delivery configuration remained intact.
4. Triggered the job manually and received the exact expected WhatsApp message.
5. Verified the persisted run record had status `ok`, no error, and the expected output.
6. Removed the temporary job and confirmed the original permanent job was the only remaining job.
7. Restarted the final image and verified health, WhatsApp authentication, cron loading, and MCP startup.
