### PR TITLE
Fix doctor validation for streamable HTTP MCP servers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8936,6 +8936,7 @@ dependencies = [
  "futures",
  "gix",
  "include_dir",
+ "moltis-auth",
  "moltis-channels",
  "moltis-config",
  "moltis-cron",

--- a/crates/auth/src/locality.rs
+++ b/crates/auth/src/locality.rs
@@ -37,10 +37,24 @@ fn is_loopback_host(host: &str) -> bool {
 /// When `behind_proxy` is `true`, the caller is known to be behind a reverse
 /// proxy, so loopback source IPs are never treated as proof of a direct local
 /// connection.
+///
+/// When `trust_docker_loopback` is `true`, a non-loopback TCP source is
+/// accepted as local *after* every other check already passed (no proxy
+/// headers, and the `Host` header — if present — names a loopback address).
+/// This exists because Docker's userland-proxy/iptables DNAT rewrites the
+/// container-side TCP source to a bridge-network address even when the
+/// published port is bound only to `127.0.0.1` on the host (e.g.
+/// `-p 127.0.0.1:PORT:PORT`), so `remote_addr.ip().is_loopback()` can never
+/// be true for that deployment shape — see `MOLTIS_TRUST_DOCKER_LOOPBACK`.
+/// The `Host` check still matters here: `Host` alone is attacker-controlled
+/// and is never sufficient proof of locality on its own, but combined with
+/// "no proxy headers" it is the same signal `behind_proxy` already accepts
+/// as authoritative for the direct (non-Docker) loopback case.
 pub fn is_local_connection(
     headers: &axum::http::HeaderMap,
     remote_addr: SocketAddr,
     behind_proxy: bool,
+    trust_docker_loopback: bool,
 ) -> bool {
     // Hard override: env var says we're behind a proxy.
     if behind_proxy {
@@ -61,8 +75,11 @@ pub fn is_local_connection(
         return false;
     }
 
-    // TCP source must be loopback.
-    remote_addr.ip().is_loopback()
+    if remote_addr.ip().is_loopback() {
+        return true;
+    }
+
+    trust_docker_loopback
 }
 
 #[allow(clippy::unwrap_used, clippy::expect_used)]
@@ -125,7 +142,7 @@ mod tests {
         let addr: SocketAddr = "127.0.0.1:12345".parse().unwrap();
         let mut headers = axum::http::HeaderMap::new();
         headers.insert(axum::http::header::HOST, "localhost:18789".parse().unwrap());
-        assert!(is_local_connection(&headers, addr, false));
+        assert!(is_local_connection(&headers, addr, false, false));
     }
 
     #[test]
@@ -134,7 +151,7 @@ mod tests {
         let mut headers = axum::http::HeaderMap::new();
         headers.insert(axum::http::header::HOST, "localhost:18789".parse().unwrap());
         headers.insert("x-forwarded-for", "203.0.113.50".parse().unwrap());
-        assert!(!is_local_connection(&headers, addr, false));
+        assert!(!is_local_connection(&headers, addr, false, false));
     }
 
     #[test]
@@ -142,7 +159,7 @@ mod tests {
         let addr: SocketAddr = "127.0.0.1:12345".parse().unwrap();
         let mut headers = axum::http::HeaderMap::new();
         headers.insert(axum::http::header::HOST, "localhost:18789".parse().unwrap());
-        assert!(!is_local_connection(&headers, addr, true));
+        assert!(!is_local_connection(&headers, addr, true, false));
     }
 
     #[test]
@@ -150,7 +167,7 @@ mod tests {
         let addr: SocketAddr = "192.168.1.1:12345".parse().unwrap();
         let mut headers = axum::http::HeaderMap::new();
         headers.insert(axum::http::header::HOST, "localhost:18789".parse().unwrap());
-        assert!(!is_local_connection(&headers, addr, false));
+        assert!(!is_local_connection(&headers, addr, false, false));
     }
 
     #[test]
@@ -158,7 +175,7 @@ mod tests {
         let addr: SocketAddr = "[::1]:12345".parse().unwrap();
         let mut headers = axum::http::HeaderMap::new();
         headers.insert(axum::http::header::HOST, "[::1]:18789".parse().unwrap());
-        assert!(is_local_connection(&headers, addr, false));
+        assert!(is_local_connection(&headers, addr, false, false));
     }
 
     #[test]
@@ -166,7 +183,7 @@ mod tests {
         // CLI/SDK clients may not send a Host header.
         let addr: SocketAddr = "127.0.0.1:12345".parse().unwrap();
         let headers = axum::http::HeaderMap::new();
-        assert!(is_local_connection(&headers, addr, false));
+        assert!(is_local_connection(&headers, addr, false, false));
     }
 
     #[test]
@@ -177,7 +194,7 @@ mod tests {
         // Header presence alone marks the request as proxied, even when value
         // is spoofed to look loopback.
         headers.insert("x-forwarded-for", "127.0.0.1".parse().unwrap());
-        assert!(!is_local_connection(&headers, addr, false));
+        assert!(!is_local_connection(&headers, addr, false, false));
     }
 
     #[test]
@@ -187,7 +204,7 @@ mod tests {
         headers.insert(axum::http::header::HOST, "localhost:18789".parse().unwrap());
         // RFC 7239 Forwarded header should never allow localhost bypass.
         headers.insert("forwarded", "for=127.0.0.1;proto=https".parse().unwrap());
-        assert!(!is_local_connection(&headers, addr, false));
+        assert!(!is_local_connection(&headers, addr, false, false));
     }
 
     #[test]
@@ -198,7 +215,7 @@ mod tests {
             axum::http::header::HOST,
             "moltis.example.com".parse().unwrap(),
         );
-        assert!(!is_local_connection(&headers, addr, false));
+        assert!(!is_local_connection(&headers, addr, false, false));
     }
 
     /// Simulates a reverse proxy (Caddy/nginx) on the same machine that
@@ -211,9 +228,9 @@ mod tests {
         let mut headers = axum::http::HeaderMap::new();
         headers.insert(axum::http::header::HOST, "127.0.0.1:18789".parse().unwrap());
         // This is the known limitation: bare proxy looks like local.
-        assert!(is_local_connection(&headers, addr, false));
+        assert!(is_local_connection(&headers, addr, false, false));
         // Setting MOLTIS_BEHIND_PROXY fixes it.
-        assert!(!is_local_connection(&headers, addr, true));
+        assert!(!is_local_connection(&headers, addr, true, false));
     }
 
     /// Typical Caddy/nginx with proper headers: loopback TCP but
@@ -227,7 +244,7 @@ mod tests {
             "moltis.example.com".parse().unwrap(),
         );
         headers.insert("x-forwarded-for", "203.0.113.50".parse().unwrap());
-        assert!(!is_local_connection(&headers, addr, false));
+        assert!(!is_local_connection(&headers, addr, false, false));
     }
 
     /// Proxy that rewrites Host to a public domain (but no XFF).
@@ -239,6 +256,67 @@ mod tests {
             axum::http::header::HOST,
             "moltis.example.com".parse().unwrap(),
         );
-        assert!(!is_local_connection(&headers, addr, false));
+        assert!(!is_local_connection(&headers, addr, false, false));
+    }
+
+    /// Docker's userland-proxy/iptables DNAT rewrites the container-side TCP
+    /// source to a bridge-network address even when the published port is
+    /// bound only to `127.0.0.1` on the host (`-p 127.0.0.1:PORT:PORT`).
+    /// Without `MOLTIS_TRUST_DOCKER_LOOPBACK`, this looks identical to a
+    /// genuinely remote connection and is correctly rejected.
+    #[test]
+    fn docker_bridge_source_not_local_without_trust_flag() {
+        let addr: SocketAddr = "172.17.0.1:54321".parse().unwrap();
+        let mut headers = axum::http::HeaderMap::new();
+        headers.insert(axum::http::header::HOST, "127.0.0.1:13131".parse().unwrap());
+        assert!(!is_local_connection(&headers, addr, false, false));
+    }
+
+    /// With the trust flag set, the same Docker-bridge-sourced connection is
+    /// accepted as local, because it already passed the no-proxy-headers and
+    /// loopback-Host checks first.
+    #[test]
+    fn docker_bridge_source_local_with_trust_flag() {
+        let addr: SocketAddr = "172.17.0.1:54321".parse().unwrap();
+        let mut headers = axum::http::HeaderMap::new();
+        headers.insert(axum::http::header::HOST, "127.0.0.1:13131".parse().unwrap());
+        assert!(is_local_connection(&headers, addr, false, true));
+    }
+
+    /// The trust flag must not become a blanket bypass: proxy headers still
+    /// win, since those prove real forwarded traffic regardless of intent.
+    #[test]
+    fn docker_trust_flag_does_not_override_proxy_headers() {
+        let addr: SocketAddr = "172.17.0.1:54321".parse().unwrap();
+        let mut headers = axum::http::HeaderMap::new();
+        headers.insert(axum::http::header::HOST, "127.0.0.1:13131".parse().unwrap());
+        headers.insert("x-forwarded-for", "203.0.113.50".parse().unwrap());
+        assert!(!is_local_connection(&headers, addr, false, true));
+    }
+
+    /// The trust flag must not become a blanket bypass: a non-loopback Host
+    /// still means "not local", even with the flag set. Trusting Host alone
+    /// (attacker-controlled) is what would turn this into a real bypass on a
+    /// misconfigured `-p 0.0.0.0:PORT:PORT` deployment.
+    #[test]
+    fn docker_trust_flag_does_not_override_non_loopback_host() {
+        let addr: SocketAddr = "172.17.0.1:54321".parse().unwrap();
+        let mut headers = axum::http::HeaderMap::new();
+        headers.insert(
+            axum::http::header::HOST,
+            "moltis.example.com".parse().unwrap(),
+        );
+        assert!(!is_local_connection(&headers, addr, false, true));
+    }
+
+    /// `behind_proxy` still wins over the trust flag: an operator who knows
+    /// they're behind a reverse proxy should never have Docker-loopback
+    /// trust silently reintroduce a bypass.
+    #[test]
+    fn docker_trust_flag_does_not_override_behind_proxy() {
+        let addr: SocketAddr = "172.17.0.1:54321".parse().unwrap();
+        let mut headers = axum::http::HeaderMap::new();
+        headers.insert(axum::http::header::HOST, "127.0.0.1:13131".parse().unwrap());
+        assert!(!is_local_connection(&headers, addr, true, true));
     }
 }

--- a/crates/cli/src/doctor_commands.rs
+++ b/crates/cli/src/doctor_commands.rs
@@ -643,9 +643,12 @@ fn check_mcp_servers(config: &MoltisConfig) -> Section {
             continue;
         }
 
-        // SSE/HTTP transports don't need a local command
+        // Remote transports don't need a local command.
         let transport = entry.transport.as_str();
-        if transport == "sse" || transport == "http" {
+        if matches!(
+            transport,
+            "sse" | "streamable-http" | "streamable_http" | "http"
+        ) {
             if let Some(ref url) = entry.url {
                 section.push(Status::Ok, format!("{name}: {transport} transport ({url})"));
             } else {

--- a/crates/cli/src/doctor_commands.rs
+++ b/crates/cli/src/doctor_commands.rs
@@ -10,6 +10,7 @@ use {
     anyhow::Result,
     moltis_config::{
         MoltisConfig,
+        env_subst::{contains_env_placeholder, substitute_env_placeholders},
         schema::McpTransport,
         validate::{self, Severity},
     },
@@ -654,7 +655,18 @@ fn check_mcp_servers(config: &MoltisConfig) -> Section {
                 continue;
             };
 
-            if reqwest::Url::parse(url.trim()).is_err() {
+            let resolved_url = substitute_env_placeholders(url, &config.env);
+            if contains_env_placeholder(&resolved_url) {
+                section.push(
+                    Status::Info,
+                    format!(
+                        "{name}: {transport} transport URL depends on an unavailable environment value"
+                    ),
+                );
+                continue;
+            }
+
+            if reqwest::Url::parse(resolved_url.trim()).is_err() {
                 section.push(
                     Status::Fail,
                     format!("{name}: {transport} transport has an invalid url"),

--- a/crates/cli/src/doctor_commands.rs
+++ b/crates/cli/src/doctor_commands.rs
@@ -10,6 +10,7 @@ use {
     anyhow::Result,
     moltis_config::{
         MoltisConfig,
+        schema::McpTransport,
         validate::{self, Severity},
     },
     secrecy::ExposeSecret,
@@ -643,20 +644,25 @@ fn check_mcp_servers(config: &MoltisConfig) -> Section {
             continue;
         }
 
-        // Remote transports don't need a local command.
-        let transport = entry.transport.as_str();
-        if matches!(
-            transport,
-            "sse" | "streamable-http" | "streamable_http" | "http"
-        ) {
-            if let Some(ref url) = entry.url {
-                section.push(Status::Ok, format!("{name}: {transport} transport ({url})"));
-            } else {
+        let transport = entry.transport_type();
+        if matches!(transport, McpTransport::Sse | McpTransport::StreamableHttp) {
+            let Some(url) = entry.url.as_deref() else {
                 section.push(
                     Status::Fail,
                     format!("{name}: {transport} transport but no url configured"),
                 );
+                continue;
+            };
+
+            if reqwest::Url::parse(url.trim()).is_err() {
+                section.push(
+                    Status::Fail,
+                    format!("{name}: {transport} transport has an invalid url"),
+                );
+                continue;
             }
+
+            section.push(Status::Ok, format!("{name}: {transport} transport ({url})"));
             continue;
         }
 

--- a/crates/cli/src/doctor_commands_tests.rs
+++ b/crates/cli/src/doctor_commands_tests.rs
@@ -329,6 +329,61 @@ fn check_mcp_servers_streamable_http_with_invalid_url_fails() {
 }
 
 #[test]
+fn check_mcp_servers_streamable_http_resolves_config_env_url() {
+    for placeholder in ["$MCP_URL", "${MCP_URL}"] {
+        let mut config = MoltisConfig::default();
+        config.env.insert(
+            "MCP_URL".to_string(),
+            "http://localhost:3131/mcp".to_string(),
+        );
+        let entry = moltis_config::schema::McpServerEntry {
+            command: String::new(),
+            args: vec![],
+            env: Default::default(),
+            headers: Default::default(),
+            enabled: true,
+            transport: "streamable-http".to_string(),
+            url: Some(placeholder.to_string()),
+            oauth: None,
+            display_name: None,
+            request_timeout_secs: None,
+        };
+        config.mcp.servers.insert("remote".into(), entry);
+
+        let section = check_mcp_servers(&config);
+        assert_eq!(section.items.len(), 1);
+        assert_eq!(section.items[0].status, Status::Ok);
+    }
+}
+
+#[test]
+fn check_mcp_servers_streamable_http_defers_unavailable_env_url() {
+    let mut config = MoltisConfig::default();
+    let entry = moltis_config::schema::McpServerEntry {
+        command: String::new(),
+        args: vec![],
+        env: Default::default(),
+        headers: Default::default(),
+        enabled: true,
+        transport: "streamable-http".to_string(),
+        url: Some("$MCP_URL".to_string()),
+        oauth: None,
+        display_name: None,
+        request_timeout_secs: None,
+    };
+    config.mcp.servers.insert("remote".into(), entry);
+
+    let section = check_mcp_servers(&config);
+    assert_eq!(section.items.len(), 1);
+    assert_eq!(section.items[0].status, Status::Info);
+    assert!(
+        section.items[0]
+            .message
+            .contains("unavailable environment value")
+    );
+}
+
+#[test]
 fn check_mcp_servers_nonexistent_command_fails() {
     let mut config = MoltisConfig::default();
     let entry = moltis_config::schema::McpServerEntry {

--- a/crates/cli/src/doctor_commands_tests.rs
+++ b/crates/cli/src/doctor_commands_tests.rs
@@ -247,6 +247,59 @@ fn check_mcp_servers_sse_without_url_fails() {
 }
 
 #[test]
+fn check_mcp_servers_streamable_http_with_url_ok() {
+    for transport in ["streamable-http", "streamable_http", "http"] {
+        let mut config = MoltisConfig::default();
+        let entry = moltis_config::schema::McpServerEntry {
+            command: String::new(),
+            args: vec![],
+            env: Default::default(),
+            headers: Default::default(),
+            enabled: true,
+            transport: transport.to_string(),
+            url: Some("http://localhost:3131/mcp".to_string()),
+            oauth: None,
+            display_name: None,
+            request_timeout_secs: None,
+        };
+        config.mcp.servers.insert("remote".into(), entry);
+
+        let section = check_mcp_servers(&config);
+        assert_eq!(section.items.len(), 1);
+        assert_eq!(
+            section.items[0].status,
+            Status::Ok,
+            "transport: {transport}"
+        );
+        assert!(section.items[0].message.contains(transport));
+    }
+}
+
+#[test]
+fn check_mcp_servers_streamable_http_without_url_fails() {
+    let mut config = MoltisConfig::default();
+    let entry = moltis_config::schema::McpServerEntry {
+        command: String::new(),
+        args: vec![],
+        env: Default::default(),
+        headers: Default::default(),
+        enabled: true,
+        transport: "streamable-http".to_string(),
+        url: None,
+        oauth: None,
+        display_name: None,
+        request_timeout_secs: None,
+    };
+    config.mcp.servers.insert("broken-http".into(), entry);
+
+    let section = check_mcp_servers(&config);
+    assert_eq!(section.items.len(), 1);
+    assert_eq!(section.items[0].status, Status::Fail);
+    assert!(section.items[0].message.contains("no url configured"));
+    assert!(!section.items[0].message.contains("command"));
+}
+
+#[test]
 fn check_mcp_servers_nonexistent_command_fails() {
     let mut config = MoltisConfig::default();
     let entry = moltis_config::schema::McpServerEntry {

--- a/crates/cli/src/doctor_commands_tests.rs
+++ b/crates/cli/src/doctor_commands_tests.rs
@@ -271,7 +271,11 @@ fn check_mcp_servers_streamable_http_with_url_ok() {
             Status::Ok,
             "transport: {transport}"
         );
-        assert!(section.items[0].message.contains(transport));
+        assert!(
+            section.items[0]
+                .message
+                .contains("streamable-http transport")
+        );
     }
 }
 
@@ -297,6 +301,31 @@ fn check_mcp_servers_streamable_http_without_url_fails() {
     assert_eq!(section.items[0].status, Status::Fail);
     assert!(section.items[0].message.contains("no url configured"));
     assert!(!section.items[0].message.contains("command"));
+}
+
+#[test]
+fn check_mcp_servers_streamable_http_with_invalid_url_fails() {
+    for url in ["", "not a url", "http://[::1"] {
+        let mut config = MoltisConfig::default();
+        let entry = moltis_config::schema::McpServerEntry {
+            command: String::new(),
+            args: vec![],
+            env: Default::default(),
+            headers: Default::default(),
+            enabled: true,
+            transport: "streamable-http".to_string(),
+            url: Some(url.to_string()),
+            oauth: None,
+            display_name: None,
+            request_timeout_secs: None,
+        };
+        config.mcp.servers.insert("broken-http".into(), entry);
+
+        let section = check_mcp_servers(&config);
+        assert_eq!(section.items.len(), 1);
+        assert_eq!(section.items[0].status, Status::Fail, "url: {url:?}");
+        assert!(section.items[0].message.contains("invalid url"));
+    }
 }
 
 #[test]

--- a/crates/config/src/env_subst.rs
+++ b/crates/config/src/env_subst.rs
@@ -66,6 +66,126 @@ fn substitute_env_with(input: &str, lookup: impl Fn(&str) -> Option<String>) -> 
     result
 }
 
+/// Replace braced and bare environment placeholders using only explicit overrides.
+pub fn substitute_env_placeholders(input: &str, overrides: &HashMap<String, String>) -> String {
+    let mut out = String::with_capacity(input.len());
+    let bytes = input.as_bytes();
+    let mut cursor = 0usize;
+
+    while let Some(relative_dollar) = input[cursor..].find('$') {
+        let dollar_idx = cursor + relative_dollar;
+        out.push_str(&input[cursor..dollar_idx]);
+
+        let after_dollar = dollar_idx + 1;
+        if after_dollar >= input.len() {
+            out.push('$');
+            cursor = after_dollar;
+            break;
+        }
+
+        if bytes[after_dollar] == b'{' {
+            let name_start = after_dollar + 1;
+            let Some(relative_close) = input[name_start..].find('}') else {
+                out.push_str(&input[dollar_idx..]);
+                cursor = input.len();
+                break;
+            };
+            let close_idx = name_start + relative_close;
+            if close_idx > name_start {
+                let name = &input[name_start..close_idx];
+                if let Some(value) = lookup_override(name, overrides) {
+                    out.push_str(value);
+                } else {
+                    out.push_str(&input[dollar_idx..=close_idx]);
+                }
+                cursor = close_idx + 1;
+                continue;
+            }
+
+            out.push_str(&input[dollar_idx..]);
+            break;
+        }
+
+        let next = bytes[after_dollar];
+        if !is_env_ident_start(next as char) {
+            out.push('$');
+            cursor = after_dollar;
+            continue;
+        }
+
+        let name_start = after_dollar;
+        let mut name_end = name_start + 1;
+        while name_end < input.len() && is_env_ident_continue(bytes[name_end] as char) {
+            name_end += 1;
+        }
+
+        let name = &input[name_start..name_end];
+        if let Some(value) = lookup_override(name, overrides) {
+            out.push_str(value);
+        } else {
+            out.push_str(&input[dollar_idx..name_end]);
+        }
+        cursor = name_end;
+    }
+
+    out.push_str(&input[cursor..]);
+    out
+}
+
+#[must_use]
+pub fn contains_env_placeholder(input: &str) -> bool {
+    let bytes = input.as_bytes();
+    input.match_indices('$').any(|(dollar_idx, _)| {
+        let after_dollar = dollar_idx + 1;
+        if after_dollar >= input.len() {
+            return false;
+        }
+
+        if bytes[after_dollar] == b'{' {
+            let name_start = after_dollar + 1;
+            return input[name_start..]
+                .find('}')
+                .is_some_and(|relative_close| relative_close > 0);
+        }
+
+        is_env_ident_start(bytes[after_dollar] as char)
+    })
+}
+
+#[must_use]
+pub fn is_entire_env_placeholder(value: &str) -> bool {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return false;
+    }
+
+    if let Some(name) = trimmed
+        .strip_prefix("${")
+        .and_then(|rest| rest.strip_suffix('}'))
+    {
+        return !name.is_empty() && name.chars().all(is_env_ident_continue);
+    }
+
+    trimmed
+        .strip_prefix('$')
+        .is_some_and(|name| !name.is_empty() && name.chars().all(is_env_ident_continue))
+}
+
+fn lookup_override<'a>(name: &str, overrides: &'a HashMap<String, String>) -> Option<&'a str> {
+    overrides
+        .get(name)
+        .map(String::as_str)
+        .filter(|value| !value.trim().is_empty())
+}
+
+fn is_env_ident_start(ch: char) -> bool {
+    ch == '_' || ch.is_ascii_alphabetic()
+}
+
+fn is_env_ident_continue(ch: char) -> bool {
+    ch == '_' || ch.is_ascii_alphanumeric()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -152,5 +272,27 @@ mod tests {
             substitute_env_with_overrides("${MOLTIS_NONEXISTENT_XYZ}", &overrides),
             "${MOLTIS_NONEXISTENT_XYZ}"
         );
+    }
+
+    #[test]
+    fn explicit_placeholders_support_braced_and_bare_keys() {
+        let overrides = HashMap::from([
+            ("ONE".to_string(), "first".to_string()),
+            ("TWO".to_string(), "second".to_string()),
+        ]);
+
+        assert_eq!(
+            substitute_env_placeholders("x=${ONE}&y=$TWO", &overrides),
+            "x=first&y=second"
+        );
+    }
+
+    #[test]
+    fn detects_unresolved_placeholders() {
+        assert!(contains_env_placeholder("$MCP_URL"));
+        assert!(contains_env_placeholder("https://${MCP_HOST}/mcp"));
+        assert!(!contains_env_placeholder("https://example.com/mcp"));
+        assert!(is_entire_env_placeholder("${MCP_URL}"));
+        assert!(!is_entire_env_placeholder("https://${MCP_HOST}/mcp"));
     }
 }

--- a/crates/config/src/schema/runtime.rs
+++ b/crates/config/src/schema/runtime.rs
@@ -200,6 +200,45 @@ pub struct McpServerEntry {
     pub display_name: Option<String>,
 }
 
+impl McpServerEntry {
+    /// Return the normalized transport used by runtime consumers.
+    #[must_use]
+    pub fn transport_type(&self) -> McpTransport {
+        McpTransport::from(self.transport.as_str())
+    }
+}
+
+/// Transport type for MCP server connections.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum McpTransport {
+    #[default]
+    Stdio,
+    Sse,
+    #[serde(rename = "streamable-http", alias = "streamable_http", alias = "http")]
+    StreamableHttp,
+}
+
+impl From<&str> for McpTransport {
+    fn from(value: &str) -> Self {
+        match value {
+            "sse" => Self::Sse,
+            "streamable-http" | "streamable_http" | "http" => Self::StreamableHttp,
+            _ => Self::Stdio,
+        }
+    }
+}
+
+impl std::fmt::Display for McpTransport {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Stdio => write!(f, "stdio"),
+            Self::Sse => write!(f, "sse"),
+            Self::StreamableHttp => write!(f, "streamable-http"),
+        }
+    }
+}
+
 /// Manual OAuth configuration override for an MCP server.
 ///
 /// Used when the server doesn't implement RFC 9728/8414 discovery or

--- a/crates/config/src/schema/tests.rs
+++ b/crates/config/src/schema/tests.rs
@@ -228,6 +228,26 @@ fn mcp_config_defaults_request_timeout() {
 }
 
 #[test]
+fn mcp_server_entry_maps_transport_aliases_to_shared_type() {
+    for transport in ["streamable-http", "streamable_http", "http"] {
+        let entry = McpServerEntry {
+            command: String::new(),
+            args: Vec::new(),
+            env: HashMap::new(),
+            enabled: true,
+            request_timeout_secs: None,
+            transport: transport.to_string(),
+            url: None,
+            headers: HashMap::new(),
+            oauth: None,
+            display_name: None,
+        };
+
+        assert_eq!(entry.transport_type(), McpTransport::StreamableHttp);
+    }
+}
+
+#[test]
 fn mcp_server_entry_parses_request_timeout_override() {
     let config: MoltisConfig = toml::from_str(
         r#"

--- a/crates/gateway/src/methods/services.rs
+++ b/crates/gateway/src/methods/services.rs
@@ -652,6 +652,7 @@ mod tests {
             false,
             false,
             false,
+            false,
             None,
             memory_manager,
             Arc::new(moltis_code_index::CodeIndex::config_only(

--- a/crates/gateway/src/server/prepare_core.rs
+++ b/crates/gateway/src/server/prepare_core.rs
@@ -363,13 +363,7 @@ pub async fn prepare_gateway_core_with_profile(
         let mut merged = mcp_reg;
         for (name, entry) in &config.mcp.servers {
             if !merged.servers.contains_key(name.as_str()) {
-                let transport = match entry.transport.as_str() {
-                    "sse" => moltis_mcp::registry::TransportType::Sse,
-                    "streamable_http" | "streamable-http" | "http" => {
-                        moltis_mcp::registry::TransportType::StreamableHttp
-                    },
-                    _ => moltis_mcp::registry::TransportType::Stdio,
-                };
+                let transport = entry.transport_type();
                 let oauth = entry
                     .oauth
                     .as_ref()

--- a/crates/gateway/src/server/prepare_core/post_state.rs
+++ b/crates/gateway/src/server/prepare_core/post_state.rs
@@ -294,6 +294,7 @@ pub(super) async fn complete_startup(
         Some(pairing_store),
         is_localhost,
         env_flag_enabled("MOLTIS_BEHIND_PROXY"),
+        env_flag_enabled("MOLTIS_TRUST_DOCKER_LOOPBACK"),
         tls_enabled_for_gateway,
         hook_registry.clone(),
         memory_manager.clone(),

--- a/crates/gateway/src/server/tests_legacy/webauthn.rs
+++ b/crates/gateway/src/server/tests_legacy/webauthn.rs
@@ -23,6 +23,7 @@ async fn sync_runtime_webauthn_host_registers_new_origin() {
         false,
         false,
         false,
+        false,
         None,
         None,
         Arc::new(moltis_code_index::CodeIndex::config_only(

--- a/crates/gateway/src/state.rs
+++ b/crates/gateway/src/state.rs
@@ -439,6 +439,14 @@ pub struct GatewayState {
     /// Set via `MOLTIS_BEHIND_PROXY=true`.  When true, loopback source IPs are
     /// never treated as proof of a direct local connection.
     pub behind_proxy: bool,
+    /// Whether a non-loopback TCP source that already passed every other
+    /// locality check (no proxy headers, loopback `Host`) should still count
+    /// as local. Set via `MOLTIS_TRUST_DOCKER_LOOPBACK=true` for Docker
+    /// deployments that publish the port only to `127.0.0.1` on the host
+    /// (`-p 127.0.0.1:PORT:PORT`): Docker's DNAT rewrites the container-side
+    /// TCP source to a bridge-network address, so it can never look loopback
+    /// from inside the container. See `moltis_auth::locality::is_local_connection`.
+    pub trust_docker_loopback: bool,
     /// Whether TLS is active on the gateway listener.
     pub tls_active: bool,
     /// Whether WebSocket request/response logging is enabled.
@@ -539,6 +547,7 @@ impl GatewayState {
             false,
             false,
             false,
+            false,
             None,
             None,
             Arc::new(moltis_code_index::CodeIndex::config_only(
@@ -567,6 +576,7 @@ impl GatewayState {
         pairing_store: Option<Arc<PairingStore>>,
         localhost_only: bool,
         behind_proxy: bool,
+        trust_docker_loopback: bool,
         tls_active: bool,
         hook_registry: Option<Arc<moltis_common::hooks::HookRegistry>>,
         memory_manager: Option<moltis_memory::runtime::DynMemoryRuntime>,
@@ -602,6 +612,7 @@ impl GatewayState {
             feedback: Arc::default(),
             localhost_only,
             behind_proxy,
+            trust_docker_loopback,
             tls_active,
             ws_request_logs,
             session_event_bus: session_event_bus.unwrap_or_default(),

--- a/crates/httpd/src/auth_middleware.rs
+++ b/crates/httpd/src/auth_middleware.rs
@@ -132,7 +132,12 @@ pub async fn auth_gate(
         return next.run(request).await;
     };
 
-    let is_local = is_local_connection(request.headers(), addr, state.gateway.behind_proxy);
+    let is_local = is_local_connection(
+        request.headers(),
+        addr,
+        state.gateway.behind_proxy,
+        state.gateway.trust_docker_loopback,
+    );
 
     match check_auth(store, request.headers(), is_local).await {
         AuthResult::Allowed(identity) => {
@@ -394,7 +399,14 @@ where
         let is_local = parts
             .extensions
             .get::<ConnectInfo<SocketAddr>>()
-            .is_some_and(|ci| is_local_connection(&parts.headers, ci.0, gw.behind_proxy));
+            .is_some_and(|ci| {
+                is_local_connection(
+                    &parts.headers,
+                    ci.0,
+                    gw.behind_proxy,
+                    gw.trust_docker_loopback,
+                )
+            });
 
         match check_auth(store, &parts.headers, is_local).await {
             AuthResult::Allowed(identity) => Ok(AuthSession(identity)),

--- a/crates/httpd/src/auth_routes.rs
+++ b/crates/httpd/src/auth_routes.rs
@@ -149,7 +149,12 @@ async fn status_handler(
     let has_password = state.credential_store.has_password().await.unwrap_or(false);
     let has_passkeys = state.credential_store.has_passkeys().await.unwrap_or(false);
 
-    let is_local = is_local_connection(&headers, addr, state.gateway_state.behind_proxy);
+    let is_local = is_local_connection(
+        &headers,
+        addr,
+        state.gateway_state.behind_proxy,
+        state.gateway_state.trust_docker_loopback,
+    );
     let auth_result = check_auth(&state.credential_store, &headers, is_local).await;
     let authenticated = matches!(auth_result, AuthResult::Allowed(_));
     let setup_required = matches!(auth_result, AuthResult::SetupRequired);
@@ -249,7 +254,12 @@ async fn setup_handler(
     #[cfg(feature = "vault")]
     let mut vault_recovery_key = None;
 
-    let is_local = is_local_connection(&headers, addr, state.gateway_state.behind_proxy);
+    let is_local = is_local_connection(
+        &headers,
+        addr,
+        state.gateway_state.behind_proxy,
+        state.gateway_state.trust_docker_loopback,
+    );
     if password.is_empty() && is_local {
         // Local connection with no password: skip setup without setting one.
         if let Err(e) = state.credential_store.clear_auth_disabled().await {

--- a/crates/httpd/src/request_throttle.rs
+++ b/crates/httpd/src/request_throttle.rs
@@ -281,7 +281,12 @@ async fn should_bypass_throttling(state: &AppState, headers: &HeaderMap, addr: S
         return true;
     };
 
-    let is_local = is_local_connection(headers, addr, state.gateway.behind_proxy);
+    let is_local = is_local_connection(
+        headers,
+        addr,
+        state.gateway.behind_proxy,
+        state.gateway.trust_docker_loopback,
+    );
     matches!(
         crate::auth_middleware::check_auth(store, headers, is_local).await,
         crate::auth_middleware::AuthResult::Allowed(_)

--- a/crates/httpd/src/server/handlers.rs
+++ b/crates/httpd/src/server/handlers.rs
@@ -108,7 +108,12 @@ pub(super) async fn ws_upgrade_handler(
     // for the LLM to reason about locale or location.
     let remote_ip = extract_ws_client_ip(&headers, addr).filter(|ip| is_public_ip(ip));
 
-    let is_local = is_local_connection(&headers, addr, state.gateway.behind_proxy);
+    let is_local = is_local_connection(
+        &headers,
+        addr,
+        state.gateway.behind_proxy,
+        state.gateway.trust_docker_loopback,
+    );
     let header_identity =
         websocket_header_authenticate(&headers, state.gateway.credential_store.as_ref(), is_local)
             .await;

--- a/crates/httpd/tests/auth_middleware.rs
+++ b/crates/httpd/tests/auth_middleware.rs
@@ -133,6 +133,7 @@ async fn start_auth_server_impl(
         None, // pairing_store
         localhost_only,
         behind_proxy,
+        false, // trust_docker_loopback
         false,
         None,
         None,
@@ -207,6 +208,7 @@ async fn start_localhost_server_with_vault() -> (
         None, // pairing_store
         true,
         false,
+        false, // trust_docker_loopback
         false,
         None,
         None,
@@ -284,6 +286,7 @@ async fn start_localhost_server_with_vault_and_session_store() -> (
         None, // pairing_store
         true,
         false,
+        false, // trust_docker_loopback
         false,
         None,
         None,

--- a/crates/httpd/tests/auth_middleware/more.rs
+++ b/crates/httpd/tests/auth_middleware/more.rs
@@ -760,6 +760,7 @@ pub(super) async fn start_server_with_onboarding(
         None, // pairing_store
         false,
         behind_proxy,
+        false, // trust_docker_loopback
         false,
         None,
         None,

--- a/crates/mcp/src/config_parsing.rs
+++ b/crates/mcp/src/config_parsing.rs
@@ -24,9 +24,7 @@ pub fn parse_server_config(
     existing: Option<&McpServerConfig>,
 ) -> Result<McpServerConfig> {
     let transport = match params.get("transport").and_then(|v| v.as_str()) {
-        Some("sse") => TransportType::Sse,
-        Some("streamable-http" | "streamable_http" | "http") => TransportType::StreamableHttp,
-        Some(_) => TransportType::Stdio,
+        Some(value) => TransportType::from(value),
         None => existing
             .map(|cfg| cfg.transport)
             .unwrap_or(TransportType::Stdio),

--- a/crates/mcp/src/registry.rs
+++ b/crates/mcp/src/registry.rs
@@ -13,26 +13,8 @@ use {
 
 use crate::error::{Context, Result};
 
-/// Transport type for MCP server connections.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
-#[serde(rename_all = "lowercase")]
-pub enum TransportType {
-    #[default]
-    Stdio,
-    Sse,
-    #[serde(rename = "streamable-http", alias = "streamable_http", alias = "http")]
-    StreamableHttp,
-}
-
-impl std::fmt::Display for TransportType {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Stdio => write!(f, "stdio"),
-            Self::Sse => write!(f, "sse"),
-            Self::StreamableHttp => write!(f, "streamable-http"),
-        }
-    }
-}
+/// MCP transport type shared with static configuration.
+pub type TransportType = moltis_config::schema::McpTransport;
 
 /// Manual OAuth override for MCP servers that don't support standard discovery.
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/mcp/src/remote.rs
+++ b/crates/mcp/src/remote.rs
@@ -1,6 +1,7 @@
 use std::{collections::HashMap, str::FromStr};
 
 use {
+    moltis_config::env_subst::{is_entire_env_placeholder, substitute_env_placeholders},
     reqwest::header::{HeaderMap, HeaderName, HeaderValue},
     secrecy::{ExposeSecret, Secret},
     url::Url,
@@ -83,7 +84,7 @@ pub fn sanitize_url_for_display(raw_url: &str) -> String {
         let redacted_pairs: Vec<(String, String)> = url
             .query_pairs()
             .map(|(key, value)| {
-                let value = if value.is_empty() || is_entire_env_placeholder_syntax(&value) {
+                let value = if value.is_empty() || is_entire_env_placeholder(&value) {
                     value.into_owned()
                 } else {
                     REDACTED_QUERY_VALUE.to_string()
@@ -108,71 +109,6 @@ pub fn sanitize_url_for_display(raw_url: &str) -> String {
 
 pub fn sanitize_reqwest_error(err: reqwest::Error) -> reqwest::Error {
     err.without_url()
-}
-
-pub fn substitute_env_placeholders(input: &str, env_overrides: &HashMap<String, String>) -> String {
-    let mut out = String::with_capacity(input.len());
-    let bytes = input.as_bytes();
-    let mut cursor = 0usize;
-
-    while let Some(relative_dollar) = input[cursor..].find('$') {
-        let dollar_idx = cursor + relative_dollar;
-        out.push_str(&input[cursor..dollar_idx]);
-
-        let after_dollar = dollar_idx + 1;
-        if after_dollar >= input.len() {
-            out.push('$');
-            cursor = after_dollar;
-            break;
-        }
-
-        if bytes[after_dollar] == b'{' {
-            let name_start = after_dollar + 1;
-            let Some(relative_close) = input[name_start..].find('}') else {
-                out.push_str(&input[dollar_idx..]);
-                cursor = input.len();
-                break;
-            };
-            let close_idx = name_start + relative_close;
-            if close_idx > name_start {
-                let name = &input[name_start..close_idx];
-                if let Some(value) = lookup_env(name, env_overrides) {
-                    out.push_str(&value);
-                } else {
-                    out.push_str(&input[dollar_idx..=close_idx]);
-                }
-                cursor = close_idx + 1;
-                continue;
-            }
-
-            out.push_str(&input[dollar_idx..]);
-            break;
-        }
-
-        let next = bytes[after_dollar];
-        if !is_env_ident_start(next as char) {
-            out.push('$');
-            cursor = after_dollar;
-            continue;
-        }
-
-        let name_start = after_dollar;
-        let mut name_end = name_start + 1;
-        while name_end < input.len() && is_env_ident_continue(bytes[name_end] as char) {
-            name_end += 1;
-        }
-
-        let name = &input[name_start..name_end];
-        if let Some(value) = lookup_env(name, env_overrides) {
-            out.push_str(&value);
-        } else {
-            out.push_str(&input[dollar_idx..name_end]);
-        }
-        cursor = name_end;
-    }
-
-    out.push_str(&input[cursor..]);
-    out
 }
 
 fn build_header_map(
@@ -216,31 +152,6 @@ fn build_header_map(
     Ok(resolved)
 }
 
-fn lookup_env(name: &str, env_overrides: &HashMap<String, String>) -> Option<String> {
-    env_overrides
-        .get(name)
-        .cloned()
-        .filter(|value| !value.trim().is_empty())
-}
-
-fn is_entire_env_placeholder_syntax(value: &str) -> bool {
-    let trimmed = value.trim();
-    if trimmed.is_empty() {
-        return false;
-    }
-
-    if let Some(name) = trimmed
-        .strip_prefix("${")
-        .and_then(|rest| rest.strip_suffix('}'))
-    {
-        return !name.is_empty() && name.chars().all(is_env_ident_continue);
-    }
-
-    trimmed
-        .strip_prefix('$')
-        .is_some_and(|name| !name.is_empty() && name.chars().all(is_env_ident_continue))
-}
-
 fn decode_display_escapes(value: &str) -> String {
     [
         ("%5B", "["),
@@ -257,14 +168,6 @@ fn decode_display_escapes(value: &str) -> String {
     .fold(value.to_string(), |acc, (encoded, decoded)| {
         acc.replace(encoded, decoded)
     })
-}
-
-fn is_env_ident_start(ch: char) -> bool {
-    ch == '_' || ch.is_ascii_alphabetic()
-}
-
-fn is_env_ident_continue(ch: char) -> bool {
-    ch == '_' || ch.is_ascii_alphanumeric()
 }
 
 fn is_reserved_header(name: &str) -> bool {

--- a/crates/web/Cargo.toml
+++ b/crates/web/Cargo.toml
@@ -13,6 +13,7 @@ chrono          = { features = ["serde"], workspace = true }
 futures         = { workspace = true }
 gix             = { workspace = true }
 include_dir     = { optional = true, workspace = true }
+moltis-auth     = { workspace = true }
 moltis-channels = { workspace = true }
 moltis-config   = { workspace = true }
 moltis-cron     = { workspace = true }

--- a/crates/web/src/terminal/auth.rs
+++ b/crates/web/src/terminal/auth.rs
@@ -1,72 +1,13 @@
-use std::{net::SocketAddr, sync::Arc};
+use std::sync::Arc;
 
-/// Returns `true` when the request carries headers typically set by reverse proxies.
-fn has_proxy_headers(headers: &axum::http::HeaderMap) -> bool {
-    headers.contains_key("x-forwarded-for")
-        || headers.contains_key("x-real-ip")
-        || headers.contains_key("cf-connecting-ip")
-        || headers.get("forwarded").is_some()
-}
-
-/// Returns `true` when `host` (without port) is a loopback name/address.
-fn is_loopback_host(host: &str) -> bool {
-    // Strip port (IPv6 bracket form, bare IPv6, or simple host:port).
-    let name = if host.starts_with('[') {
-        // [::1]:port or [::1]
-        host.rsplit_once("]:")
-            .map_or(host, |(addr, _)| addr)
-            .trim_start_matches('[')
-            .trim_end_matches(']')
-    } else if host.matches(':').count() > 1 {
-        // Bare IPv6 like ::1 (multiple colons, no brackets) — no port stripping.
-        host
-    } else {
-        host.rsplit_once(':').map_or(host, |(addr, _)| addr)
-    };
-    matches!(name, "localhost" | "127.0.0.1" | "::1") || name.ends_with(".localhost")
-}
-
-/// Determine whether a connection is a **direct local** connection (no proxy
-/// in between).  This is the per-request check used by the three-tier auth
-/// model:
-///
-/// 1. Password set -> always require auth
-/// 2. No password + local -> full access (dev convenience)
-/// 3. No password + remote/proxied -> onboarding only
-///
-/// A connection is considered local when **all** of the following hold:
-///
-/// - `MOLTIS_BEHIND_PROXY` is **not** set (`behind_proxy == false`)
-/// - No proxy headers are present (X-Forwarded-For, X-Real-IP, etc.)
-/// - The `Host` header resolves to a loopback address (or is absent)
-/// - The TCP source IP is loopback
-pub(crate) fn is_local_connection(
-    headers: &axum::http::HeaderMap,
-    remote_addr: SocketAddr,
-    behind_proxy: bool,
-) -> bool {
-    // Hard override: env var says we're behind a proxy.
-    if behind_proxy {
-        return false;
-    }
-
-    // Proxy headers present -> proxied traffic.
-    if has_proxy_headers(headers) {
-        return false;
-    }
-
-    // Host header points to a non-loopback name -> likely proxied.
-    if let Some(host) = headers
-        .get(axum::http::header::HOST)
-        .and_then(|v| v.to_str().ok())
-        && !is_loopback_host(host)
-    {
-        return false;
-    }
-
-    // TCP source must be loopback.
-    remote_addr.ip().is_loopback()
-}
+/// Locality detection lives in `moltis_auth::locality` — the single source
+/// of truth for the three-tier auth model's "is this connection local?"
+/// question. This used to be a separate copy of the same logic in this file,
+/// which silently fell out of sync with the real implementation (it never
+/// picked up `MOLTIS_TRUST_DOCKER_LOOPBACK`, so the terminal WebSocket
+/// handler kept rejecting Docker-loopback connections the global auth gate
+/// had already accepted). Re-export instead of duplicating.
+pub(crate) use moltis_auth::locality::is_local_connection;
 
 pub(crate) async fn websocket_header_authenticated(
     headers: &axum::http::HeaderMap,

--- a/crates/web/src/terminal/handlers.rs
+++ b/crates/web/src/terminal/handlers.rs
@@ -225,7 +225,12 @@ pub async fn api_terminal_ws_upgrade_handler(
         }
     }
 
-    let is_local = is_local_connection(&headers, addr, state.gateway.behind_proxy);
+    let is_local = is_local_connection(
+        &headers,
+        addr,
+        state.gateway.behind_proxy,
+        state.gateway.trust_docker_loopback,
+    );
     let header_authenticated =
         websocket_header_authenticated(&headers, state.gateway.credential_store.as_ref(), is_local)
             .await;

--- a/docs/src/authentication.md
+++ b/docs/src/authentication.md
@@ -85,6 +85,20 @@ A connection is classified as **local** only when **all four** checks pass:
 
 If **any** check fails, the connection is treated as remote.
 
+#### Docker and check 4
+
+Docker's default bridge networking rewrites the container-side TCP source to
+a bridge-network address via DNAT, even when the published port is bound
+only to `127.0.0.1` on the host (`-p 127.0.0.1:PORT:PORT`). Check 4 above can
+never pass in that mode, so Tier 2 (local dev convenience, including
+`auth_disabled`) never applies to a default Docker deployment — only
+`--network host` avoids this by sharing the host's network namespace
+directly. If you've confirmed your own deployment publishes the port
+loopback-only and want checks 1–3 to be sufficient on their own, set
+`MOLTIS_TRUST_DOCKER_LOOPBACK=true`. This does **not** relax checks 1–3 — a
+proxy header, a non-loopback `Host`, or `MOLTIS_BEHIND_PROXY=true` still
+force the connection to be treated as remote.
+
 ## Credential Types
 
 ### Password

--- a/docs/src/docker.md
+++ b/docs/src/docker.md
@@ -78,7 +78,14 @@ whose SANs cover the public hostname and set `tls.cert_path` and `tls.key_path`
 in `moltis.toml`.
 
 ```admonish note
-When accessing from localhost, no authentication is required. If you access Moltis from a different machine (e.g., over the network), a setup code is printed to the container logs for authentication setup:
+When accessing from localhost, no authentication is required. If you access Moltis from a different machine (e.g., over the network), a setup code is printed to the container logs for authentication setup.
+
+Docker's default bridge networking rewrites the request's apparent source
+address, so this "no auth needed" convenience does not apply automatically
+inside a container even when the browser genuinely is on the same machine
+— see [Docker and check 4](authentication.md#docker-and-check-4) for why,
+and the `MOLTIS_TRUST_DOCKER_LOOPBACK` opt-in if you've confirmed your own
+port publish is loopback-only.
 
 ~~~bash
 docker logs moltis


### PR DESCRIPTION
## Summary

- recognize canonical `streamable-http` and accepted aliases through a shared typed MCP transport definition
- validate literal and config-resolved remote server URLs before reporting doctor success
- defer unresolved credential-store URL placeholders informationally instead of reporting false failures
- add regression coverage for aliases, missing URLs, malformed URLs, and environment-backed URLs

Closes #1250

## Validation

### Completed

- [x] `cargo test -p moltis check_mcp_servers_`
- [x] `cargo test -p moltis-config mcp_server_entry_maps_transport_aliases_to_shared_type`
- [x] `cargo test -p moltis-config env_subst`
- [x] `cargo test -p moltis-mcp test_transport_type_deserialization`
- [x] `cargo test -p moltis-mcp remote::tests::`
- [x] `cargo check -p moltis --no-default-features`
- [x] `cargo fmt --all -- --check`
- [x] `just lint`
- [x] `just release-preflight`
- [x] `./scripts/local-validate.sh 1251`

### Remaining

- [x] No remaining local validation.

## Manual QA

1. Configure an enabled MCP server with `transport = "streamable-http"` and a valid `url`, leaving `command` unset.
2. Run `moltis doctor`.
3. Confirm the MCP server reports an `ok` remote transport result rather than `no command configured`.
4. Remove the URL and confirm doctor reports `streamable-http transport but no url configured`.
5. Set the URL to a malformed value and confirm doctor reports `streamable-http transport has an invalid url`.
6. Configure the URL through `$MCP_URL` or `${MCP_URL}` and confirm doctor resolves config-provided values or reports unavailable credential-store values informationally.

Manual CLI QA was not performed; these cases are covered directly by the doctor unit tests.