### PR TITLE
fix(whatsapp): persist inbound files for local tools

### DIFF
--- a/crates/whatsapp/src/handlers.rs
+++ b/crates/whatsapp/src/handlers.rs
@@ -19,6 +19,7 @@ use moltis_channels::{
 use crate::{
     access::{self, AccessDenied},
     config::WhatsAppAccountConfig,
+    inbound_media::{MAX_SAVED_INBOUND_FILE_BYTES, save_inbound_file},
     otp::{OTP_CHALLENGE_MSG, OtpInitResult, OtpVerifyResult},
     state::{AccountState, AccountStateMap, has_bot_watermark},
 };
@@ -528,7 +529,7 @@ async fn handle_photo(
     client: &Client,
     account_id: &str,
     reply_to: ChannelReplyTarget,
-    meta: ChannelMessageMeta,
+    mut meta: ChannelMessageMeta,
     _chat_jid: &Jid,
     state: &AccountState,
 ) {
@@ -541,6 +542,21 @@ async fn handle_photo(
     match client.download(img.as_ref()).await {
         Ok(image_data) => {
             debug!(account_id, size = image_data.len(), %mime, "downloaded WhatsApp image");
+
+            if image_data.len() <= MAX_SAVED_INBOUND_FILE_BYTES
+                && let Some(ref sink) = state.event_sink
+            {
+                meta.documents = save_inbound_file(
+                    sink,
+                    &reply_to,
+                    &image_data,
+                    None,
+                    &mime,
+                    img.file_sha256.as_deref(),
+                )
+                .await
+                .map(|document| vec![document]);
+            }
 
             let (final_data, media_type) = match moltis_media::image_ops::optimize_for_llm(
                 &image_data,
@@ -726,14 +742,14 @@ async fn handle_video(
     }
 }
 
-/// Handle an inbound document message: dispatch with caption.
+/// Handle an inbound document message: download, save, and dispatch its local path.
 #[allow(clippy::too_many_arguments)]
 async fn handle_document(
     msg: &wa::Message,
-    _client: &Client,
+    client: &Client,
     account_id: &str,
     reply_to: ChannelReplyTarget,
-    meta: ChannelMessageMeta,
+    mut meta: ChannelMessageMeta,
     _chat_jid: &Jid,
     state: &AccountState,
 ) {
@@ -754,8 +770,79 @@ async fn handle_document(
     } else {
         format!("{caption}\n[Document: {filename} ({mime})]")
     };
-    if let Some(ref sink) = state.event_sink {
-        sink.dispatch_to_chat(&text, reply_to, meta).await;
+
+    if doc
+        .file_length
+        .is_some_and(|size| size > MAX_SAVED_INBOUND_FILE_BYTES as u64)
+    {
+        warn!(
+            account_id,
+            filename,
+            size = ?doc.file_length,
+            limit = MAX_SAVED_INBOUND_FILE_BYTES,
+            "skipping oversized WhatsApp document"
+        );
+        if let Some(ref sink) = state.event_sink {
+            sink.dispatch_to_chat(
+                &format!("{text}\n[Document was not downloaded: file exceeds the 20 MB limit]"),
+                reply_to,
+                meta,
+            )
+            .await;
+        }
+        return;
+    }
+
+    match client.download(doc.as_ref()).await {
+        Ok(document_data) if document_data.len() <= MAX_SAVED_INBOUND_FILE_BYTES => {
+            debug!(
+                account_id,
+                filename,
+                size = document_data.len(),
+                "downloaded WhatsApp document"
+            );
+            if let Some(ref sink) = state.event_sink {
+                meta.documents = save_inbound_file(
+                    sink,
+                    &reply_to,
+                    &document_data,
+                    Some(filename),
+                    mime,
+                    doc.file_sha256.as_deref(),
+                )
+                .await
+                .map(|document| vec![document]);
+                sink.dispatch_to_chat(&text, reply_to, meta).await;
+            }
+        },
+        Ok(document_data) => {
+            warn!(
+                account_id,
+                filename,
+                size = document_data.len(),
+                limit = MAX_SAVED_INBOUND_FILE_BYTES,
+                "discarding oversized WhatsApp document"
+            );
+            if let Some(ref sink) = state.event_sink {
+                sink.dispatch_to_chat(
+                    &format!("{text}\n[Document was not saved: file exceeds the 20 MB limit]"),
+                    reply_to,
+                    meta,
+                )
+                .await;
+            }
+        },
+        Err(error) => {
+            warn!(account_id, filename, %error, "failed to download WhatsApp document");
+            if let Some(ref sink) = state.event_sink {
+                sink.dispatch_to_chat(
+                    &format!("{text}\n[Document download failed]"),
+                    reply_to,
+                    meta,
+                )
+                .await;
+            }
+        },
     }
 }
 

--- a/crates/whatsapp/src/inbound_media.rs
+++ b/crates/whatsapp/src/inbound_media.rs
@@ -1,0 +1,125 @@
+use {
+    base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD},
+    moltis_channels::{
+        ChannelDocumentFile, ChannelEventSink, ChannelReplyTarget, SavedChannelFile,
+    },
+    std::sync::Arc,
+};
+
+pub(super) const MAX_SAVED_INBOUND_FILE_BYTES: usize = 20 * 1024 * 1024;
+
+fn sanitize_filename(name: &str) -> String {
+    let sanitized: String = name
+        .chars()
+        .filter(|character| {
+            character.is_ascii_alphanumeric() || matches!(character, '-' | '_' | '.')
+        })
+        .take(160)
+        .collect();
+    sanitized.trim_start_matches('.').to_string()
+}
+
+fn saved_filename(display_name: Option<&str>, mime: &str, file_sha256: Option<&[u8]>) -> String {
+    let extension = moltis_media::mime::extension_for_mime(mime);
+    let base = display_name
+        .map(str::trim)
+        .filter(|name| !name.is_empty())
+        .map(sanitize_filename)
+        .filter(|name| !name.is_empty())
+        .unwrap_or_else(|| format!("whatsapp-file.{extension}"));
+    let base = if extension != "bin"
+        && !base
+            .to_ascii_lowercase()
+            .ends_with(&format!(".{extension}"))
+    {
+        format!("{base}.{extension}")
+    } else {
+        base
+    };
+    let prefix = file_sha256
+        .map(|hash| URL_SAFE_NO_PAD.encode(hash))
+        .filter(|value| !value.is_empty())
+        .map(|value| value.chars().take(16).collect::<String>())
+        .unwrap_or_else(|| {
+            time::OffsetDateTime::now_utc()
+                .unix_timestamp_nanos()
+                .to_string()
+        });
+    format!("{prefix}_{base}")
+}
+
+fn document_metadata(
+    saved: &SavedChannelFile,
+    display_name: Option<&str>,
+    mime: &str,
+    size_bytes: usize,
+) -> ChannelDocumentFile {
+    ChannelDocumentFile {
+        display_name: display_name
+            .map(str::trim)
+            .filter(|name| !name.is_empty())
+            .unwrap_or(&saved.filename)
+            .to_string(),
+        stored_filename: saved.filename.clone(),
+        mime_type: mime.to_string(),
+        size_bytes: u64::try_from(size_bytes).ok(),
+    }
+}
+
+pub(super) async fn save_inbound_file(
+    sink: &Arc<dyn ChannelEventSink>,
+    reply_to: &ChannelReplyTarget,
+    data: &[u8],
+    display_name: Option<&str>,
+    mime: &str,
+    file_sha256: Option<&[u8]>,
+) -> Option<ChannelDocumentFile> {
+    let filename = saved_filename(display_name, mime, file_sha256);
+    let saved = sink
+        .save_channel_attachment(data, &filename, reply_to)
+        .await?;
+    Some(document_metadata(&saved, display_name, mime, data.len()))
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn saved_filename_is_unique_and_sanitized() {
+        let filename = saved_filename(
+            Some("../../blood result 2026"),
+            "application/pdf",
+            Some(&[1, 2, 3, 4]),
+        );
+
+        assert_eq!(filename, "AQIDBA_bloodresult2026.pdf");
+        assert!(!filename.contains('/'));
+    }
+
+    #[test]
+    fn saved_filename_is_bounded() {
+        let long_name = format!("{}.pdf", "a".repeat(300));
+        let filename = saved_filename(Some(&long_name), "application/pdf", Some(&[1; 32]));
+
+        assert!(filename.len() <= 181);
+        assert!(filename.ends_with(".pdf"));
+    }
+
+    #[test]
+    fn document_metadata_preserves_display_name() {
+        let saved = SavedChannelFile {
+            filename: "AQIDBA_result.pdf".to_string(),
+            media_ref: "media/main/AQIDBA_result.pdf".to_string(),
+            absolute_path: "/tmp/AQIDBA_result.pdf".to_string(),
+        };
+
+        let document = document_metadata(&saved, Some("Blood result.pdf"), "application/pdf", 42);
+
+        assert_eq!(document.display_name, "Blood result.pdf");
+        assert_eq!(document.stored_filename, saved.filename);
+        assert_eq!(document.mime_type, "application/pdf");
+        assert_eq!(document.size_bytes, Some(42));
+    }
+}

--- a/crates/whatsapp/src/lib.rs
+++ b/crates/whatsapp/src/lib.rs
@@ -9,6 +9,7 @@ pub mod connection;
 pub mod error;
 mod formatting;
 pub mod handlers;
+mod inbound_media;
 pub mod memory_store;
 pub mod otp;
 pub mod outbound;

--- a/docs/src/whatsapp.md
+++ b/docs/src/whatsapp.md
@@ -340,11 +340,11 @@ WhatsApp supports rich media messages. Moltis handles each type:
 | Message Type | Handling |
 |--------------|----------|
 | **Text** | Dispatched directly to the LLM |
-| **Image** | Downloaded, optimized for LLM consumption (resized if needed), sent as attachment |
+| **Image** | Downloaded, saved in session media up to 20 MB for local tools, optimized for LLM consumption (resized if needed), sent as attachment |
 | **Voice** | Downloaded and transcribed via STT (if configured); falls back to text guidance |
 | **Audio** | Same as voice, but classified separately (non-PTT audio files) |
 | **Video** | Thumbnail extracted and sent as image attachment with caption |
-| **Document** | Caption and filename/MIME metadata dispatched as text |
+| **Document** | Downloaded up to 20 MB, saved in session media for local tools, and filename/MIME metadata dispatched as text |
 | **Location** | Resolves pending location tool requests, or dispatches coordinates to LLM |
 
 ```admonish info title="Voice Transcription"


### PR DESCRIPTION
## Summary

- download inbound WhatsApp documents instead of exposing only filename/MIME metadata
- persist inbound photos and documents through the existing session media interface so local tools receive a stable `local_path`
- keep the implementation bounded and dependency-free: 20 MB limit, sanitized/length-bounded filenames, content-hash prefixes, and existing text fallbacks on failure
- update the WhatsApp media-handling documentation

```mermaid
flowchart LR
    WA[WhatsApp media] --> Limit{Within 20 MB?}
    Limit -->|yes| Download[Verified whatsapp-rust download]
    Limit -->|no| Fallback[Text fallback]
    Download --> Store[Existing session media store]
    Store --> Meta[ChannelDocumentFile metadata]
    Meta --> Agent[Agent receives local_path and media_ref]
    Store -. failure .-> Fallback
```

## Security

- Rejects documents whose declared size exceeds 20 MB before download and checks the actual downloaded size again before persistence.
- Sanitizes stored filenames to ASCII-safe characters, caps the user-controlled portion at 160 characters, and prevents path separators/dot-prefix traversal.
- Prefixes names with a bounded content-hash identifier to avoid ordinary filename collisions.
- Stores media as inert session data through the existing validated storage boundary; the change does not execute or parse document content.
- Preserves the current metadata-only path when download or storage fails, so approved senders are not silently dropped.

## Validation

### Completed

- [x] `cargo fmt --all -- --check`
- [x] `./scripts/check-file-size.sh`
- [x] `docker run --rm -v /home/rubenssoto/moltis-wa-documents-pr:/work -v moltis-pr-cargo-home:/usr/local/cargo -v moltis-pr-target:/cargo-target -e CARGO_TARGET_DIR=/cargo-target -w /work rust:trixie cargo test -p moltis-whatsapp` — 111 passed
- [x] `docker run --rm -v /home/rubenssoto/moltis-wa-documents-pr:/work -v moltis-pr-cargo-home:/usr/local/cargo -v moltis-pr-target:/cargo-target -e CARGO_TARGET_DIR=/cargo-target -w /work rust:trixie cargo clippy -p moltis-whatsapp --all-targets --all-features -- -D warnings`
- [x] `./scripts/local-validate.sh 1228` — passed with Rust lint/build/test commands executed in the disposable build container; unrelated frontend, i18n, zizmor, and E2E commands were skipped because this PR changes only Rust and Markdown and those host toolchains are unavailable

### Remaining

- [ ] Manual QA with a paired WhatsApp account

## Manual QA

1. Send a captioned JPEG to a paired WhatsApp account and confirm the model still receives the image plus an inbound-document context containing `local_path` and `media_ref`.
2. Send a PDF below 20 MB and confirm it is present under the session media directory and its local path is available to tools.
3. Send a document with spaces, Unicode, and path-like characters in its filename; confirm the display name is preserved while the stored filename is safe.
4. Send or synthesize a document declaring more than 20 MB; confirm it is not downloaded and the agent receives the explicit size-limit fallback.
5. Simulate a download/storage failure and confirm the filename/MIME fallback still reaches the agent.
