### PR TITLE
fix(memory): bound local embedding encoder batches

### DIFF
--- a/crates/memory/src/embeddings_local.rs
+++ b/crates/memory/src/embeddings_local.rs
@@ -2,10 +2,10 @@
 ///
 /// Provides offline embedding via small GGUF models (e.g. EmbeddingGemma-300M).
 /// Requires the `local-embeddings` feature flag and CMake + C++ compiler at build time.
-use std::path::PathBuf;
+use std::{num::NonZeroU32, path::PathBuf};
 
 use {
-    anyhow::{Context, Result, bail},
+    anyhow::{Context, Result},
     async_trait::async_trait,
     llama_cpp_2::{
         context::params::LlamaContextParams,
@@ -14,14 +14,14 @@ use {
         model::{LlamaModel, params::LlamaModelParams},
     },
     tokio::sync::Mutex,
-    tracing::info,
+    tracing::{info, warn},
 };
 
 use crate::embeddings::EmbeddingProvider;
 
 /// Default model: EmbeddingGemma-300M quantized to Q8_0 (~300MB, 768 dims).
 const DEFAULT_MODEL_FILENAME: &str = "embeddinggemma-300M-Q8_0.gguf";
-const DEFAULT_MODEL_URL: &str = "https://huggingface.co/lmstudio-community/EmbeddingGemma-300M-GGUF/resolve/main/EmbeddingGemma-300M-Q8_0.gguf";
+const DEFAULT_MODEL_URL: &str = "https://huggingface.co/ggml-org/embeddinggemma-300M-GGUF/resolve/main/embeddinggemma-300M-Q8_0.gguf";
 const DEFAULT_DIMS: usize = 768;
 
 /// Wrapper around `LlamaBackend` that opts into `Send + Sync`.
@@ -109,22 +109,56 @@ impl LocalGgufEmbeddingProvider {
     }
 }
 
+fn embedding_context_size(model: &LlamaModel) -> Result<NonZeroU32> {
+    NonZeroU32::new(model.n_ctx_train()).context("embedding model reports a zero context size")
+}
+
+fn embedding_context_params(context_size: NonZeroU32) -> LlamaContextParams {
+    // Non-causal encoders must process the complete input in one physical batch.
+    // Keeping all three limits equal prevents llama.cpp from aborting when an input
+    // is larger than its default 512-token ubatch.
+    LlamaContextParams::default()
+        .with_n_ctx(Some(context_size))
+        .with_n_batch(context_size.get())
+        .with_n_ubatch(context_size.get())
+        .with_embeddings(true)
+}
+
+fn truncate_tokens_to_context<T>(tokens: &mut Vec<T>, context_size: NonZeroU32) -> bool {
+    let max_tokens = context_size.get() as usize;
+    if tokens.len() <= max_tokens {
+        return false;
+    }
+
+    tokens.truncate(max_tokens);
+    true
+}
+
 /// Embed a text using the given model and backend. Must be called from a sync context.
 fn embed_sync(backend: &LlamaBackend, model: &LlamaModel, text: &str) -> Result<Vec<f32>> {
-    let ctx_params = LlamaContextParams::default()
-        .with_n_ctx(std::num::NonZeroU32::new(512))
-        .with_embeddings(true);
-    let mut ctx = model
-        .new_context(backend, ctx_params)
-        .map_err(|e| anyhow::anyhow!("failed to create llama context: {e}"))?;
+    let max_context_size = embedding_context_size(model)?;
 
-    let tokens = model
+    let mut tokens = model
         .str_to_token(text, llama_cpp_2::model::AddBos::Always)
         .map_err(|e| anyhow::anyhow!("tokenization failed: {e}"))?;
 
-    if tokens.is_empty() {
-        bail!("empty token sequence");
+    let input_tokens = tokens.len();
+    if truncate_tokens_to_context(&mut tokens, max_context_size) {
+        warn!(
+            input_tokens,
+            max_tokens = max_context_size.get(),
+            "local embedding input exceeds model context; truncating"
+        );
     }
+
+    let batch_size = u32::try_from(tokens.len())
+        .context("embedding token count exceeds the supported batch size")?;
+    let batch_size = NonZeroU32::new(batch_size).context("empty token sequence")?;
+    let ctx_params = embedding_context_params(batch_size);
+
+    let mut ctx = model
+        .new_context(backend, ctx_params)
+        .map_err(|e| anyhow::anyhow!("failed to create llama context: {e}"))?;
 
     let mut batch = LlamaBatch::new(tokens.len(), 1);
     for (i, &token) in tokens.iter().enumerate() {
@@ -171,6 +205,7 @@ impl EmbeddingProvider for LocalGgufEmbeddingProvider {
 }
 
 #[cfg(test)]
+#[allow(clippy::expect_used)]
 mod tests {
     use super::*;
 
@@ -178,5 +213,187 @@ mod tests {
     fn test_default_cache_dir() {
         let dir = LocalGgufEmbeddingProvider::default_cache_dir();
         assert!(dir.to_string_lossy().contains("models"));
+    }
+
+    #[test]
+    fn context_params_use_one_full_encoder_batch() {
+        let context_size = NonZeroU32::new(2_048).expect("test context must be non-zero");
+        let params = embedding_context_params(context_size);
+
+        assert_eq!(params.n_ctx(), Some(context_size));
+        assert_eq!(params.n_batch(), context_size.get());
+        assert_eq!(params.n_ubatch(), context_size.get());
+    }
+
+    #[test]
+    fn token_truncation_preserves_inputs_at_or_below_context() {
+        let context_size = NonZeroU32::new(3).expect("test context must be non-zero");
+        let mut below = vec![1, 2];
+        let mut exact = vec![1, 2, 3];
+
+        assert!(!truncate_tokens_to_context(&mut below, context_size));
+        assert_eq!(below, vec![1, 2]);
+        assert!(!truncate_tokens_to_context(&mut exact, context_size));
+        assert_eq!(exact, vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn token_truncation_caps_inputs_above_context() {
+        let context_size = NonZeroU32::new(3).expect("test context must be non-zero");
+        let mut tokens = vec![1, 2, 3, 4];
+
+        assert!(truncate_tokens_to_context(&mut tokens, context_size));
+        assert_eq!(tokens, vec![1, 2, 3]);
+    }
+
+    /// Exercises the real default GGUF without making the 300 MB artifact a CI dependency.
+    ///
+    /// Run with:
+    /// `MOLTIS_TEST_LOCAL_MODEL=/path/to/model.gguf cargo test -p moltis-memory \
+    ///   --features local-embeddings real_default_model_handles_context_edges_and_indexing \
+    ///   -- --ignored`
+    #[tokio::test(flavor = "multi_thread")]
+    #[ignore]
+    async fn real_default_model_handles_context_edges_and_indexing() {
+        use crate::{
+            config::MemoryConfig, manager::MemoryManager, schema::run_migrations,
+            store_sqlite::SqliteMemoryStore,
+        };
+
+        let model_path = std::env::var("MOLTIS_TEST_LOCAL_MODEL")
+            .expect("MOLTIS_TEST_LOCAL_MODEL must point to the default EmbeddingGemma GGUF");
+        let backend = LlamaBackend::init().expect("llama backend should initialize");
+        let model = LlamaModel::load_from_file(
+            &backend,
+            PathBuf::from(model_path),
+            &LlamaModelParams::default(),
+        )
+        .expect("default embedding model should load");
+        let within_context = "Uma memória semântica em português brasileiro. ".repeat(160);
+        let within_context_tokens = model
+            .str_to_token(&within_context, llama_cpp_2::model::AddBos::Always)
+            .expect("test text should tokenize");
+
+        assert!(
+            within_context_tokens.len() > 512,
+            "fixture must reproduce the old limit"
+        );
+        assert!(
+            within_context_tokens.len() <= model.n_ctx_train() as usize,
+            "fixture must fit the model context"
+        );
+
+        assert_valid_embedding(
+            embed_sync(&backend, &model, &within_context)
+                .expect("input within the model context should embed"),
+        );
+
+        let over_context = "Conteúdo longo para testar um limite seguro. ".repeat(600);
+        let over_context_tokens = model
+            .str_to_token(&over_context, llama_cpp_2::model::AddBos::Always)
+            .expect("oversized test text should tokenize");
+        assert!(
+            over_context_tokens.len() > model.n_ctx_train() as usize,
+            "fixture must exceed the model context"
+        );
+        assert_valid_embedding(
+            embed_sync(&backend, &model, &over_context)
+                .expect("oversized input should be truncated instead of aborting"),
+        );
+
+        assert_valid_embedding(
+            embed_sync(&backend, &model, "")
+                .expect("empty text should still embed its tokenizer special token"),
+        );
+        assert_valid_embedding(
+            embed_sync(
+                &backend,
+                &model,
+                "Texto Unicode: informação, coração, ação, 日本語, 🧠 e 🚀.",
+            )
+            .expect("multilingual Unicode text should embed"),
+        );
+
+        let memory_dir = tempfile::tempdir().expect("temporary memory directory should exist");
+        let garden_text = "O manjericão é uma erva aromática que cresce bem em vasos com luz suave, solo úmido e rega equilibrada. ".repeat(40);
+        let garden_tokens = model
+            .str_to_token(&garden_text, llama_cpp_2::model::AddBos::Always)
+            .expect("synthetic memory should tokenize");
+        assert!(
+            garden_tokens.len() > 512,
+            "indexed fixture must reproduce the old limit"
+        );
+        assert!(
+            garden_tokens.len() <= model.n_ctx_train() as usize,
+            "indexed fixture must fit the model context"
+        );
+
+        std::fs::write(memory_dir.path().join("garden.md"), garden_text)
+            .expect("synthetic garden memory should be written");
+        std::fs::write(
+            memory_dir.path().join("systems.md"),
+            "Backups de banco de dados precisam de retenção, verificação e testes de restauração.",
+        )
+        .expect("synthetic systems memory should be written");
+
+        let provider = LocalGgufEmbeddingProvider {
+            backend: SendSyncBackend(backend),
+            model: Mutex::new(model),
+            dims: DEFAULT_DIMS,
+        };
+        let pool = sqlx::SqlitePool::connect(":memory:")
+            .await
+            .expect("in-memory SQLite should connect");
+        run_migrations(&pool)
+            .await
+            .expect("memory migrations should run");
+        let config = MemoryConfig {
+            db_path: ":memory:".into(),
+            memory_dirs: vec![memory_dir.path().to_path_buf()],
+            ..Default::default()
+        };
+        let manager = MemoryManager::new(
+            config,
+            Box::new(SqliteMemoryStore::new(pool)),
+            Box::new(provider),
+        );
+
+        let report = manager
+            .sync()
+            .await
+            .expect("synthetic memories should index");
+        assert_eq!(report.files_updated, 2);
+        assert_eq!(report.errors, 0);
+        assert!(report.cache_misses >= 2);
+
+        let status = manager.status().await.expect("memory status should load");
+        assert_eq!(status.total_files, 2);
+        assert!(status.total_chunks >= 2);
+        assert_eq!(status.embedding_model, "local-gguf");
+
+        let results = manager
+            .search(
+                "Qual erva aromática cresce bem dentro de casa em um vaso?",
+                2,
+            )
+            .await
+            .expect("Portuguese semantic search should succeed");
+        let first = results.first().expect("search should return a result");
+        assert!(
+            first.text.contains("manjericão"),
+            "the semantically related memory should rank first"
+        );
+
+        let unchanged = manager
+            .sync()
+            .await
+            .expect("repeated sync should remain healthy");
+        assert_eq!(unchanged.files_unchanged, 2);
+        assert_eq!(unchanged.errors, 0);
+    }
+
+    fn assert_valid_embedding(embedding: Vec<f32>) {
+        assert_eq!(embedding.len(), DEFAULT_DIMS);
+        assert!(embedding.iter().all(|value| value.is_finite()));
     }
 }

--- a/docs/src/memory.md
+++ b/docs/src/memory.md
@@ -271,7 +271,7 @@ The built-in backend supports multiple embedding providers:
 
 | Provider | Model | Dimensions | Notes |
 |----------|-------|------------|-------|
-| Local (GGUF) | EmbeddingGemma-300M | 768 | Offline, ~300MB download |
+| Local (GGUF) | EmbeddingGemma-300M | 768 | Offline, ~300MB download, 2048-token context |
 | Ollama | nomic-embed-text | 768 | Requires Ollama running |
 | OpenAI | text-embedding-3-small | 1536 | Requires API key |
 | Custom | Configurable | Varies | OpenAI-compatible endpoint |
@@ -280,6 +280,11 @@ The system auto-detects available providers and creates a fallback chain:
 1. Try configured provider first
 2. Fall back to other available providers if it fails
 3. Use keyword-only search if no embedding provider is available
+
+The local provider reads the context capacity from the GGUF model and sizes a
+single encoder batch for each input. Inputs longer than the model context are
+truncated at the token boundary so an oversized line or query cannot terminate
+the Moltis process.
 
 ## Memory Directories
 


### PR DESCRIPTION
## Summary

Local GGUF memory embeddings can currently terminate the entire Moltis process when a tokenized chunk or query exceeds 512 tokens. The provider sets `n_ctx = 512`, leaves `n_batch = 2048`, and inherits `n_ubatch = 512`. Non-causal llama.cpp encoders require the complete input to fit in one physical batch, so a valid EmbeddingGemma input between 513 and 2048 tokens reaches a native assertion instead of returning a Rust error.

This PR:

- reads the supported context size from the GGUF metadata;
- tokenizes before context creation and caps pathological inputs at the model boundary;
- sizes `n_ctx`, `n_batch`, and `n_ubatch` together for the actual bounded input, avoiding both the native assertion and unnecessary allocation for short queries;
- logs only token counts when truncation occurs, never input content;
- switches the default download from the now-authenticated LM Studio repository to the public `ggml-org` EmbeddingGemma artifact;
- documents the local context and truncation behavior.

```mermaid
flowchart LR
    A[Input text] --> B[Tokenize]
    B --> C{Above GGUF context?}
    C -- No --> D[Keep all tokens]
    C -- Yes --> E[Truncate at token boundary]
    D --> F[Set n_ctx = n_batch = n_ubatch]
    E --> F
    F --> G[Run non-causal encoder]
    G --> H[Return embedding]
```

The production change remains local to the existing provider and does not alter the embedding trait, SQLite schema, chunk IDs, cache keys, remote providers, or keyword-only memory.

## Validation

### Completed

- [x] `cargo fmt --all -- --check`
- [x] `bash ./scripts/check-file-size.sh`
- [x] `cargo test -p moltis-memory --all-features` — 114 passed, 0 failed, 1 model-backed test ignored by default
- [x] `cargo clippy -p moltis-memory --all-features --all-targets -- -D warnings`
- [x] `MOLTIS_TEST_LOCAL_MODEL=/path/to/embeddinggemma-300M-Q8_0.gguf cargo test -p moltis-memory --features local-embeddings real_default_model_handles_context_edges_and_indexing -- --ignored` — 1 passed
- [x] Public artifact range request returned HTTP 206; the previous URL returned HTTP 401
- [x] Downloaded artifact SHA-256 matched the Hugging Face linked ETag: `b5ce9d77a3fc4b3b39ccb5643c36777911cc4eb46a66962eadfa3f5f60490d63`

### Repository validation

- [x] `./scripts/local-validate.sh 1236` with lint/build/test commands scoped to `moltis-memory`; all quick project checks and applicable local E2E checks passed, and commit statuses were published
- [x] Production-feature, CPU-only Docker image build; the built binary reports the expected release version
- [ ] Full-workspace `--all-features` lint/build is not available in the CPU-only local builder because it enables the optional CUDA backend and requires a CUDA toolkit. The affected crate passed strict Clippy/build with all of its own features and targets
- [ ] `zizmor` is not installed in the local builder. No workflow files are changed by this PR

## Manual QA

The model-backed regression test uses only synthetic Portuguese text and an in-memory SQLite database. On the parent commit, its 512+ token case reproduces the native `encoder requires n_ubatch >= n_tokens` assertion and exits with signal 6. With this change, the same test verifies:

1. an input above the old 512-token limit but within the 2048-token model context returns a finite 768-dimensional vector;
2. an input above 2048 tokens is safely truncated and returns a valid vector instead of aborting;
3. empty and multilingual Unicode inputs return valid vectors;
4. a Markdown chunk above 512 model tokens indexes through `MemoryManager` with zero sync errors;
5. hybrid SQLite search ranks the related synthetic Portuguese memory first;
6. a second sync reports both files unchanged.

## Privacy

The full debugging session is intentionally omitted because it contains private deployment context. No user memory, transcript, configuration, path, name, examination, credential, or other personal data was copied into this branch, test fixture, commit, or PR.