### PR TITLE
fix(sandbox): drop DMI sysfs masks on arm64 Docker daemons

### DIFF
--- a/crates/tools/src/sandbox/docker.rs
+++ b/crates/tools/src/sandbox/docker.rs
@@ -1329,6 +1329,17 @@ pub(crate) enum DaemonArch {
     Unknown,
 }
 
+/// Parse the trimmed stdout of `docker info --format {{.Architecture}}`.
+/// Split out from `docker_daemon_arch` so the parsing logic is unit-testable
+/// without shelling out to a real `docker` binary.
+pub(crate) fn parse_docker_daemon_arch(output: &str) -> DaemonArch {
+    match output.trim().to_lowercase().as_str() {
+        "x86_64" | "amd64" => DaemonArch::X86_64,
+        "aarch64" | "arm64" => DaemonArch::Arm64,
+        _ => DaemonArch::Unknown,
+    }
+}
+
 /// Query the Docker daemon's architecture via `docker info`. Never panics;
 /// returns `Unknown` on any failure (docker missing, non-UTF8 output, etc.).
 pub(crate) fn docker_daemon_arch() -> DaemonArch {
@@ -1338,32 +1349,42 @@ pub(crate) fn docker_daemon_arch() -> DaemonArch {
     else {
         return DaemonArch::Unknown;
     };
-    match String::from_utf8_lossy(&output.stdout)
-        .trim()
-        .to_lowercase()
-        .as_str()
-    {
-        "x86_64" | "amd64" => DaemonArch::X86_64,
-        "aarch64" | "arm64" => DaemonArch::Arm64,
-        _ => DaemonArch::Unknown,
-    }
+    parse_docker_daemon_arch(&String::from_utf8_lossy(&output.stdout))
 }
 
+/// Cached daemon architecture. `Unknown` is deliberately never cached: it
+/// usually means the daemon wasn't reachable yet (e.g. Docker Desktop still
+/// starting), and caching it would permanently downgrade masking for every
+/// later sandbox even after the daemon comes up as a confirmed x86_64 host.
+/// A confirmed X86_64/Arm64 result is cached forever — the daemon's
+/// architecture cannot change during the process's lifetime.
+fn cached_docker_daemon_arch() -> DaemonArch {
+    static ARCH: OnceLock<DaemonArch> = OnceLock::new();
+    if let Some(arch) = ARCH.get() {
+        return *arch;
+    }
+    let arch = docker_daemon_arch();
+    if arch != DaemonArch::Unknown {
+        let _ = ARCH.set(arch);
+    }
+    arch
+}
+
+/// Not cached as a whole: the Linux branch is a cheap local-filesystem probe
+/// (safe and fine to repeat), and the non-Linux branch defers to
+/// `cached_docker_daemon_arch`, which already caches the one part that's
+/// actually expensive (the `docker info` subprocess) — see its doc comment
+/// for why a failed probe must not be cached.
 pub(crate) fn sysfs_paths_to_mask() -> Vec<&'static str> {
-    static PATHS: OnceLock<Vec<&'static str>> = OnceLock::new();
-    PATHS
-        .get_or_init(|| {
-            let paths = sysfs_paths_to_mask_from("/sys", docker_daemon_arch);
-            let skipped = SYSFS_MASK_PATHS.len() - paths.len();
-            if skipped > 0 {
-                warn!(
-                    skipped,
-                    "some sysfs mask paths do not exist on this host/daemon and will be skipped"
-                );
-            }
-            paths
-        })
-        .clone()
+    let paths = sysfs_paths_to_mask_from("/sys", cached_docker_daemon_arch);
+    let skipped = SYSFS_MASK_PATHS.len() - paths.len();
+    if skipped > 0 {
+        warn!(
+            skipped,
+            "some sysfs mask paths do not exist on this host/daemon and will be skipped"
+        );
+    }
+    paths
 }
 
 /// Testable inner helper: probes each `SYSFS_MASK_PATHS` entry and returns

--- a/crates/tools/src/sandbox/docker.rs
+++ b/crates/tools/src/sandbox/docker.rs
@@ -1301,9 +1301,13 @@ impl Sandbox for NoSandbox {
 /// mountpoints on the read-only sysfs.  We probe each path and only mount
 /// the ones that actually exist.
 ///
-/// On non-Linux hosts (macOS), Docker Desktop runs in a Linux VM with full
-/// sysfs, so all paths are included unconditionally — the host `/sys` layout
-/// is irrelevant.
+/// On non-Linux hosts (macOS), Docker Desktop runs in a Linux VM and the host
+/// `/sys` layout is irrelevant — but the VM's sysfs is not guaranteed to have
+/// every path either.  `/sys/class/dmi` and `/sys/devices/virtual/dmi` are
+/// x86 SMBIOS-only: an arm64 VM (the default on Apple Silicon) doesn't have
+/// them, and the mkdirat failure above happens there too (#1085).  We ask the
+/// daemon for its actual architecture and drop the DMI paths when it isn't
+/// x86_64.
 pub(crate) const SYSFS_MASK_PATHS: &[&str] = &[
     "/sys/firmware",
     "/sys/class/dmi",
@@ -1311,16 +1315,50 @@ pub(crate) const SYSFS_MASK_PATHS: &[&str] = &[
     "/sys/class/block",
 ];
 
+/// Architecture of the Docker daemon actually running containers — not the
+/// host's, since Docker Desktop runs a VM that can differ (and on macOS the
+/// host has no `/sys` to probe at all).
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(crate) enum DaemonArch {
+    X86_64,
+    Arm64,
+    /// `docker info` failed or returned something unrecognized. Treated the
+    /// same as Arm64: masking fewer paths only weakens isolation slightly,
+    /// while assuming x86_64 on an arm64 daemon breaks sandbox startup
+    /// outright, which is the worse failure mode.
+    Unknown,
+}
+
+/// Query the Docker daemon's architecture via `docker info`. Never panics;
+/// returns `Unknown` on any failure (docker missing, non-UTF8 output, etc.).
+pub(crate) fn docker_daemon_arch() -> DaemonArch {
+    let Ok(output) = std::process::Command::new("docker")
+        .args(["info", "--format", "{{.Architecture}}"])
+        .output()
+    else {
+        return DaemonArch::Unknown;
+    };
+    match String::from_utf8_lossy(&output.stdout)
+        .trim()
+        .to_lowercase()
+        .as_str()
+    {
+        "x86_64" | "amd64" => DaemonArch::X86_64,
+        "aarch64" | "arm64" => DaemonArch::Arm64,
+        _ => DaemonArch::Unknown,
+    }
+}
+
 pub(crate) fn sysfs_paths_to_mask() -> Vec<&'static str> {
     static PATHS: OnceLock<Vec<&'static str>> = OnceLock::new();
     PATHS
         .get_or_init(|| {
-            let paths = sysfs_paths_to_mask_from("/sys");
+            let paths = sysfs_paths_to_mask_from("/sys", docker_daemon_arch);
             let skipped = SYSFS_MASK_PATHS.len() - paths.len();
             if skipped > 0 {
                 warn!(
                     skipped,
-                    "some sysfs mask paths do not exist on this host and will be skipped"
+                    "some sysfs mask paths do not exist on this host/daemon and will be skipped"
                 );
             }
             paths
@@ -1330,12 +1368,22 @@ pub(crate) fn sysfs_paths_to_mask() -> Vec<&'static str> {
 
 /// Testable inner helper: probes each `SYSFS_MASK_PATHS` entry and returns
 /// only those that exist under `sysfs_root`.  If `sysfs_root` itself doesn't
-/// exist (macOS), all paths are returned — Docker Desktop's VM will have them.
-pub(crate) fn sysfs_paths_to_mask_from(sysfs_root: &str) -> Vec<&'static str> {
+/// exist (macOS), `detect_arch` decides which paths the Docker VM actually
+/// has: DMI paths are dropped unless the daemon is confirmed x86_64.
+pub(crate) fn sysfs_paths_to_mask_from(
+    sysfs_root: &str,
+    detect_arch: impl FnOnce() -> DaemonArch,
+) -> Vec<&'static str> {
     let root = Path::new(sysfs_root);
     if !root.exists() {
-        // Non-Linux host (macOS): Docker runs in a VM with full sysfs.
-        return SYSFS_MASK_PATHS.to_vec();
+        // Non-Linux host (macOS): Docker runs in a VM, so probe the daemon's
+        // reported architecture instead of a host sysfs that doesn't exist.
+        let is_x86 = detect_arch() == DaemonArch::X86_64;
+        return SYSFS_MASK_PATHS
+            .iter()
+            .copied()
+            .filter(|p| is_x86 || !p.contains("dmi"))
+            .collect();
     }
     SYSFS_MASK_PATHS
         .iter()

--- a/crates/tools/src/sandbox/tests/core.rs
+++ b/crates/tools/src/sandbox/tests/core.rs
@@ -388,6 +388,32 @@ fn test_sysfs_mask_paths_constant_contains_expected_entries() {
 }
 
 #[test]
+fn test_parse_docker_daemon_arch_recognizes_x86_64() {
+    assert_eq!(parse_docker_daemon_arch("x86_64"), DaemonArch::X86_64);
+    assert_eq!(parse_docker_daemon_arch("amd64"), DaemonArch::X86_64);
+    // docker info's output is newline-terminated and can vary in case.
+    assert_eq!(parse_docker_daemon_arch("X86_64\n"), DaemonArch::X86_64);
+    assert_eq!(parse_docker_daemon_arch("  amd64  \n"), DaemonArch::X86_64);
+}
+
+#[test]
+fn test_parse_docker_daemon_arch_recognizes_arm64() {
+    assert_eq!(parse_docker_daemon_arch("aarch64"), DaemonArch::Arm64);
+    assert_eq!(parse_docker_daemon_arch("arm64"), DaemonArch::Arm64);
+    assert_eq!(parse_docker_daemon_arch("ARM64\n"), DaemonArch::Arm64);
+}
+
+#[test]
+fn test_parse_docker_daemon_arch_unrecognized_output_is_unknown() {
+    assert_eq!(parse_docker_daemon_arch(""), DaemonArch::Unknown);
+    assert_eq!(parse_docker_daemon_arch("armv7l"), DaemonArch::Unknown);
+    assert_eq!(
+        parse_docker_daemon_arch("Error: Cannot connect to the Docker daemon"),
+        DaemonArch::Unknown
+    );
+}
+
+#[test]
 fn test_workspace_mount_display() {
     assert_eq!(WorkspaceMount::None.to_string(), "none");
     assert_eq!(WorkspaceMount::Ro.to_string(), "ro");

--- a/crates/tools/src/sandbox/tests/core.rs
+++ b/crates/tools/src/sandbox/tests/core.rs
@@ -36,14 +36,13 @@ fn test_docker_hardening_args_prebuilt() {
         "sandbox",
         "--hostname value should be 'sandbox'"
     );
-    // Sysfs masks are present (actual set depends on host — macOS includes
-    // all because /sys doesn't exist; Linux includes only existing paths).
-    // On macOS CI all four are present.
+    // Sysfs masks: the exact set is host/daemon-dependent (see the dedicated
+    // sysfs_paths_to_mask_from tests for the DMI/arch logic), but
+    // /sys/firmware and /sys/class/block are never arch-conditional and
+    // must always be present on non-Linux hosts.
     #[cfg(not(target_os = "linux"))]
     {
         assert!(args.contains(&"/sys/firmware:ro,nosuid".to_string()));
-        assert!(args.contains(&"/sys/class/dmi:ro,nosuid".to_string()));
-        assert!(args.contains(&"/sys/devices/virtual/dmi:ro,nosuid".to_string()));
         assert!(args.contains(&"/sys/class/block:ro,nosuid".to_string()));
     }
 }
@@ -69,11 +68,13 @@ fn test_docker_hardening_args_not_prebuilt() {
         "sandbox",
         "--hostname value should be 'sandbox'"
     );
+    // Sysfs masks: the exact set is host/daemon-dependent (see the dedicated
+    // sysfs_paths_to_mask_from tests for the DMI/arch logic), but
+    // /sys/firmware and /sys/class/block are never arch-conditional and
+    // must always be present on non-Linux hosts.
     #[cfg(not(target_os = "linux"))]
     {
         assert!(args.contains(&"/sys/firmware:ro,nosuid".to_string()));
-        assert!(args.contains(&"/sys/class/dmi:ro,nosuid".to_string()));
-        assert!(args.contains(&"/sys/devices/virtual/dmi:ro,nosuid".to_string()));
         assert!(args.contains(&"/sys/class/block:ro,nosuid".to_string()));
     }
 }
@@ -326,16 +327,35 @@ fn test_docker_run_error_does_not_get_podman_context() {
 }
 
 #[test]
-fn test_sysfs_paths_to_mask_no_sysfs_root_returns_all() {
-    // When /sys doesn't exist (macOS), all paths should be returned because
-    // Docker Desktop runs in a Linux VM with full sysfs.
-    let paths = sysfs_paths_to_mask_from("/nonexistent/sysfs/root");
+fn test_sysfs_paths_to_mask_no_sysfs_root_x86_returns_all() {
+    // When /sys doesn't exist (macOS) and the daemon is confirmed x86_64,
+    // all paths should be returned — DMI is a real x86 SMBIOS feature there.
+    let paths = sysfs_paths_to_mask_from("/nonexistent/sysfs/root", || DaemonArch::X86_64);
     assert_eq!(paths, vec![
         "/sys/firmware",
         "/sys/class/dmi",
         "/sys/devices/virtual/dmi",
         "/sys/class/block",
     ]);
+}
+
+#[test]
+fn test_sysfs_paths_to_mask_no_sysfs_root_arm_drops_dmi() {
+    // When /sys doesn't exist (macOS) and the daemon is arm64 (default
+    // Docker Desktop VM on Apple Silicon), DMI paths must be dropped:
+    // DMI is x86-only and mounting it fails with a read-only-sysfs error
+    // that prevents the sandbox from starting at all (#1085).
+    let paths = sysfs_paths_to_mask_from("/nonexistent/sysfs/root", || DaemonArch::Arm64);
+    assert_eq!(paths, vec!["/sys/firmware", "/sys/class/block"]);
+}
+
+#[test]
+fn test_sysfs_paths_to_mask_no_sysfs_root_unknown_arch_drops_dmi() {
+    // If we can't determine the daemon's architecture (docker missing,
+    // unexpected output), fail safe: drop DMI rather than risk the same
+    // mkdirat failure on an arm64 daemon we couldn't detect.
+    let paths = sysfs_paths_to_mask_from("/nonexistent/sysfs/root", || DaemonArch::Unknown);
+    assert_eq!(paths, vec!["/sys/firmware", "/sys/class/block"]);
 }
 
 #[test]
@@ -349,7 +369,10 @@ fn test_sysfs_paths_to_mask_filters_missing_paths() {
     std::fs::create_dir_all(sysfs_root.join("firmware")).unwrap();
     std::fs::create_dir_all(sysfs_root.join("class/block")).unwrap();
 
-    let paths = sysfs_paths_to_mask_from(sysfs_root.to_str().unwrap());
+    // detect_arch must not even be called when the sysfs root exists.
+    let paths = sysfs_paths_to_mask_from(sysfs_root.to_str().unwrap(), || {
+        panic!("detect_arch should not be called when sysfs_root exists")
+    });
     // Only the two paths that exist under the tempdir sysfs root are returned.
     assert_eq!(paths, vec!["/sys/firmware", "/sys/class/block"]);
 }


### PR DESCRIPTION
## Summary

Closes #1085.

`sysfs_paths_to_mask_from()` in `crates/tools/src/sandbox/docker.rs` treats a non-existent host `/sys` (macOS) as proof that Docker Desktop's VM has a full sysfs, and masks `/sys/class/dmi` + `/sys/devices/virtual/dmi` unconditionally in that branch. DMI is an x86 SMBIOS feature. On Apple Silicon, Docker Desktop's default VM is arm64 Linux and has no DMI nodes, so the tmpfs mount fails:

```
error mounting "tmpfs" to rootfs at "/sys/class/dmi": create mountpoint for
/sys/class/dmi mount: make mountpoint ".../sys/class/dmi": mkdirat
.../merged/sys/class/dmi: read-only file system
```

— exactly the error and root cause the reporter identified via `docker inspect`.

## Fix

Added `docker_daemon_arch()`, which asks the daemon directly (`docker info --format {{.Architecture}}`) rather than guessing from host OS. `sysfs_paths_to_mask_from()` now takes a `detect_arch` closure and, on the "no host sysfs to probe" branch, drops the two DMI-specific paths unless the daemon is confirmed `x86_64`. Unknown/undetectable architecture (docker missing, unexpected output) also drops DMI — failing toward "sandbox starts with slightly less masking" rather than "sandbox never starts," which is the worse failure mode.

`/sys/firmware` and `/sys/class/block` are untouched by this and still masked unconditionally on non-Linux hosts, same as before.

## Test plan

- Added 3 new tests covering the arch-aware branch: x86_64 daemon (all paths, unchanged behavior), arm64 daemon (drops DMI), unknown/undetectable arch (drops DMI, fails safe).
- Updated `test_sysfs_paths_to_mask_filters_missing_paths` to assert `detect_arch` is never called when a real sysfs root exists (Linux path is untouched by this change).
- Updated the two `hardening_args` macOS-branch assertions that previously hardcoded "all four sysfs paths present" — that assumption is what caused #1085, so those tests now only assert the arch-independent paths (`/sys/firmware`, `/sys/class/block`); the arch-conditional DMI behavior has its own dedicated tests above.
- `cargo test -p moltis-tools sandbox::tests::core`: all sysfs/hardening tests pass. (One unrelated, pre-existing flaky test — `test_podman_socket_validation_requires_live_unix_socket` — intermittently fails under parallel execution on `main` too, confirmed via `git stash`; unaffected by this diff.)
- `cargo fmt --check` and `cargo clippy -- -D warnings` both clean.