### PR TITLE
Bound Apple container identifiers to 64 characters

### DIFF
--- a/crates/chat/src/service/chat_impl.rs
+++ b/crates/chat/src/service/chat_impl.rs
@@ -689,6 +689,7 @@ impl ChatService for LiveChatService {
             };
             let id = router.sandbox_id_for(&session_key);
             let resolved_backend = router.resolve_backend(&session_key).await;
+            let runtime_info = resolved_backend.runtime_info(&id).await;
             let container_name = {
                 let fallback = format!(
                     "{}-{}",
@@ -698,11 +699,11 @@ impl ChatService for LiveChatService {
                         .unwrap_or("moltis-sandbox"),
                     id.key
                 );
-                resolved_backend.runtime_name(&id).await.unwrap_or(fallback)
+                runtime_info.runtime_name.unwrap_or(fallback)
             };
             serde_json::json!({
                 "enabled": is_sandboxed,
-                "backend": resolved_backend.backend_name(),
+                "backend": runtime_info.backend_name,
                 "mode": config.mode,
                 "scope": config.scope,
                 "workspaceMount": config.workspace_mount,

--- a/crates/chat/src/service/chat_impl.rs
+++ b/crates/chat/src/service/chat_impl.rs
@@ -687,8 +687,9 @@ impl ChatService for LiveChatService {
                 Some(img) if !img.is_empty() => img,
                 _ => router.resolve_default_image_nowait().await,
             };
+            let id = router.sandbox_id_for(&session_key);
+            let resolved_backend = router.resolve_backend(&session_key).await;
             let container_name = {
-                let id = router.sandbox_id_for(&session_key);
                 let fallback = format!(
                     "{}-{}",
                     config
@@ -697,16 +698,11 @@ impl ChatService for LiveChatService {
                         .unwrap_or("moltis-sandbox"),
                     id.key
                 );
-                router
-                    .resolve_backend(&session_key)
-                    .await
-                    .runtime_name(&id)
-                    .await
-                    .unwrap_or(fallback)
+                resolved_backend.runtime_name(&id).await.unwrap_or(fallback)
             };
             serde_json::json!({
                 "enabled": is_sandboxed,
-                "backend": router.backend_name(),
+                "backend": resolved_backend.backend_name(),
                 "mode": config.mode,
                 "scope": config.scope,
                 "workspaceMount": config.workspace_mount,

--- a/crates/chat/src/service/chat_impl.rs
+++ b/crates/chat/src/service/chat_impl.rs
@@ -689,14 +689,20 @@ impl ChatService for LiveChatService {
             };
             let container_name = {
                 let id = router.sandbox_id_for(&session_key);
-                format!(
+                let fallback = format!(
                     "{}-{}",
                     config
                         .container_prefix
                         .as_deref()
                         .unwrap_or("moltis-sandbox"),
                     id.key
-                )
+                );
+                router
+                    .resolve_backend(&session_key)
+                    .await
+                    .runtime_name(&id)
+                    .await
+                    .unwrap_or(fallback)
             };
             serde_json::json!({
                 "enabled": is_sandboxed,

--- a/crates/gateway/src/server/helpers.rs
+++ b/crates/gateway/src/server/helpers.rs
@@ -148,6 +148,10 @@ pub(crate) fn sandbox_container_prefix(instance_slug: &str) -> String {
     format!("moltis-{instance_slug}-sandbox")
 }
 
+pub fn sandbox_container_prefix_for_config(config: &moltis_config::MoltisConfig) -> String {
+    sandbox_container_prefix(&instance_slug(config))
+}
+
 pub(crate) fn browser_container_prefix(instance_slug: &str) -> String {
     format!("moltis-{instance_slug}-browser")
 }

--- a/crates/gateway/src/server/helpers.rs
+++ b/crates/gateway/src/server/helpers.rs
@@ -643,3 +643,16 @@ pub(crate) fn restore_saved_local_llm_models(
         let _ = (registry, providers_config);
     }
 }
+
+#[cfg(test)]
+mod container_prefix_tests {
+    use super::*;
+
+    #[test]
+    fn sandbox_prefix_for_config_is_identity_scoped() {
+        let prefix = sandbox_container_prefix_for_config(&moltis_config::MoltisConfig::default());
+
+        assert!(prefix.starts_with("moltis-"));
+        assert!(prefix.ends_with("-sandbox"));
+    }
+}

--- a/crates/gateway/src/server/mod.rs
+++ b/crates/gateway/src/server/mod.rs
@@ -36,7 +36,7 @@ pub mod instrumentation;
 
 pub(crate) use hooks::discover_and_build_hooks;
 pub use {
-    helpers::approval_manager_from_config,
+    helpers::{approval_manager_from_config, sandbox_container_prefix_for_config},
     prepare_core::{prepare_gateway_core, prepare_gateway_core_with_profile},
     prepared::{CoreStartupProfile, PreparedGatewayCore},
     startup::{

--- a/crates/swift-bridge/src/ffi_sandbox.rs
+++ b/crates/swift-bridge/src/ffi_sandbox.rs
@@ -529,7 +529,9 @@ pub extern "C" fn moltis_sandbox_stop_container(request_json: *const c_char) -> 
 
         let config = moltis_config::discover_and_load();
         let prefix = sandbox_container_prefix(&config);
-        if !name.starts_with(&prefix) {
+        if !name.starts_with(&prefix)
+            && !moltis_tools::sandbox::has_apple_container_prefix(name, &prefix)
+        {
             record_error(
                 "moltis_sandbox_stop_container",
                 SANDBOX_CONTAINER_PREFIX_MISMATCH,
@@ -582,7 +584,9 @@ pub extern "C" fn moltis_sandbox_remove_container(request_json: *const c_char) -
 
         let config = moltis_config::discover_and_load();
         let prefix = sandbox_container_prefix(&config);
-        if !name.starts_with(&prefix) {
+        if !name.starts_with(&prefix)
+            && !moltis_tools::sandbox::has_apple_container_prefix(name, &prefix)
+        {
             record_error(
                 "moltis_sandbox_remove_container",
                 SANDBOX_CONTAINER_PREFIX_MISMATCH,

--- a/crates/swift-bridge/src/helpers.rs
+++ b/crates/swift-bridge/src/helpers.rs
@@ -5,7 +5,7 @@ use std::ffi::{CStr, CString, c_char};
 use {moltis_config::validate::Severity, serde::Serialize};
 
 use crate::{
-    state::BRIDGE,
+    state::{BRIDGE, HTTPD},
     types::{
         ErrorEnvelope, ErrorPayload, SandboxSharedHomeConfigResponse, SandboxStatusResponse,
         ValidationSummary,
@@ -164,10 +164,14 @@ pub(crate) fn sandbox_status_from_config(
 }
 
 pub(crate) fn sandbox_container_prefix(config: &moltis_config::MoltisConfig) -> String {
-    let runtime_cfg = moltis_tools::sandbox::SandboxConfig::from(&config.tools.exec.sandbox);
-    runtime_cfg
-        .container_prefix
-        .unwrap_or_else(|| "moltis-sandbox".to_owned())
+    let runtime_prefix = HTTPD
+        .lock()
+        .unwrap_or_else(|error| error.into_inner())
+        .as_ref()
+        .and_then(|handle| handle.state.sandbox_router.as_ref())
+        .and_then(|router| router.config().container_prefix.clone());
+    runtime_prefix
+        .unwrap_or_else(|| moltis_gateway::server::sandbox_container_prefix_for_config(config))
 }
 
 pub(crate) fn sandbox_shared_home_config_from_config(

--- a/crates/tools/src/sandbox/apple.rs
+++ b/crates/tools/src/sandbox/apple.rs
@@ -135,12 +135,11 @@ impl AppleContainerSandbox {
         )
     }
 
-    fn base_container_name(&self, id: &SandboxId) -> String {
-        format!("{}-{}", self.container_prefix(), id.key)
+    fn container_name_for_generation(&self, id: &SandboxId, generation: u32) -> String {
+        super::container_name::apple_container_name(self.container_prefix(), &id.key, generation)
     }
 
     pub(crate) async fn container_name(&self, id: &SandboxId) -> String {
-        let base = self.base_container_name(id);
         let generation = self
             .name_generations
             .read()
@@ -148,11 +147,7 @@ impl AppleContainerSandbox {
             .get(&id.key)
             .copied()
             .unwrap_or(0);
-        if generation == 0 {
-            base
-        } else {
-            format!("{base}-g{generation}")
-        }
+        self.container_name_for_generation(id, generation)
     }
 
     pub(crate) async fn bump_container_generation(&self, id: &SandboxId) -> String {
@@ -162,8 +157,7 @@ impl AppleContainerSandbox {
             *entry += 1;
             *entry
         };
-        let base = self.base_container_name(id);
-        let next_name = format!("{base}-g{next_generation}");
+        let next_name = self.container_name_for_generation(id, next_generation);
         warn!(
             session_key = %id.key,
             generation = next_generation,
@@ -781,6 +775,10 @@ impl Sandbox for AppleContainerSandbox {
         "apple-container"
     }
 
+    async fn runtime_name(&self, id: &SandboxId) -> Option<String> {
+        Some(self.container_name(id).await)
+    }
+
     fn provides_fs_isolation(&self) -> bool {
         true
     }
@@ -1277,7 +1275,6 @@ impl Sandbox for AppleContainerSandbox {
     }
 
     async fn cleanup(&self, id: &SandboxId) -> Result<()> {
-        let base = self.base_container_name(id);
         let max_generation = self
             .name_generations
             .read()
@@ -1287,11 +1284,7 @@ impl Sandbox for AppleContainerSandbox {
             .unwrap_or(0);
 
         for generation in 0..=max_generation {
-            let name = if generation == 0 {
-                base.clone()
-            } else {
-                format!("{base}-g{generation}")
-            };
+            let name = self.container_name_for_generation(id, generation);
             info!(name, "cleaning up apple container");
             let _ = tokio::process::Command::new("container")
                 .args(["stop", &name])

--- a/crates/tools/src/sandbox/container_name.rs
+++ b/crates/tools/src/sandbox/container_name.rs
@@ -1,0 +1,127 @@
+//! Apple Container identifier generation.
+
+use sha2::{Digest, Sha256};
+
+pub(crate) const APPLE_CONTAINER_ID_MAX_LEN: usize = 64;
+const DIGEST_LEN: usize = 24;
+const APPLE_CONTAINER_PREFIX_MAX_LEN: usize = 27;
+
+pub(crate) fn apple_container_prefix(prefix: &str) -> String {
+    let normalized = normalize_component(prefix, "moltis-sandbox");
+    compact_component(
+        &normalized,
+        prefix,
+        APPLE_CONTAINER_PREFIX_MAX_LEN,
+        normalized != prefix,
+    )
+}
+
+pub(crate) fn has_apple_container_prefix(name: &str, prefix: &str) -> bool {
+    let prefix = apple_container_prefix(prefix);
+    name.strip_prefix(&prefix)
+        .is_some_and(|remainder| remainder.starts_with('-'))
+}
+
+pub(crate) fn apple_container_name(prefix: &str, key: &str, generation: u32) -> String {
+    let prefix = apple_container_prefix(prefix);
+    let normalized_key = normalize_component(key, "sandbox");
+    let suffix = if generation == 0 {
+        String::new()
+    } else {
+        format!("-g{generation}")
+    };
+    let key_max_len = APPLE_CONTAINER_ID_MAX_LEN.saturating_sub(prefix.len() + suffix.len() + 1);
+    let key = compact_component(&normalized_key, key, key_max_len, normalized_key != key);
+    format!("{prefix}-{key}{suffix}")
+}
+
+fn normalize_component(value: &str, fallback: &str) -> String {
+    let normalized: String = value
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.') {
+                ch
+            } else {
+                '-'
+            }
+        })
+        .collect();
+    if normalized.is_empty() {
+        fallback.to_string()
+    } else {
+        normalized
+    }
+}
+
+fn compact_component(value: &str, hash_source: &str, max_len: usize, force: bool) -> String {
+    if !force && value.len() <= max_len {
+        return value.to_string();
+    }
+
+    let digest = format!("{:x}", Sha256::digest(hash_source.as_bytes()));
+    if max_len <= DIGEST_LEN {
+        return digest.get(..max_len).unwrap_or(digest.as_str()).to_string();
+    }
+    let readable_len = max_len - DIGEST_LEN - 1;
+    let readable = value
+        .get(..readable_len)
+        .unwrap_or(value)
+        .trim_end_matches(['-', '_', '.']);
+    let short_digest = digest.get(..DIGEST_LEN).unwrap_or(digest.as_str());
+    format!("{readable}-{short_digest}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn preserves_names_that_fit() {
+        assert_eq!(
+            apple_container_name("moltis-test-sandbox", "session-abc", 0),
+            "moltis-test-sandbox-session-abc"
+        );
+    }
+
+    #[test]
+    fn bounds_default_session_name() {
+        let name = apple_container_name(
+            "moltis-moltis-sandbox",
+            "session-4fc5159e-0cb6-49f2-8eba-553ba3ec897b",
+            0,
+        );
+        assert!(name.len() <= APPLE_CONTAINER_ID_MAX_LEN);
+        assert!(name.starts_with("moltis-moltis-sandbox-session-"));
+    }
+
+    #[test]
+    fn reserves_space_for_generation_suffix() {
+        let name = apple_container_name(
+            "moltis-moltis-sandbox",
+            "session-4fc5159e-0cb6-49f2-8eba-553ba3ec897b",
+            u32::MAX,
+        );
+        assert!(name.len() <= APPLE_CONTAINER_ID_MAX_LEN);
+        assert!(name.ends_with("-g4294967295"));
+    }
+
+    #[test]
+    fn long_inputs_are_stable_and_distinct() {
+        let first = apple_container_name(&"prefix".repeat(20), &"key-a".repeat(20), 0);
+        let repeated = apple_container_name(&"prefix".repeat(20), &"key-a".repeat(20), 0);
+        let second = apple_container_name(&"prefix".repeat(20), &"key-b".repeat(20), 0);
+        assert_eq!(first, repeated);
+        assert_ne!(first, second);
+        assert!(first.len() <= APPLE_CONTAINER_ID_MAX_LEN);
+        assert!(has_apple_container_prefix(&first, &"prefix".repeat(20)));
+    }
+
+    #[test]
+    fn normalized_inputs_remain_distinct() {
+        let first = apple_container_name("moltis/sandbox", "session:abc", 0);
+        let second = apple_container_name("moltis?sandbox", "session?abc", 0);
+        assert_ne!(first, second);
+        assert!(first.len() <= APPLE_CONTAINER_ID_MAX_LEN);
+        assert!(has_apple_container_prefix(&first, "moltis/sandbox"));
+    }
+}

--- a/crates/tools/src/sandbox/container_name.rs
+++ b/crates/tools/src/sandbox/container_name.rs
@@ -16,13 +16,13 @@ pub(crate) fn apple_container_prefix(prefix: &str) -> String {
     )
 }
 
-pub(crate) fn has_apple_container_prefix(name: &str, prefix: &str) -> bool {
+pub fn has_apple_container_prefix(name: &str, prefix: &str) -> bool {
     let prefix = apple_container_prefix(prefix);
     name.strip_prefix(&prefix)
         .is_some_and(|remainder| remainder.starts_with('-'))
 }
 
-pub(crate) fn apple_container_name(prefix: &str, key: &str, generation: u32) -> String {
+pub fn apple_container_name(prefix: &str, key: &str, generation: u32) -> String {
     let prefix = apple_container_prefix(prefix);
     let normalized_key = normalize_component(key, "sandbox");
     let suffix = if generation == 0 {

--- a/crates/tools/src/sandbox/containers.rs
+++ b/crates/tools/src/sandbox/containers.rs
@@ -588,8 +588,10 @@ pub async fn list_running_containers_for_prefixes(
                     .pointer("/configuration/id")
                     .and_then(|v| v.as_str())
                     .unwrap_or_default();
-                if !prefixes.iter().any(|prefix| name.starts_with(prefix))
-                    || !seen.insert(name.to_string())
+                if !prefixes.iter().any(|prefix| {
+                    super::container_name::has_apple_container_prefix(name, prefix)
+                        || name.starts_with(prefix)
+                }) || !seen.insert(name.to_string())
                 {
                     continue;
                 }

--- a/crates/tools/src/sandbox/docker.rs
+++ b/crates/tools/src/sandbox/docker.rs
@@ -898,6 +898,10 @@ impl Sandbox for DockerSandbox {
         self.backend_label
     }
 
+    async fn runtime_name(&self, id: &SandboxId) -> Option<String> {
+        Some(self.container_name(id))
+    }
+
     fn provides_fs_isolation(&self) -> bool {
         true
     }

--- a/crates/tools/src/sandbox/mod.rs
+++ b/crates/tools/src/sandbox/mod.rs
@@ -4,6 +4,7 @@
 
 #[cfg(target_os = "macos")]
 pub(crate) mod apple;
+pub(crate) mod container_name;
 pub(crate) mod containers;
 pub(crate) mod daytona;
 pub(crate) mod docker;

--- a/crates/tools/src/sandbox/mod.rs
+++ b/crates/tools/src/sandbox/mod.rs
@@ -40,6 +40,7 @@ pub use vercel::{VercelSandbox, VercelSandboxConfig};
 #[cfg(feature = "wasm")]
 pub use wasm::WasmSandbox;
 pub use {
+    container_name::{apple_container_name, has_apple_container_prefix},
     containers::{
         ContainerBackend, ContainerDiskUsage, ContainerRunState, RunningContainer, SandboxImage,
         clean_all_containers, clean_sandbox_images, container_cli, container_disk_usage,

--- a/crates/tools/src/sandbox/mod.rs
+++ b/crates/tools/src/sandbox/mod.rs
@@ -57,6 +57,6 @@ pub use {
     types::{
         BuildImageResult, DEFAULT_SANDBOX_IMAGE, HomePersistence, ManagedFilesMount, NetworkPolicy,
         ResourceLimits, SANDBOX_FILES_DIR, Sandbox, SandboxBackendId, SandboxConfig, SandboxId,
-        SandboxMode, SandboxScope, WorkspaceMount,
+        SandboxMode, SandboxRuntimeInfo, SandboxScope, WorkspaceMount,
     },
 };

--- a/crates/tools/src/sandbox/router.rs
+++ b/crates/tools/src/sandbox/router.rs
@@ -26,7 +26,8 @@ use {
         file_system::{SandboxGrepOptions, SandboxListFilesResult, SandboxReadResult},
         platform::RestrictedHostSandbox,
         types::{
-            BuildImageResult, DEFAULT_SANDBOX_IMAGE, Sandbox, SandboxConfig, SandboxId, SandboxMode,
+            BuildImageResult, DEFAULT_SANDBOX_IMAGE, Sandbox, SandboxConfig, SandboxId,
+            SandboxMode, SandboxRuntimeInfo,
         },
     },
     crate::{
@@ -108,11 +109,16 @@ impl Sandbox for FailoverSandbox {
     }
 
     async fn runtime_name(&self, id: &SandboxId) -> Option<String> {
-        if self.fallback_enabled().await {
-            self.fallback.runtime_name(id).await
+        self.runtime_info(id).await.runtime_name
+    }
+
+    async fn runtime_info(&self, id: &SandboxId) -> SandboxRuntimeInfo {
+        let backend = if self.fallback_enabled().await {
+            Arc::clone(&self.fallback)
         } else {
-            self.primary.runtime_name(id).await
-        }
+            Arc::clone(&self.primary)
+        };
+        backend.runtime_info(id).await
     }
 
     fn provides_fs_isolation(&self) -> bool {

--- a/crates/tools/src/sandbox/router.rs
+++ b/crates/tools/src/sandbox/router.rs
@@ -107,6 +107,14 @@ impl Sandbox for FailoverSandbox {
         }
     }
 
+    async fn runtime_name(&self, id: &SandboxId) -> Option<String> {
+        if self.fallback_enabled().await {
+            self.fallback.runtime_name(id).await
+        } else {
+            self.primary.runtime_name(id).await
+        }
+    }
+
     fn provides_fs_isolation(&self) -> bool {
         // On lock contention, conservatively report the fallback's (weaker)
         // isolation level rather than the primary's.

--- a/crates/tools/src/sandbox/tests/apple.rs
+++ b/crates/tools/src/sandbox/tests/apple.rs
@@ -66,6 +66,9 @@ async fn apple_container_names_fit_runtime_limit() {
         Arc::new(DockerSandbox::new(SandboxConfig::default())),
     );
     assert_eq!(failover.runtime_name(&id).await, Some(initial));
+    let runtime_info = failover.runtime_info(&id).await;
+    assert_eq!(runtime_info.backend_name, "apple-container");
+    assert_eq!(runtime_info.runtime_name, failover.runtime_name(&id).await);
 }
 
 /// When both Docker and Apple Container are available, test that we can
@@ -589,6 +592,7 @@ async fn test_failover_sandbox_switches_from_apple_to_docker() {
 
     assert_eq!(primary.ensure_ready_calls(), 1);
     assert_eq!(fallback.ensure_ready_calls(), 2);
+    assert_eq!(sandbox.runtime_info(&id).await.backend_name, "docker");
 }
 
 #[tokio::test]

--- a/crates/tools/src/sandbox/tests/apple.rs
+++ b/crates/tools/src/sandbox/tests/apple.rs
@@ -38,6 +38,36 @@ async fn test_apple_container_name_generation_rotation() {
     assert_eq!(current_name, "moltis-sandbox-session-abc-g1");
 }
 
+#[cfg(target_os = "macos")]
+#[tokio::test]
+async fn apple_container_names_fit_runtime_limit() {
+    let sandbox = AppleContainerSandbox::new(SandboxConfig {
+        container_prefix: Some("moltis-moltis-sandbox".into()),
+        ..Default::default()
+    });
+    let id = SandboxId {
+        scope: SandboxScope::Session,
+        key: "session-4fc5159e-0cb6-49f2-8eba-553ba3ec897b".into(),
+    };
+
+    let initial = sandbox.container_name(&id).await;
+    assert!(initial.len() <= container_name::APPLE_CONTAINER_ID_MAX_LEN);
+    assert_eq!(sandbox.runtime_name(&id).await, Some(initial.clone()));
+
+    let rotated = sandbox.bump_container_generation(&id).await;
+    assert!(rotated.len() <= container_name::APPLE_CONTAINER_ID_MAX_LEN);
+    assert!(rotated.ends_with("-g1"));
+
+    let failover = FailoverSandbox::new(
+        Arc::new(AppleContainerSandbox::new(SandboxConfig {
+            container_prefix: Some("moltis-moltis-sandbox".into()),
+            ..Default::default()
+        })),
+        Arc::new(DockerSandbox::new(SandboxConfig::default())),
+    );
+    assert_eq!(failover.runtime_name(&id).await, Some(initial));
+}
+
 /// When both Docker and Apple Container are available, test that we can
 /// explicitly select each one.
 #[test]

--- a/crates/tools/src/sandbox/types.rs
+++ b/crates/tools/src/sandbox/types.rs
@@ -432,6 +432,11 @@ pub trait Sandbox: Send + Sync {
     /// Human-readable backend name (e.g. "docker", "podman", "apple-container", "cgroup", "none").
     fn backend_name(&self) -> &'static str;
 
+    /// Runtime resource name for operator-facing diagnostics, when applicable.
+    async fn runtime_name(&self, _id: &SandboxId) -> Option<String> {
+        None
+    }
+
     /// Ensure the sandbox environment is ready (e.g., container started).
     /// If `image_override` is provided, use that image instead of the configured default.
     async fn ensure_ready(&self, id: &SandboxId, image_override: Option<&str>) -> Result<()>;

--- a/crates/tools/src/sandbox/types.rs
+++ b/crates/tools/src/sandbox/types.rs
@@ -426,6 +426,13 @@ pub struct BuildImageResult {
     pub built: bool,
 }
 
+/// Active backend and runtime resource name captured from one routing decision.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SandboxRuntimeInfo {
+    pub backend_name: &'static str,
+    pub runtime_name: Option<String>,
+}
+
 /// Trait for sandbox implementations (Docker, cgroups, Apple Container, etc.).
 #[async_trait]
 pub trait Sandbox: Send + Sync {
@@ -435,6 +442,14 @@ pub trait Sandbox: Send + Sync {
     /// Runtime resource name for operator-facing diagnostics, when applicable.
     async fn runtime_name(&self, _id: &SandboxId) -> Option<String> {
         None
+    }
+
+    /// Operator-facing runtime details from one backend selection snapshot.
+    async fn runtime_info(&self, id: &SandboxId) -> SandboxRuntimeInfo {
+        SandboxRuntimeInfo {
+            backend_name: self.backend_name(),
+            runtime_name: self.runtime_name(id).await,
+        }
     }
 
     /// Ensure the sandbox environment is ready (e.g., container started).

--- a/crates/web/src/api.rs
+++ b/crates/web/src/api.rs
@@ -1414,15 +1414,6 @@ mod tests {
     use super::*;
 
     #[test]
-    fn managed_container_name_accepts_compacted_apple_prefix() {
-        let mut config = moltis_config::MoltisConfig::default();
-        let prefix = "custom-sandbox-prefix-that-is-much-too-long";
-        config.tools.exec.sandbox.container_prefix = Some(prefix.to_string());
-        let name = moltis_tools::sandbox::apple_container_name(prefix, "session-abc", 0);
-        assert!(managed_container_name(&config, &name));
-    }
-
-    #[test]
     fn content_disposition_inline_for_pdf() {
         let result = media_content_disposition("report.pdf", "application/pdf");
         assert!(result.starts_with("inline;"));

--- a/crates/web/src/api.rs
+++ b/crates/web/src/api.rs
@@ -94,9 +94,9 @@ fn browser_image_repository(config: &moltis_config::MoltisConfig) -> Option<Stri
 }
 
 fn managed_container_name(config: &moltis_config::MoltisConfig, name: &str) -> bool {
-    managed_container_prefixes(config)
-        .iter()
-        .any(|prefix| name.starts_with(prefix))
+    managed_container_prefixes(config).iter().any(|prefix| {
+        name.starts_with(prefix) || moltis_tools::sandbox::has_apple_container_prefix(name, prefix)
+    })
 }
 
 #[derive(serde::Deserialize)]
@@ -1412,6 +1412,15 @@ pub async fn api_restart_daemon_handler() -> impl IntoResponse {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn managed_container_name_accepts_compacted_apple_prefix() {
+        let mut config = moltis_config::MoltisConfig::default();
+        let prefix = "custom-sandbox-prefix-that-is-much-too-long";
+        config.tools.exec.sandbox.container_prefix = Some(prefix.to_string());
+        let name = moltis_tools::sandbox::apple_container_name(prefix, "session-abc", 0);
+        assert!(managed_container_name(&config, &name));
+    }
 
     #[test]
     fn content_disposition_inline_for_pdf() {

--- a/crates/web/src/api.rs
+++ b/crates/web/src/api.rs
@@ -17,7 +17,10 @@ use {
     tracing::warn,
 };
 
-use crate::templates::{build_nav_counts, onboarding_completed};
+use crate::{
+    container_management::{managed_container_name, managed_container_prefixes},
+    templates::{build_nav_counts, onboarding_completed},
+};
 
 const MCP_LIST_FAILED: &str = "MCP_LIST_FAILED";
 const IMAGE_CACHE_DELETE_FAILED: &str = "IMAGE_CACHE_DELETE_FAILED";
@@ -62,41 +65,10 @@ fn configured_secret(secret: &Option<Secret<String>>) -> bool {
         .is_some_and(|secret| !secret.expose_secret().is_empty())
 }
 
-fn sandbox_container_prefix_from_config(config: &moltis_config::MoltisConfig) -> String {
-    config
-        .tools
-        .exec
-        .sandbox
-        .container_prefix
-        .clone()
-        .unwrap_or_else(|| "moltis-sandbox".to_string())
-}
-
-fn browser_container_prefix_from_config(config: &moltis_config::MoltisConfig) -> String {
-    let _ = config;
-    "moltis-browser".to_string()
-}
-
-fn managed_container_prefixes(config: &moltis_config::MoltisConfig) -> Vec<String> {
-    let sandbox_prefix = sandbox_container_prefix_from_config(config);
-    let browser_prefix = browser_container_prefix_from_config(config);
-    if sandbox_prefix == browser_prefix {
-        vec![sandbox_prefix]
-    } else {
-        vec![sandbox_prefix, browser_prefix]
-    }
-}
-
 fn browser_image_repository(config: &moltis_config::MoltisConfig) -> Option<String> {
     let image = config.tools.browser.sandbox_image.trim();
     let (repo, _) = image.rsplit_once(':').unwrap_or((image, "latest"));
     (!repo.is_empty()).then(|| repo.to_string())
-}
-
-fn managed_container_name(config: &moltis_config::MoltisConfig, name: &str) -> bool {
-    managed_container_prefixes(config).iter().any(|prefix| {
-        name.starts_with(prefix) || moltis_tools::sandbox::has_apple_container_prefix(name, prefix)
-    })
 }
 
 #[derive(serde::Deserialize)]
@@ -1317,9 +1289,11 @@ WORKDIR /home/sandbox\n"
 
 // ── Containers ───────────────────────────────────────────────────────────────
 
-pub async fn api_list_containers_handler() -> impl IntoResponse {
-    let config = moltis_config::discover_and_load();
-    let prefixes = managed_container_prefixes(&config);
+pub async fn api_list_containers_handler(State(state): State<AppState>) -> impl IntoResponse {
+    let prefixes = managed_container_prefixes(
+        &state.gateway.config,
+        state.gateway.sandbox_router.as_deref(),
+    );
     match moltis_tools::sandbox::list_running_containers_for_prefixes(&prefixes).await {
         Ok(containers) => Json(serde_json::json!({ "containers": containers })).into_response(),
         Err(e) => api_error_response(
@@ -1330,9 +1304,15 @@ pub async fn api_list_containers_handler() -> impl IntoResponse {
     }
 }
 
-pub async fn api_stop_container_handler(Path(name): Path<String>) -> impl IntoResponse {
-    let config = moltis_config::discover_and_load();
-    if !managed_container_name(&config, &name) {
+pub async fn api_stop_container_handler(
+    State(state): State<AppState>,
+    Path(name): Path<String>,
+) -> impl IntoResponse {
+    if !managed_container_name(
+        &state.gateway.config,
+        state.gateway.sandbox_router.as_deref(),
+        &name,
+    ) {
         return api_error_response(
             StatusCode::FORBIDDEN,
             SANDBOX_CONTAINER_PREFIX_MISMATCH,
@@ -1349,9 +1329,15 @@ pub async fn api_stop_container_handler(Path(name): Path<String>) -> impl IntoRe
     }
 }
 
-pub async fn api_remove_container_handler(Path(name): Path<String>) -> impl IntoResponse {
-    let config = moltis_config::discover_and_load();
-    if !managed_container_name(&config, &name) {
+pub async fn api_remove_container_handler(
+    State(state): State<AppState>,
+    Path(name): Path<String>,
+) -> impl IntoResponse {
+    if !managed_container_name(
+        &state.gateway.config,
+        state.gateway.sandbox_router.as_deref(),
+        &name,
+    ) {
         return api_error_response(
             StatusCode::FORBIDDEN,
             SANDBOX_CONTAINER_PREFIX_MISMATCH,
@@ -1368,10 +1354,12 @@ pub async fn api_remove_container_handler(Path(name): Path<String>) -> impl Into
     }
 }
 
-pub async fn api_clean_all_containers_handler() -> impl IntoResponse {
-    let config = moltis_config::discover_and_load();
+pub async fn api_clean_all_containers_handler(State(state): State<AppState>) -> impl IntoResponse {
     let mut removed = 0usize;
-    for prefix in managed_container_prefixes(&config) {
+    for prefix in managed_container_prefixes(
+        &state.gateway.config,
+        state.gateway.sandbox_router.as_deref(),
+    ) {
         match moltis_tools::sandbox::clean_all_containers(&prefix).await {
             Ok(count) => removed += count,
             Err(e) => {

--- a/crates/web/src/container_management.rs
+++ b/crates/web/src/container_management.rs
@@ -1,0 +1,73 @@
+use moltis_tools::sandbox::SandboxRouter;
+
+fn configured_sandbox_prefix(config: &moltis_config::MoltisConfig) -> String {
+    config
+        .tools
+        .exec
+        .sandbox
+        .container_prefix
+        .clone()
+        .unwrap_or_else(|| "moltis-sandbox".to_string())
+}
+
+fn browser_prefix(_config: &moltis_config::MoltisConfig) -> String {
+    "moltis-browser".to_string()
+}
+
+pub(crate) fn managed_container_prefixes(
+    config: &moltis_config::MoltisConfig,
+    router: Option<&SandboxRouter>,
+) -> Vec<String> {
+    let sandbox_prefix = router
+        .and_then(|router| router.config().container_prefix.clone())
+        .unwrap_or_else(|| configured_sandbox_prefix(config));
+    let browser_prefix = browser_prefix(config);
+    if sandbox_prefix == browser_prefix {
+        vec![sandbox_prefix]
+    } else {
+        vec![sandbox_prefix, browser_prefix]
+    }
+}
+
+pub(crate) fn managed_container_name(
+    config: &moltis_config::MoltisConfig,
+    router: Option<&SandboxRouter>,
+    name: &str,
+) -> bool {
+    managed_container_prefixes(config, router)
+        .iter()
+        .any(|prefix| {
+            name.starts_with(prefix)
+                || moltis_tools::sandbox::has_apple_container_prefix(name, prefix)
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn uses_runtime_sandbox_prefix_for_management() {
+        let config = moltis_config::MoltisConfig::default();
+        let router = SandboxRouter::new(moltis_tools::sandbox::SandboxConfig {
+            container_prefix: Some("moltis-identity-scoped-sandbox".to_string()),
+            ..Default::default()
+        });
+        let apple_name = moltis_tools::sandbox::apple_container_name(
+            "moltis-identity-scoped-sandbox",
+            "session-4fc5159e-0cb6-49f2-8eba-553ba3ec897b",
+            0,
+        );
+
+        assert_eq!(
+            managed_container_prefixes(&config, Some(&router))[0],
+            "moltis-identity-scoped-sandbox"
+        );
+        assert!(managed_container_name(&config, Some(&router), &apple_name));
+        assert!(!managed_container_name(
+            &config,
+            Some(&router),
+            "moltis-sandbox-unrelated"
+        ));
+    }
+}

--- a/crates/web/src/container_management.rs
+++ b/crates/web/src/container_management.rs
@@ -70,4 +70,14 @@ mod tests {
             "moltis-sandbox-unrelated"
         ));
     }
+
+    #[test]
+    fn falls_back_to_configured_prefix_and_deduplicates() {
+        let mut config = moltis_config::MoltisConfig::default();
+        config.tools.exec.sandbox.container_prefix = Some("moltis-browser".to_string());
+
+        assert_eq!(managed_container_prefixes(&config, None), vec![
+            "moltis-browser"
+        ]);
+    }
 }

--- a/crates/web/src/lib.rs
+++ b/crates/web/src/lib.rs
@@ -7,6 +7,7 @@
 
 pub mod api;
 pub mod assets;
+mod container_management;
 pub mod error;
 pub mod gon;
 pub mod oauth;


### PR DESCRIPTION
## Summary

- Fix Apple Container sandbox startup failures when identity-scoped prefixes plus session UUIDs exceed the 64-character identifier limit.
- Generate stable Apple-only names with SHA-256 suffixes, reserve room for stale-container generation suffixes, and keep startup/per-session cleanup discoverable.
- Report the actual active container name through sandbox and failover backends without changing Docker container naming.

```mermaid
flowchart LR
    A[Instance prefix + session key] --> B[Normalize components]
    B --> C[Bound prefix and key with stable digest]
    C --> D[Reserve generation suffix]
    D --> E[Apple container ID at most 64 chars]
    E --> F[Create, report, and clean same ID]
```

Closes #1137

## Validation

### Completed

- [x] `cargo test -p moltis-tools container_name`
- [x] `cargo test -p moltis-tools apple_container_names_fit_runtime_limit`
- [x] `cargo check -p moltis-chat`
- [x] `just release-preflight`
- [x] `./scripts/local-validate.sh 1237`

### Remaining

- [ ] Live Apple Container smoke test on a machine with sandbox execution configured.

## Manual QA

1. Configure `tools.exec.sandbox.backend = "apple-container"` with the default Moltis identity.
2. Start a new chat session and execute a sandboxed command.
3. Confirm the Apple container starts and its logged identifier is no longer than 64 characters.
4. Trigger session cleanup and confirm the generated container is removed.