### PR TITLE
fix(tts): stop treating default Coqui as configured

### DIFF
--- a/crates/gateway/src/voice/tts_service.rs
+++ b/crates/gateway/src/voice/tts_service.rs
@@ -137,8 +137,10 @@ impl LiveTtsService {
     }
 
     /// List all providers with their configuration status.
-    fn list_providers() -> Vec<(TtsProviderId, bool)> {
-        let config = Self::load_config();
+    /// Provider eligibility derived from an already-loaded TTS config.
+    ///
+    /// Kept pure so default-state tests can assert without ambient env/config.
+    fn configured_providers(config: &TtsConfig) -> Vec<(TtsProviderId, bool)> {
         vec![
             (
                 TtsProviderId::ElevenLabs,
@@ -160,16 +162,26 @@ impl LiveTtsService {
         ]
     }
 
+    fn list_providers() -> Vec<(TtsProviderId, bool)> {
+        Self::configured_providers(&Self::load_config())
+    }
+
     /// Resolve the active provider: explicit config value, or first configured.
     fn resolve_provider(config_provider: Option<TtsProviderId>) -> Option<TtsProviderId> {
+        Self::resolve_provider_from(config_provider, &Self::list_providers())
+    }
+
+    fn resolve_provider_from(
+        config_provider: Option<TtsProviderId>,
+        providers: &[(TtsProviderId, bool)],
+    ) -> Option<TtsProviderId> {
         if let Some(id) = config_provider {
             return Some(id);
         }
-        // Auto-select: first configured provider
-        Self::list_providers()
-            .into_iter()
+        providers
+            .iter()
             .find(|(_, configured)| *configured)
-            .map(|(id, _)| id)
+            .map(|(id, _)| *id)
     }
 
     /// Parse provider from JSON params, falling back to config/auto-select.
@@ -512,7 +524,6 @@ mod tests {
         _lock: std::sync::MutexGuard<'static, ()>,
         _config_dir: TempDir,
         _data_dir: TempDir,
-        saved_env: Vec<(&'static str, Option<String>)>,
     }
 
     impl VoiceConfigTestGuard {
@@ -526,40 +537,16 @@ mod tests {
                 .unwrap_or_else(|error| panic!("config should be written: {error}"));
             moltis_config::set_config_dir(config_dir.path().to_path_buf());
             moltis_config::set_data_dir(data_dir.path().to_path_buf());
-
-            // Clear ambient TTS credentials so default-state assertions are not
-            // polluted by the developer/CI environment (#1114 Greptile P1).
-            let mut saved_env = Vec::new();
-            for key in [
-                "OPENAI_API_KEY",
-                "ELEVENLABS_API_KEY",
-                "GOOGLE_API_KEY",
-                "GEMINI_API_KEY",
-            ] {
-                saved_env.push((key, std::env::var(key).ok()));
-                // SAFETY: tests hold `config_override_test_lock`, so concurrent
-                // config/env mutation in this crate is serialized.
-                unsafe { std::env::remove_var(key) };
-            }
-
             Self {
                 _lock: lock,
                 _config_dir: config_dir,
                 _data_dir: data_dir,
-                saved_env,
             }
         }
     }
 
     impl Drop for VoiceConfigTestGuard {
         fn drop(&mut self) {
-            for (key, value) in self.saved_env.drain(..) {
-                // SAFETY: same lock-serialized test cleanup as construction.
-                match value {
-                    Some(v) => unsafe { std::env::set_var(key, v) },
-                    None => unsafe { std::env::remove_var(key) },
-                }
-            }
             moltis_config::clear_config_dir();
             moltis_config::clear_data_dir();
         }
@@ -567,21 +554,24 @@ mod tests {
 
     #[test]
     fn test_live_tts_resolve_provider_handles_explicit_and_auto_selection() {
-        // Isolate from machine-local voice config / env keys so the default
-        // unconfigured contract is what we assert (#1114 / Greptile P1).
-        let _guard = VoiceConfigTestGuard::with_config("");
+        // Pure helpers: no ambient config/env involvement (#1114 Greptile P1).
+        let providers = LiveTtsService::configured_providers(&TtsConfig::default());
         assert_eq!(
-            LiveTtsService::resolve_provider(Some(TtsProviderId::OpenAi)),
+            LiveTtsService::resolve_provider_from(Some(TtsProviderId::OpenAi), &providers),
             Some(TtsProviderId::OpenAi)
         );
-        // Empty isolated config has no API keys / local models, and default
-        // Coqui is not considered configured, so auto-select must return None.
-        assert_eq!(LiveTtsService::resolve_provider(None), None);
+        // Default TTS config has no API keys / local models, and default Coqui
+        // is not considered configured, so auto-select must return None.
+        assert_eq!(LiveTtsService::resolve_provider_from(None, &providers), None);
+        let coqui = providers
+            .iter()
+            .find(|(id, _)| *id == TtsProviderId::Coqui)
+            .expect("coqui listed");
+        assert!(!coqui.1, "default Coqui endpoint must not count as configured");
     }
 
     #[tokio::test]
     async fn test_live_tts_service_status() {
-        let _guard = VoiceConfigTestGuard::with_config("");
         let service = LiveTtsService::new(TtsConfig::default());
         let status = service.status().await.unwrap();
 
@@ -589,10 +579,9 @@ mod tests {
         assert!(status.get("enabled").is_some());
         assert!(status.get("configured").is_some());
         assert!(status.get("provider").is_some());
-        // With isolated empty config and no API keys / local models, no
-        // provider is configured — including Coqui (default endpoint alone is
-        // not enough).
-        assert_eq!(status["configured"], false);
+        // Do not assert configured==false here: status() reloads ambient
+        // config/env. Default-state eligibility is covered by the pure helper
+        // test above (Greptile P1).
     }
 
     #[tokio::test]

--- a/crates/gateway/src/voice/tts_service.rs
+++ b/crates/gateway/src/voice/tts_service.rs
@@ -512,6 +512,7 @@ mod tests {
         _lock: std::sync::MutexGuard<'static, ()>,
         _config_dir: TempDir,
         _data_dir: TempDir,
+        saved_env: Vec<(&'static str, Option<String>)>,
     }
 
     impl VoiceConfigTestGuard {
@@ -525,16 +526,40 @@ mod tests {
                 .unwrap_or_else(|error| panic!("config should be written: {error}"));
             moltis_config::set_config_dir(config_dir.path().to_path_buf());
             moltis_config::set_data_dir(data_dir.path().to_path_buf());
+
+            // Clear ambient TTS credentials so default-state assertions are not
+            // polluted by the developer/CI environment (#1114 Greptile P1).
+            let mut saved_env = Vec::new();
+            for key in [
+                "OPENAI_API_KEY",
+                "ELEVENLABS_API_KEY",
+                "GOOGLE_API_KEY",
+                "GEMINI_API_KEY",
+            ] {
+                saved_env.push((key, std::env::var(key).ok()));
+                // SAFETY: tests hold `config_override_test_lock`, so concurrent
+                // config/env mutation in this crate is serialized.
+                unsafe { std::env::remove_var(key) };
+            }
+
             Self {
                 _lock: lock,
                 _config_dir: config_dir,
                 _data_dir: data_dir,
+                saved_env,
             }
         }
     }
 
     impl Drop for VoiceConfigTestGuard {
         fn drop(&mut self) {
+            for (key, value) in self.saved_env.drain(..) {
+                // SAFETY: same lock-serialized test cleanup as construction.
+                match value {
+                    Some(v) => unsafe { std::env::set_var(key, v) },
+                    None => unsafe { std::env::remove_var(key) },
+                }
+            }
             moltis_config::clear_config_dir();
             moltis_config::clear_data_dir();
         }
@@ -542,17 +567,21 @@ mod tests {
 
     #[test]
     fn test_live_tts_resolve_provider_handles_explicit_and_auto_selection() {
+        // Isolate from machine-local voice config / env keys so the default
+        // unconfigured contract is what we assert (#1114 / Greptile P1).
+        let _guard = VoiceConfigTestGuard::with_config("");
         assert_eq!(
             LiveTtsService::resolve_provider(Some(TtsProviderId::OpenAi)),
             Some(TtsProviderId::OpenAi)
         );
-        // Default config has no API keys / local models, and default Coqui is
-        // not considered configured, so auto-select must return None.
+        // Empty isolated config has no API keys / local models, and default
+        // Coqui is not considered configured, so auto-select must return None.
         assert_eq!(LiveTtsService::resolve_provider(None), None);
     }
 
     #[tokio::test]
     async fn test_live_tts_service_status() {
+        let _guard = VoiceConfigTestGuard::with_config("");
         let service = LiveTtsService::new(TtsConfig::default());
         let status = service.status().await.unwrap();
 
@@ -560,8 +589,9 @@ mod tests {
         assert!(status.get("enabled").is_some());
         assert!(status.get("configured").is_some());
         assert!(status.get("provider").is_some());
-        // With default config and no API keys / local models, no provider is
-        // configured — including Coqui (default endpoint alone is not enough).
+        // With isolated empty config and no API keys / local models, no
+        // provider is configured — including Coqui (default endpoint alone is
+        // not enough).
         assert_eq!(status["configured"], false);
     }
 

--- a/crates/gateway/src/voice/tts_service.rs
+++ b/crates/gateway/src/voice/tts_service.rs
@@ -150,7 +150,13 @@ impl LiveTtsService {
             ),
             (TtsProviderId::Google, config.google.api_key.is_some()),
             (TtsProviderId::Piper, config.piper.model_path.is_some()),
-            (TtsProviderId::Coqui, true), // Always available if server running
+            // Match CoquiTts::is_configured(): default localhost:5002 alone is
+            // not enough — require a non-default endpoint or explicit model so
+            // auto-select does not pick an unconfigured Coqui (#1114).
+            (
+                TtsProviderId::Coqui,
+                CoquiTts::new(&config.coqui).is_configured(),
+            ),
         ]
     }
 
@@ -540,8 +546,9 @@ mod tests {
             LiveTtsService::resolve_provider(Some(TtsProviderId::OpenAi)),
             Some(TtsProviderId::OpenAi)
         );
-        // None means auto-select — returns first configured.
-        assert!(LiveTtsService::resolve_provider(None).is_some());
+        // None means auto-select — returns first configured provider, or None
+        // when nothing (including Coqui) is actually configured.
+        let _ = LiveTtsService::resolve_provider(None);
     }
 
     #[tokio::test]
@@ -553,9 +560,9 @@ mod tests {
         assert!(status.get("enabled").is_some());
         assert!(status.get("configured").is_some());
         assert!(status.get("provider").is_some());
-        // Coqui is always considered "configured" (local service)
-        // so configured will be true even with no API keys
-        assert_eq!(status["configured"], true);
+        // With default config and no API keys / local models, no provider is
+        // configured — including Coqui (default endpoint alone is not enough).
+        assert_eq!(status["configured"], false);
     }
 
     #[tokio::test]

--- a/crates/gateway/src/voice/tts_service.rs
+++ b/crates/gateway/src/voice/tts_service.rs
@@ -546,9 +546,9 @@ mod tests {
             LiveTtsService::resolve_provider(Some(TtsProviderId::OpenAi)),
             Some(TtsProviderId::OpenAi)
         );
-        // None means auto-select — returns first configured provider, or None
-        // when nothing (including Coqui) is actually configured.
-        let _ = LiveTtsService::resolve_provider(None);
+        // Default config has no API keys / local models, and default Coqui is
+        // not considered configured, so auto-select must return None.
+        assert_eq!(LiveTtsService::resolve_provider(None), None);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- Stop hard-coding Coqui as `configured=true` in TTS provider auto-select
- Use `CoquiTts::is_configured()` (non-default endpoint or explicit model)
- Prevents red `provider 'coqui' not configured` warnings when no TTS provider is set up

Fixes #1114

## Root cause

`list_providers()` returned `(Coqui, true)` unconditionally \"if server running\", while `create_provider(Coqui)` still required `is_configured()`. Auto-select / status therefore claimed Coqui was available, then convert failed.

## Test plan

- [ ] `cargo test -p moltis-gateway tts`
- [ ] With default voice config and no TTS keys, `tts.status.configured` is false
- [ ] With only default Coqui endpoint, auto voice replies no longer attempt Coqui
- [ ] With `[voice.tts.coqui] model = \"...\"` (or non-default endpoint), Coqui remains selectable