### PR TITLE
fix(cron): preserve delivered channel context

### DIFF
--- a/crates/channels/src/registry.rs
+++ b/crates/channels/src/registry.rs
@@ -156,6 +156,17 @@ impl ChannelRegistry {
         index.get(account_id).cloned()
     }
 
+    /// Resolve an account to one of the built-in channel types.
+    ///
+    /// The registry keeps string identifiers internally so it can route
+    /// dynamically named plugins. Domain consumers should use this typed
+    /// boundary when they need [`ChannelType`] semantics.
+    pub fn resolve_known_channel_type(&self, account_id: &str) -> Result<Option<ChannelType>> {
+        self.resolve_channel_type(account_id)
+            .map(|channel_type| channel_type.parse())
+            .transpose()
+    }
+
     /// Resolve an outbound sender for the given account.
     pub async fn resolve_outbound(&self, account_id: &str) -> Option<Arc<dyn ChannelOutbound>> {
         let channel_type = self.resolve_channel_type(account_id)?;
@@ -902,6 +913,26 @@ mod tests {
             registry.resolve_channel_type("bot1"),
             Some("telegram".into())
         );
+        assert_eq!(
+            registry.resolve_known_channel_type("bot1").unwrap(),
+            Some(ChannelType::Telegram)
+        );
+    }
+
+    #[test]
+    fn typed_resolution_distinguishes_missing_and_unknown_channel_types() {
+        let registry = ChannelRegistry::new();
+
+        assert_eq!(
+            registry.resolve_known_channel_type("missing").unwrap(),
+            None
+        );
+
+        registry.index_account("custom-account", "custom-plugin");
+        let error = registry
+            .resolve_known_channel_type("custom-account")
+            .unwrap_err();
+        assert!(error.to_string().contains("unknown channel type"));
     }
 
     #[tokio::test]

--- a/crates/gateway/src/server/helpers.rs
+++ b/crates/gateway/src/server/helpers.rs
@@ -577,10 +577,132 @@ pub(crate) fn log_startup_config_storage_diagnostics() {
 
 // ── Cron delivery ────────────────────────────────────────────────────────────
 
+pub(crate) struct CronDeliveryHistory {
+    pub(crate) registry: Arc<moltis_channels::ChannelRegistry>,
+    pub(crate) metadata: Arc<moltis_sessions::metadata::SqliteSessionMetadata>,
+    pub(crate) store: Arc<moltis_sessions::store::SessionStore>,
+    pub(crate) delivery_id: String,
+}
+
+fn cron_delivery_target(
+    registry: &moltis_channels::ChannelRegistry,
+    account_id: &str,
+    outbound_to: &str,
+) -> Option<moltis_channels::ChannelReplyTarget> {
+    let channel_type = registry.resolve_channel_type(account_id)?.parse().ok()?;
+    let (chat_id, thread_id) = if channel_type == moltis_channels::ChannelType::Telegram {
+        match outbound_to.split_once(':') {
+            Some((chat_id, thread_id)) if !chat_id.is_empty() && !thread_id.is_empty() => {
+                (chat_id.to_string(), Some(thread_id.to_string()))
+            },
+            Some(_) => return None,
+            None => (outbound_to.to_string(), None),
+        }
+    } else {
+        (outbound_to.to_string(), None)
+    };
+
+    Some(moltis_channels::ChannelReplyTarget {
+        channel_type,
+        account_id: account_id.to_string(),
+        chat_id,
+        message_id: None,
+        thread_id,
+        ack_message_id: None,
+    })
+}
+
+fn same_channel_conversation(
+    left: &moltis_channels::ChannelReplyTarget,
+    right: &moltis_channels::ChannelReplyTarget,
+) -> bool {
+    left.channel_type == right.channel_type
+        && left.account_id == right.account_id
+        && left.chat_id == right.chat_id
+        && left.thread_id == right.thread_id
+}
+
+async fn bound_cron_delivery_session(
+    history: &CronDeliveryHistory,
+    account_id: &str,
+    outbound_to: &str,
+) -> Option<String> {
+    let target = cron_delivery_target(&history.registry, account_id, outbound_to)?;
+    let session_key = history
+        .metadata
+        .get_active_session(
+            target.channel_type.as_str(),
+            &target.account_id,
+            &target.chat_id,
+            target.thread_id.as_deref(),
+        )
+        .await
+        .unwrap_or_else(|| target.default_session_key());
+    let entry = history.metadata.get(&session_key).await?;
+    let binding = entry.channel_binding.as_deref()?;
+    let bound_target = serde_json::from_str::<moltis_channels::ChannelReplyTarget>(binding).ok()?;
+    same_channel_conversation(&target, &bound_target).then_some(session_key)
+}
+
+fn cron_delivery_run_id(delivery_id: &str) -> String {
+    format!("cron-delivery:{delivery_id}")
+}
+
+fn cron_delivery_message(delivery_text: &str, run_id: &str) -> serde_json::Value {
+    let created_at = u64::try_from(
+        (time::OffsetDateTime::now_utc() - time::OffsetDateTime::UNIX_EPOCH).whole_milliseconds(),
+    )
+    .unwrap_or_default();
+    serde_json::json!({
+        "role": "assistant",
+        "content": delivery_text,
+        "created_at": created_at,
+        "run_id": run_id,
+        // A scheduled answer delivered to a shared chat is already public to
+        // that audience. Marking it keeps the message in that chat's public
+        // history filter without exposing anything from the isolated run.
+        "channel": { "private_context": false },
+    })
+}
+
+async fn cron_delivery_was_recorded(
+    history: &CronDeliveryHistory,
+    session_key: &str,
+    run_id: &str,
+) -> bool {
+    match history.store.read_by_run_id(session_key, run_id).await {
+        Ok(messages) => !messages.is_empty(),
+        Err(error) => {
+            warn!(
+                session = session_key,
+                %error,
+                "could not check cron delivery history; continuing delivery"
+            );
+            false
+        },
+    }
+}
+
+async fn record_cron_delivery(
+    history: &CronDeliveryHistory,
+    session_key: &str,
+    delivery_text: &str,
+    run_id: &str,
+) -> moltis_sessions::Result<()> {
+    history
+        .store
+        .append(session_key, &cron_delivery_message(delivery_text, run_id))
+        .await?;
+    let message_count = history.store.count(session_key).await?;
+    history.metadata.touch(session_key, message_count).await;
+    Ok(())
+}
+
 pub(crate) async fn maybe_deliver_cron_output(
     outbound: Option<Arc<dyn moltis_channels::ChannelOutbound>>,
     req: &moltis_cron::service::AgentTurnRequest,
     delivery_text: &str,
+    history: Option<&CronDeliveryHistory>,
 ) -> moltis_cron::Result<()> {
     if !req.deliver || delivery_text.trim().is_empty() {
         return Ok(());
@@ -595,6 +717,24 @@ pub(crate) async fn maybe_deliver_cron_output(
     let outbound = outbound.ok_or_else(|| {
         moltis_cron::Error::message("cron delivery requested but channel outbound is unavailable")
     })?;
+
+    let bound_session = match history {
+        Some(history) => bound_cron_delivery_session(history, channel_account, chat_id).await,
+        None => None,
+    };
+    let run_id = history.map(|history| cron_delivery_run_id(&history.delivery_id));
+    if let (Some(history), Some(session_key), Some(run_id)) =
+        (history, bound_session.as_deref(), run_id.as_deref())
+        && cron_delivery_was_recorded(history, session_key, run_id).await
+    {
+        debug!(
+            session = session_key,
+            delivery_id = %history.delivery_id,
+            "cron output delivery already recorded; skipping duplicate"
+        );
+        return Ok(());
+    }
+
     outbound
         .send_text(channel_account, chat_id, delivery_text, None)
         .await
@@ -602,7 +742,35 @@ pub(crate) async fn maybe_deliver_cron_output(
             moltis_cron::Error::message(format!(
                 "failed to deliver cron output to {channel_account}: {error}"
             ))
-        })
+        })?;
+
+    let bound_session_after_delivery = match history {
+        Some(history) => bound_cron_delivery_session(history, channel_account, chat_id).await,
+        None => None,
+    };
+    if let (Some(history), Some(session_key), Some(run_id)) = (
+        history,
+        bound_session_after_delivery.as_deref(),
+        run_id.as_deref(),
+    ) {
+        if let Err(error) = record_cron_delivery(history, session_key, delivery_text, run_id).await
+        {
+            warn!(
+                session = session_key,
+                delivery_id = %history.delivery_id,
+                %error,
+                "cron output was delivered but could not be added to channel history"
+            );
+        } else {
+            debug!(
+                session = session_key,
+                delivery_id = %history.delivery_id,
+                "added delivered cron output to channel history"
+            );
+        }
+    }
+
+    Ok(())
 }
 
 // ── Skill hot-reload watcher ─────────────────────────────────────────────────

--- a/crates/gateway/src/server/helpers.rs
+++ b/crates/gateway/src/server/helpers.rs
@@ -589,7 +589,18 @@ fn cron_delivery_target(
     account_id: &str,
     outbound_to: &str,
 ) -> Option<moltis_channels::ChannelReplyTarget> {
-    let channel_type = registry.resolve_channel_type(account_id)?.parse().ok()?;
+    let channel_type = match registry.resolve_known_channel_type(account_id) {
+        Ok(Some(channel_type)) => channel_type,
+        Ok(None) => return None,
+        Err(error) => {
+            warn!(
+                account_id,
+                %error,
+                "cannot add cron delivery to history for an unknown channel type"
+            );
+            return None;
+        },
+    };
     let (chat_id, thread_id) = match channel_type {
         moltis_channels::ChannelType::Telegram => match outbound_to.split_once(':') {
             Some((chat_id, thread_id)) if !chat_id.is_empty() && !thread_id.is_empty() => {
@@ -652,21 +663,43 @@ fn cron_delivery_run_id(delivery_id: &str) -> String {
     format!("cron-delivery:{delivery_id}")
 }
 
-fn cron_delivery_message(delivery_text: &str, run_id: &str) -> serde_json::Value {
+#[derive(serde::Serialize)]
+#[serde(rename_all = "lowercase")]
+enum CronDeliveryRole {
+    Assistant,
+}
+
+#[derive(serde::Serialize)]
+struct CronDeliveryChannelContext {
+    private_context: bool,
+}
+
+#[derive(serde::Serialize)]
+struct CronDeliveryMessage<'a> {
+    role: CronDeliveryRole,
+    content: &'a str,
+    created_at: u64,
+    run_id: &'a str,
+    channel: CronDeliveryChannelContext,
+}
+
+fn cron_delivery_message<'a>(delivery_text: &'a str, run_id: &'a str) -> CronDeliveryMessage<'a> {
     let created_at = u64::try_from(
         (time::OffsetDateTime::now_utc() - time::OffsetDateTime::UNIX_EPOCH).whole_milliseconds(),
     )
     .unwrap_or_default();
-    serde_json::json!({
-        "role": "assistant",
-        "content": delivery_text,
-        "created_at": created_at,
-        "run_id": run_id,
+    CronDeliveryMessage {
+        role: CronDeliveryRole::Assistant,
+        content: delivery_text,
+        created_at,
+        run_id,
         // A scheduled answer delivered to a shared chat is already public to
         // that audience. Marking it keeps the message in that chat's public
         // history filter without exposing anything from the isolated run.
-        "channel": { "private_context": false },
-    })
+        channel: CronDeliveryChannelContext {
+            private_context: false,
+        },
+    }
 }
 
 async fn cron_delivery_was_recorded(
@@ -693,10 +726,8 @@ async fn record_cron_delivery(
     delivery_text: &str,
     run_id: &str,
 ) -> moltis_sessions::Result<()> {
-    history
-        .store
-        .append(session_key, &cron_delivery_message(delivery_text, run_id))
-        .await?;
+    let message = serde_json::to_value(cron_delivery_message(delivery_text, run_id))?;
+    history.store.append(session_key, &message).await?;
     let message_count = history.store.count(session_key).await?;
     history.metadata.touch(session_key, message_count).await;
     Ok(())
@@ -752,11 +783,18 @@ pub(crate) async fn maybe_deliver_cron_output(
         Some(history) => bound_cron_delivery_session(history, channel_account, chat_id).await,
         None => None,
     };
-    if let (Some(history), Some(session_key), Some(run_id)) = (
-        history,
-        bound_session_after_delivery.as_deref(),
-        run_id.as_deref(),
-    ) {
+    if let (Some(history), Some(session_key), Some(run_id)) =
+        (history, bound_session.as_deref(), run_id.as_deref())
+    {
+        if bound_session_after_delivery.as_deref() != Some(session_key) {
+            warn!(
+                session = session_key,
+                delivery_id = %history.delivery_id,
+                "cron output was delivered but the channel session changed; skipping history"
+            );
+            return Ok(());
+        }
+
         if let Err(error) = record_cron_delivery(history, session_key, delivery_text, run_id).await
         {
             warn!(

--- a/crates/gateway/src/server/helpers.rs
+++ b/crates/gateway/src/server/helpers.rs
@@ -590,16 +590,20 @@ fn cron_delivery_target(
     outbound_to: &str,
 ) -> Option<moltis_channels::ChannelReplyTarget> {
     let channel_type = registry.resolve_channel_type(account_id)?.parse().ok()?;
-    let (chat_id, thread_id) = if channel_type == moltis_channels::ChannelType::Telegram {
-        match outbound_to.split_once(':') {
+    let (chat_id, thread_id) = match channel_type {
+        moltis_channels::ChannelType::Telegram => match outbound_to.split_once(':') {
             Some((chat_id, thread_id)) if !chat_id.is_empty() && !thread_id.is_empty() => {
                 (chat_id.to_string(), Some(thread_id.to_string()))
             },
             Some(_) => return None,
             None => (outbound_to.to_string(), None),
-        }
-    } else {
-        (outbound_to.to_string(), None)
+        },
+        // WhatsApp accepts bare phone numbers for outbound sends, but inbound
+        // conversations are keyed by their canonical phone-number JID.
+        moltis_channels::ChannelType::Whatsapp if !outbound_to.contains('@') => {
+            (format!("{outbound_to}@s.whatsapp.net"), None)
+        },
+        _ => (outbound_to.to_string(), None),
     };
 
     Some(moltis_channels::ChannelReplyTarget {

--- a/crates/gateway/src/server/prepare_core.rs
+++ b/crates/gateway/src/server/prepare_core.rs
@@ -1,7 +1,7 @@
 use {
     super::{
         helpers::{
-            StartupMemProbe, approval_manager_from_config, env_flag_enabled,
+            CronDeliveryHistory, StartupMemProbe, approval_manager_from_config, env_flag_enabled,
             log_startup_config_storage_diagnostics, log_startup_model_inventory,
             maybe_deliver_cron_output, restore_saved_local_llm_models,
             validate_proxy_tls_configuration,
@@ -768,11 +768,12 @@ pub async fn prepare_gateway_core_with_profile(
             }
 
             let chat = state.chat();
+            let cron_turn_id = uuid::Uuid::new_v4().to_string();
             let session_key = match &req.session_target {
                 moltis_cron::types::SessionTarget::Named(name) => {
                     format!("cron:{name}")
                 },
-                _ => format!("cron:{}", uuid::Uuid::new_v4()),
+                _ => format!("cron:{cron_turn_id}"),
             };
 
             if matches!(
@@ -876,19 +877,35 @@ pub async fn prepare_gateway_core_with_profile(
                 text.clone()
             };
 
-            let delivery_error =
-                if req.deliver && !is_heartbeat_turn && delivery_text.trim().is_empty() {
-                    Some("cron agent produced an empty response; nothing was delivered".to_string())
-                } else {
-                    maybe_deliver_cron_output(
-                        state.services.channel_outbound_arc(),
-                        &req,
-                        &delivery_text,
-                    )
-                    .await
-                    .err()
-                    .map(|error| error.to_string())
+            let delivery_error = if req.deliver
+                && !is_heartbeat_turn
+                && delivery_text.trim().is_empty()
+            {
+                Some("cron agent produced an empty response; nothing was delivered".to_string())
+            } else {
+                let delivery_history = match (
+                    state.services.channel_registry.as_ref(),
+                    state.services.session_metadata.as_ref(),
+                    state.services.session_store.as_ref(),
+                ) {
+                    (Some(registry), Some(metadata), Some(store)) => Some(CronDeliveryHistory {
+                        registry: Arc::clone(registry),
+                        metadata: Arc::clone(metadata),
+                        store: Arc::clone(store),
+                        delivery_id: cron_turn_id.clone(),
+                    }),
+                    _ => None,
                 };
+                maybe_deliver_cron_output(
+                    state.services.channel_outbound_arc(),
+                    &req,
+                    &delivery_text,
+                    delivery_history.as_ref(),
+                )
+                .await
+                .err()
+                .map(|error| error.to_string())
+            };
 
             Ok(moltis_cron::service::AgentTurnResult {
                 output: text,

--- a/crates/gateway/src/server/tests_legacy/cron.rs
+++ b/crates/gateway/src/server/tests_legacy/cron.rs
@@ -85,6 +85,10 @@ fn reply_target(
     }
 }
 
+fn whatsapp_target(chat_id: &str) -> ChannelReplyTarget {
+    reply_target(ChannelType::Whatsapp, "bot-main", chat_id, None)
+}
+
 struct FailingChannelOutbound;
 
 #[async_trait]
@@ -234,9 +238,9 @@ async fn maybe_deliver_cron_output_propagates_channel_failure() {
 }
 
 #[tokio::test]
-async fn successful_delivery_is_recorded_once_in_bound_conversation() {
+async fn bare_whatsapp_number_delivery_is_recorded_once_in_bound_conversation() {
     let fixture = CronHistoryFixture::new(ChannelType::Whatsapp, "bot-main").await;
-    let target = reply_target(ChannelType::Whatsapp, "bot-main", "123456", None);
+    let target = whatsapp_target("123456@s.whatsapp.net");
     fixture.bind(&target, "session:whatsapp", true).await;
     let outbound = Arc::new(RecordingChannelOutbound::default());
     let req = cron_delivery_request();
@@ -280,7 +284,7 @@ async fn successful_delivery_is_recorded_once_in_bound_conversation() {
 #[tokio::test]
 async fn failed_delivery_is_not_added_to_conversation_history() {
     let fixture = CronHistoryFixture::new(ChannelType::Whatsapp, "bot-main").await;
-    let target = reply_target(ChannelType::Whatsapp, "bot-main", "123456", None);
+    let target = whatsapp_target("123456@s.whatsapp.net");
     fixture.bind(&target, "session:whatsapp", true).await;
     let req = cron_delivery_request();
     let history = fixture.history("failed-run");
@@ -308,7 +312,7 @@ async fn failed_delivery_is_not_added_to_conversation_history() {
 #[tokio::test]
 async fn delivered_output_does_not_fail_when_history_cannot_be_written() {
     let fixture = CronHistoryFixture::new(ChannelType::Whatsapp, "bot-main").await;
-    let target = reply_target(ChannelType::Whatsapp, "bot-main", "123456", None);
+    let target = whatsapp_target("123456@s.whatsapp.net");
     fixture.bind(&target, "session:whatsapp", true).await;
     let blocked_path = fixture._directory.path().join("not-a-directory");
     std::fs::write(&blocked_path, b"file blocks session directory").unwrap();
@@ -363,10 +367,7 @@ async fn delivery_without_an_existing_bound_session_stays_out_of_history() {
     assert!(
         fixture
             .store
-            .read(
-                &reply_target(ChannelType::Whatsapp, "bot-main", "123456", None)
-                    .default_session_key()
-            )
+            .read(&whatsapp_target("123456@s.whatsapp.net").default_session_key())
             .await
             .unwrap()
             .is_empty()
@@ -376,8 +377,8 @@ async fn delivery_without_an_existing_bound_session_stays_out_of_history() {
 #[tokio::test]
 async fn delivery_is_isolated_to_the_exact_recipient() {
     let fixture = CronHistoryFixture::new(ChannelType::Whatsapp, "bot-main").await;
-    let intended = reply_target(ChannelType::Whatsapp, "bot-main", "123456", None);
-    let other = reply_target(ChannelType::Whatsapp, "bot-main", "999999", None);
+    let intended = whatsapp_target("123456@s.whatsapp.net");
+    let other = whatsapp_target("999999@s.whatsapp.net");
     fixture.bind(&intended, "session:intended", true).await;
     fixture.bind(&other, "session:other", true).await;
     let outbound = Arc::new(RecordingChannelOutbound::default());
@@ -410,8 +411,8 @@ async fn delivery_is_isolated_to_the_exact_recipient() {
 #[tokio::test]
 async fn stale_mapping_to_another_recipient_fails_closed() {
     let fixture = CronHistoryFixture::new(ChannelType::Whatsapp, "bot-main").await;
-    let intended = reply_target(ChannelType::Whatsapp, "bot-main", "123456", None);
-    let other = reply_target(ChannelType::Whatsapp, "bot-main", "999999", None);
+    let intended = whatsapp_target("123456@s.whatsapp.net");
+    let other = whatsapp_target("999999@s.whatsapp.net");
     fixture.bind(&other, "session:other", false).await;
     fixture
         .metadata
@@ -450,8 +451,8 @@ async fn stale_mapping_to_another_recipient_fails_closed() {
 #[tokio::test]
 async fn binding_is_revalidated_after_the_external_send() {
     let fixture = CronHistoryFixture::new(ChannelType::Whatsapp, "bot-main").await;
-    let intended = reply_target(ChannelType::Whatsapp, "bot-main", "123456", None);
-    let other = reply_target(ChannelType::Whatsapp, "bot-main", "999999", None);
+    let intended = whatsapp_target("123456@s.whatsapp.net");
+    let other = whatsapp_target("999999@s.whatsapp.net");
     fixture.bind(&intended, "session:intended", true).await;
     fixture.bind(&other, "session:other", false).await;
     let outbound = Arc::new(RemappingChannelOutbound {
@@ -517,7 +518,7 @@ async fn telegram_delivery_is_isolated_to_the_exact_topic() {
 #[tokio::test]
 async fn default_bound_conversation_is_used_without_an_active_override() {
     let fixture = CronHistoryFixture::new(ChannelType::Whatsapp, "bot-main").await;
-    let target = reply_target(ChannelType::Whatsapp, "bot-main", "123456", None);
+    let target = whatsapp_target("123456@s.whatsapp.net");
     let default_key = target.default_session_key();
     fixture.bind(&target, &default_key, false).await;
     let outbound = Arc::new(RecordingChannelOutbound::default());

--- a/crates/gateway/src/server/tests_legacy/cron.rs
+++ b/crates/gateway/src/server/tests_legacy/cron.rs
@@ -491,6 +491,47 @@ async fn binding_is_revalidated_after_the_external_send() {
 }
 
 #[tokio::test]
+async fn same_target_session_remap_during_send_is_not_recorded() {
+    let fixture = CronHistoryFixture::new(ChannelType::Whatsapp, "bot-main").await;
+    let intended = whatsapp_target("123456@s.whatsapp.net");
+    fixture.bind(&intended, "session:before-send", true).await;
+    fixture.bind(&intended, "session:after-send", false).await;
+    let outbound = Arc::new(RemappingChannelOutbound {
+        metadata: Arc::clone(&fixture.metadata),
+        target: intended,
+        session_key: "session:after-send".to_string(),
+    });
+    let req = cron_delivery_request();
+    let history = fixture.history("same-target-remap-run");
+
+    crate::server::helpers::maybe_deliver_cron_output(
+        Some(outbound as Arc<dyn moltis_channels::ChannelOutbound>),
+        &req,
+        "Delivered while the active session changed",
+        Some(&history),
+    )
+    .await
+    .unwrap();
+
+    assert!(
+        fixture
+            .store
+            .read("session:before-send")
+            .await
+            .unwrap()
+            .is_empty()
+    );
+    assert!(
+        fixture
+            .store
+            .read("session:after-send")
+            .await
+            .unwrap()
+            .is_empty()
+    );
+}
+
+#[tokio::test]
 async fn telegram_delivery_is_isolated_to_the_exact_topic() {
     let fixture = CronHistoryFixture::new(ChannelType::Telegram, "bot-main").await;
     let topic = reply_target(ChannelType::Telegram, "bot-main", "-100123", Some("42"));

--- a/crates/gateway/src/server/tests_legacy/cron.rs
+++ b/crates/gateway/src/server/tests_legacy/cron.rs
@@ -3,8 +3,87 @@ use std::sync::Arc;
 use {
     super::common::{DeliveredMessage, RecordingChannelOutbound, cron_delivery_request},
     async_trait::async_trait,
+    moltis_channels::{ChannelReplyTarget, ChannelType},
     moltis_common::types::ReplyPayload,
+    moltis_sessions::{metadata::SqliteSessionMetadata, store::SessionStore},
+    sqlx::sqlite::SqlitePoolOptions,
 };
+
+struct CronHistoryFixture {
+    _directory: tempfile::TempDir,
+    registry: Arc<moltis_channels::ChannelRegistry>,
+    metadata: Arc<SqliteSessionMetadata>,
+    store: Arc<SessionStore>,
+}
+
+impl CronHistoryFixture {
+    async fn new(channel_type: ChannelType, account_id: &str) -> Self {
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect("sqlite::memory:")
+            .await
+            .unwrap();
+        sqlx::query("CREATE TABLE projects (id TEXT PRIMARY KEY)")
+            .execute(&pool)
+            .await
+            .unwrap();
+        SqliteSessionMetadata::init(&pool).await.unwrap();
+        let metadata = Arc::new(SqliteSessionMetadata::new(pool));
+        let directory = tempfile::tempdir().unwrap();
+        let store = Arc::new(SessionStore::new(directory.path().to_path_buf()));
+        let registry = Arc::new(moltis_channels::ChannelRegistry::new());
+        registry.index_account(account_id, channel_type.as_str());
+        Self {
+            _directory: directory,
+            registry,
+            metadata,
+            store,
+        }
+    }
+
+    async fn bind(&self, target: &ChannelReplyTarget, session_key: &str, explicit: bool) {
+        self.metadata.upsert(session_key, None).await.unwrap();
+        self.metadata
+            .set_channel_binding(session_key, Some(serde_json::to_string(target).unwrap()))
+            .await;
+        if explicit {
+            self.metadata
+                .set_active_session(
+                    target.channel_type.as_str(),
+                    &target.account_id,
+                    &target.chat_id,
+                    target.thread_id.as_deref(),
+                    session_key,
+                )
+                .await;
+        }
+    }
+
+    fn history(&self, delivery_id: &str) -> crate::server::helpers::CronDeliveryHistory {
+        crate::server::helpers::CronDeliveryHistory {
+            registry: Arc::clone(&self.registry),
+            metadata: Arc::clone(&self.metadata),
+            store: Arc::clone(&self.store),
+            delivery_id: delivery_id.to_string(),
+        }
+    }
+}
+
+fn reply_target(
+    channel_type: ChannelType,
+    account_id: &str,
+    chat_id: &str,
+    thread_id: Option<&str>,
+) -> ChannelReplyTarget {
+    ChannelReplyTarget {
+        channel_type,
+        account_id: account_id.to_string(),
+        chat_id: chat_id.to_string(),
+        message_id: None,
+        thread_id: thread_id.map(str::to_string),
+        ack_message_id: None,
+    }
+}
 
 struct FailingChannelOutbound;
 
@@ -31,6 +110,44 @@ impl moltis_channels::ChannelOutbound for FailingChannelOutbound {
     }
 }
 
+struct RemappingChannelOutbound {
+    metadata: Arc<SqliteSessionMetadata>,
+    target: ChannelReplyTarget,
+    session_key: String,
+}
+
+#[async_trait]
+impl moltis_channels::ChannelOutbound for RemappingChannelOutbound {
+    async fn send_text(
+        &self,
+        _account_id: &str,
+        _to: &str,
+        _text: &str,
+        _reply_to: Option<&str>,
+    ) -> moltis_channels::Result<()> {
+        self.metadata
+            .set_active_session(
+                self.target.channel_type.as_str(),
+                &self.target.account_id,
+                &self.target.chat_id,
+                self.target.thread_id.as_deref(),
+                &self.session_key,
+            )
+            .await;
+        Ok(())
+    }
+
+    async fn send_media(
+        &self,
+        _account_id: &str,
+        _to: &str,
+        _reply: &ReplyPayload,
+        _reply_to: Option<&str>,
+    ) -> moltis_channels::Result<()> {
+        Ok(())
+    }
+}
+
 #[tokio::test]
 async fn maybe_deliver_cron_output_sends_to_configured_channel() {
     let outbound = Arc::new(RecordingChannelOutbound::default());
@@ -40,6 +157,7 @@ async fn maybe_deliver_cron_output_sends_to_configured_channel() {
         Some(outbound.clone() as Arc<dyn moltis_channels::ChannelOutbound>),
         &req,
         "Daily digest ready",
+        None,
     )
     .await
     .unwrap();
@@ -62,6 +180,7 @@ async fn maybe_deliver_cron_output_skips_blank_messages() {
         Some(outbound.clone() as Arc<dyn moltis_channels::ChannelOutbound>),
         &req,
         "   ",
+        None,
     )
     .await
     .unwrap();
@@ -79,6 +198,7 @@ async fn maybe_deliver_cron_output_skips_when_deliver_is_false() {
         Some(outbound.clone() as Arc<dyn moltis_channels::ChannelOutbound>),
         &req,
         "should not be sent",
+        None,
     )
     .await
     .unwrap();
@@ -90,9 +210,10 @@ async fn maybe_deliver_cron_output_skips_when_deliver_is_false() {
 async fn maybe_deliver_cron_output_fails_when_no_outbound_is_configured() {
     let req = cron_delivery_request();
 
-    let error = crate::server::helpers::maybe_deliver_cron_output(None, &req, "Daily digest ready")
-        .await
-        .unwrap_err();
+    let error =
+        crate::server::helpers::maybe_deliver_cron_output(None, &req, "Daily digest ready", None)
+            .await
+            .unwrap_err();
     assert!(error.to_string().contains("outbound is unavailable"));
 }
 
@@ -105,8 +226,312 @@ async fn maybe_deliver_cron_output_propagates_channel_failure() {
         Some(outbound),
         &req,
         "Daily digest ready",
+        None,
     )
     .await
     .unwrap_err();
     assert!(error.to_string().contains("test delivery failure"));
+}
+
+#[tokio::test]
+async fn successful_delivery_is_recorded_once_in_bound_conversation() {
+    let fixture = CronHistoryFixture::new(ChannelType::Whatsapp, "bot-main").await;
+    let target = reply_target(ChannelType::Whatsapp, "bot-main", "123456", None);
+    fixture.bind(&target, "session:whatsapp", true).await;
+    let outbound = Arc::new(RecordingChannelOutbound::default());
+    let req = cron_delivery_request();
+    let history = fixture.history("run-1");
+
+    for _ in 0..2 {
+        crate::server::helpers::maybe_deliver_cron_output(
+            Some(outbound.clone() as Arc<dyn moltis_channels::ChannelOutbound>),
+            &req,
+            "Services total R$ 1.042,30",
+            Some(&history),
+        )
+        .await
+        .unwrap();
+    }
+
+    assert_eq!(outbound.delivered.lock().await.len(), 1);
+    let messages = fixture.store.read("session:whatsapp").await.unwrap();
+    assert_eq!(messages.len(), 1);
+    assert_eq!(messages[0]["role"], "assistant");
+    assert_eq!(messages[0]["content"], "Services total R$ 1.042,30");
+    assert_eq!(messages[0]["run_id"], "cron-delivery:run-1");
+    assert_eq!(messages[0]["channel"]["private_context"], false);
+    let llm_history = moltis_agents::model::values_to_chat_messages(&messages);
+    assert!(matches!(
+        &llm_history[0],
+        moltis_agents::model::ChatMessage::Assistant { content: Some(content), .. }
+            if content == "Services total R$ 1.042,30"
+    ));
+    assert_eq!(
+        fixture
+            .metadata
+            .get("session:whatsapp")
+            .await
+            .unwrap()
+            .message_count,
+        1
+    );
+}
+
+#[tokio::test]
+async fn failed_delivery_is_not_added_to_conversation_history() {
+    let fixture = CronHistoryFixture::new(ChannelType::Whatsapp, "bot-main").await;
+    let target = reply_target(ChannelType::Whatsapp, "bot-main", "123456", None);
+    fixture.bind(&target, "session:whatsapp", true).await;
+    let req = cron_delivery_request();
+    let history = fixture.history("failed-run");
+
+    let error = crate::server::helpers::maybe_deliver_cron_output(
+        Some(Arc::new(FailingChannelOutbound)),
+        &req,
+        "This was not delivered",
+        Some(&history),
+    )
+    .await
+    .unwrap_err();
+
+    assert!(error.to_string().contains("test delivery failure"));
+    assert!(
+        fixture
+            .store
+            .read("session:whatsapp")
+            .await
+            .unwrap()
+            .is_empty()
+    );
+}
+
+#[tokio::test]
+async fn delivered_output_does_not_fail_when_history_cannot_be_written() {
+    let fixture = CronHistoryFixture::new(ChannelType::Whatsapp, "bot-main").await;
+    let target = reply_target(ChannelType::Whatsapp, "bot-main", "123456", None);
+    fixture.bind(&target, "session:whatsapp", true).await;
+    let blocked_path = fixture._directory.path().join("not-a-directory");
+    std::fs::write(&blocked_path, b"file blocks session directory").unwrap();
+    let bad_store = Arc::new(SessionStore::new(blocked_path));
+    let history = crate::server::helpers::CronDeliveryHistory {
+        registry: Arc::clone(&fixture.registry),
+        metadata: Arc::clone(&fixture.metadata),
+        store: bad_store,
+        delivery_id: "history-failure-run".to_string(),
+    };
+    let outbound = Arc::new(RecordingChannelOutbound::default());
+    let req = cron_delivery_request();
+
+    crate::server::helpers::maybe_deliver_cron_output(
+        Some(outbound.clone() as Arc<dyn moltis_channels::ChannelOutbound>),
+        &req,
+        "The recipient received this",
+        Some(&history),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(outbound.delivered.lock().await.len(), 1);
+    assert_eq!(
+        fixture
+            .metadata
+            .get("session:whatsapp")
+            .await
+            .unwrap()
+            .message_count,
+        0
+    );
+}
+
+#[tokio::test]
+async fn delivery_without_an_existing_bound_session_stays_out_of_history() {
+    let fixture = CronHistoryFixture::new(ChannelType::Whatsapp, "bot-main").await;
+    let outbound = Arc::new(RecordingChannelOutbound::default());
+    let req = cron_delivery_request();
+    let history = fixture.history("unbound-run");
+
+    crate::server::helpers::maybe_deliver_cron_output(
+        Some(outbound.clone() as Arc<dyn moltis_channels::ChannelOutbound>),
+        &req,
+        "Delivered without a conversation",
+        Some(&history),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(outbound.delivered.lock().await.len(), 1);
+    assert!(
+        fixture
+            .store
+            .read(
+                &reply_target(ChannelType::Whatsapp, "bot-main", "123456", None)
+                    .default_session_key()
+            )
+            .await
+            .unwrap()
+            .is_empty()
+    );
+}
+
+#[tokio::test]
+async fn delivery_is_isolated_to_the_exact_recipient() {
+    let fixture = CronHistoryFixture::new(ChannelType::Whatsapp, "bot-main").await;
+    let intended = reply_target(ChannelType::Whatsapp, "bot-main", "123456", None);
+    let other = reply_target(ChannelType::Whatsapp, "bot-main", "999999", None);
+    fixture.bind(&intended, "session:intended", true).await;
+    fixture.bind(&other, "session:other", true).await;
+    let outbound = Arc::new(RecordingChannelOutbound::default());
+    let req = cron_delivery_request();
+    let history = fixture.history("isolated-run");
+
+    crate::server::helpers::maybe_deliver_cron_output(
+        Some(outbound as Arc<dyn moltis_channels::ChannelOutbound>),
+        &req,
+        "Only the intended recipient saw this",
+        Some(&history),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(
+        fixture.store.read("session:intended").await.unwrap().len(),
+        1
+    );
+    assert!(
+        fixture
+            .store
+            .read("session:other")
+            .await
+            .unwrap()
+            .is_empty()
+    );
+}
+
+#[tokio::test]
+async fn stale_mapping_to_another_recipient_fails_closed() {
+    let fixture = CronHistoryFixture::new(ChannelType::Whatsapp, "bot-main").await;
+    let intended = reply_target(ChannelType::Whatsapp, "bot-main", "123456", None);
+    let other = reply_target(ChannelType::Whatsapp, "bot-main", "999999", None);
+    fixture.bind(&other, "session:other", false).await;
+    fixture
+        .metadata
+        .set_active_session(
+            intended.channel_type.as_str(),
+            &intended.account_id,
+            &intended.chat_id,
+            None,
+            "session:other",
+        )
+        .await;
+    let outbound = Arc::new(RecordingChannelOutbound::default());
+    let req = cron_delivery_request();
+    let history = fixture.history("stale-mapping-run");
+
+    crate::server::helpers::maybe_deliver_cron_output(
+        Some(outbound.clone() as Arc<dyn moltis_channels::ChannelOutbound>),
+        &req,
+        "Delivered, but never written into another recipient's history",
+        Some(&history),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(outbound.delivered.lock().await.len(), 1);
+    assert!(
+        fixture
+            .store
+            .read("session:other")
+            .await
+            .unwrap()
+            .is_empty()
+    );
+}
+
+#[tokio::test]
+async fn binding_is_revalidated_after_the_external_send() {
+    let fixture = CronHistoryFixture::new(ChannelType::Whatsapp, "bot-main").await;
+    let intended = reply_target(ChannelType::Whatsapp, "bot-main", "123456", None);
+    let other = reply_target(ChannelType::Whatsapp, "bot-main", "999999", None);
+    fixture.bind(&intended, "session:intended", true).await;
+    fixture.bind(&other, "session:other", false).await;
+    let outbound = Arc::new(RemappingChannelOutbound {
+        metadata: Arc::clone(&fixture.metadata),
+        target: intended,
+        session_key: "session:other".to_string(),
+    });
+    let req = cron_delivery_request();
+    let history = fixture.history("remapped-run");
+
+    crate::server::helpers::maybe_deliver_cron_output(
+        Some(outbound as Arc<dyn moltis_channels::ChannelOutbound>),
+        &req,
+        "Delivered while the binding changed",
+        Some(&history),
+    )
+    .await
+    .unwrap();
+
+    assert!(
+        fixture
+            .store
+            .read("session:intended")
+            .await
+            .unwrap()
+            .is_empty()
+    );
+    assert!(
+        fixture
+            .store
+            .read("session:other")
+            .await
+            .unwrap()
+            .is_empty()
+    );
+}
+
+#[tokio::test]
+async fn telegram_delivery_is_isolated_to_the_exact_topic() {
+    let fixture = CronHistoryFixture::new(ChannelType::Telegram, "bot-main").await;
+    let topic = reply_target(ChannelType::Telegram, "bot-main", "-100123", Some("42"));
+    let base_chat = reply_target(ChannelType::Telegram, "bot-main", "-100123", None);
+    fixture.bind(&topic, "session:topic", true).await;
+    fixture.bind(&base_chat, "session:base", true).await;
+    let outbound = Arc::new(RecordingChannelOutbound::default());
+    let mut req = cron_delivery_request();
+    req.to = Some("-100123:42".to_string());
+    let history = fixture.history("topic-run");
+
+    crate::server::helpers::maybe_deliver_cron_output(
+        Some(outbound as Arc<dyn moltis_channels::ChannelOutbound>),
+        &req,
+        "Topic-only report",
+        Some(&history),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(fixture.store.read("session:topic").await.unwrap().len(), 1);
+    assert!(fixture.store.read("session:base").await.unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn default_bound_conversation_is_used_without_an_active_override() {
+    let fixture = CronHistoryFixture::new(ChannelType::Whatsapp, "bot-main").await;
+    let target = reply_target(ChannelType::Whatsapp, "bot-main", "123456", None);
+    let default_key = target.default_session_key();
+    fixture.bind(&target, &default_key, false).await;
+    let outbound = Arc::new(RecordingChannelOutbound::default());
+    let req = cron_delivery_request();
+    let history = fixture.history("default-run");
+
+    crate::server::helpers::maybe_deliver_cron_output(
+        Some(outbound as Arc<dyn moltis_channels::ChannelOutbound>),
+        &req,
+        "Default conversation report",
+        Some(&history),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(fixture.store.read(&default_key).await.unwrap().len(), 1);
 }

--- a/docs/src/scheduling.md
+++ b/docs/src/scheduling.md
@@ -172,8 +172,16 @@ Example:
 
 Channel delivery is separate from session targeting. The cron job still runs in
 an isolated cron session, then Moltis forwards the finished output to the
-requested channel destination. Delivery failures and empty non-heartbeat
-outputs are recorded as failed cron runs. The `run` action returns that run
+requested channel destination. After a successful send, Moltis also adds the
+delivered text to that destination's existing bound conversation. A follow-up
+in the same chat (and, where supported, the same topic) can therefore refer to
+the scheduled message naturally. No additional configuration is required.
+
+Moltis only updates history when the channel account and exact destination map
+to an existing bound conversation. Delivery to a new or unbound destination
+still succeeds, but does not create a conversation implicitly. Delivery
+failures and empty non-heartbeat outputs are recorded as failed cron runs and
+are never added to conversation history. The `run` action returns that run
 record with the completed output, token usage, and session key intact so callers
 can distinguish agent execution from successful delivery.
 


### PR DESCRIPTION
## Summary

- Fix follow-up questions losing the context of a scheduled message delivered to WhatsApp or another channel. Cron execution remains isolated, but its final delivered text is now appended as an assistant message to the destination's existing conversation.
- Resolve history by the exact channel account, chat, and thread. The session key is captured before the external send and must resolve to the same valid key afterward; a concurrent remap fails closed instead of moving stale context into the replacement conversation.
- Normalize bare WhatsApp phone numbers to the same canonical JID used by inbound conversations, so the common `to: "1555..."` form finds the correct bound session.
- Persist only after a successful send and use a per-execution delivery ID to avoid duplicate delivery/history. A local history failure cannot turn an already successful external send into a retry that would duplicate the WhatsApp message.
- Use a typed cron-history schema and a typed `ChannelRegistry` boundary. Dynamic plugin identifiers remain internal to the registry; unknown identifiers are reported and history persistence fails closed.
- Never create an implicit conversation for an arbitrary cron recipient. No additional configuration is required.

```mermaid
sequenceDiagram
    participant Cron as Isolated cron session
    participant Binding as Exact session binding
    participant Outbound as Channel outbound
    participant Chat as WhatsApp / channel chat
    participant History as Channel session history
    participant Model

    Cron->>Binding: resolve session A
    Cron->>Outbound: final delivery text
    Outbound->>Chat: send text
    Chat-->>Outbound: success
    Outbound->>Binding: re-resolve account + chat + thread
    alt binding is still session A
        Outbound->>History: append delivered assistant text
    else binding changed or is invalid
        Outbound-->>History: fail closed without append
    end
    Chat->>History: user's follow-up
    History->>Model: delivered text + follow-up
```

## Validation

### Completed on `bb3db74f`

- [x] `cargo fmt --all -- --check`
- [x] `git diff --check`
- [x] `./scripts/check-file-size.sh`
- [x] `cargo test -p moltis-channels registry::tests::typed_resolution_distinguishes_missing_and_unknown_channel_types -- --nocapture` (1 passed)
- [x] `cargo test -p moltis-gateway --no-default-features --features whatsapp server::tests_legacy::cron -- --nocapture` (15 passed with the real WhatsApp integration compiled)
- [x] `cargo test -p moltis-gateway --no-default-features server::tests_legacy::cron -- --nocapture` (15 passed)
- [x] `cargo clippy -p moltis-channels --all-targets --no-deps`
- [x] `cargo clippy -p moltis-gateway --no-default-features --lib --tests --no-deps`
- [x] `./scripts/local-validate.sh 1243` (all 15 local statuses published successfully; auxiliary, formatting, TypeScript, security workflow, WASM, no-default build, and cron tests passed)

Coverage includes model-history conversion, bare WhatsApp number normalization, duplicate invocation, failed delivery, failed local history writes, unbound destinations, exact recipient isolation, stale bindings, remapping to another recipient, remapping between two valid sessions for the same recipient, Telegram topic isolation, deterministic default sessions, and missing/unknown channel-type resolution.

### Environment-limited gates

- [ ] Strict default-feature lint / `just lint` — the native model backend requires `libclang` and the all-features gate additionally requires the CUDA Toolkit / `nvcc`; neither is installed on this Linux host. The scoped clippy gates above passed.
- [ ] `just release-preflight` — reaches the same native-toolchain requirements through `just lint`; expected to run in equipped CI.
- [ ] Hosted CI — GitHub reports `action_required` because this pull request comes from a fork; a Moltis maintainer must approve the workflow. No CI job has failed.

## Security and failure behavior

- History lookup and both validations require an exact account, chat, and thread match.
- A send failure writes no history; a history failure does not retry an already delivered external message.
- A missing, stale, unknown, or concurrently changed binding writes to no session.
- Only the final text already delivered to the channel is persisted; isolated cron prompts, tool calls, and private context are not copied.

## Manual QA

- Automated channel doubles verified the complete send-then-persist behavior without sending a real external message.
- Live WhatsApp delivery was not run locally because it would mutate the connected account. To verify manually, run an isolated cron targeting an already bound WhatsApp chat, then reply in that chat with a question referring to a detail from the scheduled answer; the model should answer using that delivered text as context.
