### PR TITLE
fix(browser): support Browserless v2 containers

### DIFF
--- a/crates/browser/src/browserless.rs
+++ b/crates/browser/src/browserless.rs
@@ -1,0 +1,170 @@
+use {
+    base64::{Engine as _, engine::general_purpose::STANDARD},
+    serde::Serialize,
+    url::Url,
+};
+
+use crate::{error::Error, types::BrowserlessApiVersion};
+
+type Result<T> = std::result::Result<T, Error>;
+
+#[derive(Serialize)]
+struct LaunchOptions<'a> {
+    args: &'a [String],
+}
+
+/// Compute the Browserless session timeout from Moltis pool lifecycle settings.
+pub(crate) fn session_timeout_ms(
+    idle_timeout_secs: u64,
+    navigation_timeout_ms: u64,
+    max_instance_lifetime_secs: u64,
+) -> u64 {
+    let ceiling_ms = max_instance_lifetime_secs.saturating_mul(1000);
+    idle_timeout_secs
+        .max(max_instance_lifetime_secs)
+        .saturating_mul(1000)
+        .max(navigation_timeout_ms)
+        .min(ceiling_ms)
+}
+
+/// Build the environment passed to a Browserless container.
+///
+/// V1 receives both timeout names because older images only understand
+/// `CONNECTION_TIMEOUT`, while keeping `TIMEOUT` preserves compatibility with
+/// v1-compatible images that already accepted the newer alias. V2 launch
+/// options are sent on the websocket URL rather than through removed
+/// `DEFAULT_LAUNCH_ARGS` and `PREBOOT_CHROME` variables.
+pub(crate) fn container_env(
+    api_version: BrowserlessApiVersion,
+    timeout_ms: u64,
+    launch_args: &[String],
+) -> Result<Vec<String>> {
+    match api_version {
+        BrowserlessApiVersion::V1 => {
+            let launch_args = serde_json::to_string(launch_args).map_err(|error| {
+                Error::LaunchFailed(format!(
+                    "failed to serialize Browserless v1 launch arguments: {error}"
+                ))
+            })?;
+            Ok(vec![
+                format!("DEFAULT_LAUNCH_ARGS={launch_args}"),
+                format!("TIMEOUT={timeout_ms}"),
+                format!("CONNECTION_TIMEOUT={timeout_ms}"),
+                "MAX_CONCURRENT_SESSIONS=1".to_string(),
+                "PREBOOT_CHROME=true".to_string(),
+            ])
+        },
+        BrowserlessApiVersion::V2 => Ok(vec![
+            format!("TIMEOUT={timeout_ms}"),
+            "CONCURRENT=1".to_string(),
+        ]),
+    }
+}
+
+/// Build the Browserless websocket URL for the configured API version.
+pub(crate) fn websocket_url(
+    host: &str,
+    port: u16,
+    api_version: BrowserlessApiVersion,
+    launch_args: &[String],
+) -> Result<String> {
+    let base_url = format!("ws://{host}:{port}");
+    if api_version == BrowserlessApiVersion::V1 {
+        return Ok(base_url);
+    }
+
+    let mut url = Url::parse(&base_url).map_err(|error| {
+        Error::LaunchFailed(format!(
+            "failed to build Browserless websocket URL from {base_url}: {error}"
+        ))
+    })?;
+    let launch = serde_json::to_vec(&LaunchOptions { args: launch_args }).map_err(|error| {
+        Error::LaunchFailed(format!(
+            "failed to serialize Browserless v2 launch options: {error}"
+        ))
+    })?;
+    let encoded_launch = STANDARD.encode(launch);
+    url.query_pairs_mut().append_pair("launch", &encoded_launch);
+    Ok(url.to_string())
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn session_timeout_uses_moltis_lifecycle_floor() {
+        assert_eq!(session_timeout_ms(300, 30_000, 1800), 1_800_000);
+    }
+
+    #[test]
+    fn session_timeout_caps_at_max_lifetime() {
+        assert_eq!(session_timeout_ms(3_600, 30_000, 1800), 1_800_000);
+        assert_eq!(session_timeout_ms(60, 3_900_000, 1800), 1_800_000);
+        assert_eq!(session_timeout_ms(60, 600_000, 1800), 1_800_000);
+    }
+
+    #[test]
+    fn v1_environment_keeps_legacy_settings_and_both_timeout_names() {
+        let args = vec![
+            "--window-size=1920,1080".to_string(),
+            "--user-data-dir=/data/browser-profile".to_string(),
+        ];
+        let env = container_env(BrowserlessApiVersion::V1, 1_800_000, &args).unwrap();
+
+        assert_eq!(env, vec![
+            r#"DEFAULT_LAUNCH_ARGS=["--window-size=1920,1080","--user-data-dir=/data/browser-profile"]"#,
+            "TIMEOUT=1800000",
+            "CONNECTION_TIMEOUT=1800000",
+            "MAX_CONCURRENT_SESSIONS=1",
+            "PREBOOT_CHROME=true",
+        ]);
+    }
+
+    #[test]
+    fn v2_environment_omits_removed_v1_settings() {
+        let env = container_env(BrowserlessApiVersion::V2, 1_800_000, &[
+            "--window-size=1920,1080".to_string(),
+        ])
+        .unwrap();
+
+        assert_eq!(env, vec!["TIMEOUT=1800000", "CONCURRENT=1"]);
+        assert!(env.iter().all(|entry| !entry.starts_with("DEFAULT_")));
+        assert!(env.iter().all(|entry| !entry.starts_with("PREBOOT_")));
+    }
+
+    #[test]
+    fn v1_websocket_url_remains_unchanged() {
+        let url = websocket_url("browser-host.local", 45029, BrowserlessApiVersion::V1, &[
+            "--window-size=1920,1080".to_string(),
+        ])
+        .unwrap();
+
+        assert_eq!(url, "ws://browser-host.local:45029");
+    }
+
+    #[test]
+    fn v2_websocket_url_contains_base64_launch_options() {
+        let args = vec![
+            "--window-size=1920,1080".to_string(),
+            "--user-data-dir=/data/profile with spaces".to_string(),
+        ];
+        let url = websocket_url(
+            "browser-host.local",
+            45029,
+            BrowserlessApiVersion::V2,
+            &args,
+        )
+        .unwrap();
+        let parsed = Url::parse(&url).unwrap();
+        let encoded = parsed
+            .query_pairs()
+            .find_map(|(key, value)| (key == "launch").then(|| value.into_owned()))
+            .expect("launch query parameter");
+        let decoded = STANDARD.decode(encoded).unwrap();
+        let launch: serde_json::Value = serde_json::from_slice(&decoded).unwrap();
+
+        assert_eq!(launch["args"], serde_json::json!(args));
+    }
+}

--- a/crates/browser/src/container.rs
+++ b/crates/browser/src/container.rs
@@ -3,17 +3,24 @@
 //! Supports Docker, Podman, and Apple Container backends, auto-detecting the
 //! best available option (Apple Container on macOS → Podman → Docker).
 
+mod cleanup;
+
 use std::{
     fmt::Display,
     fs::{File, OpenOptions},
     path::{Path, PathBuf},
     process::{Command, Output},
+    sync::atomic::{AtomicBool, Ordering},
 };
 
 use {
     crate::{browserless, error::Error, types::BrowserlessApiVersion},
+    cleanup::{profile_lock_to_quarantine, quarantine_profile_lock, stop_container_by_id},
     tracing::{debug, info, warn},
 };
+
+#[cfg(test)]
+use cleanup::cleanup_was_confirmed;
 
 type Result<T> = std::result::Result<T, Error>;
 
@@ -346,62 +353,6 @@ impl ContainerBackend {
     }
 }
 
-fn stop_container_by_id(backend: ContainerBackend, container_id: &str) {
-    let cli = backend.cli();
-    let result = Command::new(cli).args(["stop", container_id]).output();
-
-    match result {
-        Ok(output) if output.status.success() => {
-            debug!(container_id, backend = cli, "browser container stopped");
-        },
-        Ok(output) => {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            warn!(
-                container_id,
-                backend = cli,
-                error = %stderr.trim(),
-                "failed to stop browser container"
-            );
-        },
-        Err(e) => {
-            warn!(
-                container_id,
-                backend = cli,
-                error = %e,
-                "failed to run {} stop",
-                cli
-            );
-        },
-    }
-
-    // Containers are started without --rm so that logs and status remain
-    // available for diagnostics after a crash.  Explicitly remove the
-    // container after stopping it.
-    match Command::new(cli).args(["rm", container_id]).output() {
-        Ok(output) if output.status.success() => {
-            debug!(container_id, backend = cli, "browser container removed");
-        },
-        Ok(output) => {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            warn!(
-                container_id,
-                backend = cli,
-                error = %stderr.trim(),
-                "failed to remove browser container"
-            );
-        },
-        Err(e) => {
-            warn!(
-                container_id,
-                backend = cli,
-                error = %e,
-                "failed to run {} rm",
-                cli
-            );
-        },
-    }
-}
-
 /// A running browser container instance.
 pub struct BrowserContainer {
     /// Container ID or name.
@@ -414,6 +365,8 @@ pub struct BrowserContainer {
     websocket_url: String,
     /// Exclusive profile lock held for the lifetime of a Browserless v2 container.
     _profile_lock: Option<File>,
+    /// Whether the backend confirmed that this container stopped or was removed.
+    cleanup_confirmed: AtomicBool,
     /// The image used.
     #[allow(dead_code)]
     image: String,
@@ -565,7 +518,7 @@ impl BrowserContainer {
             &launch_args,
         )?;
 
-        let profile_lock = match browserless_api_version {
+        let mut profile_lock = match browserless_api_version {
             BrowserlessApiVersion::V1 => {
                 if let Some(guest_dir) =
                     profile_precreate_dir(profile_dir, profile_mount_dir.as_deref())
@@ -671,7 +624,10 @@ impl BrowserContainer {
                 );
             }
 
-            stop_container_by_id(backend, &container_id);
+            let cleanup_confirmed = stop_container_by_id(backend, &container_id);
+            if let Some(lock) = profile_lock_to_quarantine(profile_lock.take(), cleanup_confirmed) {
+                quarantine_profile_lock(lock, backend, &container_id, profile_dir);
+            }
             if let Some(hint) = permission_hint {
                 return Err(launch_error_with_hint(error, hint));
             }
@@ -692,6 +648,7 @@ impl BrowserContainer {
             host: container_host.to_string(),
             websocket_url,
             _profile_lock: profile_lock,
+            cleanup_confirmed: AtomicBool::new(false),
             image: image.to_string(),
             backend,
         })
@@ -711,12 +668,17 @@ impl BrowserContainer {
 
     /// Stop and remove the container.
     pub fn stop(&self) {
+        if self.cleanup_confirmed.load(Ordering::Relaxed) {
+            return;
+        }
         info!(
             container_id = %self.container_id,
             backend = self.backend.cli(),
             "stopping browser container"
         );
-        stop_container_by_id(self.backend, &self.container_id);
+        if stop_container_by_id(self.backend, &self.container_id) {
+            self.cleanup_confirmed.store(true, Ordering::Relaxed);
+        }
     }
 
     /// Get the container ID.
@@ -735,6 +697,11 @@ impl BrowserContainer {
 impl Drop for BrowserContainer {
     fn drop(&mut self) {
         self.stop();
+        if !self.cleanup_confirmed.load(Ordering::Relaxed)
+            && let Some(lock) = profile_lock_to_quarantine(self._profile_lock.take(), false)
+        {
+            quarantine_profile_lock(lock, self.backend, &self.container_id, None);
+        }
     }
 }
 

--- a/crates/browser/src/container.rs
+++ b/crates/browser/src/container.rs
@@ -10,7 +10,7 @@ use std::{
 };
 
 use {
-    crate::error::Error,
+    crate::{browserless, error::Error, types::BrowserlessApiVersion},
     tracing::{debug, info, warn},
 };
 
@@ -248,6 +248,28 @@ fn ensure_profile_dir(dir: &Path) {
     }
 }
 
+fn remove_stale_profile_singletons(dir: &Path) {
+    for name in ["SingletonLock", "SingletonCookie", "SingletonSocket"] {
+        let path = dir.join(name);
+        match std::fs::symlink_metadata(&path) {
+            Ok(_) => match std::fs::remove_file(&path) {
+                Ok(()) => debug!(path = %path.display(), "removed stale browser profile singleton"),
+                Err(error) => warn!(
+                    path = %path.display(),
+                    %error,
+                    "failed to remove stale browser profile singleton"
+                ),
+            },
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {},
+            Err(error) => warn!(
+                path = %path.display(),
+                %error,
+                "failed to inspect browser profile singleton"
+            ),
+        }
+    }
+}
+
 #[cfg(unix)]
 fn set_container_dir_permissions(dir: &Path) {
     use std::os::unix::fs::PermissionsExt;
@@ -353,6 +375,8 @@ pub struct BrowserContainer {
     host_port: u16,
     /// Hostname or IP used to connect to the container.
     host: String,
+    /// Version-aware WebSocket URL, including Browserless v2 launch options.
+    websocket_url: String,
     /// The image used.
     #[allow(dead_code)]
     image: String,
@@ -379,8 +403,35 @@ impl BrowserContainer {
         host_data_dir: Option<&Path>,
         container_host: &str,
     ) -> Result<Self> {
+        Self::start_with_api_version(
+            image,
+            container_prefix,
+            viewport_width,
+            viewport_height,
+            low_memory_threshold_mb,
+            session_timeout_ms,
+            profile_dir,
+            host_data_dir,
+            container_host,
+            BrowserlessApiVersion::V1,
+        )
+    }
+
+    /// Start a new browser container for a specific Browserless API version.
+    pub fn start_with_api_version(
+        image: &str,
+        container_prefix: &str,
+        viewport_width: u32,
+        viewport_height: u32,
+        low_memory_threshold_mb: u64,
+        session_timeout_ms: u64,
+        profile_dir: Option<&Path>,
+        host_data_dir: Option<&Path>,
+        container_host: &str,
+        browserless_api_version: BrowserlessApiVersion,
+    ) -> Result<Self> {
         let backend = detect_backend()?;
-        Self::start_with_backend(
+        Self::start_with_backend_and_api_version(
             backend,
             image,
             container_prefix,
@@ -391,6 +442,7 @@ impl BrowserContainer {
             profile_dir,
             host_data_dir,
             container_host,
+            browserless_api_version,
         )
     }
 
@@ -406,6 +458,36 @@ impl BrowserContainer {
         profile_dir: Option<&Path>,
         host_data_dir: Option<&Path>,
         container_host: &str,
+    ) -> Result<Self> {
+        Self::start_with_backend_and_api_version(
+            backend,
+            image,
+            container_prefix,
+            viewport_width,
+            viewport_height,
+            low_memory_threshold_mb,
+            session_timeout_ms,
+            profile_dir,
+            host_data_dir,
+            container_host,
+            BrowserlessApiVersion::V1,
+        )
+    }
+
+    /// Start a new browser container with a specific backend and API version.
+    #[allow(clippy::too_many_arguments)]
+    pub fn start_with_backend_and_api_version(
+        backend: ContainerBackend,
+        image: &str,
+        container_prefix: &str,
+        viewport_width: u32,
+        viewport_height: u32,
+        low_memory_threshold_mb: u64,
+        session_timeout_ms: u64,
+        profile_dir: Option<&Path>,
+        host_data_dir: Option<&Path>,
+        container_host: &str,
+        browserless_api_version: BrowserlessApiVersion,
     ) -> Result<Self> {
         use std::time::Instant;
 
@@ -424,15 +506,42 @@ impl BrowserContainer {
             host_port,
             backend = backend.cli(),
             container_host,
+            browserless_api_version = %browserless_api_version,
             "starting browser container"
         );
 
         let t0 = Instant::now();
         let profile_mount_dir =
             profile_dir.map(|dir| profile_mount_dir_for_backend(backend, dir, host_data_dir));
+        let container_profile_dir = profile_mount_dir.as_ref().map(|_| CONTAINER_PROFILE_PATH);
+        let launch_args = build_container_launch_args(
+            viewport_width,
+            viewport_height,
+            low_memory_threshold_mb,
+            container_profile_dir,
+            backend,
+        );
+        let websocket_url = browserless::websocket_url(
+            container_host,
+            host_port,
+            browserless_api_version,
+            &launch_args,
+        )?;
 
-        if let Some(guest_dir) = profile_precreate_dir(profile_dir, profile_mount_dir.as_deref()) {
-            ensure_profile_dir(guest_dir);
+        match browserless_api_version {
+            BrowserlessApiVersion::V1 => {
+                if let Some(guest_dir) =
+                    profile_precreate_dir(profile_dir, profile_mount_dir.as_deref())
+                {
+                    ensure_profile_dir(guest_dir);
+                }
+            },
+            BrowserlessApiVersion::V2 => {
+                if let Some(guest_dir) = profile_dir {
+                    ensure_profile_dir(guest_dir);
+                    remove_stale_profile_singletons(guest_dir);
+                }
+            },
         }
 
         let container_id = match backend {
@@ -441,10 +550,9 @@ impl BrowserContainer {
                 image,
                 container_prefix,
                 host_port,
-                viewport_width,
-                viewport_height,
-                low_memory_threshold_mb,
                 session_timeout_ms,
+                browserless_api_version,
+                &launch_args,
                 profile_mount_dir.as_deref(),
             )?,
             #[cfg(target_os = "macos")]
@@ -452,10 +560,9 @@ impl BrowserContainer {
                 image,
                 container_prefix,
                 host_port,
-                viewport_width,
-                viewport_height,
-                low_memory_threshold_mb,
                 session_timeout_ms,
+                browserless_api_version,
+                &launch_args,
                 profile_mount_dir.as_deref(),
             )?,
         };
@@ -544,6 +651,7 @@ impl BrowserContainer {
             container_id,
             host_port,
             host: container_host.to_string(),
+            websocket_url,
             image: image.to_string(),
             backend,
         })
@@ -552,8 +660,7 @@ impl BrowserContainer {
     /// Get the WebSocket URL for CDP connection.
     #[must_use]
     pub fn websocket_url(&self) -> String {
-        // browserless/chrome provides a direct WebSocket endpoint
-        format!("ws://{}:{}", self.host, self.host_port)
+        self.websocket_url.clone()
     }
 
     /// Get the HTTP URL for health checks.
@@ -594,7 +701,7 @@ impl Drop for BrowserContainer {
 /// Path inside the container where the browser profile is mounted.
 const CONTAINER_PROFILE_PATH: &str = "/data/browser-profile";
 
-/// Build the `DEFAULT_LAUNCH_ARGS` env-var value for containerised Chrome.
+/// Build launch arguments for containerised Chrome.
 ///
 /// Always includes `--window-size`; appends low-memory flags when the host
 /// system RAM is below the given threshold. Adds `--user-data-dir` when a
@@ -605,7 +712,7 @@ fn build_container_launch_args(
     low_memory_threshold_mb: u64,
     container_profile_dir: Option<&str>,
     backend: ContainerBackend,
-) -> String {
+) -> Vec<String> {
     use crate::pool::low_memory_chrome_args;
 
     let mut args = vec![format!("--window-size={viewport_width},{viewport_height}")];
@@ -632,40 +739,7 @@ fn build_container_launch_args(
         }
     }
 
-    let joined = args
-        .iter()
-        .map(|a| format!("\"{a}\""))
-        .collect::<Vec<_>>()
-        .join(",");
-    format!("DEFAULT_LAUNCH_ARGS=[{joined}]")
-}
-
-/// Compute the browserless container `TIMEOUT` (in ms) from pool lifecycle settings.
-///
-/// The result is `max(idle_timeout_secs, max_instance_lifetime_secs)` converted
-/// to milliseconds, then floored against `navigation_timeout_ms` so that a single
-/// long navigation cannot exceed the container's own timeout. The final value is
-/// capped at `max_instance_lifetime_secs * 1000` to prevent disagree­ment with the
-/// Moltis-side hard TTL when `navigation_timeout_ms` is very large.
-pub(crate) fn browserless_session_timeout_ms(
-    idle_timeout_secs: u64,
-    navigation_timeout_ms: u64,
-    max_instance_lifetime_secs: u64,
-) -> u64 {
-    let ceiling_ms = max_instance_lifetime_secs.saturating_mul(1000);
-    idle_timeout_secs
-        .max(max_instance_lifetime_secs)
-        .saturating_mul(1000)
-        .max(navigation_timeout_ms)
-        .min(ceiling_ms)
-}
-
-fn browserless_container_env(session_timeout_ms: u64) -> Vec<String> {
-    vec![
-        format!("TIMEOUT={session_timeout_ms}"),
-        "MAX_CONCURRENT_SESSIONS=1".to_string(),
-        "PREBOOT_CHROME=true".to_string(),
-    ]
+    args
 }
 
 /// Start a Docker container for the browser.
@@ -674,24 +748,16 @@ fn start_oci_container(
     image: &str,
     container_prefix: &str,
     host_port: u16,
-    viewport_width: u32,
-    viewport_height: u32,
-    low_memory_threshold_mb: u64,
     session_timeout_ms: u64,
+    browserless_api_version: BrowserlessApiVersion,
+    launch_args: &[String],
     profile_dir: Option<&Path>,
 ) -> Result<String> {
     let cli = backend.cli();
     let container_name = new_browser_container_name(container_prefix);
 
-    let container_profile_dir = profile_dir.map(|_| CONTAINER_PROFILE_PATH);
-    let launch_args = build_container_launch_args(
-        viewport_width,
-        viewport_height,
-        low_memory_threshold_mb,
-        container_profile_dir,
-        backend,
-    );
-    let browserless_env = browserless_container_env(session_timeout_ms);
+    let browserless_env =
+        browserless::container_env(browserless_api_version, session_timeout_ms, launch_args)?;
 
     let mut run_args = vec![
         "run".to_string(),
@@ -700,8 +766,6 @@ fn start_oci_container(
         container_name.clone(),
         "-p".to_string(),
         format!("{}:3000", host_port),
-        "-e".to_string(),
-        launch_args,
         "--shm-size=2gb".to_string(),
     ];
 
@@ -756,23 +820,15 @@ fn start_apple_container(
     image: &str,
     container_prefix: &str,
     host_port: u16,
-    viewport_width: u32,
-    viewport_height: u32,
-    low_memory_threshold_mb: u64,
     session_timeout_ms: u64,
+    browserless_api_version: BrowserlessApiVersion,
+    launch_args: &[String],
     profile_dir: Option<&Path>,
 ) -> Result<String> {
     let container_name = new_browser_container_name(container_prefix);
 
-    let container_profile_dir = profile_dir.map(|_| CONTAINER_PROFILE_PATH);
-    let launch_args = build_container_launch_args(
-        viewport_width,
-        viewport_height,
-        low_memory_threshold_mb,
-        container_profile_dir,
-        ContainerBackend::AppleContainer,
-    );
-    let browserless_env = browserless_container_env(session_timeout_ms);
+    let browserless_env =
+        browserless::container_env(browserless_api_version, session_timeout_ms, launch_args)?;
 
     let mut container_args = vec![
         "run".to_string(),
@@ -781,8 +837,6 @@ fn start_apple_container(
         container_name.clone(),
         "-p".to_string(),
         format!("{}:3000", host_port),
-        "-e".to_string(),
-        launch_args,
         // Chrome requires shared memory for rendering; Docker uses --shm-size=2gb,
         // Apple Container doesn't support --shm-size so mount tmpfs at /dev/shm.
         "--tmpfs".to_string(),

--- a/crates/browser/src/container.rs
+++ b/crates/browser/src/container.rs
@@ -5,6 +5,7 @@
 
 use std::{
     fmt::Display,
+    fs::{File, OpenOptions},
     path::{Path, PathBuf},
     process::{Command, Output},
 };
@@ -270,6 +271,40 @@ fn remove_stale_profile_singletons(dir: &Path) {
     }
 }
 
+fn lock_profile_dir(dir: &Path) -> Result<File> {
+    let lock_path = dir.join(".moltis.lock");
+    let lock = OpenOptions::new()
+        .create(true)
+        .read(true)
+        .truncate(false)
+        .write(true)
+        .open(&lock_path)
+        .with_context(|| format!("failed to open profile lock at {}", lock_path.display()))?;
+
+    lock.try_lock().map_err(|error| {
+        let message = match error {
+            std::fs::TryLockError::WouldBlock => format!(
+                "browser profile at {} is already in use by another Moltis browser container",
+                dir.display()
+            ),
+            std::fs::TryLockError::Error(error) => format!(
+                "failed to lock browser profile at {}: {error}",
+                dir.display()
+            ),
+        };
+        Error::LaunchFailed(message)
+    })?;
+
+    Ok(lock)
+}
+
+fn prepare_browserless_v2_profile(dir: &Path) -> Result<File> {
+    ensure_profile_dir(dir);
+    let lock = lock_profile_dir(dir)?;
+    remove_stale_profile_singletons(dir);
+    Ok(lock)
+}
+
 #[cfg(unix)]
 fn set_container_dir_permissions(dir: &Path) {
     use std::os::unix::fs::PermissionsExt;
@@ -377,6 +412,8 @@ pub struct BrowserContainer {
     host: String,
     /// Version-aware WebSocket URL, including Browserless v2 launch options.
     websocket_url: String,
+    /// Exclusive profile lock held for the lifetime of a Browserless v2 container.
+    _profile_lock: Option<File>,
     /// The image used.
     #[allow(dead_code)]
     image: String,
@@ -528,21 +565,23 @@ impl BrowserContainer {
             &launch_args,
         )?;
 
-        match browserless_api_version {
+        let profile_lock = match browserless_api_version {
             BrowserlessApiVersion::V1 => {
                 if let Some(guest_dir) =
                     profile_precreate_dir(profile_dir, profile_mount_dir.as_deref())
                 {
                     ensure_profile_dir(guest_dir);
                 }
+                None
             },
             BrowserlessApiVersion::V2 => {
                 if let Some(guest_dir) = profile_dir {
-                    ensure_profile_dir(guest_dir);
-                    remove_stale_profile_singletons(guest_dir);
+                    Some(prepare_browserless_v2_profile(guest_dir)?)
+                } else {
+                    None
                 }
             },
-        }
+        };
 
         let container_id = match backend {
             ContainerBackend::Docker | ContainerBackend::Podman => start_oci_container(
@@ -652,6 +691,7 @@ impl BrowserContainer {
             host_port,
             host: container_host.to_string(),
             websocket_url,
+            _profile_lock: profile_lock,
             image: image.to_string(),
             backend,
         })

--- a/crates/browser/src/container/cleanup.rs
+++ b/crates/browser/src/container/cleanup.rs
@@ -1,0 +1,117 @@
+use std::{
+    fs::File,
+    path::Path,
+    process::Command,
+    sync::{Mutex, OnceLock},
+};
+
+use tracing::{debug, warn};
+
+use super::ContainerBackend;
+
+pub(super) fn cleanup_was_confirmed(stop_succeeded: bool, remove_succeeded: bool) -> bool {
+    stop_succeeded || remove_succeeded
+}
+
+pub(super) fn profile_lock_to_quarantine(
+    profile_lock: Option<File>,
+    cleanup_confirmed: bool,
+) -> Option<File> {
+    if cleanup_confirmed {
+        None
+    } else {
+        profile_lock
+    }
+}
+
+pub(super) fn quarantine_profile_lock(
+    profile_lock: File,
+    backend: ContainerBackend,
+    container_id: &str,
+    profile_dir: Option<&Path>,
+) {
+    static QUARANTINED_PROFILE_LOCKS: OnceLock<Mutex<Vec<File>>> = OnceLock::new();
+
+    warn!(
+        container_id,
+        backend = backend.cli(),
+        profile_dir = profile_dir.map(|path| path.display().to_string()),
+        "browser container cleanup could not be confirmed; retaining profile lock until Moltis exits"
+    );
+    QUARANTINED_PROFILE_LOCKS
+        .get_or_init(|| Mutex::new(Vec::new()))
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .push(profile_lock);
+}
+
+/// Stop and remove a browser container.
+///
+/// Returns `true` only when at least one backend command confirms the
+/// container is no longer running. A successful `stop` is sufficient because
+/// browser containers have no restart policy; a successful `rm` confirms the
+/// container no longer exists. If both commands fail, callers must assume the
+/// container may still be using its mounted browser profile.
+pub(super) fn stop_container_by_id(backend: ContainerBackend, container_id: &str) -> bool {
+    let cli = backend.cli();
+    let result = Command::new(cli).args(["stop", container_id]).output();
+
+    let stop_succeeded = match result {
+        Ok(output) if output.status.success() => {
+            debug!(container_id, backend = cli, "browser container stopped");
+            true
+        },
+        Ok(output) => {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            warn!(
+                container_id,
+                backend = cli,
+                error = %stderr.trim(),
+                "failed to stop browser container"
+            );
+            false
+        },
+        Err(e) => {
+            warn!(
+                container_id,
+                backend = cli,
+                error = %e,
+                "failed to run {} stop",
+                cli
+            );
+            false
+        },
+    };
+
+    // Containers are started without --rm so that logs and status remain
+    // available for diagnostics after a crash. Explicitly remove the
+    // container after stopping it.
+    let remove_succeeded = match Command::new(cli).args(["rm", container_id]).output() {
+        Ok(output) if output.status.success() => {
+            debug!(container_id, backend = cli, "browser container removed");
+            true
+        },
+        Ok(output) => {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            warn!(
+                container_id,
+                backend = cli,
+                error = %stderr.trim(),
+                "failed to remove browser container"
+            );
+            false
+        },
+        Err(e) => {
+            warn!(
+                container_id,
+                backend = cli,
+                error = %e,
+                "failed to run {} rm",
+                cli
+            );
+            false
+        },
+    };
+
+    cleanup_was_confirmed(stop_succeeded, remove_succeeded)
+}

--- a/crates/browser/src/container/tests.rs
+++ b/crates/browser/src/container/tests.rs
@@ -182,6 +182,7 @@ fn remove_stale_profile_singletons_removes_dangling_symlinks() {
 }
 
 #[test]
+#[serial_test::serial(browser_profile_lock)]
 fn browser_profile_lock_prevents_live_singleton_cleanup() {
     let temp_dir = tempfile::tempdir().unwrap();
     let first_lock = prepare_browserless_v2_profile(temp_dir.path()).unwrap();
@@ -193,8 +194,40 @@ fn browser_profile_lock_prevents_live_singleton_cleanup() {
     assert!(singleton.is_file());
 
     drop(first_lock);
-    assert!(prepare_browserless_v2_profile(temp_dir.path()).is_ok());
+    drop(prepare_browserless_v2_profile(temp_dir.path()).unwrap());
     assert!(!singleton.exists());
+}
+
+#[test]
+fn container_cleanup_is_confirmed_when_stop_or_remove_succeeds() {
+    assert!(!cleanup_was_confirmed(false, false));
+    assert!(cleanup_was_confirmed(true, false));
+    assert!(cleanup_was_confirmed(false, true));
+    assert!(cleanup_was_confirmed(true, true));
+}
+
+#[test]
+#[serial_test::serial(browser_profile_lock)]
+fn failed_cleanup_retains_browser_profile_lock() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let profile_lock = prepare_browserless_v2_profile(temp_dir.path()).unwrap();
+
+    let retained_lock = profile_lock_to_quarantine(Some(profile_lock), false);
+    let error = prepare_browserless_v2_profile(temp_dir.path()).unwrap_err();
+    assert!(error.to_string().contains("already in use"));
+
+    drop(retained_lock);
+    drop(prepare_browserless_v2_profile(temp_dir.path()).unwrap());
+}
+
+#[test]
+#[serial_test::serial(browser_profile_lock)]
+fn confirmed_cleanup_releases_browser_profile_lock() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let profile_lock = prepare_browserless_v2_profile(temp_dir.path()).unwrap();
+
+    assert!(profile_lock_to_quarantine(Some(profile_lock), true).is_none());
+    drop(prepare_browserless_v2_profile(temp_dir.path()).unwrap());
 }
 
 #[test]

--- a/crates/browser/src/container/tests.rs
+++ b/crates/browser/src/container/tests.rs
@@ -71,7 +71,7 @@ fn test_detect_backend_returns_some() {
 #[test]
 fn test_build_container_launch_args_without_low_memory() {
     let args = build_container_launch_args(1920, 1080, 0, None, ContainerBackend::Docker);
-    assert_eq!(args, r#"DEFAULT_LAUNCH_ARGS=["--window-size=1920,1080"]"#);
+    assert_eq!(args, vec!["--window-size=1920,1080"]);
 }
 
 #[test]
@@ -83,14 +83,14 @@ fn test_build_container_launch_args_with_profile_dir() {
         Some("/data/browser-profile"),
         ContainerBackend::Docker,
     );
-    assert!(args.contains("--user-data-dir=/data/browser-profile"));
-    assert!(args.contains("--window-size=1920,1080"));
+    assert!(args.contains(&"--user-data-dir=/data/browser-profile".to_string()));
+    assert!(args.contains(&"--window-size=1920,1080".to_string()));
 }
 
 #[test]
 fn test_build_container_launch_args_without_profile_dir() {
     let args = build_container_launch_args(1920, 1080, 0, None, ContainerBackend::Docker);
-    assert!(!args.contains("--user-data-dir"));
+    assert!(args.iter().all(|arg| !arg.starts_with("--user-data-dir")));
 }
 
 #[test]
@@ -162,6 +162,25 @@ fn browser_profile_precreate_skips_untranslated_mount() {
     );
 }
 
+#[cfg(unix)]
+#[test]
+fn remove_stale_profile_singletons_removes_dangling_symlinks() {
+    use std::os::unix::fs::symlink;
+
+    let temp_dir = tempfile::tempdir().unwrap();
+    let profile_dir = temp_dir.path().join("profile");
+    std::fs::create_dir_all(&profile_dir).unwrap();
+    for name in ["SingletonLock", "SingletonCookie", "SingletonSocket"] {
+        symlink("missing-target", profile_dir.join(name)).unwrap();
+    }
+
+    remove_stale_profile_singletons(&profile_dir);
+
+    for name in ["SingletonLock", "SingletonCookie", "SingletonSocket"] {
+        assert!(std::fs::symlink_metadata(profile_dir.join(name)).is_err());
+    }
+}
+
 #[test]
 fn browser_profile_permission_hint_points_to_host_data_dir() {
     let logs = "Failed to create /data/browser-profile/SingletonLock: Permission denied (13)";
@@ -198,44 +217,12 @@ fn browser_profile_permission_hint_skips_when_host_data_dir_is_configured() {
 #[test]
 fn test_build_container_launch_args_apple_container_has_disable_shm() {
     let args = build_container_launch_args(1920, 1080, 0, None, ContainerBackend::AppleContainer);
-    assert!(args.contains("--disable-dev-shm-usage"));
-    assert!(args.contains("--window-size=1920,1080"));
+    assert!(args.contains(&"--disable-dev-shm-usage".to_string()));
+    assert!(args.contains(&"--window-size=1920,1080".to_string()));
 }
 
 #[test]
 fn test_build_container_launch_args_docker_no_disable_shm() {
     let args = build_container_launch_args(1920, 1080, 0, None, ContainerBackend::Docker);
-    assert!(!args.contains("--disable-dev-shm-usage"));
-}
-
-#[test]
-fn test_browserless_session_timeout_uses_moltis_lifecycle_floor() {
-    let timeout_ms = browserless_session_timeout_ms(300, 30_000, 1800);
-    assert_eq!(timeout_ms, 1_800_000);
-}
-
-#[test]
-fn test_browserless_session_timeout_caps_at_max_lifetime() {
-    let timeout_ms = browserless_session_timeout_ms(3_600, 30_000, 1800);
-    assert_eq!(timeout_ms, 1_800_000);
-}
-
-#[test]
-fn test_browserless_session_timeout_caps_large_navigation_timeout() {
-    let timeout_ms = browserless_session_timeout_ms(60, 3_900_000, 1800);
-    assert_eq!(timeout_ms, 1_800_000);
-}
-
-#[test]
-fn test_browserless_session_timeout_nav_within_ceiling() {
-    let timeout_ms = browserless_session_timeout_ms(60, 600_000, 1800);
-    assert_eq!(timeout_ms, 1_800_000);
-}
-
-#[test]
-fn test_browserless_container_env_includes_timeout() {
-    let env = browserless_container_env(1_800_000);
-    assert_eq!(env[0], "TIMEOUT=1800000");
-    assert!(env.contains(&"MAX_CONCURRENT_SESSIONS=1".to_string()));
-    assert!(env.contains(&"PREBOOT_CHROME=true".to_string()));
+    assert!(!args.contains(&"--disable-dev-shm-usage".to_string()));
 }

--- a/crates/browser/src/container/tests.rs
+++ b/crates/browser/src/container/tests.rs
@@ -182,6 +182,22 @@ fn remove_stale_profile_singletons_removes_dangling_symlinks() {
 }
 
 #[test]
+fn browser_profile_lock_prevents_live_singleton_cleanup() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let first_lock = prepare_browserless_v2_profile(temp_dir.path()).unwrap();
+    let singleton = temp_dir.path().join("SingletonLock");
+    std::fs::write(&singleton, "live-browser").unwrap();
+
+    let error = prepare_browserless_v2_profile(temp_dir.path()).unwrap_err();
+    assert!(error.to_string().contains("already in use"));
+    assert!(singleton.is_file());
+
+    drop(first_lock);
+    assert!(prepare_browserless_v2_profile(temp_dir.path()).is_ok());
+    assert!(!singleton.exists());
+}
+
+#[test]
 fn browser_profile_permission_hint_points_to_host_data_dir() {
     let logs = "Failed to create /data/browser-profile/SingletonLock: Permission denied (13)";
     let hint = browser_profile_permission_hint(

--- a/crates/browser/src/lib.rs
+++ b/crates/browser/src/lib.rs
@@ -37,6 +37,8 @@ pub mod pool;
 pub mod snapshot;
 pub mod types;
 
+mod browserless;
+
 pub use {
     error::Error,
     manager::BrowserManager,

--- a/crates/browser/src/pool.rs
+++ b/crates/browser/src/pool.rs
@@ -20,7 +20,8 @@ use {
 };
 
 use crate::{
-    container::{BrowserContainer, browserless_session_timeout_ms},
+    browserless::session_timeout_ms as browserless_session_timeout_ms,
+    container::BrowserContainer,
     error::Error,
     types::{BrowserConfig, BrowserKind, BrowserPreference, BrowserlessApiVersion},
 };
@@ -408,6 +409,7 @@ impl BrowserPool {
         let profile_dir = sandbox_profile_dir(self.config.resolved_profile_dir(), session_id);
         let host_data_dir = self.config.host_data_dir.clone();
         let container_host = self.config.container_host.clone();
+        let browserless_api_version = self.config.browserless_api_version;
 
         info!(
             session_id,
@@ -415,6 +417,7 @@ impl BrowserPool {
             container_host = %container_host,
             profile_dir = ?profile_dir,
             session_timeout_ms,
+            browserless_api_version = %browserless_api_version,
             "launching sandboxed browser container"
         );
 
@@ -457,7 +460,7 @@ impl BrowserPool {
             }
 
             // Start the container (includes readiness polling)
-            BrowserContainer::start(
+            BrowserContainer::start_with_api_version(
                 &image,
                 &prefix,
                 vw,
@@ -467,6 +470,7 @@ impl BrowserPool {
                 profile_dir.as_deref(),
                 host_data_dir.as_deref(),
                 &container_host,
+                browserless_api_version,
             )
             .map_err(|e| Error::LaunchFailed(format!("failed to start browser container: {e}")))
         })
@@ -1270,6 +1274,19 @@ mod tests {
             "ws://browser-host.local:45029/".to_string(),
             "ws://browser-host.local:45029/chrome".to_string(),
             "ws://browser-host.local:45029/chromium".to_string()
+        ]);
+    }
+
+    #[test]
+    fn websocket_candidates_v2_preserves_launch_query() {
+        let candidates = websocket_connect_candidates(
+            "ws://browser-host.local:45029/?launch=encoded-options",
+            BrowserlessApiVersion::V2,
+        );
+        assert_eq!(candidates, vec![
+            "ws://browser-host.local:45029/?launch=encoded-options".to_string(),
+            "ws://browser-host.local:45029/chrome?launch=encoded-options".to_string(),
+            "ws://browser-host.local:45029/chromium?launch=encoded-options".to_string()
         ]);
     }
 

--- a/crates/browser/src/types.rs
+++ b/crates/browser/src/types.rs
@@ -477,7 +477,8 @@ pub struct BrowserConfig {
     /// browser sandbox containers from inside another container.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub host_data_dir: Option<PathBuf>,
-    /// Browserless API compatibility mode (`v1` or `v2`).
+    /// Browserless container API compatibility mode (`v1` or `v2`).
+    /// Must match the configured sandbox image.
     pub browserless_api_version: BrowserlessApiVersion,
 }
 

--- a/crates/browser/tests/browserless_container.rs
+++ b/crates/browser/tests/browserless_container.rs
@@ -1,0 +1,217 @@
+//! Live compatibility tests for Browserless container images.
+//!
+//! These tests pull and run multi-gigabyte browser images, so they are ignored
+//! during normal `cargo test` runs. Run them explicitly on a Docker host with:
+//!
+//! ```text
+//! cargo test -p moltis-browser --test browserless_container -- --ignored --nocapture
+//! ```
+
+use std::{error::Error as StdError, path::Path, process::Command, time::Duration};
+
+use {
+    chromiumoxide::{Browser, handler::HandlerConfig},
+    futures::StreamExt,
+    moltis_browser::{
+        container::{self, BrowserContainer, ContainerBackend},
+        types::BrowserlessApiVersion,
+    },
+};
+
+type TestResult<T = ()> = Result<T, Box<dyn StdError + Send + Sync>>;
+
+const V1_IMAGE: &str = "docker.io/browserless/chrome:latest";
+const V2_IMAGE: &str = "ghcr.io/browserless/chromium:v2.56.0";
+
+fn container_host() -> String {
+    std::env::var("MOLTIS_BROWSERLESS_TEST_HOST").unwrap_or_else(|_| "127.0.0.1".to_string())
+}
+
+async fn connect_browser(
+    container: &BrowserContainer,
+) -> TestResult<(Browser, tokio::task::JoinHandle<()>)> {
+    let handler_config = HandlerConfig {
+        request_timeout: Duration::from_secs(30),
+        ..Default::default()
+    };
+    let (browser, mut handler) =
+        match Browser::connect_with_config(container.websocket_url(), handler_config).await {
+            Ok(connection) => connection,
+            Err(error) => {
+                let logs = docker_logs(container).unwrap_or_else(|log_error| {
+                    format!("failed to read Browserless container logs: {log_error}")
+                });
+                return Err(std::io::Error::other(format!(
+                    "failed to connect to Browserless: {error}; container logs:\n{logs}"
+                ))
+                .into());
+            },
+        };
+    let handler_task = tokio::spawn(async move { while handler.next().await.is_some() {} });
+    Ok((browser, handler_task))
+}
+
+async fn disconnect_browser(
+    browser: Browser,
+    mut handler_task: tokio::task::JoinHandle<()>,
+) -> TestResult {
+    handler_task.abort();
+    let _ = (&mut handler_task).await;
+    drop(browser);
+    Ok(())
+}
+
+fn prepare_profile_dir(path: &Path) -> TestResult {
+    std::fs::create_dir_all(path)?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o777))?;
+        if let Some(parent) = path.parent() {
+            let permissions = std::fs::metadata(parent)?.permissions();
+            if permissions.mode() & 0o001 == 0 {
+                std::fs::set_permissions(parent, std::fs::Permissions::from_mode(0o777))?;
+            }
+        }
+    }
+    Ok(())
+}
+
+fn docker_logs(container: &BrowserContainer) -> TestResult<String> {
+    let output = Command::new("docker")
+        .args(["logs", container.id()])
+        .output()?;
+    if !output.status.success() {
+        return Err(std::io::Error::other(format!(
+            "docker logs failed: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        ))
+        .into());
+    }
+    Ok(format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    ))
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[serial_test::serial]
+#[ignore = "requires Docker and the Browserless v1 image"]
+async fn browserless_v1_uses_legacy_connection_timeout() -> TestResult {
+    container::ensure_image_with_backend(ContainerBackend::Docker, V1_IMAGE)?;
+    let container_host = container_host();
+    let container = BrowserContainer::start_with_backend(
+        ContainerBackend::Docker,
+        V1_IMAGE,
+        "moltis-browserless-v1-test",
+        1280,
+        720,
+        0,
+        1_000,
+        None,
+        None,
+        &container_host,
+    )?;
+    let (browser, handler_task) = connect_browser(&container).await?;
+    let page = browser
+        .new_page("data:text/html,<title>browserless-v1-ok</title>")
+        .await?;
+
+    assert_eq!(
+        page.get_title().await?.as_deref(),
+        Some("browserless-v1-ok")
+    );
+    tokio::time::sleep(Duration::from_secs(2)).await;
+    let logs = docker_logs(&container)?;
+    assert!(
+        logs.contains("Job has timed-out, closing the WebSocket"),
+        "Browserless v1 should apply CONNECTION_TIMEOUT and close the session"
+    );
+
+    handler_task.abort();
+    drop(page);
+    drop(browser);
+    drop(container);
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[serial_test::serial]
+#[ignore = "requires Docker and pulls the pinned Browserless v2 image"]
+async fn browserless_v2_launches_and_reuses_profile_dir() -> TestResult {
+    container::ensure_image_with_backend(ContainerBackend::Docker, V2_IMAGE)?;
+    let container_host = container_host();
+    let mut temp_dir = None;
+    let profile_dir = if let Some(path) = std::env::var_os("MOLTIS_BROWSERLESS_TEST_PROFILE_DIR") {
+        path.into()
+    } else {
+        let dir = tempfile::tempdir()?;
+        let path = dir.path().join("profile");
+        temp_dir = Some(dir);
+        path
+    };
+    prepare_profile_dir(&profile_dir)?;
+
+    let first_container = BrowserContainer::start_with_backend_and_api_version(
+        ContainerBackend::Docker,
+        V2_IMAGE,
+        "moltis-browserless-v2-test",
+        1280,
+        720,
+        0,
+        120_000,
+        Some(&profile_dir),
+        None,
+        &container_host,
+        BrowserlessApiVersion::V2,
+    )?;
+    let (first_browser, first_handler) = connect_browser(&first_container).await?;
+    let page = first_browser
+        .new_page("data:text/html,<title>browserless-v2-ok</title>")
+        .await?;
+    assert_eq!(
+        page.get_title().await?.as_deref(),
+        Some("browserless-v2-ok")
+    );
+
+    let external_page = first_browser.new_page("about:blank").await?;
+    external_page.goto("https://example.com").await?;
+    assert_eq!(
+        external_page.get_title().await?.as_deref(),
+        Some("Example Domain")
+    );
+    drop(external_page);
+    drop(page);
+    disconnect_browser(first_browser, first_handler).await?;
+    drop(first_container);
+    assert!(profile_dir.join("Local State").is_file());
+
+    let second_container = BrowserContainer::start_with_backend_and_api_version(
+        ContainerBackend::Docker,
+        V2_IMAGE,
+        "moltis-browserless-v2-test",
+        1280,
+        720,
+        0,
+        120_000,
+        Some(&profile_dir),
+        None,
+        &container_host,
+        BrowserlessApiVersion::V2,
+    )?;
+    let (second_browser, second_handler) = connect_browser(&second_container).await?;
+    let page = second_browser
+        .new_page("data:text/html,<title>browserless-v2-restarted</title>")
+        .await?;
+    assert_eq!(
+        page.get_title().await?.as_deref(),
+        Some("browserless-v2-restarted")
+    );
+
+    drop(page);
+    disconnect_browser(second_browser, second_handler).await?;
+    drop(second_container);
+    drop(temp_dir);
+    Ok(())
+}

--- a/crates/config/src/schema/tools.rs
+++ b/crates/config/src/schema/tools.rs
@@ -489,9 +489,9 @@ pub struct BrowserConfig {
     /// Moltis can reach the sibling browser container via the host's port mapping.
     #[serde(default = "default_container_host")]
     pub container_host: String,
-    /// Browserless API compatibility mode for websocket endpoints.
-    /// - "v1" (default): connect to the base websocket URL.
-    /// - "v2": try Browserless v2 paths (`/chrome`, `/chromium`) when needed.
+    /// Browserless container API compatibility mode. Must match `sandbox_image`.
+    /// - "v1" (default): legacy environment-based launch settings.
+    /// - "v2": query-based launch settings and v2 websocket paths.
     #[serde(default = "default_browserless_api_version")]
     pub browserless_api_version: BrowserlessApiVersion,
 }

--- a/crates/config/src/template.rs
+++ b/crates/config/src/template.rs
@@ -533,7 +533,7 @@ port = {port}                           # Port number (auto-generated for this i
 # lightpanda_path = "/path/to/lightpanda" # Custom Lightpanda binary path for browser = "lightpanda"
 # sandbox_image = "docker.io/browserless/chrome" # Default Browserless v1 image
 # browserless_api_version = "v1"    # Must match the Browserless image API
-# Browserless v2 example: set sandbox_image = "ghcr.io/browserless/chromium"
+# Browserless v2 example: set sandbox_image = "ghcr.io/browserless/chromium:v2.56.0"
 # and browserless_api_version = "v2" together.
 
 # ══════════════════════════════════════════════════════════════════════════════

--- a/crates/config/src/template.rs
+++ b/crates/config/src/template.rs
@@ -527,11 +527,14 @@ port = {port}                           # Port number (auto-generated for this i
 # device_scale_factor = 2.0         # HiDPI/Retina scaling
 # max_instances = 3                 # Maximum concurrent browser instances
 # idle_timeout_secs = 300           # Close idle browsers after this many seconds
-# sandbox = false                   # Run browser in container for isolation
 # allowed_domains = []              # Domain restrictions (empty = all allowed)
 # chrome_path = "/path/to/chrome"   # Custom Chrome binary path
 # obscura_path = "/path/to/obscura" # Custom Obscura binary path for browser = "obscura"
 # lightpanda_path = "/path/to/lightpanda" # Custom Lightpanda binary path for browser = "lightpanda"
+# sandbox_image = "docker.io/browserless/chrome" # Default Browserless v1 image
+# browserless_api_version = "v1"    # Must match the Browserless image API
+# Browserless v2 example: set sandbox_image = "ghcr.io/browserless/chromium"
+# and browserless_api_version = "v2" together.
 
 # ══════════════════════════════════════════════════════════════════════════════
 # SKILLS

--- a/docs/src/browser-automation.md
+++ b/docs/src/browser-automation.md
@@ -67,6 +67,7 @@ navigation_timeout_ms = 30000  # Page load timeout
 
 # Sandbox image (browser sandbox mode follows session sandbox mode)
 sandbox_image = "docker.io/browserless/chrome"  # Container image for sandboxed sessions
+browserless_api_version = "v1"                  # Must match the image API
 # allowed_domains = ["example.com", "*.trusted.org"]  # Restrict navigation
 
 # Container connectivity (for Moltis-in-Docker setups)
@@ -308,7 +309,21 @@ When the session is sandboxed, Chrome runs inside a Docker container with:
 ```toml
 [tools.browser]
 sandbox_image = "docker.io/browserless/chrome"  # Container image for sandboxed sessions
+browserless_api_version = "v1"
 ```
+
+The existing Browserless v1 image remains the default for upgrade compatibility.
+To use Browserless v2, change both settings together:
+
+```toml
+[tools.browser]
+sandbox_image = "ghcr.io/browserless/chromium"
+browserless_api_version = "v2"
+```
+
+Moltis passes viewport, low-memory, and persistent-profile launch arguments
+using the protocol expected by the selected version. Browserless v2 images no
+longer accept the legacy `DEFAULT_LAUNCH_ARGS` and `PREBOOT_CHROME` variables.
 
 Requirements:
 - Docker or Apple Container must be installed and running

--- a/docs/src/browser-automation.md
+++ b/docs/src/browser-automation.md
@@ -313,22 +313,113 @@ browserless_api_version = "v1"
 ```
 
 The existing Browserless v1 image remains the default for upgrade compatibility.
-To use Browserless v2, change both settings together:
+Browserless v2 is opt-in. Pin the image and change both settings together:
 
 ```toml
 [tools.browser]
-sandbox_image = "ghcr.io/browserless/chromium"
+sandbox_image = "ghcr.io/browserless/chromium:v2.56.0"
 browserless_api_version = "v2"
 ```
 
 Moltis passes viewport, low-memory, and persistent-profile launch arguments
 using the protocol expected by the selected version. Browserless v2 images no
 longer accept the legacy `DEFAULT_LAUNCH_ARGS` and `PREBOOT_CHROME` variables.
+For v2, Moltis sets `TIMEOUT` and `CONCURRENT` on the container and sends Chrome
+launch arguments in the Base64-encoded `launch` WebSocket query. Do not set
+those values manually.
 
 Requirements:
+
 - Docker or Apple Container must be installed and running
 - The container image is pulled automatically on first use
 - Session sandbox mode must be enabled (`[tools.exec.sandbox] mode = "all"`)
+
+#### Browserless v2 setup checklist
+
+1. Close active browser sessions before changing versions. Browser containers
+   already running with v1 do not change protocol in place.
+2. Pin a Browserless v2 image and set `browserless_api_version = "v2"` in the
+   same configuration change.
+3. If Moltis runs in Docker, mount the container-runtime socket, configure a
+   host-reachable `container_host`, and make the host data path visible with
+   `host_data_dir` when persistent profiles are enabled.
+4. Restart Moltis. It pulls the configured image during startup.
+5. Start a new sandboxed browser session and verify the startup logs show
+   `browserless_api_version=v2` and the pinned image.
+
+For a native Moltis installation, the minimal configuration is:
+
+```toml
+[tools.exec.sandbox]
+mode = "all"
+
+[tools.browser]
+sandbox_image = "ghcr.io/browserless/chromium:v2.56.0"
+browserless_api_version = "v2"
+```
+
+When Moltis runs inside Docker and launches sibling browser containers, use the
+host-visible data path rather than the path inside the Moltis container:
+
+```toml
+[tools.exec.sandbox]
+mode = "all"
+host_data_dir = "/srv/moltis/data"
+
+[tools.browser]
+sandbox_image = "ghcr.io/browserless/chromium:v2.56.0"
+browserless_api_version = "v2"
+container_host = "host.docker.internal"
+```
+
+The matching Compose service needs the same data directory, the Docker socket,
+and a host-gateway mapping on Linux:
+
+```yaml
+services:
+  moltis:
+    volumes:
+      - /srv/moltis/data:/home/moltis/.moltis
+      - /var/run/docker.sock:/var/run/docker.sock
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+```
+
+The Moltis user inside the container must be allowed to access the socket. If
+the socket is group-owned, add its host group ID with Compose `group_add`.
+Mounting the Docker socket grants container-management privileges equivalent to
+host-level control; only use this setup with a trusted Moltis instance. See
+[Docker Socket Sandbox Execution](docker.md#docker-socket-sandbox-execution)
+for the complete Docker setup.
+
+To validate the configuration and image before opening a browser session:
+
+```bash
+moltis config check
+docker pull ghcr.io/browserless/chromium:v2.56.0
+```
+
+After the first v2 browser action, the Moltis logs should report a browser
+container using the v2 image and `browserless_api_version=v2`. Its environment
+contains `TIMEOUT` and `CONCURRENT`, not the v1-only `DEFAULT_LAUNCH_ARGS`,
+`PREBOOT_CHROME`, or `MAX_CONCURRENT_SESSIONS` variables.
+
+Common setup failures:
+
+- A v2 image with `browserless_api_version = "v1"` (or the reverse) causes
+  WebSocket timeouts or missing launch options. Always change the pair together.
+- A connection to `127.0.0.1` from Moltis-in-Docker targets the Moltis container,
+  not the sibling browser. Configure `container_host` as described below.
+- `Permission denied` mentioning `/data/browser-profile/SingletonLock` means the
+  host profile mount is wrong or not writable. Set the correct absolute
+  `host_data_dir` and ensure the directory is writable by the browser container.
+- `Permission denied` for `/var/run/docker.sock` means the Moltis container user
+  is missing the socket's group ID or the socket was not mounted.
+
+Browserless v2.56.0 can mount and safely restart the same `userDataDir`, but it
+currently does not reliably restore cookies or local storage across new
+container instances. Track the upstream limitation in
+[browserless/browserless#4913](https://github.com/browserless/browserless/issues/4913).
 
 ### Moltis Inside Docker (Sibling Containers)
 

--- a/docs/src/configuration-reference.md
+++ b/docs/src/configuration-reference.md
@@ -492,13 +492,13 @@ Default `tool_overrides` entries:
 | `navigation_timeout_ms` | integer | `30000` | Default navigation timeout in milliseconds. |
 | `user_agent` | optional string | `null` | Custom user agent string (uses Chrome default if not set). |
 | `chrome_args` | array | `[]` | Additional Chrome command-line arguments. |
-| `sandbox_image` | string | `"docker.io/browserless/chrome"` | Docker image for sandboxed browser instances. |
+| `sandbox_image` | string | `"docker.io/browserless/chrome"` | Docker image for sandboxed browser instances. Must match `browserless_api_version`. |
 | `allowed_domains` | array | `[]` | Allowed navigation domains (empty = all allowed). Supports wildcards (`"*.example.com"`). |
 | `low_memory_threshold_mb` | integer | `2048` | System RAM threshold (MB) below which memory-saving Chrome flags are injected (0 to disable). |
 | `persist_profile` | bool | `true` | Persist Chrome user profile (cookies, auth, local storage) across sessions. |
 | `profile_dir` | optional string | `null` | Custom path for persistent Chrome profile directory. Implies `persist_profile = true`. |
 | `container_host` | string | `"127.0.0.1"` | Hostname/IP to connect to the browser container from the host. Use `"host.docker.internal"` when Moltis runs inside Docker. |
-| `browserless_api_version` | enum: `"v1"`, `"v2"` | `"v1"` | Browserless API compatibility mode for websocket endpoints. |
+| `browserless_api_version` | enum: `"v1"`, `"v2"` | `"v1"` | Browserless container protocol for environment settings, launch options, and websocket paths. Must match `sandbox_image`. |
 
 ---
 

--- a/docs/src/configuration-reference.md
+++ b/docs/src/configuration-reference.md
@@ -492,13 +492,13 @@ Default `tool_overrides` entries:
 | `navigation_timeout_ms` | integer | `30000` | Default navigation timeout in milliseconds. |
 | `user_agent` | optional string | `null` | Custom user agent string (uses Chrome default if not set). |
 | `chrome_args` | array | `[]` | Additional Chrome command-line arguments. |
-| `sandbox_image` | string | `"docker.io/browserless/chrome"` | Docker image for sandboxed browser instances. Must match `browserless_api_version`. |
+| `sandbox_image` | string | `"docker.io/browserless/chrome"` | Docker image for sandboxed browser instances. Must match `browserless_api_version`; use a pinned `ghcr.io/browserless/chromium:v2.x` image for v2. |
 | `allowed_domains` | array | `[]` | Allowed navigation domains (empty = all allowed). Supports wildcards (`"*.example.com"`). |
 | `low_memory_threshold_mb` | integer | `2048` | System RAM threshold (MB) below which memory-saving Chrome flags are injected (0 to disable). |
 | `persist_profile` | bool | `true` | Persist Chrome user profile (cookies, auth, local storage) across sessions. |
 | `profile_dir` | optional string | `null` | Custom path for persistent Chrome profile directory. Implies `persist_profile = true`. |
 | `container_host` | string | `"127.0.0.1"` | Hostname/IP to connect to the browser container from the host. Use `"host.docker.internal"` when Moltis runs inside Docker. |
-| `browserless_api_version` | enum: `"v1"`, `"v2"` | `"v1"` | Browserless container protocol for environment settings, launch options, and websocket paths. Must match `sandbox_image`. |
+| `browserless_api_version` | enum: `"v1"`, `"v2"` | `"v1"` | Browserless container protocol for environment settings, launch options, and WebSocket paths. Must match `sandbox_image`; see [Browser Automation](browser-automation.md#browserless-v2-setup-checklist) for the complete v2 setup. |
 
 ---
 


### PR DESCRIPTION
## Summary

- add complete Browserless v2 container-protocol support while retaining the existing Browserless v1 image, configuration, and public start APIs as defaults
- send v2 launch arguments through the supported Base64 `launch` websocket query, use `TIMEOUT` / `CONCURRENT`, and preserve the query across root, `/chrome`, and `/chromium` endpoint candidates
- keep the v1 legacy environment contract compatible, including `DEFAULT_LAUNCH_ARGS`, `PREBOOT_CHROME`, `MAX_CONCURRENT_SESSIONS`, and the `CONNECTION_TIMEOUT` expected by the current default image
- protect mounted v2 profiles with an OS-backed exclusive lock before removing stale Chromium singleton files, preventing concurrent launches from deleting a live browser lock
- document the complete native and Docker v2 setup, validation, troubleshooting, and add unit plus live Docker coverage for both protocols

### Why Browserless v2 support matters

- Browserless v2 is the current container protocol and image line; supporting it lets users adopt maintained `ghcr.io/browserless/*` images without relying on deprecated or ignored v1 environment variables.
- Per-session launch options now reach Chromium correctly, so viewport, low-memory flags, and the mounted profile path are honored instead of silently disappearing.
- The v2 WebSocket endpoint variants work without manual URL workarounds, and their encoded launch query survives fallback attempts.
- Version selection is explicit rather than guessed from an image tag, which keeps custom/pinned images predictable and makes future upgrades easier to diagnose.
- v1 remains the default, so updating Moltis alone does not pull a different image, change launch behavior, or require a configuration migration.

```mermaid
flowchart LR
    C[tools.browser config] --> V{browserless_api_version}
    V -->|v1 default| E1[Legacy environment launch args]
    E1 --> W1[Base websocket URL]
    V -->|v2 opt-in| E2[TIMEOUT and CONCURRENT env]
    E2 --> Q[Base64 launch query]
    Q --> W2[Root, /chrome, /chromium candidates]
    V --> P[Mounted session profile]
    P --> L[Exclusive OS file lock]
    L --> S[Safe stale-singleton cleanup]
```

## Compatibility, security, and performance

- **Backward compatibility:** `browserless_api_version = "v1"` and `docker.io/browserless/chrome` remain the defaults. Existing `BrowserContainer::start` and `start_with_backend` callers still use v1 behavior.
- **Upgrade safety:** v2 is opt-in and the docs require changing the image and API version together; no image-name heuristics can silently change behavior.
- **Concurrency safety:** singleton cleanup runs only after a non-blocking, OS-backed exclusive profile lock is acquired. The lock is held until container shutdown is confirmed; if both stop and remove fail, it remains quarantined until process exit. Different profiles still launch concurrently.
- **Filesystem safety:** cleanup remains limited to Chromium's three fixed singleton names inside the selected profile directory. Locking errors fail closed instead of risking concurrent profile mutation.
- **Security boundaries:** navigation allowlists/SSRF checks, container isolation, and secret handling are unchanged. The v2 launch payload contains Chrome flags only, not credentials.
- **Performance:** JSON/Base64 encoding and one file-lock operation occur once per v2 container launch; there is no polling, global mutex, or per-navigation overhead.
- **Upstream scope:** the live test verifies v2 profile mounting and safe restart, not authenticated-state restoration. Browserless v2.56.0 currently does not restore cookies/localStorage across new container instances with the same `userDataDir` ([upstream #4913](https://github.com/browserless/browserless/issues/4913)); this PR does not claim to fix upstream profile semantics.

## Validation

### Completed

- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p moltis-browser` (111 unit tests, integration harness, shadow-DOM test, and doc tests)
- [x] `cargo test -p moltis-config gh684_template_section_order_preserved_after_save`
- [x] `cargo clippy -p moltis-browser --all-features --all-targets -- -D warnings`
- [x] `cargo test -p moltis-browser --test browserless_container -- --ignored --nocapture`
- [x] `./scripts/check-file-size.sh`
- [x] `git diff --check`
- [x] `./scripts/local-validate.sh 1229`: fmt, Biome, TypeScript, i18n, zizmor, install-name/docs, file-size, and lockfile checks passed

### Remaining

- [ ] Workspace-wide `local/lint` / `just release-preflight` requires an NVCC/CUDA-enabled Linux environment; this runner reaches `llama-cpp-sys-2` and stops at `CUDA Toolkit not found`. The targeted all-features browser clippy check passes, and CI covers the workspace environment.

## Manual QA

1. Ran the default Browserless v1 image with a one-second timeout and verified the legacy image applied `CONNECTION_TIMEOUT` and closed the WebSocket.
2. Ran pinned Browserless v2.56.0, navigated to a data URL and `https://example.com`, stopped the container, then restarted successfully with the same mounted profile directory.
3. Verified a second v2 launch cannot delete a live profile's singleton lock, while cleanup succeeds after the first owner releases its OS lock.
4. Separately opened the originally reported forms.app page locally through Browserless v2 and filled a field with fictitious data without submitting. No forms.app URL or data is part of the automated tests.

