### PR TITLE
fix(browser): enable Obscura stealth mode by default

### DIFF
--- a/crates/browser/src/pool.rs
+++ b/crates/browser/src/pool.rs
@@ -814,7 +814,7 @@ impl BrowserPool {
             .stdout(std::process::Stdio::null())
             .stderr(std::process::Stdio::piped())
             .kill_on_drop(true);
-        for arg in spec.serve_args(port) {
+        for arg in spec.serve_args(&self.config, port) {
             command.arg(arg);
         }
         let mut child = command.spawn().map_err(|e| {
@@ -961,9 +961,16 @@ impl SidecarBrowserSpec {
         }
     }
 
-    fn serve_args(self, port: u16) -> Vec<String> {
+    fn serve_args(self, config: &BrowserConfig, port: u16) -> Vec<String> {
         match self.kind {
-            BrowserKind::Obscura => vec!["--port".to_string(), port.to_string()],
+            BrowserKind::Obscura => {
+                let mut args = Vec::with_capacity(3);
+                if config.obscura_stealth {
+                    args.push("--stealth".to_string());
+                }
+                args.extend(["--port".to_string(), port.to_string()]);
+                args
+            },
             BrowserKind::Lightpanda => vec![
                 "--host".to_string(),
                 "127.0.0.1".to_string(),
@@ -1225,7 +1232,7 @@ mod tests {
         let spec = sidecar_browser_spec(BrowserPreference::Lightpanda)
             .unwrap_or_else(|| panic!("expected Lightpanda sidecar spec"));
 
-        assert_eq!(spec.serve_args(9222), vec![
+        assert_eq!(spec.serve_args(&test_config(), 9222), vec![
             "--host".to_string(),
             "127.0.0.1".to_string(),
             "--port".to_string(),
@@ -1235,11 +1242,12 @@ mod tests {
     }
 
     #[test]
-    fn obscura_sidecar_uses_browser_ws_endpoint() {
+    fn obscura_sidecar_enables_stealth_and_uses_browser_ws_endpoint() {
         let spec = sidecar_browser_spec(BrowserPreference::Obscura)
             .unwrap_or_else(|| panic!("expected Obscura sidecar spec"));
 
-        assert_eq!(spec.serve_args(9222), vec![
+        assert_eq!(spec.serve_args(&test_config(), 9222), vec![
+            "--stealth".to_string(),
             "--port".to_string(),
             "9222".to_string()
         ]);
@@ -1247,6 +1255,21 @@ mod tests {
             spec.websocket_url(9222),
             "ws://127.0.0.1:9222/devtools/browser"
         );
+    }
+
+    #[test]
+    fn obscura_sidecar_allows_stealth_to_be_disabled() {
+        let spec = sidecar_browser_spec(BrowserPreference::Obscura)
+            .unwrap_or_else(|| panic!("expected Obscura sidecar spec"));
+        let config = BrowserConfig {
+            obscura_stealth: false,
+            ..test_config()
+        };
+
+        assert_eq!(spec.serve_args(&config, 9222), vec![
+            "--port".to_string(),
+            "9222".to_string()
+        ]);
     }
 
     #[test]

--- a/crates/browser/src/types.rs
+++ b/crates/browser/src/types.rs
@@ -427,6 +427,8 @@ pub struct BrowserConfig {
     /// Path to the Obscura binary (auto-detected from PATH if not set).
     /// Obscura is a lightweight Rust-based headless browser that supports CDP.
     pub obscura_path: Option<String>,
+    /// Whether to launch Obscura with its anti-detection mode enabled.
+    pub obscura_stealth: bool,
     /// Path to the Lightpanda binary (auto-detected from PATH if not set).
     /// Lightpanda is a lightweight Zig-based headless browser that supports CDP.
     pub lightpanda_path: Option<String>,
@@ -512,6 +514,7 @@ impl Default for BrowserConfig {
             enabled: true,
             chrome_path: None,
             obscura_path: None,
+            obscura_stealth: true,
             lightpanda_path: None,
             headless: true,
             viewport_width: 2560,
@@ -559,6 +562,7 @@ impl From<&moltis_config::schema::BrowserConfig> for BrowserConfig {
             enabled: cfg.enabled,
             chrome_path: cfg.chrome_path.clone(),
             obscura_path: cfg.obscura_path.clone(),
+            obscura_stealth: cfg.obscura_stealth,
             lightpanda_path: cfg.lightpanda_path.clone(),
             headless: cfg.headless,
             viewport_width: cfg.viewport_width,
@@ -672,6 +676,16 @@ mod tests {
             Err(error) => panic!("failed to deserialize browser preference: {error}"),
         };
         assert_eq!(value, BrowserPreference::Brave);
+    }
+
+    #[test]
+    fn config_conversion_preserves_obscura_stealth_setting() {
+        let source = moltis_config::schema::BrowserConfig {
+            obscura_stealth: false,
+            ..Default::default()
+        };
+
+        assert!(!BrowserConfig::from(&source).obscura_stealth);
     }
 
     #[test]

--- a/crates/config/src/schema/tests.rs
+++ b/crates/config/src/schema/tests.rs
@@ -796,6 +796,15 @@ browserless_api_version = "v2"
 }
 
 #[test]
+fn obscura_stealth_defaults_enabled_and_can_be_disabled() {
+    let defaults: BrowserConfig = toml::from_str("").unwrap();
+    assert!(defaults.obscura_stealth);
+
+    let disabled: BrowserConfig = toml::from_str("obscura_stealth = false").unwrap();
+    assert!(!disabled.obscura_stealth);
+}
+
+#[test]
 fn browserless_api_version_rejects_non_lowercase_variants() {
     let parsed: Result<BrowserConfig, _> = toml::from_str(
         r#"

--- a/crates/config/src/schema/tools.rs
+++ b/crates/config/src/schema/tools.rs
@@ -434,6 +434,10 @@ pub struct BrowserConfig {
     /// Path to the Obscura binary (auto-detected from PATH if not set).
     /// Set `browser = "obscura"` in requests to use this lightweight headless browser.
     pub obscura_path: Option<String>,
+    /// Whether to enable Obscura's anti-detection mode.
+    /// Enabled by default. Full TLS impersonation requires an Obscura binary
+    /// built with its upstream `stealth` feature.
+    pub obscura_stealth: bool,
     /// Path to the Lightpanda binary (auto-detected from PATH if not set).
     /// Set `browser = "lightpanda"` in requests to use this lightweight headless browser.
     pub lightpanda_path: Option<String>,
@@ -530,6 +534,7 @@ impl Default for BrowserConfig {
             enabled: true,
             chrome_path: None,
             obscura_path: None,
+            obscura_stealth: true,
             lightpanda_path: None,
             headless: true,
             viewport_width: 2560,

--- a/crates/config/src/template.rs
+++ b/crates/config/src/template.rs
@@ -531,6 +531,7 @@ port = {port}                           # Port number (auto-generated for this i
 # allowed_domains = []              # Domain restrictions (empty = all allowed)
 # chrome_path = "/path/to/chrome"   # Custom Chrome binary path
 # obscura_path = "/path/to/obscura" # Custom Obscura binary path for browser = "obscura"
+# obscura_stealth = true             # Pass --stealth (full TLS mode needs a stealth build)
 # lightpanda_path = "/path/to/lightpanda" # Custom Lightpanda binary path for browser = "lightpanda"
 
 # ══════════════════════════════════════════════════════════════════════════════

--- a/crates/config/src/validate/schema_map.rs
+++ b/crates/config/src/validate/schema_map.rs
@@ -175,6 +175,7 @@ pub(super) fn build_schema_map() -> KnownKeys {
             ("enabled", Leaf),
             ("chrome_path", Leaf),
             ("obscura_path", Leaf),
+            ("obscura_stealth", Leaf),
             ("lightpanda_path", Leaf),
             ("headless", Leaf),
             ("viewport_width", Leaf),

--- a/crates/config/src/validate/tests/tools.rs
+++ b/crates/config/src/validate/tests/tools.rs
@@ -233,10 +233,11 @@ host = "ssh"
 }
 
 #[test]
-fn browser_obscura_path_accepted() {
+fn browser_obscura_fields_accepted() {
     let toml = r#"
 [tools.browser]
 obscura_path = "/usr/local/bin/obscura"
+obscura_stealth = false
 "#;
     let result = validate_toml_str(toml);
     let unknown = result
@@ -246,6 +247,15 @@ obscura_path = "/usr/local/bin/obscura"
     assert!(
         unknown.is_none(),
         "obscura_path should be accepted as a browser config field, got: {:?}",
+        result.diagnostics
+    );
+    let unknown = result
+        .diagnostics
+        .iter()
+        .find(|d| d.category == "unknown-field" && d.path == "tools.browser.obscura_stealth");
+    assert!(
+        unknown.is_none(),
+        "obscura_stealth should be accepted as a browser config field, got: {:?}",
         result.diagnostics
     );
 }

--- a/docs/src/browser-automation.md
+++ b/docs/src/browser-automation.md
@@ -61,6 +61,7 @@ navigation_timeout_ms = 30000  # Page load timeout
 # Optional customization
 # chrome_path = "/path/to/chrome"  # Custom Chrome path
 # obscura_path = "/path/to/obscura"  # Custom Obscura path
+# obscura_stealth = true            # Pass --stealth to Obscura (default)
 # lightpanda_path = "/path/to/lightpanda"  # Custom Lightpanda path
 # user_agent = "Custom UA"         # Custom user agent
 # chrome_args = ["--disable-extensions"]  # Extra args
@@ -165,7 +166,14 @@ detection.
 
 `obscura` launches the Obscura sidecar binary from `obscura_path`, the
 `OBSCURA` environment variable, or `PATH`. It supports DOM-oriented browsing
-through CDP, but not pixel screenshots.
+through CDP, but not pixel screenshots. Moltis passes Obscura's
+[`--stealth` mode](https://github.com/h4ckf0r0day/obscura/wiki/Configure-stealth-and-proxies)
+flag by default, enabling the anti-detection behavior available in the
+installed binary. Full TLS impersonation requires Obscura 0.1.1 or newer built
+with its upstream `stealth` feature. Choose a release asset whose name includes
+`-stealth`, or add `--features stealth` when installing from source. Set
+`obscura_stealth = false` when tracker blocking or the stealth network stack is
+undesirable.
 
 `lightpanda` launches the Lightpanda sidecar binary from `lightpanda_path`, the
 `LIGHTPANDA` environment variable, or `PATH`. It supports DOM-oriented browsing

--- a/docs/src/configuration-reference.md
+++ b/docs/src/configuration-reference.md
@@ -481,6 +481,7 @@ Default `tool_overrides` entries:
 | `enabled` | bool | `true` | Whether browser support is enabled. |
 | `chrome_path` | optional string | `null` | Path to Chrome/Chromium binary (auto-detected if not set). |
 | `obscura_path` | optional string | `null` | Path to the Obscura binary for `browser = "obscura"` requests (auto-detected from `OBSCURA` or `PATH` if not set). |
+| `obscura_stealth` | bool | `true` | Pass `--stealth` when launching Obscura. Full TLS impersonation requires an Obscura binary built with its upstream `stealth` feature. |
 | `lightpanda_path` | optional string | `null` | Path to the Lightpanda binary for `browser = "lightpanda"` requests (auto-detected from `LIGHTPANDA` or `PATH` if not set). |
 | `headless` | bool | `true` | Whether to run in headless mode. |
 | `viewport_width` | integer | `2560` | Default viewport width in pixels. |


### PR DESCRIPTION
## Summary

- Launch the Obscura sidecar with its opt-in `--stealth` flag by default.
- Add `tools.browser.obscura_stealth` (default: `true`) so operators can retain the standard Obscura network behavior when needed.
- Propagate and validate the setting across the config and browser crates, cover both enabled and disabled launch arguments, and document the upstream build requirement for full TLS impersonation.

Moltis currently starts Obscura as `obscura serve --port <port>`, although upstream keeps its anti-detection mode behind `--stealth`. This makes the integration's advertised anti-detection behavior unavailable unless users replace the configured binary with a wrapper script.

There is also a historical timing explanation for the gap: the original Moltis integration in #869 was authored on April 24, 2026, while Obscura v0.1.1 made `--stealth` effective in `serve` mode on April 25. This change updates Moltis for the now-supported behavior while retaining an explicit opt-out.

The resulting commands are:

```text
# default
obscura serve --stealth --port <port>

# tools.browser.obscura_stealth = false
obscura serve --port <port>
```

The setting is a boolean that only controls a static command-line literal; it does not expose arbitrary sidecar arguments. Obscura's loopback binding and Moltis's CDP endpoint handling remain unchanged. The opt-out is important because stealth can change tracker requests and network trust behavior, and full TLS impersonation requires an Obscura binary built with the upstream `stealth` feature.

Upstream references:

- https://github.com/h4ckf0r0day/obscura/wiki/Configure-stealth-and-proxies
- https://github.com/h4ckf0r0day/obscura/releases/tag/v0.1.1

## Validation

### Completed

- [x] `cargo fetch --locked`
- [x] `cargo fmt --all -- --check`
- [x] `cargo test --locked -p moltis-config obscura_stealth_defaults_enabled_and_can_be_disabled`
- [x] `cargo test --locked -p moltis-config browser_obscura_fields_accepted`
- [x] `cargo test --locked -p moltis-browser obscura_sidecar` — 2 passed
- [x] `cargo test --locked -p moltis-browser config_conversion_preserves_obscura_stealth_setting`
- [x] `cargo clippy -Z unstable-options -p moltis-config -p moltis-browser --all-features --all-targets -- -D warnings`
- [x] `cargo build --locked -p moltis-config -p moltis-browser --all-features --all-targets`
- [x] `bash scripts/check-file-size.sh`
- [x] `bash scripts/check-changelog-guard.sh origin/main HEAD`
- [x] `ASTRO_TELEMETRY_DISABLED=1 XDG_CONFIG_HOME=/tmp/config npm run build` in `docs/` — 76 pages built
- [x] Staged-diff secret scan and `git diff --check`
- [x] `./scripts/local-validate.sh 1227` — all applicable `local/*` statuses published successfully; focused all-features Rust overrides were used for the two changed crates because the host lacks CUDA, and workflow checks were not applicable because no workflow files changed

### Remaining

- [ ] Workspace-wide `just release-preflight` in CI. It was attempted locally and reached `llama-cpp-sys-2`, where the Linux `--all-features` path enabled CUDA and stopped because this host has no CUDA Toolkit (`nvcc`). The focused all-features Clippy and build commands for both changed crates pass.

No web UI files changed, so Playwright coverage is not applicable.

## Manual QA

1. Downloaded the official Obscura v0.2.0 `obscura-x86_64-linux-stealth` release binary.
2. Started it with the exact default argument shape produced by this change: `obscura serve --stealth --port 49334`.
3. Requested `http://127.0.0.1:49334/json/version` and confirmed the CDP server reported `Chrome/145.0.0.0` and `ws://127.0.0.1:49334/devtools/browser`.
4. Also started the non-stealth v0.2.0 release with `--stealth` to verify that current standard builds accept the flag; the documentation still makes clear that full TLS impersonation requires a stealth-enabled upstream build.
5. Covered the opt-out path in unit tests and confirmed it emits only `--port <port>`.

The full session export is not attached because this environment does not expose a session-export artifact. The implementation decisions, upstream compatibility findings, exact validation commands, and manual QA are included above.
