### PR TITLE
fix(mcp): resolve current client after server restart

### DIFF
--- a/crates/mcp/src/client_slot.rs
+++ b/crates/mcp/src/client_slot.rs
@@ -1,0 +1,48 @@
+//! Stable handles for replaceable MCP client connections.
+
+use std::sync::Arc;
+
+use tokio::sync::{OwnedRwLockReadGuard, RwLock};
+
+use crate::traits::McpClientTrait;
+
+pub(crate) type SharedMcpClient = Arc<RwLock<dyn McpClientTrait>>;
+
+/// A stable per-server handle whose client can be replaced after a restart.
+#[derive(Default)]
+pub(crate) struct ClientSlot {
+    current: RwLock<Option<SharedMcpClient>>,
+}
+
+impl ClientSlot {
+    pub(crate) fn empty() -> Self {
+        Self::default()
+    }
+
+    pub(crate) fn with_client(client: SharedMcpClient) -> Self {
+        Self {
+            current: RwLock::new(Some(client)),
+        }
+    }
+
+    pub(crate) async fn current(&self) -> Option<SharedMcpClient> {
+        self.current.read().await.clone()
+    }
+
+    pub(crate) async fn read_client(&self) -> Option<OwnedRwLockReadGuard<dyn McpClientTrait>> {
+        let current = self.current.read().await;
+        let client = current.as_ref()?.clone();
+
+        // Keep the slot read-locked until the client is read-locked. A restart
+        // therefore cannot remove and close this client between the two steps.
+        Some(client.read_owned().await)
+    }
+
+    pub(crate) async fn replace(&self, client: SharedMcpClient) -> Option<SharedMcpClient> {
+        self.current.write().await.replace(client)
+    }
+
+    pub(crate) async fn take(&self) -> Option<SharedMcpClient> {
+        self.current.write().await.take()
+    }
+}

--- a/crates/mcp/src/lib.rs
+++ b/crates/mcp/src/lib.rs
@@ -12,6 +12,7 @@
 
 pub mod auth;
 pub mod client;
+mod client_slot;
 pub mod config_parsing;
 pub mod error;
 pub mod legacy_sse_transport;

--- a/crates/mcp/src/manager.rs
+++ b/crates/mcp/src/manager.rs
@@ -18,6 +18,7 @@ use {
 use crate::{
     auth::{McpAuthState, McpOAuthOverride, McpOAuthProvider, SharedAuthProvider},
     client::{McpClient, McpClientState},
+    client_slot::{ClientSlot, SharedMcpClient},
     error::{Context, Error, Result},
     registry::{McpOAuthConfig, McpRegistry, McpServerConfig, TransportType},
     remote::{ResolvedRemoteConfig, header_names, sanitize_url_for_display},
@@ -59,18 +60,18 @@ pub struct ServerStatus {
 }
 
 /// Mutable state behind the single `RwLock` on [`McpManager`].
-pub struct McpManagerInner {
-    pub clients: HashMap<String, Arc<RwLock<dyn McpClientTrait>>>,
-    pub tools: HashMap<String, Vec<McpToolDef>>,
-    pub registry: McpRegistry,
+struct McpManagerInner {
+    clients: HashMap<String, Arc<ClientSlot>>,
+    tools: HashMap<String, Vec<McpToolDef>>,
+    registry: McpRegistry,
     /// OAuth auth providers for SSE servers, keyed by server name.
-    pub auth_providers: HashMap<String, SharedAuthProvider>,
-    pub env_overrides: HashMap<String, String>,
+    auth_providers: HashMap<String, SharedAuthProvider>,
+    env_overrides: HashMap<String, String>,
 }
 
 /// Manages the lifecycle of multiple MCP server connections.
 pub struct McpManager {
-    pub inner: RwLock<McpManagerInner>,
+    inner: RwLock<McpManagerInner>,
     request_timeout_secs: AtomicU64,
 }
 
@@ -200,14 +201,68 @@ impl McpManager {
             .await
     }
 
+    async fn publish_started_client(
+        &self,
+        name: &str,
+        slot: &Arc<ClientSlot>,
+        client: SharedMcpClient,
+        tool_defs: Vec<McpToolDef>,
+        auth_provider: Option<SharedAuthProvider>,
+    ) -> Result<()> {
+        let (published, client_to_shutdown) = {
+            let mut inner = self.inner.write().await;
+            let slot_is_current = inner
+                .clients
+                .get(name)
+                .is_some_and(|current| Arc::ptr_eq(current, slot));
+
+            if slot_is_current {
+                let replaced = slot.replace(client).await;
+                inner.tools.insert(name.to_string(), tool_defs);
+                if let Some(auth) = auth_provider {
+                    inner.auth_providers.insert(name.to_string(), auth);
+                }
+                (true, replaced)
+            } else {
+                (false, Some(client))
+            }
+        };
+
+        if let Some(client) = client_to_shutdown {
+            client.write().await.shutdown().await;
+        }
+
+        if !published {
+            return Err(Error::message(format!(
+                "MCP server '{name}' start was superseded by a lifecycle change"
+            )));
+        }
+
+        Ok(())
+    }
+
     pub async fn start_server_with_options(
         &self,
         name: &str,
         config: &McpServerConfig,
         stdio_options: &StdioLaunchOptions,
     ) -> Result<()> {
-        // Shut down existing connection if any.
-        self.stop_server(name).await;
+        // Keep the per-server slot stable across restarts so retained tool
+        // bridges can follow the replacement connection.
+        let slot = {
+            let mut inner = self.inner.write().await;
+            inner.tools.remove(name);
+            Arc::clone(
+                inner
+                    .clients
+                    .entry(name.to_string())
+                    .or_insert_with(|| Arc::new(ClientSlot::empty())),
+            )
+        };
+        if let Some(client) = slot.take().await {
+            let mut client = client.write().await;
+            client.shutdown().await;
+        }
 
         // Network work happens outside the lock.
         let (client, auth_provider) = match config.transport {
@@ -492,31 +547,28 @@ impl McpManager {
             "MCP server started with tools"
         );
 
-        // Atomic insert of client, tools, and auth provider.
-        let client: Arc<RwLock<dyn McpClientTrait>> = Arc::new(RwLock::new(client));
-        let mut inner = self.inner.write().await;
-        inner.clients.insert(name.to_string(), client);
-        inner.tools.insert(name.to_string(), tool_defs);
-
-        if let Some(auth) = auth_provider {
-            inner.auth_providers.insert(name.to_string(), auth);
-        }
-
-        Ok(())
+        // Publish only if the slot is still registered. Stop, removal,
+        // disable, and configuration changes invalidate an in-flight start by
+        // removing its slot.
+        let client: SharedMcpClient = Arc::new(RwLock::new(client));
+        self.publish_started_client(name, &slot, client, tool_defs, auth_provider)
+            .await
     }
 
     /// Stop a server connection.
     pub async fn stop_server(&self, name: &str) {
         // Atomically remove client and tools, then drop the lock before async shutdown.
         // Keep auth_providers for potential reconnection.
-        let client = {
+        let slot = {
             let mut inner = self.inner.write().await;
             inner.tools.remove(name);
             inner.clients.remove(name)
         };
-        if let Some(client) = client {
-            let mut c = client.write().await;
-            c.shutdown().await;
+        if let Some(slot) = slot
+            && let Some(client) = slot.take().await
+        {
+            let mut client = client.write().await;
+            client.shutdown().await;
         }
     }
 
@@ -616,7 +668,12 @@ impl McpManager {
 
         let mut statuses = Vec::new();
         for (name, config) in &inner.registry.servers {
-            let state = if let Some(client) = inner.clients.get(name) {
+            let client = if let Some(slot) = inner.clients.get(name) {
+                slot.current().await
+            } else {
+                None
+            };
+            let state = if let Some(client) = client {
                 let c = client.read().await;
                 match c.state() {
                     McpClientState::Ready => {
@@ -670,13 +727,9 @@ impl McpManager {
         let inner = self.inner.read().await;
         let mut bridges = Vec::new();
 
-        for (name, client) in inner.clients.iter() {
+        for (name, slot) in &inner.clients {
             if let Some(tool_defs) = inner.tools.get(name) {
-                bridges.extend(McpToolBridge::from_client(
-                    name,
-                    tool_defs,
-                    Arc::clone(client),
-                ));
+                bridges.extend(McpToolBridge::from_slot(name, tool_defs, Arc::clone(slot)));
             }
         }
 
@@ -745,19 +798,27 @@ impl McpManager {
 
     /// Update a server's configuration and restart it if running.
     pub async fn update_server(&self, name: &str, config: McpServerConfig) -> Result<()> {
+        // A registered slot represents a server that is running or in the
+        // process of starting. Empty slots must still be restarted after the
+        // configuration change.
         let was_running = {
             let inner = self.inner.read().await;
             inner.clients.contains_key(name)
         };
-        {
+        let updated_config = {
             let mut inner = self.inner.write().await;
             let enabled = inner.registry.get(name).is_none_or(|c| c.enabled);
             let mut new_config = config;
             new_config.enabled = enabled;
-            inner.registry.add(name.to_string(), new_config)?;
-        }
+            inner.registry.add(name.to_string(), new_config.clone())?;
+            new_config
+        };
+        // A configuration change may point this name at a different trust
+        // boundary. Always invalidate the old slot, including while a restart
+        // has temporarily removed its client.
+        self.stop_server(name).await;
         if was_running {
-            self.restart_server(name).await?;
+            self.start_server(name, &updated_config).await?;
         }
         Ok(())
     }
@@ -773,12 +834,58 @@ impl McpManager {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
+    use std::sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    };
 
     use {
         super::*,
-        crate::auth::{McpAuthProvider, McpAuthState},
+        crate::{
+            auth::{McpAuthProvider, McpAuthState},
+            types::ToolsCallResult,
+        },
     };
+
+    struct ShutdownTrackingClient {
+        shutdown: Arc<AtomicBool>,
+        tools: Vec<McpToolDef>,
+    }
+
+    #[async_trait::async_trait]
+    impl McpClientTrait for ShutdownTrackingClient {
+        fn server_name(&self) -> &str {
+            "test"
+        }
+
+        fn state(&self) -> McpClientState {
+            McpClientState::Ready
+        }
+
+        fn tools(&self) -> &[McpToolDef] {
+            &self.tools
+        }
+
+        async fn list_tools(&mut self) -> Result<&[McpToolDef]> {
+            Ok(&self.tools)
+        }
+
+        async fn call_tool(
+            &self,
+            _name: &str,
+            _arguments: serde_json::Value,
+        ) -> Result<ToolsCallResult> {
+            Err(Error::message("not implemented"))
+        }
+
+        async fn is_alive(&self) -> bool {
+            true
+        }
+
+        async fn shutdown(&mut self) {
+            self.shutdown.store(true, Ordering::SeqCst);
+        }
+    }
 
     #[test]
     fn test_manager_creation() {
@@ -826,6 +933,78 @@ mod tests {
         let mgr = McpManager::new(McpRegistry::new());
         let bridges = mgr.tool_bridges().await;
         assert!(bridges.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_publish_started_client_rejects_invalidated_slot() {
+        let mgr = McpManager::new(McpRegistry::new());
+        let slot = Arc::new(ClientSlot::empty());
+        mgr.inner
+            .write()
+            .await
+            .clients
+            .insert("test".to_string(), Arc::clone(&slot));
+        mgr.stop_server("test").await;
+
+        let shutdown = Arc::new(AtomicBool::new(false));
+        let client: SharedMcpClient = Arc::new(RwLock::new(ShutdownTrackingClient {
+            shutdown: Arc::clone(&shutdown),
+            tools: Vec::new(),
+        }));
+
+        let result = mgr
+            .publish_started_client("test", &slot, client, Vec::new(), None)
+            .await;
+
+        assert!(result.is_err());
+        assert!(shutdown.load(Ordering::SeqCst));
+        assert!(slot.current().await.is_none());
+        let inner = mgr.inner.read().await;
+        assert!(!inner.clients.contains_key("test"));
+        assert!(!inner.tools.contains_key("test"));
+    }
+
+    #[tokio::test]
+    async fn test_update_server_restarts_with_new_slot_during_restart() {
+        let registry_dir = tempfile::tempdir().unwrap();
+        let registry_path = registry_dir.path().join("mcp-servers.json");
+        let mut registry = McpRegistry::load(&registry_path).unwrap();
+        registry
+            .servers
+            .insert("test".to_string(), McpServerConfig {
+                command: "old-command".to_string(),
+                ..Default::default()
+            });
+        let mgr = McpManager::new(registry);
+        let slot = Arc::new(ClientSlot::empty());
+        mgr.inner
+            .write()
+            .await
+            .clients
+            .insert("test".to_string(), Arc::clone(&slot));
+
+        let result = mgr
+            .update_server("test", McpServerConfig {
+                command: "new-command".to_string(),
+                ..Default::default()
+            })
+            .await;
+
+        // The replacement command is intentionally unavailable. Its start
+        // failure proves that update_server attempted to restart the server
+        // rather than leaving it stopped after invalidating the old slot.
+        assert!(result.is_err());
+
+        let inner = mgr.inner.read().await;
+        let replacement_slot = inner.clients.get("test").unwrap();
+        assert!(!Arc::ptr_eq(replacement_slot, &slot));
+        assert_eq!(
+            inner
+                .registry
+                .get("test")
+                .map(|config| config.command.as_str()),
+            Some("new-command")
+        );
     }
 
     #[tokio::test]

--- a/crates/mcp/src/tool_bridge.rs
+++ b/crates/mcp/src/tool_bridge.rs
@@ -6,11 +6,13 @@ use async_trait::async_trait;
 
 use {
     crate::{
+        client_slot::ClientSlot,
         error::{Error, Result},
         traits::McpClientTrait,
         types::{McpToolDef, ToolContent},
     },
     moltis_config::schema::McpServerId,
+    tokio::sync::RwLock,
 };
 
 /// Recursively strip null values from nested objects and arrays.
@@ -47,7 +49,7 @@ pub struct McpToolBridge {
     server_name: McpServerId,
     description: String,
     input_schema: serde_json::Value,
-    client: Arc<tokio::sync::RwLock<dyn McpClientTrait>>,
+    client_slot: Arc<ClientSlot>,
 }
 
 impl McpToolBridge {
@@ -55,7 +57,19 @@ impl McpToolBridge {
     pub fn new(
         server_name: &str,
         tool_def: &McpToolDef,
-        client: Arc<tokio::sync::RwLock<dyn McpClientTrait>>,
+        client: Arc<RwLock<dyn McpClientTrait>>,
+    ) -> Self {
+        Self::from_slot_tool(
+            server_name,
+            tool_def,
+            Arc::new(ClientSlot::with_client(client)),
+        )
+    }
+
+    fn from_slot_tool(
+        server_name: &str,
+        tool_def: &McpToolDef,
+        client_slot: Arc<ClientSlot>,
     ) -> Self {
         Self {
             prefixed_name: format!("mcp__{}__{}", server_name, tool_def.name),
@@ -66,19 +80,31 @@ impl McpToolBridge {
                 .clone()
                 .unwrap_or_else(|| format!("MCP tool: {}", tool_def.name)),
             input_schema: tool_def.input_schema.clone(),
-            client,
+            client_slot,
         }
     }
 
-    /// Create bridges for all tools from a client.
+    /// Create bridges backed by the provided client.
     pub fn from_client(
         server_name: &str,
         tools: &[McpToolDef],
-        client: Arc<tokio::sync::RwLock<dyn McpClientTrait>>,
+        client: Arc<RwLock<dyn McpClientTrait>>,
+    ) -> Vec<Self> {
+        Self::from_slot(
+            server_name,
+            tools,
+            Arc::new(ClientSlot::with_client(client)),
+        )
+    }
+
+    pub(crate) fn from_slot(
+        server_name: &str,
+        tools: &[McpToolDef],
+        client_slot: Arc<ClientSlot>,
     ) -> Vec<Self> {
         tools
             .iter()
-            .map(|t| Self::new(server_name, t, Arc::clone(&client)))
+            .map(|tool| Self::from_slot_tool(server_name, tool, Arc::clone(&client_slot)))
             .collect()
     }
 
@@ -134,7 +160,12 @@ impl McpAgentTool for McpToolBridge {
             other => other,
         };
 
-        let client = self.client.read().await;
+        // Resolve the client for every call. Restarts replace the slot's
+        // client instance, while agent turns may retain this bridge for the
+        // lifetime of the turn.
+        let client = self.client_slot.read_client().await.ok_or_else(|| {
+            Error::message(format!("MCP server '{}' is not running", self.server_name))
+        })?;
         let result = client.call_tool(&self.original_name, params).await?;
 
         if result.is_error {
@@ -178,6 +209,7 @@ mod tests {
         super::*,
         crate::{
             client::McpClientState,
+            traits::McpClientTrait,
             types::{McpToolDef, ToolContent, ToolsCallResult},
         },
         std::sync::Arc,
@@ -240,6 +272,26 @@ mod tests {
         let name = "mcp__my-server__read_file";
         let parts: Vec<&str> = name.splitn(3, "__").collect();
         assert_eq!(parts, vec!["mcp", "my-server", "read_file"]);
+    }
+
+    #[test]
+    fn test_from_client_shares_slot_between_bridges() {
+        let client: Arc<RwLock<dyn McpClientTrait>> = Arc::new(RwLock::new(MockMcpClient {
+            received_args: Arc::new(tokio::sync::Mutex::new(None)),
+        }));
+        let tools = ["first", "second"].map(|name| McpToolDef {
+            name: name.to_string(),
+            description: None,
+            input_schema: serde_json::json!({"type": "object"}),
+        });
+
+        let bridges = McpToolBridge::from_client("test", &tools, client);
+
+        assert_eq!(bridges.len(), 2);
+        assert!(Arc::ptr_eq(
+            &bridges[0].client_slot,
+            &bridges[1].client_slot
+        ));
     }
 
     #[tokio::test]
@@ -402,5 +454,65 @@ mod tests {
         let project = &forwarded["project"];
         assert_eq!(project["name"], "Inbox");
         assert!(project.get("color").is_none());
+    }
+
+    #[tokio::test]
+    async fn test_execute_uses_replacement_client_after_restart() {
+        let old_received = Arc::new(tokio::sync::Mutex::new(None));
+        let old_client: Arc<RwLock<dyn McpClientTrait>> = Arc::new(RwLock::new(MockMcpClient {
+            received_args: Arc::clone(&old_received),
+        }));
+        let slot = Arc::new(ClientSlot::with_client(old_client));
+
+        let tool_def = McpToolDef {
+            name: "query".to_string(),
+            description: Some("Search".to_string()),
+            input_schema: serde_json::json!({"type": "object"}),
+        };
+        let bridge = McpToolBridge::from_slot_tool("search", &tool_def, Arc::clone(&slot));
+
+        let replacement_received = Arc::new(tokio::sync::Mutex::new(None));
+        let replacement: Arc<RwLock<dyn McpClientTrait>> = Arc::new(RwLock::new(MockMcpClient {
+            received_args: Arc::clone(&replacement_received),
+        }));
+        let _ = slot.replace(replacement).await;
+
+        let params = serde_json::json!({"query": "moltis"});
+        bridge.execute(params.clone()).await.unwrap();
+
+        assert!(old_received.lock().await.is_none());
+        assert_eq!(replacement_received.lock().await.as_ref(), Some(&params));
+    }
+
+    #[tokio::test]
+    async fn test_invalidated_slot_does_not_follow_recreated_server() {
+        let old_received = Arc::new(tokio::sync::Mutex::new(None));
+        let old_client: Arc<RwLock<dyn McpClientTrait>> = Arc::new(RwLock::new(MockMcpClient {
+            received_args: Arc::clone(&old_received),
+        }));
+        let old_slot = Arc::new(ClientSlot::with_client(old_client));
+
+        let tool_def = McpToolDef {
+            name: "query".to_string(),
+            description: Some("Search".to_string()),
+            input_schema: serde_json::json!({"type": "object"}),
+        };
+        let bridge = McpToolBridge::from_slot_tool("search", &tool_def, Arc::clone(&old_slot));
+
+        let _ = old_slot.take().await;
+        let replacement_received = Arc::new(tokio::sync::Mutex::new(None));
+        let replacement: Arc<RwLock<dyn McpClientTrait>> = Arc::new(RwLock::new(MockMcpClient {
+            received_args: Arc::clone(&replacement_received),
+        }));
+        let _new_slot = ClientSlot::with_client(replacement);
+
+        let error = bridge
+            .execute(serde_json::json!({"query": "moltis"}))
+            .await
+            .expect_err("invalidated bridge should not call a recreated server");
+
+        assert!(error.to_string().contains("is not running"));
+        assert!(old_received.lock().await.is_none());
+        assert!(replacement_received.lock().await.is_none());
     }
 }


### PR DESCRIPTION
MCP tool bridges captured the client that existed when the tool registry was synchronized. Restarting a server closed that client and installed a replacement, but active chat turns kept dispatching through the closed instance until the next turn rebuilt its registry.

Keep each server connection behind a stable client slot and resolve the slot immediately before dispatch. Health and manual restarts replace the client in place. Publish replacements only while their slot remains registered, and invalidate slots on stop, removal, disable, or configuration changes so in-flight starts and retained turns cannot cross server identities.

Calls racing with the restart may still fail transiently; in-flight tool calls are not retried, but subsequent calls from the same turn resolve the replacement client. This is not a regression.