### PR TITLE
fix(tools): make object schemas OpenAI-safe

### DIFF
--- a/crates/gateway/src/mcp_agent_tools.rs
+++ b/crates/gateway/src/mcp_agent_tools.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 use {
     async_trait::async_trait,
     moltis_agents::tool_registry::AgentTool,
-    serde_json::{Value, json},
+    serde_json::{Map, Value, json},
 };
 
 use crate::services::McpService;
@@ -62,6 +62,36 @@ impl McpAddTool {
     }
 }
 
+fn normalize_env(mut params: Value) -> anyhow::Result<Value> {
+    let Some(env) = params.get_mut("env") else {
+        return Ok(params);
+    };
+    if env.is_null() {
+        return Ok(params);
+    }
+    let entries = env
+        .as_array()
+        .ok_or_else(|| anyhow::anyhow!("'env' must be an array of name/value entries"))?;
+    let mut normalized = Map::new();
+    for entry in entries {
+        let name = entry
+            .get("name")
+            .and_then(Value::as_str)
+            .filter(|name| !name.is_empty())
+            .ok_or_else(|| anyhow::anyhow!("each 'env' entry must have a non-empty name"))?;
+        let value = entry
+            .get("value")
+            .and_then(Value::as_str)
+            .ok_or_else(|| anyhow::anyhow!("each 'env' entry must have a string value"))?;
+        if normalized.contains_key(name) {
+            return Err(anyhow::anyhow!("duplicate 'env' entry name '{name}'"));
+        }
+        normalized.insert(name.to_string(), Value::String(value.to_string()));
+    }
+    *env = Value::Object(normalized);
+    Ok(params)
+}
+
 #[async_trait]
 impl AgentTool for McpAddTool {
     fn name(&self) -> &str {
@@ -100,8 +130,16 @@ impl AgentTool for McpAddTool {
                     "description": "URL for remote transports (sse, streamable-http)"
                 },
                 "env": {
-                    "type": "object",
-                    "description": "Environment variables as key-value pairs"
+                    "type": "array",
+                    "description": "Environment variables as name/value entries.",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "name": { "type": "string", "description": "Environment variable name" },
+                            "value": { "type": "string", "description": "Environment variable value" }
+                        },
+                        "required": ["name", "value"]
+                    }
                 },
                 "display_name": {
                     "type": "string",
@@ -112,6 +150,7 @@ impl AgentTool for McpAddTool {
     }
 
     async fn execute(&self, params: Value) -> anyhow::Result<Value> {
+        let params = normalize_env(params)?;
         self.service
             .add(params)
             .await
@@ -245,5 +284,60 @@ impl AgentTool for McpRestartTool {
             .restart(params)
             .await
             .map_err(|e| anyhow::anyhow!("{e}"))
+    }
+}
+
+#[allow(clippy::unwrap_used)]
+#[cfg(test)]
+mod tests {
+    use moltis_service_traits::NoopMcpService;
+
+    use super::*;
+
+    #[test]
+    fn env_schema_uses_name_value_entries() {
+        let tool = McpAddTool::new(Arc::new(NoopMcpService));
+        let schema = tool.parameters_schema();
+        let env = &schema["properties"]["env"];
+        let items = &env["items"];
+
+        assert_eq!(env["type"], "array");
+        assert_eq!(items["type"], "object");
+        assert_eq!(items["properties"]["name"]["type"], "string");
+        assert_eq!(items["properties"]["value"]["type"], "string");
+        assert_eq!(items["required"], json!(["name", "value"]));
+    }
+
+    #[test]
+    fn normalizes_env_entries_to_object() {
+        let params = normalize_env(json!({
+            "name": "example",
+            "env": [
+                { "name": "API_TOKEN", "value": "secret" },
+                { "name": "REGION", "value": "eu" }
+            ]
+        }))
+        .unwrap();
+
+        assert_eq!(params["env"]["API_TOKEN"], "secret");
+        assert_eq!(params["env"]["REGION"], "eu");
+    }
+
+    #[test]
+    fn rejects_object_env_input() {
+        let error = normalize_env(json!({"env": {"API_TOKEN": "secret"}})).unwrap_err();
+        assert!(error.to_string().contains("must be an array"));
+    }
+
+    #[test]
+    fn rejects_duplicate_env_entry_names() {
+        let error = normalize_env(json!({
+            "env": [
+                { "name": "API_TOKEN", "value": "first" },
+                { "name": "API_TOKEN", "value": "second" }
+            ]
+        }))
+        .unwrap_err();
+        assert!(error.to_string().contains("duplicate 'env' entry name"));
     }
 }

--- a/crates/home-assistant/src/tool.rs
+++ b/crates/home-assistant/src/tool.rs
@@ -17,6 +17,25 @@ use crate::{
 /// Shared client handle behind an Arc.
 type SharedClient = Arc<HomeAssistantClient>;
 
+fn optional_object_parameter(params: &Value, field: &str) -> anyhow::Result<Option<Value>> {
+    let Some(value) = params.get(field) else {
+        return Ok(None);
+    };
+    match value {
+        Value::Null => Ok(None),
+        Value::Object(_) => Ok(Some(value.clone())),
+        Value::String(encoded) => {
+            let decoded: Value = serde_json::from_str(encoded)
+                .map_err(|error| anyhow::anyhow!("invalid JSON object in '{field}': {error}"))?;
+            if !decoded.is_object() {
+                return Err(anyhow::anyhow!("'{field}' must encode a JSON object"));
+            }
+            Ok(Some(decoded))
+        },
+        _ => Err(anyhow::anyhow!("'{field}' must be a JSON object")),
+    }
+}
+
 /// Home Assistant agent tool providing entity control and state queries.
 ///
 /// Connections to HA instances are lazily initialised on first use.
@@ -183,8 +202,14 @@ impl AgentTool for HomeAssistantTool {
                     "description": "Service name for call_service (e.g. 'turn_on')"
                 },
                 "data": {
-                    "type": "object",
-                    "description": "JSON object data (for call_service or fire_event)"
+                    "description": "JSON object data (for call_service or fire_event)",
+                    "anyOf": [
+                        { "type": "object" },
+                        {
+                            "type": "string",
+                            "description": "JSON-encoded object; use this form with strict tool-calling providers."
+                        }
+                    ]
                 },
                 "event_type": {
                     "type": "string",
@@ -337,15 +362,10 @@ impl AgentTool for HomeAssistantTool {
                 }
                 let target =
                     (!target.entity_id.is_empty() || !target.area_id.is_empty()).then_some(target);
+                let data = optional_object_parameter(&params, "data")?;
 
                 let result = client
-                    .call_service(
-                        domain,
-                        service,
-                        target.as_ref(),
-                        params.get("data").cloned(),
-                        false,
-                    )
+                    .call_service(domain, service, target.as_ref(), data, false)
                     .await
                     .map_err(|e| anyhow::anyhow!("{e}"))?;
 
@@ -432,8 +452,9 @@ impl AgentTool for HomeAssistantTool {
                     .and_then(|v| v.as_str())
                     .ok_or_else(|| anyhow::anyhow!("missing 'event_type' parameter"))?;
 
+                let data = optional_object_parameter(&params, "data")?;
                 client
-                    .fire_event(event_type, params.get("data").cloned())
+                    .fire_event(event_type, data)
                     .await
                     .map_err(|e| anyhow::anyhow!("{e}"))?;
 
@@ -691,6 +712,36 @@ mod tests {
         assert!(ops.contains(&json!("get_history")));
         assert!(ops.contains(&json!("fire_event")));
         assert!(ops.contains(&json!("health_check")));
+    }
+
+    #[tokio::test]
+    async fn tool_schema_allows_json_encoded_data_object() {
+        let server = MockServer::start().await;
+        let tool = make_tool(&server);
+        let schema = tool.parameters_schema();
+        let variants = schema
+            .pointer("/properties/data/anyOf")
+            .unwrap()
+            .as_array()
+            .unwrap();
+
+        assert!(variants.iter().any(|variant| variant["type"] == "string"));
+    }
+
+    #[test]
+    fn parses_json_encoded_data_object() {
+        let params = json!({"data": "{\"brightness\":128}"});
+        let data = optional_object_parameter(&params, "data").unwrap().unwrap();
+
+        assert_eq!(data["brightness"], 128);
+    }
+
+    #[test]
+    fn rejects_json_encoded_non_object_data() {
+        let params = json!({"data": "[1,2,3]"});
+        let error = optional_object_parameter(&params, "data").unwrap_err();
+
+        assert!(error.to_string().contains("must encode a JSON object"));
     }
 
     // --- execute: list_entities ---

--- a/crates/tools/src/webhook_tool.rs
+++ b/crates/tools/src/webhook_tool.rs
@@ -20,6 +20,101 @@ impl WebhookTool {
     }
 }
 
+fn object_or_json_string_schema(description: &str) -> Value {
+    json!({
+        "description": description,
+        "anyOf": [
+            { "type": "object" },
+            {
+                "type": "string",
+                "description": "JSON-encoded object; use this form with strict tool-calling providers."
+            },
+            { "type": "null" }
+        ]
+    })
+}
+
+fn webhook_patch_parameter_schema() -> Value {
+    json!({
+        "type": "object",
+        "description": "Fields to update (for update). Any subset of webhook fields.",
+        "properties": {
+            "name": { "type": "string" },
+            "description": { "type": ["string", "null"] },
+            "enabled": { "type": "boolean" },
+            "agentId": { "type": ["string", "null"] },
+            "model": { "type": ["string", "null"] },
+            "systemPromptSuffix": { "type": ["string", "null"] },
+            "toolPolicy": {
+                "type": ["object", "null"],
+                "properties": {
+                    "allow": { "type": "array", "items": { "type": "string" } },
+                    "deny": { "type": "array", "items": { "type": "string" } }
+                }
+            },
+            "authMode": {
+                "type": "string",
+                "enum": ["none", "static_header", "bearer", "github_hmac_sha256", "gitlab_token", "stripe_webhook_signature", "linear_webhook_signature", "pagerduty_v2_signature", "sentry_webhook_signature"]
+            },
+            "authConfig": object_or_json_string_schema("Authentication configuration object."),
+            "sourceConfig": object_or_json_string_schema("Source-profile configuration object."),
+            "eventFilter": {
+                "type": "object",
+                "properties": {
+                    "allow": { "type": "array", "items": { "type": "string" } },
+                    "deny": { "type": "array", "items": { "type": "string" } }
+                }
+            },
+            "sessionMode": { "type": "string", "enum": ["per_delivery", "per_entity", "named_session"] },
+            "namedSessionKey": { "type": ["string", "null"] },
+            "allowedCidrs": { "type": "array", "items": { "type": "string" } },
+            "maxBodyBytes": { "type": "integer" },
+            "rateLimitPerMinute": { "type": "integer" },
+            "deliverOnly": { "type": "boolean" },
+            "promptTemplate": { "type": ["string", "null"] },
+            "deliverTo": { "type": ["string", "null"] },
+            "deliverExtra": object_or_json_string_schema("Extra channel delivery configuration object.")
+        }
+    })
+}
+
+fn normalize_stringified_object_fields(value: &mut Value, fields: &[&str]) -> anyhow::Result<()> {
+    let Some(object) = value.as_object_mut() else {
+        return Ok(());
+    };
+    for field in fields {
+        let Some(raw) = object.get_mut(*field) else {
+            continue;
+        };
+        let Value::String(encoded) = raw else {
+            continue;
+        };
+        let decoded: Value = serde_json::from_str(encoded)
+            .map_err(|error| anyhow::anyhow!("invalid JSON object in '{field}': {error}"))?;
+        if !decoded.is_object() {
+            return Err(anyhow::anyhow!("'{field}' must encode a JSON object"));
+        }
+        *raw = decoded;
+    }
+    Ok(())
+}
+
+fn normalize_nullable_filter_arrays(value: &mut Value) {
+    let Some(patch) = value.as_object_mut() else {
+        return;
+    };
+    for field in ["toolPolicy", "eventFilter"] {
+        let Some(filter) = patch.get_mut(field).and_then(Value::as_object_mut) else {
+            continue;
+        };
+        for array_field in ["allow", "deny"] {
+            if filter.get(array_field).is_some_and(Value::is_null) {
+                filter.remove(array_field);
+            }
+        }
+    }
+}
+
 #[async_trait]
 impl AgentTool for WebhookTool {
     fn name(&self) -> &str {
@@ -101,10 +196,7 @@ impl AgentTool for WebhookTool {
                     "type": "integer",
                     "description": "Max results (for deliveries). Default: 20."
                 },
-                "patch": {
-                    "type": "object",
-                    "description": "Fields to update (for update). Any subset of webhook fields."
-                }
+                "patch": webhook_patch_parameter_schema()
             }
         })
     }
@@ -184,7 +276,13 @@ impl AgentTool for WebhookTool {
                     .get("id")
                     .and_then(|v| v.as_i64())
                     .ok_or_else(|| anyhow::anyhow!("missing 'id' for update"))?;
-                let patch = params.get("patch").cloned().unwrap_or(json!({}));
+                let mut patch = params.get("patch").cloned().unwrap_or(json!({}));
+                normalize_stringified_object_fields(&mut patch, &[
+                    "authConfig",
+                    "sourceConfig",
+                    "deliverExtra",
+                ])?;
+                normalize_nullable_filter_arrays(&mut patch);
                 self.service
                     .update(json!({ "id": id, "patch": patch }))
                     .await
@@ -218,5 +316,74 @@ impl AgentTool for WebhookTool {
                 "unknown action '{other}'. Use: list, create, get, update, delete, profiles, deliveries"
             )),
         }
+    }
+}
+
+#[allow(clippy::unwrap_used)]
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn webhook_patch_schema_preserves_supported_shapes() {
+        let patch = webhook_patch_parameter_schema();
+        let properties = &patch["properties"];
+        assert!(
+            properties.is_object(),
+            "webhook patch schema must declare properties"
+        );
+
+        assert_eq!(properties["name"]["type"], "string");
+        assert_eq!(properties["eventFilter"]["type"], "object");
+        assert!(
+            properties["eventFilter"]["properties"]
+                .get("allow")
+                .is_some()
+        );
+
+        for field in ["authConfig", "sourceConfig", "deliverExtra"] {
+            let supports_json_string = properties[field]["anyOf"]
+                .as_array()
+                .is_some_and(|variants| variants.iter().any(|schema| schema["type"] == "string"));
+            assert!(
+                supports_json_string,
+                "webhook patch field '{field}' must accept a JSON string"
+            );
+        }
+    }
+
+    #[test]
+    fn normalizes_json_encoded_webhook_config_objects() {
+        let mut patch = json!({
+            "authConfig": "{\"header\":\"x-secret\"}",
+            "deliverExtra": {"chat_id": "123"}
+        });
+
+        normalize_stringified_object_fields(&mut patch, &[
+            "authConfig",
+            "sourceConfig",
+            "deliverExtra",
+        ])
+        .unwrap();
+
+        assert_eq!(patch["authConfig"]["header"], "x-secret");
+        assert_eq!(patch["deliverExtra"]["chat_id"], "123");
+    }
+
+    #[test]
+    fn removes_strict_mode_nulls_from_webhook_filter_arrays() {
+        let mut patch = json!({
+            "description": null,
+            "toolPolicy": { "allow": null, "deny": ["shell"] },
+            "eventFilter": { "allow": ["push"], "deny": null }
+        });
+
+        normalize_nullable_filter_arrays(&mut patch);
+
+        assert!(patch["description"].is_null());
+        assert!(patch["toolPolicy"].get("allow").is_none());
+        assert_eq!(patch["toolPolicy"]["deny"], json!(["shell"]));
+        assert_eq!(patch["eventFilter"]["allow"], json!(["push"]));
+        assert!(patch["eventFilter"].get("deny").is_none());
     }
 }


### PR DESCRIPTION
OpenAI strict tool schemas close objects with `additionalProperties=false`. Unspecified patch and map schemas therefore forced Codex to send null or empty values instead of the requested data.

Declare the webhook patch fields, represent MCP environment variables as fixed name/value entries, and provide JSON-string alternatives for free-form webhook configuration and Home Assistant data objects. Normalize these representations before dispatch, including strict-generated nulls in nested webhook filters.

I changed the MCP `env` tool argument from a free-form object to an array of `{name, value}` entries so it's expressible under strict OpenAI schemas. There is no need to preserve backwards compatibility with the old format here: it's a rarely used tool, and models are expected to respond with the new format now based on schema they receive with every request.

Nullable webhook fields were already not clearable with any provider, this is not a regression. This change enables ordinary OpenAI updates but does not lift that pre-existing limitation.