### PR TITLE
fix(memory): normalize built-in backend config value

### DIFF
--- a/crates/gateway/src/methods/services.rs
+++ b/crates/gateway/src/methods/services.rs
@@ -340,6 +340,30 @@ fn parse_memory_backend(value: &str) -> Result<moltis_config::MemoryBackend, Err
     }
 }
 
+fn configured_memory_backend_name(backend: moltis_config::MemoryBackend) -> &'static str {
+    match backend {
+        moltis_config::MemoryBackend::Builtin => "builtin",
+        moltis_config::MemoryBackend::Qmd => "qmd",
+        #[cfg(feature = "zvec")]
+        moltis_config::MemoryBackend::Zvec => "zvec",
+        #[cfg(not(feature = "zvec"))]
+        moltis_config::MemoryBackend::Zvec => "builtin",
+    }
+}
+
+fn editable_memory_backend_name(
+    configured_backend: moltis_config::MemoryBackend,
+    active_backend: Option<&str>,
+) -> &'static str {
+    match active_backend {
+        Some("sqlite") => "builtin",
+        Some("qmd") => "qmd",
+        #[cfg(feature = "zvec")]
+        Some("zvec") => "zvec",
+        _ => configured_memory_backend_name(configured_backend),
+    }
+}
+
 fn parse_memory_provider(value: &str) -> Result<Option<moltis_config::MemoryProvider>, ErrorShape> {
     match value {
         "auto" => Ok(None),
@@ -611,6 +635,41 @@ mod tests {
         }
     }
 
+    fn memory_config_test_state(
+        memory_manager: Option<moltis_memory::runtime::DynMemoryRuntime>,
+    ) -> Arc<GatewayState> {
+        GatewayState::with_options(
+            ResolvedAuth {
+                mode: AuthMode::Token,
+                token: None,
+                password: None,
+            },
+            GatewayServices::noop(),
+            moltis_config::MoltisConfig::default(),
+            None,
+            None,
+            None,
+            false,
+            false,
+            false,
+            None,
+            memory_manager,
+            Arc::new(moltis_code_index::CodeIndex::config_only(
+                moltis_code_index::CodeIndexConfig::default(),
+            )),
+            18789,
+            false,
+            None,
+            None,
+            #[cfg(feature = "metrics")]
+            None,
+            #[cfg(feature = "metrics")]
+            None,
+            #[cfg(feature = "vault")]
+            None,
+        )
+    }
+
     async fn dispatch_memory_method(method: &str, params: serde_json::Value) -> serde_json::Value {
         let mut reg = MethodRegistry::default();
         register(&mut reg);
@@ -645,6 +704,15 @@ mod tests {
         method: &str,
         params: serde_json::Value,
     ) -> moltis_protocol::ResponseFrame {
+        dispatch_memory_method_response_with_state(method, params, memory_config_test_state(None))
+            .await
+    }
+
+    async fn dispatch_memory_method_response_with_state(
+        method: &str,
+        params: serde_json::Value,
+        state: Arc<GatewayState>,
+    ) -> moltis_protocol::ResponseFrame {
         let mut reg = MethodRegistry::default();
         register(&mut reg);
         reg.dispatch(MethodContext {
@@ -654,14 +722,7 @@ mod tests {
             client_conn_id: "conn-1".into(),
             client_role: "operator".into(),
             client_scopes: vec!["operator.write".into(), "operator.read".into()],
-            state: GatewayState::new(
-                ResolvedAuth {
-                    mode: AuthMode::Token,
-                    token: None,
-                    password: None,
-                },
-                GatewayServices::noop(),
-            ),
+            state,
             channel: None,
         })
         .await
@@ -697,6 +758,79 @@ mod tests {
         assert_eq!(payload["search_merge_strategy"], "linear");
         assert_eq!(payload["session_export"], "off");
         assert_eq!(payload["prompt_memory_mode"], "frozen-at-session-start");
+    }
+
+    #[tokio::test]
+    async fn memory_config_builtin_backend_round_trips_with_active_sqlite_runtime() {
+        let _guard = MemoryConfigTestGuard::new();
+        let pool = sqlx::SqlitePool::connect("sqlite::memory:")
+            .await
+            .unwrap_or_else(|error| panic!("in-memory SQLite should open: {error}"));
+        moltis_memory::schema::run_migrations(&pool)
+            .await
+            .unwrap_or_else(|error| panic!("memory migrations should succeed: {error}"));
+        let manager = moltis_memory::manager::MemoryManager::keyword_only(
+            moltis_memory::config::MemoryConfig::default(),
+            Box::new(moltis_memory::store_sqlite::SqliteMemoryStore::new(pool)),
+        );
+        let state = memory_config_test_state(Some(Arc::new(manager)));
+
+        let get_response = dispatch_memory_method_response_with_state(
+            "memory.config.get",
+            serde_json::json!({}),
+            Arc::clone(&state),
+        )
+        .await;
+        assert!(get_response.ok, "config get should succeed");
+        let payload = get_response
+            .payload
+            .unwrap_or_else(|| panic!("config get should return a payload"));
+        assert_eq!(payload["backend"], "builtin");
+
+        let update_response = dispatch_memory_method_response_with_state(
+            "memory.config.update",
+            serde_json::json!({ "backend": payload["backend"] }),
+            state,
+        )
+        .await;
+        assert!(
+            update_response.ok,
+            "config get backend should be accepted by config update: {:?}",
+            update_response.error
+        );
+    }
+
+    #[test]
+    fn editable_memory_backend_names_match_update_contract() {
+        assert_eq!(
+            editable_memory_backend_name(moltis_config::MemoryBackend::Builtin, None),
+            "builtin"
+        );
+        assert_eq!(
+            editable_memory_backend_name(moltis_config::MemoryBackend::Qmd, None),
+            "qmd"
+        );
+        assert_eq!(
+            editable_memory_backend_name(moltis_config::MemoryBackend::Qmd, Some("sqlite")),
+            "builtin"
+        );
+        assert_eq!(
+            editable_memory_backend_name(moltis_config::MemoryBackend::Builtin, Some("qmd")),
+            "qmd"
+        );
+        assert_eq!(
+            editable_memory_backend_name(
+                moltis_config::MemoryBackend::Qmd,
+                Some("unknown-backend")
+            ),
+            "qmd"
+        );
+
+        #[cfg(feature = "zvec")]
+        assert_eq!(
+            editable_memory_backend_name(moltis_config::MemoryBackend::Builtin, Some("zvec")),
+            "zvec"
+        );
     }
 
     #[tokio::test]

--- a/crates/gateway/src/methods/services/admin.rs
+++ b/crates/gateway/src/methods/services/admin.rs
@@ -888,22 +888,16 @@ pub(super) fn register(reg: &mut MethodRegistry) {
                 let memory = &config.memory;
                 let chat = &config.chat;
 
-                // Report the active backend (runtime), not the configured one
-                // (a zvec→builtin fallback keeps the config as zvec but the
-                // manager runs the builtin store).
-                let active_backend = ctx
-                    .state
-                    .memory_manager
-                    .as_ref()
-                    .map(|mm| mm.backend_name())
-                    .unwrap_or_else(|| match memory.backend {
-                        moltis_config::MemoryBackend::Builtin => "builtin",
-                        moltis_config::MemoryBackend::Qmd => "qmd",
-                        #[cfg(feature = "zvec")]
-                        moltis_config::MemoryBackend::Zvec => "zvec",
-                        #[cfg(not(feature = "zvec"))]
-                        moltis_config::MemoryBackend::Zvec => "builtin",
-                    });
+                // Report the active backend using the editable config value.
+                // The builtin runtime identifies its SQLite implementation as
+                // "sqlite", while memory.config.update accepts "builtin".
+                let active_backend = editable_memory_backend_name(
+                    memory.backend,
+                    ctx.state
+                        .memory_manager
+                        .as_ref()
+                        .map(|manager| manager.backend_name()),
+                );
                 Ok(serde_json::json!({
                     "style": match memory.style {
                         moltis_config::MemoryStyle::Hybrid => "hybrid",
@@ -980,20 +974,7 @@ pub(super) fn register(reg: &mut MethodRegistry) {
                     .params
                     .get("backend")
                     .and_then(|v| v.as_str())
-                    .unwrap_or(match current_memory.backend {
-                        moltis_config::MemoryBackend::Builtin => "builtin",
-                        moltis_config::MemoryBackend::Qmd => "qmd",
-                        moltis_config::MemoryBackend::Zvec => {
-                            #[cfg(feature = "zvec")]
-                            {
-                                "zvec"
-                            }
-                            #[cfg(not(feature = "zvec"))]
-                            {
-                                "builtin"
-                            }
-                        },
-                    });
+                    .unwrap_or_else(|| configured_memory_backend_name(current_memory.backend));
                 let agent_write_mode = ctx
                     .params
                     .get("agent_write_mode")

--- a/crates/web/ui/e2e/specs/settings-memory.spec.js
+++ b/crates/web/ui/e2e/specs/settings-memory.spec.js
@@ -46,4 +46,14 @@ test.describe("Settings > Memory page", () => {
 
 		await expect(page.getByRole("button", { name: "Save", exact: false })).toBeVisible();
 	});
+
+	test("unchanged built-in backend can be saved", async ({ page }) => {
+		const pageErrors = watchPageErrors(page);
+		await navigateAndWait(page, "/settings/memory");
+
+		await page.getByRole("button", { name: "Save", exact: true }).click();
+
+		await expect(page.getByText("Saved", { exact: true })).toBeVisible();
+		expect(pageErrors).toEqual([]);
+	});
 });


### PR DESCRIPTION
## Summary

- normalize the built-in memory runtime name from `sqlite` to the editable config value `builtin`
- reuse one backend serialization helper for `memory.config.get` and update defaults
- add Rust round-trip coverage and an end-to-end settings save regression test

## Problem

`memory.config.get` reports the active runtime backend. The built-in `MemoryManager` correctly identifies its storage implementation as `sqlite`, so the RPC returned:

```json
{ "backend": "sqlite" }
```

The Memory settings UI stores that value and sends it back unchanged on Save. However, `memory.config.update` only accepts the configuration values `builtin`, `qmd`, and (when enabled) `zvec`. Saving any Memory setting with the built-in backend therefore failed with:

```text
invalid memory config value for 'backend': 'sqlite'
```

## Why this fix

The runtime and configuration names describe different layers:

- `sqlite` is the built-in backend's storage implementation
- `builtin` is the public, editable configuration value

This change normalizes the name at the configuration RPC boundary. `memory.status` still reports the real runtime/backend type, so observability remains unchanged. Active QMD and zvec values are preserved, and a runtime fallback to SQLite is represented as `builtin`, matching the existing active-backend behavior.

Unknown runtime names defensively fall back to the configured backend instead of leaking a value that `memory.config.update` cannot parse.

## Tests

The new Rust regression test creates a real in-memory SQLite `MemoryManager`, calls `memory.config.get`, and sends the returned backend directly to `memory.config.update`. Before the fix it failed with `left: "sqlite", right: "builtin"`; after the fix the full round trip succeeds.

Validation run:

- `cargo test -p moltis-gateway methods::services::tests:: -- --nocapture` (5 passed)
- `cargo test -p moltis-gateway --no-default-features editable_memory_backend_names_match_update_contract -- --nocapture`
- `cargo test -p moltis-gateway --no-default-features memory_config_builtin_backend_round_trips_with_active_sqlite_runtime -- --nocapture`
- `cargo clippy -p moltis-gateway --tests -- -D warnings`
- `cargo fmt --all -- --check`
- `npm run build:all`
- `npx tsc --noEmit`
- `npx biome check e2e/specs/settings-memory.spec.js`
- `npx playwright test e2e/specs/settings-memory.spec.js --project=default` (8 passed)

## Risk

Low. The only public behavior change is that `memory.config.get.backend` now returns `builtin` instead of the non-editable implementation detail `sqlite` for the built-in runtime. There are no schema, storage, or migration changes.
