### PR TITLE
fix(heartbeat): honor active_hours and accept end=24:00

### DIFF
--- a/crates/cron/src/heartbeat.rs
+++ b/crates/cron/src/heartbeat.rs
@@ -140,10 +140,13 @@ pub fn is_within_active_hours(start: &str, end: &str, timezone: &str) -> bool {
 /// Same as [`is_within_active_hours`], but takes an explicit `now_minutes`
 /// (minutes since midnight) so callers/tests can control the clock.
 pub fn is_within_active_hours_at(start: &str, end: &str, now_minutes: u32) -> bool {
-    let Some(start_minutes) = parse_hhmm_minutes(start) else {
+    // "24:00" is documented only as an end-of-day sentinel. Accepting it as a
+    // start value would create an empty 24:00–24:00 window and suppress every
+    // heartbeat; treat that as invalid/fail-open instead (#1223 review).
+    let Some(start_minutes) = parse_hhmm_minutes(start, /*allow_end_of_day=*/ false) else {
         return true; // invalid config → always active
     };
-    let Some(end_minutes) = parse_hhmm_minutes(end) else {
+    let Some(end_minutes) = parse_hhmm_minutes(end, /*allow_end_of_day=*/ true) else {
         return true;
     };
 
@@ -255,13 +258,13 @@ fn parse_hhmm(s: &str) -> Option<NaiveTime> {
 
 /// Parse `HH:MM` into minutes since midnight.
 ///
-/// Special-cases `"24:00"` as end-of-day (`24 * 60`) because chrono's `%H`
-/// only accepts 00–23 and would otherwise treat the documented default as
-/// invalid (failing open / always-active).
-fn parse_hhmm_minutes(s: &str) -> Option<u32> {
+/// When `allow_end_of_day` is true, special-cases `"24:00"` as end-of-day
+/// (`24 * 60`) because chrono's `%H` only accepts 00–23. That sentinel is not
+/// valid for the start boundary.
+fn parse_hhmm_minutes(s: &str, allow_end_of_day: bool) -> Option<u32> {
     let trimmed = s.trim();
     if trimmed == "24:00" {
-        return Some(24 * 60);
+        return allow_end_of_day.then_some(24 * 60);
     }
     let time = parse_hhmm(trimmed)?;
     Some(time.hour() * 60 + time.minute())
@@ -402,11 +405,20 @@ mod tests {
     }
 
     #[test]
-    fn parse_hhmm_minutes_accepts_24_00() {
-        assert_eq!(parse_hhmm_minutes("24:00"), Some(24 * 60));
-        assert_eq!(parse_hhmm_minutes("00:00"), Some(0));
-        assert_eq!(parse_hhmm_minutes("08:30"), Some(8 * 60 + 30));
-        assert!(parse_hhmm_minutes("25:00").is_none());
+    fn parse_hhmm_minutes_accepts_24_00_only_for_end() {
+        assert_eq!(parse_hhmm_minutes("24:00", true), Some(24 * 60));
+        assert!(parse_hhmm_minutes("24:00", false).is_none());
+        assert_eq!(parse_hhmm_minutes("00:00", false), Some(0));
+        assert_eq!(parse_hhmm_minutes("08:30", true), Some(8 * 60 + 30));
+        assert!(parse_hhmm_minutes("25:00", true).is_none());
+    }
+
+    #[test]
+    fn start_24_00_fails_open_instead_of_empty_window() {
+        // start=24:00,end=24:00 must not suppress all heartbeats.
+        assert!(is_within_active_hours_at("24:00", "24:00", 0));
+        assert!(is_within_active_hours_at("24:00", "24:00", 12 * 60));
+        assert!(is_within_active_hours_at("24:00", "08:00", 3 * 60));
     }
 
     // ── resolve_heartbeat_prompt ─────────────────────────────────────────

--- a/crates/cron/src/heartbeat.rs
+++ b/crates/cron/src/heartbeat.rs
@@ -128,26 +128,24 @@ pub fn is_heartbeat_content_empty(content: &str) -> bool {
 /// Check whether the current time falls within the active hours window.
 ///
 /// Handles overnight windows (e.g. start=22:00, end=06:00).
+/// `end = "24:00"` means end-of-day (exclusive upper bound at 24:00).
 /// If timezone is "local" or empty, uses the system local time.
+///
+/// Invalid `start`/`end` values fail open (always active) so a typo does not
+/// silently disable heartbeats.
 pub fn is_within_active_hours(start: &str, end: &str, timezone: &str) -> bool {
-    let start_time = match parse_hhmm(start) {
-        Some(t) => t,
-        None => return true, // invalid config → always active
-    };
-    let end_time = match parse_hhmm(end) {
-        Some(t) => t,
-        None => return true,
-    };
+    is_within_active_hours_at(start, end, current_minutes(timezone))
+}
 
-    // "24:00" means end-of-day.
-    let end_minutes = if end == "24:00" {
-        24 * 60
-    } else {
-        end_time.hour() * 60 + end_time.minute()
+/// Same as [`is_within_active_hours`], but takes an explicit `now_minutes`
+/// (minutes since midnight) so callers/tests can control the clock.
+pub fn is_within_active_hours_at(start: &str, end: &str, now_minutes: u32) -> bool {
+    let Some(start_minutes) = parse_hhmm_minutes(start) else {
+        return true; // invalid config → always active
     };
-    let start_minutes = start_time.hour() * 60 + start_time.minute();
-
-    let now_minutes = current_minutes(timezone);
+    let Some(end_minutes) = parse_hhmm_minutes(end) else {
+        return true;
+    };
 
     if start_minutes <= end_minutes {
         // Normal window: 08:00–24:00
@@ -255,6 +253,20 @@ fn parse_hhmm(s: &str) -> Option<NaiveTime> {
     NaiveTime::parse_from_str(s, "%H:%M").ok()
 }
 
+/// Parse `HH:MM` into minutes since midnight.
+///
+/// Special-cases `"24:00"` as end-of-day (`24 * 60`) because chrono's `%H`
+/// only accepts 00–23 and would otherwise treat the documented default as
+/// invalid (failing open / always-active).
+fn parse_hhmm_minutes(s: &str) -> Option<u32> {
+    let trimmed = s.trim();
+    if trimmed == "24:00" {
+        return Some(24 * 60);
+    }
+    let time = parse_hhmm(trimmed)?;
+    Some(time.hour() * 60 + time.minute())
+}
+
 fn current_minutes(timezone: &str) -> u32 {
     if timezone.is_empty() || timezone == "local" {
         let local = Local::now();
@@ -356,19 +368,45 @@ mod tests {
     #[test]
     fn invalid_time_always_active() {
         assert!(is_within_active_hours("invalid", "24:00", "local"));
+        assert!(is_within_active_hours_at("08:00", "not-a-time", 0));
+    }
+
+    #[test]
+    fn end_24_00_is_end_of_day_not_invalid() {
+        // Regression for #1223 / #1205: chrono rejects "24:00", so the old
+        // parse-first path failed open and ignored the window entirely.
+        assert!(!is_within_active_hours_at("08:00", "24:00", 7 * 60 + 59));
+        assert!(is_within_active_hours_at("08:00", "24:00", 8 * 60));
+        assert!(is_within_active_hours_at("08:00", "24:00", 23 * 60 + 59));
     }
 
     #[test]
     fn active_hours_normal_window() {
-        // We can't assert exact behavior without controlling time,
-        // but we can verify it doesn't panic.
+        assert!(!is_within_active_hours_at("09:00", "17:00", 8 * 60 + 59));
+        assert!(is_within_active_hours_at("09:00", "17:00", 9 * 60));
+        assert!(is_within_active_hours_at("09:00", "17:00", 16 * 60 + 59));
+        assert!(!is_within_active_hours_at("09:00", "17:00", 17 * 60));
         let _ = is_within_active_hours("08:00", "24:00", "local");
         let _ = is_within_active_hours("09:00", "17:00", "UTC");
     }
 
     #[test]
     fn active_hours_overnight_window() {
+        assert!(is_within_active_hours_at("22:00", "06:00", 22 * 60));
+        assert!(is_within_active_hours_at("22:00", "06:00", 23 * 60 + 30));
+        assert!(is_within_active_hours_at("22:00", "06:00", 0));
+        assert!(is_within_active_hours_at("22:00", "06:00", 5 * 60 + 59));
+        assert!(!is_within_active_hours_at("22:00", "06:00", 6 * 60));
+        assert!(!is_within_active_hours_at("22:00", "06:00", 12 * 60));
         let _ = is_within_active_hours("22:00", "06:00", "local");
+    }
+
+    #[test]
+    fn parse_hhmm_minutes_accepts_24_00() {
+        assert_eq!(parse_hhmm_minutes("24:00"), Some(24 * 60));
+        assert_eq!(parse_hhmm_minutes("00:00"), Some(0));
+        assert_eq!(parse_hhmm_minutes("08:30"), Some(8 * 60 + 30));
+        assert!(parse_hhmm_minutes("25:00").is_none());
     }
 
     // ── resolve_heartbeat_prompt ─────────────────────────────────────────

--- a/crates/gateway/src/server/prepare_core.rs
+++ b/crates/gateway/src/server/prepare_core.rs
@@ -743,19 +743,20 @@ pub async fn prepare_gateway_core_with_profile(
                 moltis_cron::types::SessionTarget::Named(name) if name == "heartbeat"
             );
             let has_pending_events = is_heartbeat_turn && !eq.is_empty().await;
-            if is_heartbeat_turn && !has_pending_events {
+            if is_heartbeat_turn {
                 let hb_cfg = state.inner.read().await.heartbeat_config.clone();
-                let has_prompt_override = hb_cfg
-                    .prompt
-                    .as_deref()
-                    .is_some_and(|p| !p.trim().is_empty());
-                let heartbeat_path = moltis_config::heartbeat_path();
-                let heartbeat_file_exists = heartbeat_path.exists();
-                let heartbeat_md = moltis_config::load_heartbeat_md();
-                if heartbeat_file_exists && heartbeat_md.is_none() && !has_prompt_override {
+                // Enforce [heartbeat.active_hours] even though the cron job itself
+                // is an unconditional every_ms schedule (#1205 / #1223).
+                if !moltis_cron::heartbeat::is_within_active_hours(
+                    &hb_cfg.active_hours.start,
+                    &hb_cfg.active_hours.end,
+                    &hb_cfg.active_hours.timezone,
+                ) {
                     tracing::info!(
-                        path = %heartbeat_path.display(),
-                        "skipping heartbeat LLM turn: HEARTBEAT.md is empty"
+                        start = %hb_cfg.active_hours.start,
+                        end = %hb_cfg.active_hours.end,
+                        timezone = %hb_cfg.active_hours.timezone,
+                        "skipping heartbeat LLM turn: outside active hours"
                     );
                     return Ok(moltis_cron::service::AgentTurnResult {
                         output: moltis_cron::heartbeat::HEARTBEAT_OK.to_string(),
@@ -764,6 +765,29 @@ pub async fn prepare_gateway_core_with_profile(
                         session_key: None,
                         delivery_error: None,
                     });
+                }
+
+                if !has_pending_events {
+                    let has_prompt_override = hb_cfg
+                        .prompt
+                        .as_deref()
+                        .is_some_and(|p| !p.trim().is_empty());
+                    let heartbeat_path = moltis_config::heartbeat_path();
+                    let heartbeat_file_exists = heartbeat_path.exists();
+                    let heartbeat_md = moltis_config::load_heartbeat_md();
+                    if heartbeat_file_exists && heartbeat_md.is_none() && !has_prompt_override {
+                        tracing::info!(
+                            path = %heartbeat_path.display(),
+                            "skipping heartbeat LLM turn: HEARTBEAT.md is empty"
+                        );
+                        return Ok(moltis_cron::service::AgentTurnResult {
+                            output: moltis_cron::heartbeat::HEARTBEAT_OK.to_string(),
+                            input_tokens: None,
+                            output_tokens: None,
+                            session_key: None,
+                            delivery_error: None,
+                        });
+                    }
                 }
             }
 


### PR DESCRIPTION
## Summary

- Fix `is_within_active_hours` so documented default `end = \"24:00\"` is treated as end-of-day instead of invalid/always-active (chrono `%H` rejects 24)
- Actually enforce `[heartbeat.active_hours]` in the heartbeat agent-turn path (the helper previously existed but was never called; cron job is an unconditional `every_ms` schedule)

Fixes #1223
Fixes #1205

## Root cause

1. `#1223`: `parse_hhmm(\"24:00\")` fails → fail-open branch returns `true` for every timezone, so the default window never suppresses anything.
2. `#1205`: even with a valid window like `07:00–23:00`, the heartbeat cron job is upserted as plain `every_ms` with no active-hours gate at execution time.

## Test plan

- [ ] `cargo test -p moltis-cron heartbeat`
- [ ] Unit assertions cover `08:00–24:00` before 08:00 / after 08:00, normal daytime window, overnight window
- [ ] Manual: configure `active_hours = { start = \"09:00\", end = \"17:00\" }` and confirm outside-hours ticks log `outside active hours` and return `HEARTBEAT_OK` without an LLM call