### PR TITLE
feat(reasoning): add max effort level

### DIFF
--- a/crates/config/src/loader/tests/core.rs
+++ b/crates/config/src/loader/tests/core.rs
@@ -209,6 +209,12 @@ fn write_default_config_writes_template_to_requested_path() {
         raw.contains("# push_name = \"Moltis\""),
         "generated template should document the WhatsApp push name override"
     );
+    assert!(
+        raw.contains(
+            "# reasoning_effort = \"high\"        # minimal | low | medium | high | xhigh | max"
+        ),
+        "generated template should document every reasoning effort value"
+    );
 
     let parsed: MoltisConfig = parse_config(&raw, &path).expect("parse generated config");
     assert_eq!(

--- a/crates/config/src/schema.rs
+++ b/crates/config/src/schema.rs
@@ -62,6 +62,8 @@ pub enum ReasoningEffort {
     /// Extra-high reasoning effort. Serializes as `"xhigh"`.
     #[serde(rename = "xhigh")]
     ExtraHigh,
+    /// Maximum reasoning effort. Serializes as `"max"`.
+    Max,
 }
 
 impl ReasoningEffort {
@@ -72,6 +74,7 @@ impl ReasoningEffort {
         Self::Medium,
         Self::High,
         Self::ExtraHigh,
+        Self::Max,
     ];
 
     /// Wire / serialization name (matches serde output).
@@ -83,6 +86,7 @@ impl ReasoningEffort {
             Self::Medium => "medium",
             Self::High => "high",
             Self::ExtraHigh => "xhigh",
+            Self::Max => "max",
         }
     }
 
@@ -95,6 +99,7 @@ impl ReasoningEffort {
             Self::Medium => "Medium",
             Self::High => "High",
             Self::ExtraHigh => "Extra High",
+            Self::Max => "Max",
         }
     }
 }
@@ -109,6 +114,7 @@ impl TryFrom<&str> for ReasoningEffort {
             "medium" => Ok(Self::Medium),
             "high" => Ok(Self::High),
             "xhigh" => Ok(Self::ExtraHigh),
+            "max" => Ok(Self::Max),
             other => Err(format!("unknown reasoning effort: {other}")),
         }
     }

--- a/crates/config/src/template.rs
+++ b/crates/config/src/template.rs
@@ -350,6 +350,7 @@ port = {port}                           # Port number (auto-generated for this i
 # identity.theme = "thorough, skeptical, and evidence-oriented"
 # system_prompt_suffix = "..."
 # max_iterations = 16
+# reasoning_effort = "high"        # minimal | low | medium | high | xhigh | max
 # # Optional drift-resistant per-turn controls for spawned/preset agents:
 # # [agents.presets.research.tool_controls]
 # # active_tools = ["classify_destination"]
@@ -794,7 +795,7 @@ port = {port}                           # Port number (auto-generated for this i
 # binary = "codex"
 # args = ["app-server"]
 # models = ["gpt-5.5", "gpt-5.4"]
-# efforts = ["medium", "high", "xhigh"]
+# efforts = ["medium", "high", "xhigh", "max"]
 
 # Generic manual ACP server for advanced/custom CLIs not listed below.
 # If Moltis is missing a named default for an ACP agent, check the official

--- a/crates/config/src/validate/tests/agents.rs
+++ b/crates/config/src/validate/tests/agents.rs
@@ -125,7 +125,7 @@ max_iterations = 0
 
 #[test]
 fn reasoning_effort_valid_values_no_error() {
-    for effort in &["minimal", "low", "medium", "high", "xhigh"] {
+    for effort in &["minimal", "low", "medium", "high", "xhigh", "max"] {
         let toml = format!(
             r#"
             [agents.presets.thinker]

--- a/crates/providers/src/anthropic.rs
+++ b/crates/providers/src/anthropic.rs
@@ -111,7 +111,7 @@ impl AnthropicProvider {
             ReasoningEffort::Low => 4096,
             ReasoningEffort::Medium => 10240,
             ReasoningEffort::High => 32768,
-            ReasoningEffort::ExtraHigh => 65536,
+            ReasoningEffort::ExtraHigh | ReasoningEffort::Max => 65536,
         };
         body["thinking"] = serde_json::json!({
             "type": "enabled",

--- a/crates/providers/src/model_id.rs
+++ b/crates/providers/src/model_id.rs
@@ -27,6 +27,7 @@ pub(crate) const REASONING_SUFFIXES: &[(&str, moltis_agents::model::ReasoningEff
         "reasoning-xhigh",
         moltis_agents::model::ReasoningEffort::ExtraHigh,
     ),
+    ("reasoning-max", moltis_agents::model::ReasoningEffort::Max),
 ];
 
 #[must_use]
@@ -106,6 +107,10 @@ mod tests {
             split_reasoning_suffix("gpt-5@reasoning-xhigh"),
             ("gpt-5", Some(ReasoningEffort::ExtraHigh))
         );
+        assert_eq!(
+            split_reasoning_suffix("gpt-5.6-sol@reasoning-max"),
+            ("gpt-5.6-sol", Some(ReasoningEffort::Max))
+        );
         assert_eq!(split_reasoning_suffix("gpt-4o"), ("gpt-4o", None));
         assert_eq!(
             split_reasoning_suffix("model@unknown-suffix"),
@@ -132,6 +137,10 @@ mod tests {
             "claude-opus-4-5"
         );
         assert_eq!(raw_model_id("o3@reasoning-medium"), "o3");
+        assert_eq!(
+            raw_model_id("openai-codex::gpt-5.6-sol@reasoning-max"),
+            "gpt-5.6-sol"
+        );
         assert_eq!(raw_model_id("gpt-4o"), "gpt-4o");
     }
 }

--- a/crates/providers/src/openai/provider/core.rs
+++ b/crates/providers/src/openai/provider/core.rs
@@ -260,7 +260,7 @@ impl OpenAiProvider {
                 | ReasoningEffort::Low
                 | ReasoningEffort::Medium
                 | ReasoningEffort::High => "high",
-                ReasoningEffort::ExtraHigh => "max",
+                ReasoningEffort::ExtraHigh | ReasoningEffort::Max => "max",
             }),
             ReasoningEffortPolicy::KimiMax => self.reasoning_effort.map(|_| "max"),
             ReasoningEffortPolicy::OpenAi => self.reasoning_effort.map(|e| match e {
@@ -274,10 +274,11 @@ impl OpenAiProvider {
                 ReasoningEffort::Low => "low",
                 ReasoningEffort::Medium => "medium",
                 ReasoningEffort::High => "high",
-                ReasoningEffort::ExtraHigh => {
+                ReasoningEffort::ExtraHigh | ReasoningEffort::Max => {
                     tracing::debug!(
                         model = %self.model,
-                        "reasoning effort ExtraHigh clamped to \"high\" (OpenAI maximum)"
+                        effort = e.as_str(),
+                        "reasoning effort clamped to \"high\" (OpenAI Chat Completions maximum)"
                     );
                     "high"
                 },

--- a/crates/providers/src/openai/provider/request.rs
+++ b/crates/providers/src/openai/provider/request.rs
@@ -958,22 +958,27 @@ mod tests {
     }
 
     #[test]
-    fn deepseek_v4_reasoning_effort_enables_thinking_and_maps_xhigh_to_max() {
-        let mut p = provider("deepseek-v4-pro", "deepseek", "https://api.deepseek.com")
-            .with_capabilities(OpenAiProviderCapabilities {
-                reasoning_effort_policy: ReasoningEffortPolicy::DeepSeek,
-                ..OpenAiProviderCapabilities::DEFAULT
+    fn deepseek_v4_reasoning_effort_enables_thinking_and_maps_top_levels_to_max() {
+        for effort in [
+            moltis_agents::model::ReasoningEffort::ExtraHigh,
+            moltis_agents::model::ReasoningEffort::Max,
+        ] {
+            let mut p = provider("deepseek-v4-pro", "deepseek", "https://api.deepseek.com")
+                .with_capabilities(OpenAiProviderCapabilities {
+                    reasoning_effort_policy: ReasoningEffortPolicy::DeepSeek,
+                    ..OpenAiProviderCapabilities::DEFAULT
+                });
+            p.reasoning_effort = Some(effort);
+            let mut body = serde_json::json!({
+                "model": "deepseek-v4-pro",
+                "messages": [{"role": "user", "content": "hello"}],
             });
-        p.reasoning_effort = Some(moltis_agents::model::ReasoningEffort::ExtraHigh);
-        let mut body = serde_json::json!({
-            "model": "deepseek-v4-pro",
-            "messages": [{"role": "user", "content": "hello"}],
-        });
 
-        p.apply_reasoning_effort_chat(&mut body);
+            p.apply_reasoning_effort_chat(&mut body);
 
-        assert_eq!(body["reasoning_effort"], "max");
-        assert_eq!(body["thinking"], serde_json::json!({ "type": "enabled" }));
+            assert_eq!(body["reasoning_effort"], "max");
+            assert_eq!(body["thinking"], serde_json::json!({ "type": "enabled" }));
+        }
     }
 
     #[test]
@@ -1002,6 +1007,7 @@ mod tests {
             moltis_agents::model::ReasoningEffort::Medium,
             moltis_agents::model::ReasoningEffort::High,
             moltis_agents::model::ReasoningEffort::ExtraHigh,
+            moltis_agents::model::ReasoningEffort::Max,
         ] {
             let mut p = provider("kimi-k3", "moonshot", "https://api.moonshot.ai/v1")
                 .with_capabilities(OpenAiProviderCapabilities {

--- a/crates/providers/src/openai_codex.rs
+++ b/crates/providers/src/openai_codex.rs
@@ -102,7 +102,7 @@ impl OpenAiCodexProvider {
 
     /// Add `reasoning.effort` to a Responses-API request body when an effort
     /// is configured. GPT-5 family models accept `minimal`, `low`, `medium`,
-    /// `high`, and `xhigh` (matching the official Codex client).
+    /// `high`, `xhigh`, and `max` (matching the current Codex model catalog).
     fn apply_reasoning(&self, body: &mut serde_json::Value) {
         if let Some(effort) = self.reasoning_effort {
             body["reasoning"]["effort"] = serde_json::json!(effort.as_str());
@@ -947,6 +947,7 @@ mod tests {
             (ReasoningEffort::Medium, "medium"),
             (ReasoningEffort::High, "high"),
             (ReasoningEffort::ExtraHigh, "xhigh"),
+            (ReasoningEffort::Max, "max"),
         ] {
             let mut provider = OpenAiCodexProvider::new("gpt-5.4".to_string());
             provider.reasoning_effort = Some(effort);

--- a/crates/web/ui/e2e/specs/reasoning-toggle.spec.js
+++ b/crates/web/ui/e2e/specs/reasoning-toggle.spec.js
@@ -64,7 +64,7 @@ test.describe("reasoning effort toggle", () => {
 		expect(pageErrors).toEqual([]);
 	});
 
-	test("clicking toggle opens dropdown with Off/Low/Medium/High options", async ({ page }) => {
+	test("clicking toggle opens dropdown with all reasoning effort options", async ({ page }) => {
 		const pageErrors = watchPageErrors(page);
 
 		await setMockModels(
@@ -81,13 +81,14 @@ test.describe("reasoning effort toggle", () => {
 		await expect(dropdown).toBeVisible();
 
 		const items = page.locator("#reasoningDropdownList .model-dropdown-item");
-		await expect(items).toHaveCount(6);
+		await expect(items).toHaveCount(7);
 		await expect(items.nth(0)).toHaveText("Off");
 		await expect(items.nth(1)).toHaveText("Minimal");
 		await expect(items.nth(2)).toHaveText("Low");
 		await expect(items.nth(3)).toHaveText("Medium");
 		await expect(items.nth(4)).toHaveText("High");
 		await expect(items.nth(5)).toHaveText("Extra High");
+		await expect(items.nth(6)).toHaveText("Max");
 
 		expect(pageErrors).toEqual([]);
 	});
@@ -141,12 +142,19 @@ test.describe("reasoning effort toggle", () => {
 			window.__chatWsSpyInstalled = true;
 		});
 
-		// Set up a reasoning model and select high effort
+		// Set up a reasoning model and select maximum effort
 		await setMockModels(
 			page,
-			[{ id: "claude-opus-4-5", displayName: "Claude Opus 4.5", provider: "anthropic", supportsReasoning: true }],
-			"claude-opus-4-5",
-			"high",
+			[
+				{
+					id: "openai-codex::gpt-5.6-sol",
+					displayName: "GPT-5.6 Sol",
+					provider: "openai-codex",
+					supportsReasoning: true,
+				},
+			],
+			"openai-codex::gpt-5.6-sol",
+			"max",
 		);
 
 		const chatInput = page.locator("#chatInput");
@@ -155,7 +163,7 @@ test.describe("reasoning effort toggle", () => {
 
 		const payloads = await page.evaluate(() => window.__chatSendPayloads);
 		expect(payloads.length).toBeGreaterThan(0);
-		expect(payloads[0].model).toBe("claude-opus-4-5@reasoning-high");
+		expect(payloads[0].model).toBe("openai-codex::gpt-5.6-sol@reasoning-max");
 
 		expect(pageErrors).toEqual([]);
 	});

--- a/crates/web/ui/src/locales/en/chat.ts
+++ b/crates/web/ui/src/locales/en/chat.ts
@@ -52,6 +52,7 @@ export default {
 	reasoningMedium: "Medium",
 	reasoningHigh: "High",
 	reasoningExtraHigh: "Extra High",
+	reasoningMax: "Max",
 
 	// ── Debug panel ──────────────────────────────────────────
 	debugTooltip: "Show context debug info",

--- a/crates/web/ui/src/locales/fr/chat.ts
+++ b/crates/web/ui/src/locales/fr/chat.ts
@@ -52,6 +52,7 @@ export default {
 	reasoningMedium: "Moyen",
 	reasoningHigh: "Élevé",
 	reasoningExtraHigh: "Très élevé",
+	reasoningMax: "Maximum",
 
 	// ── Debug panel ──────────────────────────────────────────
 	debugTooltip: "Show context debug info",

--- a/crates/web/ui/src/locales/zh-TW/chat.ts
+++ b/crates/web/ui/src/locales/zh-TW/chat.ts
@@ -52,6 +52,7 @@ export default {
 	reasoningMedium: "中",
 	reasoningHigh: "高",
 	reasoningExtraHigh: "極高",
+	reasoningMax: "最高（Max）",
 
 	// ── Debug panel ──────────────────────────────────────────
 	debugTooltip: "顯示上下文除錯資訊",

--- a/crates/web/ui/src/locales/zh/chat.ts
+++ b/crates/web/ui/src/locales/zh/chat.ts
@@ -52,6 +52,7 @@ export default {
 	reasoningMedium: "中",
 	reasoningHigh: "高",
 	reasoningExtraHigh: "极高",
+	reasoningMax: "最高（Max）",
 
 	// ── Debug panel ──────────────────────────────────────────
 	debugTooltip: "显示上下文调试信息",

--- a/crates/web/ui/src/reasoning-toggle.ts
+++ b/crates/web/ui/src/reasoning-toggle.ts
@@ -1,17 +1,16 @@
 // ── Reasoning effort toggle ──────────────────────────────────
 //
 // Adds a "brain" combo next to the model selector that lets users
-// pick Low / Medium / High reasoning effort for models that support
-// extended thinking.  The selected effort is appended as a
-// `@reasoning-*` suffix on the model ID sent to the backend -- no
-// backend changes required.
+// pick a supported reasoning effort for models that expose extended
+// thinking.  The selected effort is appended as a
+// `@reasoning-*` suffix on the model ID sent to the backend.
 
 import { effect } from "@preact/signals";
 import { t } from "./i18n";
 import { modelStore } from "./stores/model-store";
 import { sessionStore } from "./stores/session-store";
 
-const EFFORT_VALUES: string[] = ["", "minimal", "low", "medium", "high", "xhigh"];
+const EFFORT_VALUES: string[] = ["", "minimal", "low", "medium", "high", "xhigh", "max"];
 
 let reasoningCombo: HTMLElement | null = null;
 let reasoningComboBtn: HTMLElement | null = null;
@@ -28,6 +27,7 @@ function effortLabel(effort: string): string {
 		medium: t("chat:reasoningMedium"),
 		high: t("chat:reasoningHigh"),
 		xhigh: t("chat:reasoningExtraHigh"),
+		max: t("chat:reasoningMax"),
 	};
 	return map[effort] ?? t("chat:reasoningOff");
 }

--- a/docs/src/configuration-reference.md
+++ b/docs/src/configuration-reference.md
@@ -327,7 +327,7 @@ User profile collected during onboarding.
 | `system_prompt_suffix` | optional string | `null` | Extra instructions appended to the sub-agent system prompt. |
 | `max_iterations` | optional integer | `null` | Maximum iterations for matching direct agent sessions and spawned sub-agents. Falls back to `tools.agent_max_iterations`. |
 | `timeout_secs` | optional integer | `null` | Timeout in seconds for matching direct agent sessions and spawned sub-agents (`0` = no timeout). Direct sessions fall back to `tools.agent_timeout_secs`; spawned sub-agents preserve no-timeout behavior unless the preset sets `timeout_secs`. |
-| `reasoning_effort` | optional enum: `low`, `medium`, `high` | `null` | Reasoning/thinking effort level for models that support extended thinking (e.g. Claude Opus, OpenAI o-series). |
+| `reasoning_effort` | optional enum: `minimal`, `low`, `medium`, `high`, `xhigh`, `max` | `null` | Reasoning/thinking effort level for models that support extended thinking. Providers clamp unsupported levels to their nearest supported equivalent. |
 | `sessions` | optional `SessionAccessPolicyConfig` | `null` | Session access policy for inter-agent communication. |
 | `memory` | optional `PresetMemoryConfig` | `null` | Persistent per-agent memory configuration. |
 


### PR DESCRIPTION
## Summary

- add `max` to the shared `ReasoningEffort` schema and `@reasoning-max` model suffix parsing
- forward `max` unchanged through the OpenAI Codex Responses API while clamping providers that do not expose a distinct maximum level
- expose Max in the reasoning selector, translations, and browser coverage
- document all accepted reasoning-effort values in the configuration reference and generated template

## Validation

- `cargo test -p moltis-config reasoning_effort` (3 passed)
- `cargo test -p moltis-config write_default_config_writes_template_to_requested_path` (passed)
- `cargo test -p moltis-providers reasoning_effort` (9 passed)
- targeted suffix parsing and OpenAI Codex wire-value tests passed
- `npm run typecheck`
- Biome checks on all changed UI and E2E files
- `reasoning-toggle.spec.js` (7 passed in Chromium)
- `cargo build --bin moltis`
- `scripts/check-changelog-guard.sh origin/main HEAD`

## Manual QA

A local Moltis build was exercised through the web UI with `openai-codex::gpt-5.6-sol@reasoning-max`. The request reached the provider as `reasoning.effort = "max"` and completed successfully.

The full AI-assisted session is not attached because it contains private local authentication, deployment details, and unrelated workspace context. This PR includes the relevant implementation decisions and redacted validation results.
