### PR TITLE
Fix Fastmail MCP OAuth scope registration

### DIFF
--- a/crates/mcp/src/auth.rs
+++ b/crates/mcp/src/auth.rs
@@ -434,9 +434,10 @@ impl McpOAuthProvider {
 
         // Step 2: Get AS metadata — either from resource metadata's
         // authorization_servers list, or directly from the server's origin.
-        let (as_meta, resource) = match resource_meta_result {
+        let (as_meta, resource, resource_scopes) = match resource_meta_result {
             Ok(resource_meta) => {
                 let resource = resource_meta.resource.clone();
+                let scopes = resource_meta.scopes_supported;
                 let as_url_str = resource_meta
                     .authorization_servers
                     .first()
@@ -446,7 +447,7 @@ impl McpOAuthProvider {
                 let as_meta = fetch_as_metadata(&self.http_client, &as_url)
                     .await
                     .context("failed to fetch authorization server metadata")?;
-                (as_meta, resource)
+                (as_meta, resource, scopes)
             },
             Err(e) => {
                 debug!(
@@ -481,8 +482,13 @@ impl McpOAuthProvider {
                 // When resource metadata is unavailable we fall back to origin
                 // as the resource indicator to avoid path-scoped audience mismatches.
                 let resource = Self::origin_resource(&server_url);
-                (as_meta, resource)
+                (as_meta, resource, Vec::new())
             },
+        };
+        let scopes = if resource_scopes.is_empty() {
+            as_meta.scopes_supported.clone()
+        } else {
+            resource_scopes
         };
 
         debug!(
@@ -515,6 +521,7 @@ impl McpOAuthProvider {
                 reg_endpoint,
                 vec![redirect_uri.to_string()],
                 &format!("moltis ({})", self.server_name),
+                &scopes,
             )
             .await
             .context("failed to register OAuth client")?;
@@ -547,7 +554,7 @@ impl McpOAuthProvider {
             client_secret,
             as_meta.authorization_endpoint,
             as_meta.token_endpoint,
-            as_meta.scopes_supported,
+            scopes,
             resource,
         ))
     }
@@ -1046,6 +1053,115 @@ mod tests {
             .unwrap();
 
         assert_eq!(client_id, "client-redirect");
+        resource_meta.assert_async().await;
+        as_meta.assert_async().await;
+        register.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn fastmail_oauth_registers_and_requests_resource_scopes() {
+        let mut server = mockito::Server::new_async().await;
+        let base = server.url();
+        let redirect_uri = "http://localhost:43123/auth/callback";
+        let mcp_scope = "https://www.fastmail.com/dev/mcp";
+
+        let resource_meta = server
+            .mock("GET", "/mcp/.well-known/oauth-protected-resource")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                serde_json::json!({
+                    "resource": format!("{base}/mcp"),
+                    "authorization_servers": [base.clone()],
+                    "scopes_supported": [mcp_scope, "offline_access"],
+                    "bearer_methods_supported": ["header"],
+                    "resource_name": "Fastmail MCP API",
+                })
+                .to_string(),
+            )
+            .create_async()
+            .await;
+
+        let as_meta = server
+            .mock("GET", "/.well-known/oauth-authorization-server")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                serde_json::json!({
+                    "issuer": base.clone(),
+                    "registration_endpoint": format!("{base}/oauth/register"),
+                    "authorization_endpoint": format!("{base}/oauth/authorize"),
+                    "token_endpoint": format!("{base}/oauth/refresh"),
+                    "scopes_supported": [
+                        "urn:ietf:params:oauth:scope:mail",
+                        "urn:ietf:params:oauth:scope:contacts",
+                        "urn:ietf:params:oauth:scope:calendars",
+                        mcp_scope,
+                        "openid",
+                        "profile",
+                        "email",
+                        "offline_access",
+                    ],
+                    "response_types_supported": ["code"],
+                    "grant_types_supported": ["authorization_code", "refresh_token"],
+                    "token_endpoint_auth_methods_supported": ["none"],
+                    "code_challenge_methods_supported": ["S256"],
+                })
+                .to_string(),
+            )
+            .create_async()
+            .await;
+
+        let register = server
+            .mock("POST", "/oauth/register")
+            .match_body(Matcher::PartialJson(serde_json::json!({
+                "redirect_uris": [redirect_uri],
+                "scope": format!("{mcp_scope} offline_access"),
+            })))
+            .with_status(201)
+            .with_header("content-type", "application/json")
+            .with_body(
+                serde_json::json!({
+                    "client_id": "fastmail-client",
+                    "scope": format!("{mcp_scope} offline_access"),
+                    // Fastmail canonicalizes port-bearing loopback registrations.
+                    "redirect_uris": ["http://localhost/auth/callback"],
+                })
+                .to_string(),
+            )
+            .create_async()
+            .await;
+
+        let dir = tempfile::tempdir().unwrap();
+        let provider = McpOAuthProvider::with_stores(
+            "fastmail",
+            &format!("{base}/mcp"),
+            TokenStore::with_path(dir.path().join("tokens.json")),
+            RegistrationStore::with_path(dir.path().join("registrations.json")),
+        );
+
+        let auth_url = provider
+            .start_web_oauth_flow(redirect_uri, None)
+            .await
+            .unwrap();
+        let parsed = Url::parse(&auth_url).unwrap();
+        let params = parsed
+            .query_pairs()
+            .collect::<std::collections::HashMap<_, _>>();
+
+        assert_eq!(
+            params.get("scope").map(|value| value.as_ref()),
+            Some(format!("{mcp_scope} offline_access").as_str()),
+        );
+        assert_eq!(
+            params.get("redirect_uri").map(|value| value.as_ref()),
+            Some(redirect_uri),
+        );
+        assert_eq!(
+            params.get("resource").map(|value| value.as_ref()),
+            Some(format!("{base}/mcp").as_str()),
+        );
+
         resource_meta.assert_async().await;
         as_meta.assert_async().await;
         register.assert_async().await;

--- a/crates/oauth/src/discovery.rs
+++ b/crates/oauth/src/discovery.rs
@@ -163,6 +163,8 @@ pub struct ClientRegistrationRequest {
     pub grant_types: Vec<String>,
     pub response_types: Vec<String>,
     pub token_endpoint_auth_method: String,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub scope: String,
 }
 
 /// Successful registration response.
@@ -185,6 +187,7 @@ pub async fn register_client(
     registration_endpoint: &str,
     redirect_uris: Vec<String>,
     client_name: &str,
+    scopes: &[String],
 ) -> Result<ClientRegistrationResponse> {
     debug!(endpoint = %registration_endpoint, client_name, "registering dynamic OAuth client");
 
@@ -197,6 +200,7 @@ pub async fn register_client(
         ],
         response_types: vec!["code".to_string()],
         token_endpoint_auth_method: "none".to_string(),
+        scope: scopes.join(" "),
     };
 
     let resp = client
@@ -274,6 +278,8 @@ fn build_well_known_url(base: &Url, suffix: &str) -> Result<Url> {
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 #[cfg(test)]
 mod tests {
+    use mockito::Matcher;
+
     use super::*;
 
     // ── WWW-Authenticate parsing ───────────────────────────────────────
@@ -460,6 +466,9 @@ mod tests {
         let mut server = mockito::Server::new_async().await;
         let mock = server
             .mock("POST", "/register")
+            .match_body(Matcher::PartialJson(serde_json::json!({
+                "scope": "read write",
+            })))
             .with_status(201)
             .with_header("content-type", "application/json")
             .with_body(
@@ -480,6 +489,7 @@ mod tests {
             &format!("{}/register", server.url()),
             vec!["http://127.0.0.1:9999/auth/callback".to_string()],
             "moltis-test",
+            &["read".to_string(), "write".to_string()],
         )
         .await
         .unwrap();
@@ -512,6 +522,7 @@ mod tests {
             &format!("{}/register", server.url()),
             vec!["http://127.0.0.1:9999/auth/callback".to_string()],
             "moltis",
+            &[],
         )
         .await
         .unwrap();
@@ -536,6 +547,7 @@ mod tests {
             &format!("{}/register", server.url()),
             vec!["http://127.0.0.1:9999/auth/callback".to_string()],
             "moltis",
+            &[],
         )
         .await;
 


### PR DESCRIPTION
## Summary

- prefer protected-resource scopes over the authorization server's broader scope catalog during MCP OAuth discovery
- include the selected scopes in RFC 7591 dynamic client registration
- add a Fastmail-shaped regression test covering resource discovery, registration, localhost redirect canonicalization, and authorization parameters

Addresses the OAuth portion of #1115. The separate stale streamable-HTTP session behavior reported there is tracked independently.

## Validation

### Completed

- [x] `cargo test -p moltis-oauth`
- [x] `cargo test -p moltis-mcp auth::tests`
- [x] `cargo clippy -p moltis-oauth -p moltis-mcp --all-targets -- -D warnings`
- [x] `just release-preflight`
- [x] Verified Fastmail's production protected-resource and authorization-server metadata endpoints
- [x] Verified Fastmail's production dynamic registration accepts the scoped request and its authorization endpoint redirects to the login flow

### Remaining

- [ ] Complete the browser authorization and token exchange with a Fastmail account; Fastmail does not document a public staging environment

## Manual QA

1. Add `https://api.fastmail.com/mcp` as a streamable HTTP MCP server.
2. Start or re-start OAuth authorization.
3. Confirm Fastmail opens its login/consent flow without a registration error.
4. Complete authorization and confirm the Fastmail MCP tools become available.
