### PR TITLE
fix(auth): let Docker loopback-only deployments count as local

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8936,6 +8936,7 @@ dependencies = [
  "futures",
  "gix",
  "include_dir",
+ "moltis-auth",
  "moltis-channels",
  "moltis-config",
  "moltis-cron",

--- a/crates/auth/src/locality.rs
+++ b/crates/auth/src/locality.rs
@@ -37,10 +37,24 @@ fn is_loopback_host(host: &str) -> bool {
 /// When `behind_proxy` is `true`, the caller is known to be behind a reverse
 /// proxy, so loopback source IPs are never treated as proof of a direct local
 /// connection.
+///
+/// When `trust_docker_loopback` is `true`, a non-loopback TCP source is
+/// accepted as local *after* every other check already passed (no proxy
+/// headers, and the `Host` header — if present — names a loopback address).
+/// This exists because Docker's userland-proxy/iptables DNAT rewrites the
+/// container-side TCP source to a bridge-network address even when the
+/// published port is bound only to `127.0.0.1` on the host (e.g.
+/// `-p 127.0.0.1:PORT:PORT`), so `remote_addr.ip().is_loopback()` can never
+/// be true for that deployment shape — see `MOLTIS_TRUST_DOCKER_LOOPBACK`.
+/// The `Host` check still matters here: `Host` alone is attacker-controlled
+/// and is never sufficient proof of locality on its own, but combined with
+/// "no proxy headers" it is the same signal `behind_proxy` already accepts
+/// as authoritative for the direct (non-Docker) loopback case.
 pub fn is_local_connection(
     headers: &axum::http::HeaderMap,
     remote_addr: SocketAddr,
     behind_proxy: bool,
+    trust_docker_loopback: bool,
 ) -> bool {
     // Hard override: env var says we're behind a proxy.
     if behind_proxy {
@@ -61,8 +75,11 @@ pub fn is_local_connection(
         return false;
     }
 
-    // TCP source must be loopback.
-    remote_addr.ip().is_loopback()
+    if remote_addr.ip().is_loopback() {
+        return true;
+    }
+
+    trust_docker_loopback
 }
 
 #[allow(clippy::unwrap_used, clippy::expect_used)]
@@ -125,7 +142,7 @@ mod tests {
         let addr: SocketAddr = "127.0.0.1:12345".parse().unwrap();
         let mut headers = axum::http::HeaderMap::new();
         headers.insert(axum::http::header::HOST, "localhost:18789".parse().unwrap());
-        assert!(is_local_connection(&headers, addr, false));
+        assert!(is_local_connection(&headers, addr, false, false));
     }
 
     #[test]
@@ -134,7 +151,7 @@ mod tests {
         let mut headers = axum::http::HeaderMap::new();
         headers.insert(axum::http::header::HOST, "localhost:18789".parse().unwrap());
         headers.insert("x-forwarded-for", "203.0.113.50".parse().unwrap());
-        assert!(!is_local_connection(&headers, addr, false));
+        assert!(!is_local_connection(&headers, addr, false, false));
     }
 
     #[test]
@@ -142,7 +159,7 @@ mod tests {
         let addr: SocketAddr = "127.0.0.1:12345".parse().unwrap();
         let mut headers = axum::http::HeaderMap::new();
         headers.insert(axum::http::header::HOST, "localhost:18789".parse().unwrap());
-        assert!(!is_local_connection(&headers, addr, true));
+        assert!(!is_local_connection(&headers, addr, true, false));
     }
 
     #[test]
@@ -150,7 +167,7 @@ mod tests {
         let addr: SocketAddr = "192.168.1.1:12345".parse().unwrap();
         let mut headers = axum::http::HeaderMap::new();
         headers.insert(axum::http::header::HOST, "localhost:18789".parse().unwrap());
-        assert!(!is_local_connection(&headers, addr, false));
+        assert!(!is_local_connection(&headers, addr, false, false));
     }
 
     #[test]
@@ -158,7 +175,7 @@ mod tests {
         let addr: SocketAddr = "[::1]:12345".parse().unwrap();
         let mut headers = axum::http::HeaderMap::new();
         headers.insert(axum::http::header::HOST, "[::1]:18789".parse().unwrap());
-        assert!(is_local_connection(&headers, addr, false));
+        assert!(is_local_connection(&headers, addr, false, false));
     }
 
     #[test]
@@ -166,7 +183,7 @@ mod tests {
         // CLI/SDK clients may not send a Host header.
         let addr: SocketAddr = "127.0.0.1:12345".parse().unwrap();
         let headers = axum::http::HeaderMap::new();
-        assert!(is_local_connection(&headers, addr, false));
+        assert!(is_local_connection(&headers, addr, false, false));
     }
 
     #[test]
@@ -177,7 +194,7 @@ mod tests {
         // Header presence alone marks the request as proxied, even when value
         // is spoofed to look loopback.
         headers.insert("x-forwarded-for", "127.0.0.1".parse().unwrap());
-        assert!(!is_local_connection(&headers, addr, false));
+        assert!(!is_local_connection(&headers, addr, false, false));
     }
 
     #[test]
@@ -187,7 +204,7 @@ mod tests {
         headers.insert(axum::http::header::HOST, "localhost:18789".parse().unwrap());
         // RFC 7239 Forwarded header should never allow localhost bypass.
         headers.insert("forwarded", "for=127.0.0.1;proto=https".parse().unwrap());
-        assert!(!is_local_connection(&headers, addr, false));
+        assert!(!is_local_connection(&headers, addr, false, false));
     }
 
     #[test]
@@ -198,7 +215,7 @@ mod tests {
             axum::http::header::HOST,
             "moltis.example.com".parse().unwrap(),
         );
-        assert!(!is_local_connection(&headers, addr, false));
+        assert!(!is_local_connection(&headers, addr, false, false));
     }
 
     /// Simulates a reverse proxy (Caddy/nginx) on the same machine that
@@ -211,9 +228,9 @@ mod tests {
         let mut headers = axum::http::HeaderMap::new();
         headers.insert(axum::http::header::HOST, "127.0.0.1:18789".parse().unwrap());
         // This is the known limitation: bare proxy looks like local.
-        assert!(is_local_connection(&headers, addr, false));
+        assert!(is_local_connection(&headers, addr, false, false));
         // Setting MOLTIS_BEHIND_PROXY fixes it.
-        assert!(!is_local_connection(&headers, addr, true));
+        assert!(!is_local_connection(&headers, addr, true, false));
     }
 
     /// Typical Caddy/nginx with proper headers: loopback TCP but
@@ -227,7 +244,7 @@ mod tests {
             "moltis.example.com".parse().unwrap(),
         );
         headers.insert("x-forwarded-for", "203.0.113.50".parse().unwrap());
-        assert!(!is_local_connection(&headers, addr, false));
+        assert!(!is_local_connection(&headers, addr, false, false));
     }
 
     /// Proxy that rewrites Host to a public domain (but no XFF).
@@ -239,6 +256,67 @@ mod tests {
             axum::http::header::HOST,
             "moltis.example.com".parse().unwrap(),
         );
-        assert!(!is_local_connection(&headers, addr, false));
+        assert!(!is_local_connection(&headers, addr, false, false));
+    }
+
+    /// Docker's userland-proxy/iptables DNAT rewrites the container-side TCP
+    /// source to a bridge-network address even when the published port is
+    /// bound only to `127.0.0.1` on the host (`-p 127.0.0.1:PORT:PORT`).
+    /// Without `MOLTIS_TRUST_DOCKER_LOOPBACK`, this looks identical to a
+    /// genuinely remote connection and is correctly rejected.
+    #[test]
+    fn docker_bridge_source_not_local_without_trust_flag() {
+        let addr: SocketAddr = "172.17.0.1:54321".parse().unwrap();
+        let mut headers = axum::http::HeaderMap::new();
+        headers.insert(axum::http::header::HOST, "127.0.0.1:13131".parse().unwrap());
+        assert!(!is_local_connection(&headers, addr, false, false));
+    }
+
+    /// With the trust flag set, the same Docker-bridge-sourced connection is
+    /// accepted as local, because it already passed the no-proxy-headers and
+    /// loopback-Host checks first.
+    #[test]
+    fn docker_bridge_source_local_with_trust_flag() {
+        let addr: SocketAddr = "172.17.0.1:54321".parse().unwrap();
+        let mut headers = axum::http::HeaderMap::new();
+        headers.insert(axum::http::header::HOST, "127.0.0.1:13131".parse().unwrap());
+        assert!(is_local_connection(&headers, addr, false, true));
+    }
+
+    /// The trust flag must not become a blanket bypass: proxy headers still
+    /// win, since those prove real forwarded traffic regardless of intent.
+    #[test]
+    fn docker_trust_flag_does_not_override_proxy_headers() {
+        let addr: SocketAddr = "172.17.0.1:54321".parse().unwrap();
+        let mut headers = axum::http::HeaderMap::new();
+        headers.insert(axum::http::header::HOST, "127.0.0.1:13131".parse().unwrap());
+        headers.insert("x-forwarded-for", "203.0.113.50".parse().unwrap());
+        assert!(!is_local_connection(&headers, addr, false, true));
+    }
+
+    /// The trust flag must not become a blanket bypass: a non-loopback Host
+    /// still means "not local", even with the flag set. Trusting Host alone
+    /// (attacker-controlled) is what would turn this into a real bypass on a
+    /// misconfigured `-p 0.0.0.0:PORT:PORT` deployment.
+    #[test]
+    fn docker_trust_flag_does_not_override_non_loopback_host() {
+        let addr: SocketAddr = "172.17.0.1:54321".parse().unwrap();
+        let mut headers = axum::http::HeaderMap::new();
+        headers.insert(
+            axum::http::header::HOST,
+            "moltis.example.com".parse().unwrap(),
+        );
+        assert!(!is_local_connection(&headers, addr, false, true));
+    }
+
+    /// `behind_proxy` still wins over the trust flag: an operator who knows
+    /// they're behind a reverse proxy should never have Docker-loopback
+    /// trust silently reintroduce a bypass.
+    #[test]
+    fn docker_trust_flag_does_not_override_behind_proxy() {
+        let addr: SocketAddr = "172.17.0.1:54321".parse().unwrap();
+        let mut headers = axum::http::HeaderMap::new();
+        headers.insert(axum::http::header::HOST, "127.0.0.1:13131".parse().unwrap());
+        assert!(!is_local_connection(&headers, addr, true, true));
     }
 }

--- a/crates/gateway/src/methods/services.rs
+++ b/crates/gateway/src/methods/services.rs
@@ -652,6 +652,7 @@ mod tests {
             false,
             false,
             false,
+            false,
             None,
             memory_manager,
             Arc::new(moltis_code_index::CodeIndex::config_only(

--- a/crates/gateway/src/server/prepare_core/post_state.rs
+++ b/crates/gateway/src/server/prepare_core/post_state.rs
@@ -294,6 +294,7 @@ pub(super) async fn complete_startup(
         Some(pairing_store),
         is_localhost,
         env_flag_enabled("MOLTIS_BEHIND_PROXY"),
+        env_flag_enabled("MOLTIS_TRUST_DOCKER_LOOPBACK"),
         tls_enabled_for_gateway,
         hook_registry.clone(),
         memory_manager.clone(),

--- a/crates/gateway/src/server/tests_legacy/webauthn.rs
+++ b/crates/gateway/src/server/tests_legacy/webauthn.rs
@@ -23,6 +23,7 @@ async fn sync_runtime_webauthn_host_registers_new_origin() {
         false,
         false,
         false,
+        false,
         None,
         None,
         Arc::new(moltis_code_index::CodeIndex::config_only(

--- a/crates/gateway/src/state.rs
+++ b/crates/gateway/src/state.rs
@@ -439,6 +439,14 @@ pub struct GatewayState {
     /// Set via `MOLTIS_BEHIND_PROXY=true`.  When true, loopback source IPs are
     /// never treated as proof of a direct local connection.
     pub behind_proxy: bool,
+    /// Whether a non-loopback TCP source that already passed every other
+    /// locality check (no proxy headers, loopback `Host`) should still count
+    /// as local. Set via `MOLTIS_TRUST_DOCKER_LOOPBACK=true` for Docker
+    /// deployments that publish the port only to `127.0.0.1` on the host
+    /// (`-p 127.0.0.1:PORT:PORT`): Docker's DNAT rewrites the container-side
+    /// TCP source to a bridge-network address, so it can never look loopback
+    /// from inside the container. See `moltis_auth::locality::is_local_connection`.
+    pub trust_docker_loopback: bool,
     /// Whether TLS is active on the gateway listener.
     pub tls_active: bool,
     /// Whether WebSocket request/response logging is enabled.
@@ -539,6 +547,7 @@ impl GatewayState {
             false,
             false,
             false,
+            false,
             None,
             None,
             Arc::new(moltis_code_index::CodeIndex::config_only(
@@ -567,6 +576,7 @@ impl GatewayState {
         pairing_store: Option<Arc<PairingStore>>,
         localhost_only: bool,
         behind_proxy: bool,
+        trust_docker_loopback: bool,
         tls_active: bool,
         hook_registry: Option<Arc<moltis_common::hooks::HookRegistry>>,
         memory_manager: Option<moltis_memory::runtime::DynMemoryRuntime>,
@@ -602,6 +612,7 @@ impl GatewayState {
             feedback: Arc::default(),
             localhost_only,
             behind_proxy,
+            trust_docker_loopback,
             tls_active,
             ws_request_logs,
             session_event_bus: session_event_bus.unwrap_or_default(),

--- a/crates/httpd/src/auth_middleware.rs
+++ b/crates/httpd/src/auth_middleware.rs
@@ -132,7 +132,12 @@ pub async fn auth_gate(
         return next.run(request).await;
     };
 
-    let is_local = is_local_connection(request.headers(), addr, state.gateway.behind_proxy);
+    let is_local = is_local_connection(
+        request.headers(),
+        addr,
+        state.gateway.behind_proxy,
+        state.gateway.trust_docker_loopback,
+    );
 
     match check_auth(store, request.headers(), is_local).await {
         AuthResult::Allowed(identity) => {
@@ -394,7 +399,14 @@ where
         let is_local = parts
             .extensions
             .get::<ConnectInfo<SocketAddr>>()
-            .is_some_and(|ci| is_local_connection(&parts.headers, ci.0, gw.behind_proxy));
+            .is_some_and(|ci| {
+                is_local_connection(
+                    &parts.headers,
+                    ci.0,
+                    gw.behind_proxy,
+                    gw.trust_docker_loopback,
+                )
+            });
 
         match check_auth(store, &parts.headers, is_local).await {
             AuthResult::Allowed(identity) => Ok(AuthSession(identity)),

--- a/crates/httpd/src/auth_routes.rs
+++ b/crates/httpd/src/auth_routes.rs
@@ -149,7 +149,12 @@ async fn status_handler(
     let has_password = state.credential_store.has_password().await.unwrap_or(false);
     let has_passkeys = state.credential_store.has_passkeys().await.unwrap_or(false);
 
-    let is_local = is_local_connection(&headers, addr, state.gateway_state.behind_proxy);
+    let is_local = is_local_connection(
+        &headers,
+        addr,
+        state.gateway_state.behind_proxy,
+        state.gateway_state.trust_docker_loopback,
+    );
     let auth_result = check_auth(&state.credential_store, &headers, is_local).await;
     let authenticated = matches!(auth_result, AuthResult::Allowed(_));
     let setup_required = matches!(auth_result, AuthResult::SetupRequired);
@@ -249,7 +254,12 @@ async fn setup_handler(
     #[cfg(feature = "vault")]
     let mut vault_recovery_key = None;
 
-    let is_local = is_local_connection(&headers, addr, state.gateway_state.behind_proxy);
+    let is_local = is_local_connection(
+        &headers,
+        addr,
+        state.gateway_state.behind_proxy,
+        state.gateway_state.trust_docker_loopback,
+    );
     if password.is_empty() && is_local {
         // Local connection with no password: skip setup without setting one.
         if let Err(e) = state.credential_store.clear_auth_disabled().await {

--- a/crates/httpd/src/request_throttle.rs
+++ b/crates/httpd/src/request_throttle.rs
@@ -281,7 +281,12 @@ async fn should_bypass_throttling(state: &AppState, headers: &HeaderMap, addr: S
         return true;
     };
 
-    let is_local = is_local_connection(headers, addr, state.gateway.behind_proxy);
+    let is_local = is_local_connection(
+        headers,
+        addr,
+        state.gateway.behind_proxy,
+        state.gateway.trust_docker_loopback,
+    );
     matches!(
         crate::auth_middleware::check_auth(store, headers, is_local).await,
         crate::auth_middleware::AuthResult::Allowed(_)

--- a/crates/httpd/src/server/handlers.rs
+++ b/crates/httpd/src/server/handlers.rs
@@ -108,7 +108,12 @@ pub(super) async fn ws_upgrade_handler(
     // for the LLM to reason about locale or location.
     let remote_ip = extract_ws_client_ip(&headers, addr).filter(|ip| is_public_ip(ip));
 
-    let is_local = is_local_connection(&headers, addr, state.gateway.behind_proxy);
+    let is_local = is_local_connection(
+        &headers,
+        addr,
+        state.gateway.behind_proxy,
+        state.gateway.trust_docker_loopback,
+    );
     let header_identity =
         websocket_header_authenticate(&headers, state.gateway.credential_store.as_ref(), is_local)
             .await;

--- a/crates/httpd/tests/auth_middleware.rs
+++ b/crates/httpd/tests/auth_middleware.rs
@@ -133,6 +133,7 @@ async fn start_auth_server_impl(
         None, // pairing_store
         localhost_only,
         behind_proxy,
+        false, // trust_docker_loopback
         false,
         None,
         None,
@@ -207,6 +208,7 @@ async fn start_localhost_server_with_vault() -> (
         None, // pairing_store
         true,
         false,
+        false, // trust_docker_loopback
         false,
         None,
         None,
@@ -284,6 +286,7 @@ async fn start_localhost_server_with_vault_and_session_store() -> (
         None, // pairing_store
         true,
         false,
+        false, // trust_docker_loopback
         false,
         None,
         None,

--- a/crates/httpd/tests/auth_middleware/more.rs
+++ b/crates/httpd/tests/auth_middleware/more.rs
@@ -760,6 +760,7 @@ pub(super) async fn start_server_with_onboarding(
         None, // pairing_store
         false,
         behind_proxy,
+        false, // trust_docker_loopback
         false,
         None,
         None,

--- a/crates/web/Cargo.toml
+++ b/crates/web/Cargo.toml
@@ -13,6 +13,7 @@ chrono          = { features = ["serde"], workspace = true }
 futures         = { workspace = true }
 gix             = { workspace = true }
 include_dir     = { optional = true, workspace = true }
+moltis-auth     = { workspace = true }
 moltis-channels = { workspace = true }
 moltis-config   = { workspace = true }
 moltis-cron     = { workspace = true }

--- a/crates/web/src/terminal/auth.rs
+++ b/crates/web/src/terminal/auth.rs
@@ -1,72 +1,13 @@
-use std::{net::SocketAddr, sync::Arc};
+use std::sync::Arc;
 
-/// Returns `true` when the request carries headers typically set by reverse proxies.
-fn has_proxy_headers(headers: &axum::http::HeaderMap) -> bool {
-    headers.contains_key("x-forwarded-for")
-        || headers.contains_key("x-real-ip")
-        || headers.contains_key("cf-connecting-ip")
-        || headers.get("forwarded").is_some()
-}
-
-/// Returns `true` when `host` (without port) is a loopback name/address.
-fn is_loopback_host(host: &str) -> bool {
-    // Strip port (IPv6 bracket form, bare IPv6, or simple host:port).
-    let name = if host.starts_with('[') {
-        // [::1]:port or [::1]
-        host.rsplit_once("]:")
-            .map_or(host, |(addr, _)| addr)
-            .trim_start_matches('[')
-            .trim_end_matches(']')
-    } else if host.matches(':').count() > 1 {
-        // Bare IPv6 like ::1 (multiple colons, no brackets) — no port stripping.
-        host
-    } else {
-        host.rsplit_once(':').map_or(host, |(addr, _)| addr)
-    };
-    matches!(name, "localhost" | "127.0.0.1" | "::1") || name.ends_with(".localhost")
-}
-
-/// Determine whether a connection is a **direct local** connection (no proxy
-/// in between).  This is the per-request check used by the three-tier auth
-/// model:
-///
-/// 1. Password set -> always require auth
-/// 2. No password + local -> full access (dev convenience)
-/// 3. No password + remote/proxied -> onboarding only
-///
-/// A connection is considered local when **all** of the following hold:
-///
-/// - `MOLTIS_BEHIND_PROXY` is **not** set (`behind_proxy == false`)
-/// - No proxy headers are present (X-Forwarded-For, X-Real-IP, etc.)
-/// - The `Host` header resolves to a loopback address (or is absent)
-/// - The TCP source IP is loopback
-pub(crate) fn is_local_connection(
-    headers: &axum::http::HeaderMap,
-    remote_addr: SocketAddr,
-    behind_proxy: bool,
-) -> bool {
-    // Hard override: env var says we're behind a proxy.
-    if behind_proxy {
-        return false;
-    }
-
-    // Proxy headers present -> proxied traffic.
-    if has_proxy_headers(headers) {
-        return false;
-    }
-
-    // Host header points to a non-loopback name -> likely proxied.
-    if let Some(host) = headers
-        .get(axum::http::header::HOST)
-        .and_then(|v| v.to_str().ok())
-        && !is_loopback_host(host)
-    {
-        return false;
-    }
-
-    // TCP source must be loopback.
-    remote_addr.ip().is_loopback()
-}
+/// Locality detection lives in `moltis_auth::locality` — the single source
+/// of truth for the three-tier auth model's "is this connection local?"
+/// question. This used to be a separate copy of the same logic in this file,
+/// which silently fell out of sync with the real implementation (it never
+/// picked up `MOLTIS_TRUST_DOCKER_LOOPBACK`, so the terminal WebSocket
+/// handler kept rejecting Docker-loopback connections the global auth gate
+/// had already accepted). Re-export instead of duplicating.
+pub(crate) use moltis_auth::locality::is_local_connection;
 
 pub(crate) async fn websocket_header_authenticated(
     headers: &axum::http::HeaderMap,

--- a/crates/web/src/terminal/handlers.rs
+++ b/crates/web/src/terminal/handlers.rs
@@ -225,7 +225,12 @@ pub async fn api_terminal_ws_upgrade_handler(
         }
     }
 
-    let is_local = is_local_connection(&headers, addr, state.gateway.behind_proxy);
+    let is_local = is_local_connection(
+        &headers,
+        addr,
+        state.gateway.behind_proxy,
+        state.gateway.trust_docker_loopback,
+    );
     let header_authenticated =
         websocket_header_authenticated(&headers, state.gateway.credential_store.as_ref(), is_local)
             .await;

--- a/docs/src/authentication.md
+++ b/docs/src/authentication.md
@@ -85,6 +85,20 @@ A connection is classified as **local** only when **all four** checks pass:
 
 If **any** check fails, the connection is treated as remote.
 
+#### Docker and check 4
+
+Docker's default bridge networking rewrites the container-side TCP source to
+a bridge-network address via DNAT, even when the published port is bound
+only to `127.0.0.1` on the host (`-p 127.0.0.1:PORT:PORT`). Check 4 above can
+never pass in that mode, so Tier 2 (local dev convenience, including
+`auth_disabled`) never applies to a default Docker deployment — only
+`--network host` avoids this by sharing the host's network namespace
+directly. If you've confirmed your own deployment publishes the port
+loopback-only and want checks 1–3 to be sufficient on their own, set
+`MOLTIS_TRUST_DOCKER_LOOPBACK=true`. This does **not** relax checks 1–3 — a
+proxy header, a non-loopback `Host`, or `MOLTIS_BEHIND_PROXY=true` still
+force the connection to be treated as remote.
+
 ## Credential Types
 
 ### Password

--- a/docs/src/docker.md
+++ b/docs/src/docker.md
@@ -78,7 +78,14 @@ whose SANs cover the public hostname and set `tls.cert_path` and `tls.key_path`
 in `moltis.toml`.
 
 ```admonish note
-When accessing from localhost, no authentication is required. If you access Moltis from a different machine (e.g., over the network), a setup code is printed to the container logs for authentication setup:
+When accessing from localhost, no authentication is required. If you access Moltis from a different machine (e.g., over the network), a setup code is printed to the container logs for authentication setup.
+
+Docker's default bridge networking rewrites the request's apparent source
+address, so this "no auth needed" convenience does not apply automatically
+inside a container even when the browser genuinely is on the same machine
+— see [Docker and check 4](authentication.md#docker-and-check-4) for why,
+and the `MOLTIS_TRUST_DOCKER_LOOPBACK` opt-in if you've confirmed your own
+port publish is loopback-only.
 
 ~~~bash
 docker logs moltis


### PR DESCRIPTION
## Summary

Closes #1112.

`is_local_connection()` (`crates/auth/src/locality.rs`) gates Tier 2 (local-dev convenience, including `auth_disabled`) on the raw TCP source IP being exactly loopback. Docker's default bridge networking rewrites the container-side TCP source to a bridge-network address via DNAT — even when the published port is bound only to `127.0.0.1` on the host (`-p 127.0.0.1:PORT:PORT`, exactly what the reporter's own `docker run` command does). That check can never pass in that networking mode, so Tier 2 silently never applies to any default (non `--network host`) Docker deployment, regardless of how carefully the operator scoped the published port. The reporter confirmed the diagnosis themselves: `--network host` "fixes" it, because that's the only mode where the container shares the host's network namespace directly.

### Why not a simpler fix

I considered relaxing the check to trust the `Host` header alone once no proxy headers are present (the request already reached this point having passed "no `X-Forwarded-For`/`X-Real-IP`/etc." and "`Host` names a loopback address"). That would be unsafe: `Host` is fully attacker-controlled. On a deployment accidentally published to `0.0.0.0` instead of `127.0.0.1`, a remote client could simply set `Host: localhost` and bypass auth entirely — a real regression, not a fix.

### The fix

Add `MOLTIS_TRUST_DOCKER_LOOPBACK`, mirroring the existing `MOLTIS_BEHIND_PROXY` escape hatch in shape and threading (same `env_flag_enabled` read at startup, same field on `GatewayState`, same parameter on `is_local_connection`). It only takes effect *after* every other check already passed (no proxy headers, and `Host` — if present — names a loopback address); it never overrides `MOLTIS_BEHIND_PROXY` or proxy-header detection. Default off — no behavior change for anyone who doesn't set it.

```mermaid
flowchart TD
    A[Incoming request] --> B{behind_proxy?}
    B -->|true| R[Remote]
    B -->|false| C{Proxy headers present?}
    C -->|true| R
    C -->|false| D{Host header present<br/>and non-loopback?}
    D -->|true| R
    D -->|false| E{TCP source is loopback?}
    E -->|true| L[Local]
    E -->|false| F{trust_docker_loopback?}
    F -->|true, NEW| L
    F -->|false, default| R
```

## Validation

### Completed

- [x] `crates/auth/src/locality.rs`: 5 new unit tests covering the trust flag (Docker-bridge source accepted only with the flag; proxy headers, non-loopback `Host`, and `behind_proxy` all still win over it regardless of the flag) — `cargo +nightly-2026-06-20 test -p moltis-auth --lib locality`: 23 passed, 0 failed
- [x] `cargo +nightly-2026-06-20 fmt --all -- --check`: clean
- [x] `cargo +nightly-2026-06-20 clippy -p moltis-gateway -p moltis-httpd -p moltis-auth --lib --tests -- -D warnings`: clean
- [x] Full lib test suites for all three touched crates: `cargo test -p moltis-auth -p moltis-gateway -p moltis-httpd --lib` — 54 + 675 + 167 passed, 0 failed
- [x] `crates/httpd/tests/auth_middleware.rs` (real end-to-end auth server, incl. `setup_code_not_required_when_auth_disabled`): 67 passed, 0 failed
- [x] Docs: `docs/src/authentication.md` (added "Docker and check 4" subsection under "How local is determined") and `docs/src/docker.md` (corrected the "no auth needed from localhost" claim for Docker, pointed at the new opt-in) — CLAUDE.md requires docs stay in sync with user-facing config changes in the same PR

### Remaining

- [x] Maintainer call: is `MOLTIS_TRUST_DOCKER_LOOPBACK` the right name/shape, or would you prefer this live in `moltis.toml` instead of an env var? I matched `MOLTIS_BEHIND_PROXY`'s existing env-var-only pattern for consistency.

## Manual QA

Not manually reproduced against a live Docker container in this environment (no Docker daemon available here) — verified via the isolated control-flow unit tests instead, which exercise the exact scenario from the issue (non-loopback `remote_addr`, no proxy headers, loopback `Host`) directly against `is_local_connection()`. If you can confirm on a real Docker deployment with `-p 127.0.0.1:13131:13131` + `MOLTIS_TRUST_DOCKER_LOOPBACK=true` + `auth_disabled=true`, that would close the loop the reporter's own repro started.