### PR TITLE
fix(hooks): complete lifecycle dispatch

### DIFF
--- a/crates/agents/src/runner/helpers.rs
+++ b/crates/agents/src/runner/helpers.rs
@@ -4,7 +4,9 @@ use std::borrow::Cow;
 
 use tracing::{info, warn};
 
-use moltis_common::hooks::{ChannelBinding, HookAction, HookPayload, HookRegistry};
+use moltis_common::hooks::{
+    ChannelBinding, HookAction, HookPayload, HookRegistry, dispatch_agent_end,
+};
 
 use crate::{
     model::{
@@ -375,6 +377,25 @@ pub(crate) async fn dispatch_before_agent_start_hook(
             Ok(())
         },
     }
+}
+
+/// Notify observers after a successful agent loop has produced its final result.
+///
+/// `AgentEnd` is informational, so hook failures are logged and never replace a
+/// response the provider already produced.
+pub(crate) async fn dispatch_agent_end_hook(
+    hook_registry: Option<&std::sync::Arc<HookRegistry>>,
+    session_key: &str,
+    result: &AgentRunResult,
+) {
+    dispatch_agent_end(
+        hook_registry.map(AsRef::as_ref),
+        session_key,
+        &result.text,
+        result.iterations,
+        result.tool_calls_made,
+    )
+    .await;
 }
 
 pub(crate) fn finish_agent_run(

--- a/crates/agents/src/runner/helpers.rs
+++ b/crates/agents/src/runner/helpers.rs
@@ -386,11 +386,13 @@ pub(crate) async fn dispatch_before_agent_start_hook(
 pub(crate) async fn dispatch_agent_end_hook(
     hook_registry: Option<&std::sync::Arc<HookRegistry>>,
     session_key: &str,
+    turn_id: Option<&str>,
     result: &AgentRunResult,
 ) {
     dispatch_agent_end(
         hook_registry.map(AsRef::as_ref),
         session_key,
+        turn_id,
         &result.text,
         result.iterations,
         result.tool_calls_made,

--- a/crates/agents/src/runner/mod.rs
+++ b/crates/agents/src/runner/mod.rs
@@ -40,7 +40,7 @@ pub type SteerInbox = std::sync::Arc<tokio::sync::Mutex<Vec<String>>>;
 pub(crate) use helpers::{
     AUTO_CONTINUE_NUDGE, MALFORMED_TOOL_RETRY_PROMPT, UsageAccumulator,
     apply_before_llm_call_modify_payload, apply_loop_detector_intervention,
-    channel_binding_from_tool_context, dispatch_after_llm_call_hook,
+    channel_binding_from_tool_context, dispatch_after_llm_call_hook, dispatch_agent_end_hook,
     dispatch_before_agent_start_hook, empty_tool_name_retry_prompt,
     enforce_tool_result_context_budget, explicit_shell_command_from_user_content,
     find_empty_tool_name_call, finish_agent_run, has_named_tool_call, is_substantive_answer_text,

--- a/crates/agents/src/runner/non_streaming.rs
+++ b/crates/agents/src/runner/non_streaming.rs
@@ -743,6 +743,7 @@ pub async fn run_agent_loop_with_context_and_limits(
                     if let Some(ref hooks) = hook_registry {
                         let payload = HookPayload::BeforeToolCall {
                             session_key: session_key.clone(),
+                            turn_id: trace_correlation_key.map(ToOwned::to_owned),
                             tool_call_id: Some(tc_id.clone()),
                             tool_name: tc_name.clone(),
                             arguments: args.clone(),
@@ -794,7 +795,7 @@ pub async fn run_agent_loop_with_context_and_limits(
                     }
 
                     if let Some(tool) = tool {
-                        match tool.execute(args).await {
+                        match tool.execute(args.clone()).await {
                             Ok(val) => {
                                 let error = tool_result_failure(&val);
                                 let success = error.is_none();
@@ -802,8 +803,10 @@ pub async fn run_agent_loop_with_context_and_limits(
                                 if let Some(ref hooks) = hook_registry {
                                     let payload = HookPayload::AfterToolCall {
                                         session_key: session_key.clone(),
+                                        turn_id: trace_correlation_key.map(ToOwned::to_owned),
                                         tool_call_id: Some(tc_id.clone()),
                                         tool_name: tc_name.clone(),
+                                        arguments: Some(args.clone()),
                                         success,
                                         result: Some(val.clone()),
                                         channel: channel_for_hooks.clone(),
@@ -827,8 +830,10 @@ pub async fn run_agent_loop_with_context_and_limits(
                                 if let Some(ref hooks) = hook_registry {
                                     let payload = HookPayload::AfterToolCall {
                                         session_key: session_key.clone(),
+                                        turn_id: trace_correlation_key.map(ToOwned::to_owned),
                                         tool_call_id: Some(tc_id.clone()),
                                         tool_name: tc_name.clone(),
+                                        arguments: Some(args.clone()),
                                         success: false,
                                         result: None,
                                         channel: channel_for_hooks.clone(),
@@ -990,7 +995,13 @@ pub async fn run_agent_loop_with_context_and_limits(
     .await;
 
     if let Ok(agent_result) = &result {
-        dispatch_agent_end_hook(hook_registry.as_ref(), &session_key_for_hooks, agent_result).await;
+        dispatch_agent_end_hook(
+            hook_registry.as_ref(),
+            &session_key_for_hooks,
+            trace_correlation_key,
+            agent_result,
+        )
+        .await;
     }
     instrumentation::finish_turn(turn_recorder.as_ref().as_ref(), &result);
     result

--- a/crates/agents/src/runner/non_streaming.rs
+++ b/crates/agents/src/runner/non_streaming.rs
@@ -27,7 +27,7 @@ use super::{
     AUTO_CONTINUE_NUDGE, AgentLoopLimits, AgentRunError, AgentRunResult,
     MALFORMED_TOOL_RETRY_PROMPT, OnEvent, RunnerEvent, UsageAccumulator,
     apply_before_llm_call_modify_payload, apply_loop_detector_intervention,
-    channel_binding_from_tool_context, dispatch_after_llm_call_hook,
+    channel_binding_from_tool_context, dispatch_after_llm_call_hook, dispatch_agent_end_hook,
     dispatch_before_agent_start_hook, empty_tool_name_retry_prompt,
     explicit_shell_command_from_user_content, find_empty_tool_name_call, finish_agent_run,
     has_named_tool_call, instrumentation, is_substantive_answer_text, log_tool_argument_diagnostic,
@@ -656,7 +656,7 @@ pub async fn run_agent_loop_with_context_and_limits(
                 let session_key = session_key_for_hooks.clone();
                 let channel_for_hooks = channel_for_hooks.clone();
                 let tc_name = resolved_name.to_string();
-                let _tc_id = tc.id.clone();
+                let tc_id = tc.id.clone();
 
                 if let Some(ref ctx) = tool_context
                     && let (Some(args_obj), Some(ctx_obj)) = (args.as_object_mut(), ctx.as_object())
@@ -743,6 +743,7 @@ pub async fn run_agent_loop_with_context_and_limits(
                     if let Some(ref hooks) = hook_registry {
                         let payload = HookPayload::BeforeToolCall {
                             session_key: session_key.clone(),
+                            tool_call_id: Some(tc_id.clone()),
                             tool_name: tc_name.clone(),
                             arguments: args.clone(),
                             channel: channel_for_hooks.clone(),
@@ -801,6 +802,7 @@ pub async fn run_agent_loop_with_context_and_limits(
                                 if let Some(ref hooks) = hook_registry {
                                     let payload = HookPayload::AfterToolCall {
                                         session_key: session_key.clone(),
+                                        tool_call_id: Some(tc_id.clone()),
                                         tool_name: tc_name.clone(),
                                         success,
                                         result: Some(val.clone()),
@@ -825,6 +827,7 @@ pub async fn run_agent_loop_with_context_and_limits(
                                 if let Some(ref hooks) = hook_registry {
                                     let payload = HookPayload::AfterToolCall {
                                         session_key: session_key.clone(),
+                                        tool_call_id: Some(tc_id.clone()),
                                         tool_name: tc_name.clone(),
                                         success: false,
                                         result: None,
@@ -930,6 +933,7 @@ pub async fn run_agent_loop_with_context_and_limits(
             if let Some(ref hooks) = hook_registry {
                 let payload = HookPayload::ToolResultPersist {
                     session_key: session_key_for_hooks.clone(),
+                    tool_call_id: Some(tc.id.clone()),
                     tool_name: sanitize_tool_name(&tc.name).into_owned(),
                     result: result.clone(),
                     channel: channel_for_hooks.clone(),
@@ -985,6 +989,9 @@ pub async fn run_agent_loop_with_context_and_limits(
     }
     .await;
 
+    if let Ok(agent_result) = &result {
+        dispatch_agent_end_hook(hook_registry.as_ref(), &session_key_for_hooks, agent_result).await;
+    }
     instrumentation::finish_turn(turn_recorder.as_ref().as_ref(), &result);
     result
 }

--- a/crates/agents/src/runner/streaming.rs
+++ b/crates/agents/src/runner/streaming.rs
@@ -33,7 +33,7 @@ use super::{
     AUTO_CONTINUE_NUDGE, AgentLoopLimits, AgentRunError, AgentRunResult,
     MALFORMED_TOOL_RETRY_PROMPT, OnEvent, RunnerEvent, UsageAccumulator,
     apply_before_llm_call_modify_payload, apply_loop_detector_intervention,
-    channel_binding_from_tool_context, dispatch_after_llm_call_hook,
+    channel_binding_from_tool_context, dispatch_after_llm_call_hook, dispatch_agent_end_hook,
     dispatch_before_agent_start_hook, empty_tool_name_retry_prompt,
     explicit_shell_command_from_user_content, find_empty_tool_name_call, finish_agent_run,
     has_named_tool_call, instrumentation, is_substantive_answer_text, log_tool_argument_diagnostic,
@@ -884,6 +884,7 @@ pub async fn run_agent_loop_streaming_with_limits(
                     info!(tool = %tc_name, id = %tc.id, args = %args, "executing tool");
                 }
 
+                let tc_id = tc.id.clone();
                 async move {
                     let mut tool_step = tool_turn_recorder.as_ref().as_ref().map(|recorder| {
                         recorder.step(
@@ -910,6 +911,7 @@ pub async fn run_agent_loop_streaming_with_limits(
                     if let Some(ref hooks) = hook_registry {
                         let payload = HookPayload::BeforeToolCall {
                             session_key: session_key.clone(),
+                            tool_call_id: Some(tc_id.clone()),
                             tool_name: tc_name.clone(),
                             arguments: args.clone(),
                             channel: channel_for_hooks.clone(),
@@ -967,6 +969,7 @@ pub async fn run_agent_loop_streaming_with_limits(
                                 if let Some(ref hooks) = hook_registry {
                                     let payload = HookPayload::AfterToolCall {
                                         session_key: session_key.clone(),
+                                        tool_call_id: Some(tc_id.clone()),
                                         tool_name: tc_name.clone(),
                                         success,
                                         result: Some(val.clone()),
@@ -990,6 +993,7 @@ pub async fn run_agent_loop_streaming_with_limits(
                                 if let Some(ref hooks) = hook_registry {
                                     let payload = HookPayload::AfterToolCall {
                                         session_key: session_key.clone(),
+                                        tool_call_id: Some(tc_id.clone()),
                                         tool_name: tc_name.clone(),
                                         success: false,
                                         result: None,
@@ -1087,6 +1091,7 @@ pub async fn run_agent_loop_streaming_with_limits(
             if let Some(ref hooks) = hook_registry {
                 let payload = HookPayload::ToolResultPersist {
                     session_key: session_key_for_hooks.clone(),
+                    tool_call_id: Some(tc.id.clone()),
                     tool_name: sanitize_tool_name(&tc.name).into_owned(),
                     result: result.clone(),
                     channel: channel_for_hooks.clone(),
@@ -1156,6 +1161,9 @@ pub async fn run_agent_loop_streaming_with_limits(
     }
     .await;
 
+    if let Ok(agent_result) = &result {
+        dispatch_agent_end_hook(hook_registry.as_ref(), &session_key_for_hooks, agent_result).await;
+    }
     instrumentation::finish_turn(turn_recorder.as_ref().as_ref(), &result);
     result
 }

--- a/crates/agents/src/runner/streaming.rs
+++ b/crates/agents/src/runner/streaming.rs
@@ -911,6 +911,7 @@ pub async fn run_agent_loop_streaming_with_limits(
                     if let Some(ref hooks) = hook_registry {
                         let payload = HookPayload::BeforeToolCall {
                             session_key: session_key.clone(),
+                            turn_id: trace_correlation_key.map(ToOwned::to_owned),
                             tool_call_id: Some(tc_id.clone()),
                             tool_name: tc_name.clone(),
                             arguments: args.clone(),
@@ -962,15 +963,17 @@ pub async fn run_agent_loop_streaming_with_limits(
                     }
 
                     if let Some(tool) = tool {
-                        match tool.execute(args).await {
+                        match tool.execute(args.clone()).await {
                             Ok(val) => {
                                 let error = tool_result_failure(&val);
                                 let success = error.is_none();
                                 if let Some(ref hooks) = hook_registry {
                                     let payload = HookPayload::AfterToolCall {
                                         session_key: session_key.clone(),
+                                        turn_id: trace_correlation_key.map(ToOwned::to_owned),
                                         tool_call_id: Some(tc_id.clone()),
                                         tool_name: tc_name.clone(),
+                                        arguments: Some(args.clone()),
                                         success,
                                         result: Some(val.clone()),
                                         channel: channel_for_hooks.clone(),
@@ -993,8 +996,10 @@ pub async fn run_agent_loop_streaming_with_limits(
                                 if let Some(ref hooks) = hook_registry {
                                     let payload = HookPayload::AfterToolCall {
                                         session_key: session_key.clone(),
+                                        turn_id: trace_correlation_key.map(ToOwned::to_owned),
                                         tool_call_id: Some(tc_id.clone()),
                                         tool_name: tc_name.clone(),
+                                        arguments: Some(args.clone()),
                                         success: false,
                                         result: None,
                                         channel: channel_for_hooks.clone(),
@@ -1162,7 +1167,13 @@ pub async fn run_agent_loop_streaming_with_limits(
     .await;
 
     if let Ok(agent_result) = &result {
-        dispatch_agent_end_hook(hook_registry.as_ref(), &session_key_for_hooks, agent_result).await;
+        dispatch_agent_end_hook(
+            hook_registry.as_ref(),
+            &session_key_for_hooks,
+            trace_correlation_key,
+            agent_result,
+        )
+        .await;
     }
     instrumentation::finish_turn(turn_recorder.as_ref().as_ref(), &result);
     result

--- a/crates/agents/src/runner/tests/basic.rs
+++ b/crates/agents/src/runner/tests/basic.rs
@@ -193,6 +193,46 @@ async fn test_nested_error_data_does_not_fail_a_successful_tool_call() {
 }
 
 #[tokio::test]
+async fn test_tool_hook_lifecycle_shares_stable_call_id() {
+    let provider = Arc::new(ToolCallingProvider {
+        call_count: std::sync::atomic::AtomicUsize::new(0),
+    });
+    let mut tools = ToolRegistry::new();
+    tools.register(Box::new(EchoTool));
+    let payloads = Arc::new(std::sync::Mutex::new(Vec::new()));
+    let mut hooks = HookRegistry::new();
+    hooks.register(Arc::new(RecordingHook {
+        payloads: Arc::clone(&payloads),
+    }));
+
+    run_agent_loop_with_context(
+        provider,
+        &tools,
+        "You are a test bot.",
+        &UserContent::text("Hi"),
+        None,
+        None,
+        Some(serde_json::json!({"_session_key": "tool-session"})),
+        Some(Arc::new(hooks)),
+        None,
+    )
+    .await
+    .unwrap();
+
+    let payloads = payloads.lock().unwrap();
+    assert_eq!(payloads.len(), 3);
+    for payload in payloads.iter() {
+        let tool_call_id = match payload {
+            HookPayload::BeforeToolCall { tool_call_id, .. }
+            | HookPayload::AfterToolCall { tool_call_id, .. }
+            | HookPayload::ToolResultPersist { tool_call_id, .. } => tool_call_id,
+            other => panic!("unexpected payload: {other:?}"),
+        };
+        assert_eq!(tool_call_id.as_deref(), Some("call_1"));
+    }
+}
+
+#[tokio::test]
 async fn test_non_streaming_runner_uses_max_iteration_override() {
     let provider = Arc::new(ToolCallingProvider {
         call_count: std::sync::atomic::AtomicUsize::new(0),
@@ -256,6 +296,46 @@ async fn test_non_streaming_runner_dispatches_before_agent_start_hook() {
         &payloads[0],
         HookPayload::BeforeAgentStart { session_key, model }
             if session_key == "session-123" && model == "mock-model"
+    ));
+}
+
+#[tokio::test]
+async fn test_non_streaming_runner_dispatches_agent_end_hook() {
+    let provider = Arc::new(MockProvider {
+        response_text: "Hello!".into(),
+    });
+    let tools = ToolRegistry::new();
+    let payloads = Arc::new(std::sync::Mutex::new(Vec::new()));
+    let mut hooks = HookRegistry::new();
+    hooks.register(Arc::new(AgentEndRecordingHook {
+        payloads: Arc::clone(&payloads),
+    }));
+
+    let result = run_agent_loop_with_context(
+        provider,
+        &tools,
+        "You are a test bot.",
+        &UserContent::text("Hi"),
+        None,
+        None,
+        Some(serde_json::json!({"_session_key": "session-123"})),
+        Some(Arc::new(hooks)),
+        None,
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(result.text, "Hello!");
+    let payloads = payloads.lock().unwrap();
+    assert_eq!(payloads.len(), 1);
+    assert!(matches!(
+        &payloads[0],
+        HookPayload::AgentEnd {
+            session_key,
+            text,
+            iterations: 1,
+            tool_calls: 0,
+        } if session_key == "session-123" && text == "Hello!"
     ));
 }
 
@@ -616,6 +696,45 @@ async fn test_streaming_runner_dispatches_before_agent_start_hook() {
         &payloads[0],
         HookPayload::BeforeAgentStart { session_key, model }
             if session_key == "stream-session-123" && model == "streaming-usage-model"
+    ));
+}
+
+#[tokio::test]
+async fn test_streaming_runner_dispatches_agent_end_hook() {
+    let provider = Arc::new(StreamingUsageProvider);
+    let tools = ToolRegistry::new();
+    let payloads = Arc::new(std::sync::Mutex::new(Vec::new()));
+    let mut hooks = HookRegistry::new();
+    hooks.register(Arc::new(AgentEndRecordingHook {
+        payloads: Arc::clone(&payloads),
+    }));
+
+    let result = run_agent_loop_streaming(
+        provider,
+        &tools,
+        "You are a test bot.",
+        &UserContent::text("Hi"),
+        None,
+        None,
+        Some(serde_json::json!({"_session_key": "stream-session-123"})),
+        Some(Arc::new(hooks)),
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(result.text, "cached reply");
+    let payloads = payloads.lock().unwrap();
+    assert_eq!(payloads.len(), 1);
+    assert!(matches!(
+        &payloads[0],
+        HookPayload::AgentEnd {
+            session_key,
+            text,
+            iterations: 1,
+            tool_calls: 0,
+        } if session_key == "stream-session-123" && text == "cached reply"
     ));
 }
 

--- a/crates/agents/src/runner/tests/basic.rs
+++ b/crates/agents/src/runner/tests/basic.rs
@@ -343,7 +343,10 @@ async fn test_non_streaming_runner_dispatches_agent_end_hook() {
         &UserContent::text("Hi"),
         None,
         None,
-        Some(serde_json::json!({"_session_key": "session-123"})),
+        Some(serde_json::json!({
+            "_session_key": "session-123",
+            "_trace_correlation_key": "turn-123"
+        })),
         Some(Arc::new(hooks)),
         None,
     )
@@ -745,7 +748,10 @@ async fn test_streaming_runner_dispatches_agent_end_hook() {
         &UserContent::text("Hi"),
         None,
         None,
-        Some(serde_json::json!({"_session_key": "stream-session-123"})),
+        Some(serde_json::json!({
+            "_session_key": "stream-session-123",
+            "_trace_correlation_key": "stream-turn-123"
+        })),
         Some(Arc::new(hooks)),
         None,
         None,

--- a/crates/agents/src/runner/tests/basic.rs
+++ b/crates/agents/src/runner/tests/basic.rs
@@ -212,7 +212,10 @@ async fn test_tool_hook_lifecycle_shares_stable_call_id() {
         &UserContent::text("Hi"),
         None,
         None,
-        Some(serde_json::json!({"_session_key": "tool-session"})),
+        Some(serde_json::json!({
+            "_session_key": "tool-session",
+            "_trace_correlation_key": "turn-tool"
+        })),
         Some(Arc::new(hooks)),
         None,
     )
@@ -223,9 +226,28 @@ async fn test_tool_hook_lifecycle_shares_stable_call_id() {
     assert_eq!(payloads.len(), 3);
     for payload in payloads.iter() {
         let tool_call_id = match payload {
-            HookPayload::BeforeToolCall { tool_call_id, .. }
-            | HookPayload::AfterToolCall { tool_call_id, .. }
-            | HookPayload::ToolResultPersist { tool_call_id, .. } => tool_call_id,
+            HookPayload::BeforeToolCall {
+                turn_id,
+                tool_call_id,
+                ..
+            } => {
+                assert_eq!(turn_id.as_deref(), Some("turn-tool"));
+                tool_call_id
+            },
+            HookPayload::AfterToolCall {
+                turn_id,
+                tool_call_id,
+                arguments,
+                ..
+            } => {
+                assert_eq!(turn_id.as_deref(), Some("turn-tool"));
+                assert_eq!(
+                    arguments.as_ref().and_then(|value| value["text"].as_str()),
+                    Some("hi")
+                );
+                tool_call_id
+            },
+            HookPayload::ToolResultPersist { tool_call_id, .. } => tool_call_id,
             other => panic!("unexpected payload: {other:?}"),
         };
         assert_eq!(tool_call_id.as_deref(), Some("call_1"));
@@ -282,7 +304,10 @@ async fn test_non_streaming_runner_dispatches_before_agent_start_hook() {
         &UserContent::text("Hi"),
         None,
         None,
-        Some(serde_json::json!({"_session_key": "session-123"})),
+        Some(serde_json::json!({
+            "_session_key": "session-123",
+            "_trace_correlation_key": "turn-123"
+        })),
         Some(Arc::new(hooks)),
         None,
     )
@@ -332,10 +357,11 @@ async fn test_non_streaming_runner_dispatches_agent_end_hook() {
         &payloads[0],
         HookPayload::AgentEnd {
             session_key,
+            turn_id: Some(turn_id),
             text,
             iterations: 1,
             tool_calls: 0,
-        } if session_key == "session-123" && text == "Hello!"
+        } if session_key == "session-123" && turn_id == "turn-123" && text == "Hello!"
     ));
 }
 
@@ -681,7 +707,10 @@ async fn test_streaming_runner_dispatches_before_agent_start_hook() {
         &UserContent::text("Hi"),
         None,
         None,
-        Some(serde_json::json!({"_session_key": "stream-session-123"})),
+        Some(serde_json::json!({
+            "_session_key": "stream-session-123",
+            "_trace_correlation_key": "stream-turn-123"
+        })),
         Some(Arc::new(hooks)),
         None,
         None,
@@ -731,10 +760,11 @@ async fn test_streaming_runner_dispatches_agent_end_hook() {
         &payloads[0],
         HookPayload::AgentEnd {
             session_key,
+            turn_id: Some(turn_id),
             text,
             iterations: 1,
             tool_calls: 0,
-        } if session_key == "stream-session-123" && text == "cached reply"
+        } if session_key == "stream-session-123" && turn_id == "stream-turn-123" && text == "cached reply"
     ));
 }
 

--- a/crates/agents/src/runner/tests/helpers.rs
+++ b/crates/agents/src/runner/tests/helpers.rs
@@ -45,7 +45,11 @@ impl HookHandler for RecordingHook {
     }
 
     fn events(&self) -> &[HookEvent] {
-        static EVENTS: [HookEvent; 2] = [HookEvent::BeforeToolCall, HookEvent::AfterToolCall];
+        static EVENTS: [HookEvent; 3] = [
+            HookEvent::BeforeToolCall,
+            HookEvent::AfterToolCall,
+            HookEvent::ToolResultPersist,
+        ];
         &EVENTS
     }
 
@@ -95,6 +99,31 @@ impl HookHandler for AgentStartRecordingHook {
 
     fn events(&self) -> &[HookEvent] {
         static EVENTS: [HookEvent; 1] = [HookEvent::BeforeAgentStart];
+        &EVENTS
+    }
+
+    async fn handle(
+        &self,
+        _event: HookEvent,
+        payload: &HookPayload,
+    ) -> moltis_common::error::Result<HookAction> {
+        self.payloads.lock().unwrap().push(payload.clone());
+        Ok(HookAction::Continue)
+    }
+}
+
+pub(super) struct AgentEndRecordingHook {
+    pub payloads: Arc<std::sync::Mutex<Vec<HookPayload>>>,
+}
+
+#[async_trait]
+impl HookHandler for AgentEndRecordingHook {
+    fn name(&self) -> &str {
+        "agent-end-recording-hook"
+    }
+
+    fn events(&self) -> &[HookEvent] {
+        static EVENTS: [HookEvent; 1] = [HookEvent::AgentEnd];
         &EVENTS
     }
 

--- a/crates/agents/src/runner/tests_legacy/runner.rs
+++ b/crates/agents/src/runner/tests_legacy/runner.rs
@@ -489,7 +489,7 @@ pub async fn run_agent_loop_with_context(
                 let session_key = session_key_for_hooks.clone();
                 let channel_for_hooks = channel_for_hooks.clone();
                 let tc_name = sanitized.to_string();
-                let _tc_id = tc.id.clone();
+                let tc_id = tc.id.clone();
 
                 if let Some(ref ctx) = tool_context
                     && let (Some(args_obj), Some(ctx_obj)) = (args.as_object_mut(), ctx.as_object())
@@ -545,6 +545,7 @@ pub async fn run_agent_loop_with_context(
                     if let Some(ref hooks) = hook_registry {
                         let payload = HookPayload::BeforeToolCall {
                             session_key: session_key.clone(),
+                            tool_call_id: Some(tc_id.clone()),
                             tool_name: tc_name.clone(),
                             arguments: args.clone(),
                             channel: channel_for_hooks.clone(),
@@ -589,6 +590,7 @@ pub async fn run_agent_loop_with_context(
                                 if let Some(ref hooks) = hook_registry {
                                     let payload = HookPayload::AfterToolCall {
                                         session_key: session_key.clone(),
+                                        tool_call_id: Some(tc_id.clone()),
                                         tool_name: tc_name.clone(),
                                         success: !has_error,
                                         result: Some(val.clone()),
@@ -612,6 +614,7 @@ pub async fn run_agent_loop_with_context(
                                 if let Some(ref hooks) = hook_registry {
                                     let payload = HookPayload::AfterToolCall {
                                         session_key: session_key.clone(),
+                                        tool_call_id: Some(tc_id.clone()),
                                         tool_name: tc_name.clone(),
                                         success: false,
                                         result: None,
@@ -714,6 +717,7 @@ pub async fn run_agent_loop_with_context(
             if let Some(ref hooks) = hook_registry {
                 let payload = HookPayload::ToolResultPersist {
                     session_key: session_key_for_hooks.clone(),
+                    tool_call_id: Some(tc.id.clone()),
                     tool_name: sanitize_tool_name(&tc.name).into_owned(),
                     result: result.clone(),
                     channel: channel_for_hooks.clone(),

--- a/crates/agents/src/runner/tests_legacy/runner.rs
+++ b/crates/agents/src/runner/tests_legacy/runner.rs
@@ -545,6 +545,7 @@ pub async fn run_agent_loop_with_context(
                     if let Some(ref hooks) = hook_registry {
                         let payload = HookPayload::BeforeToolCall {
                             session_key: session_key.clone(),
+                            turn_id: None,
                             tool_call_id: Some(tc_id.clone()),
                             tool_name: tc_name.clone(),
                             arguments: args.clone(),
@@ -572,7 +573,7 @@ pub async fn run_agent_loop_with_context(
                     }
 
                     if let Some(tool) = tool {
-                        match tool.execute(args).await {
+                        match tool.execute(args.clone()).await {
                             Ok(val) => {
                                 // Check if the result indicates a logical failure
                                 // (e.g., BrowserResponse with success: false)
@@ -590,8 +591,10 @@ pub async fn run_agent_loop_with_context(
                                 if let Some(ref hooks) = hook_registry {
                                     let payload = HookPayload::AfterToolCall {
                                         session_key: session_key.clone(),
+                                        turn_id: None,
                                         tool_call_id: Some(tc_id.clone()),
                                         tool_name: tc_name.clone(),
+                                        arguments: Some(args.clone()),
                                         success: !has_error,
                                         result: Some(val.clone()),
                                         channel: channel_for_hooks.clone(),
@@ -614,8 +617,10 @@ pub async fn run_agent_loop_with_context(
                                 if let Some(ref hooks) = hook_registry {
                                     let payload = HookPayload::AfterToolCall {
                                         session_key: session_key.clone(),
+                                        turn_id: None,
                                         tool_call_id: Some(tc_id.clone()),
                                         tool_name: tc_name.clone(),
+                                        arguments: Some(args.clone()),
                                         success: false,
                                         result: None,
                                         channel: channel_for_hooks.clone(),

--- a/crates/agents/src/runner/tests_legacy/streaming.rs
+++ b/crates/agents/src/runner/tests_legacy/streaming.rs
@@ -650,6 +650,7 @@ pub async fn run_agent_loop_streaming(
                     if let Some(ref hooks) = hook_registry {
                         let payload = HookPayload::BeforeToolCall {
                             session_key: session_key.clone(),
+                            turn_id: None,
                             tool_call_id: Some(tc_id.clone()),
                             tool_name: tc_name.clone(),
                             arguments: args.clone(),
@@ -677,7 +678,7 @@ pub async fn run_agent_loop_streaming(
                     }
 
                     if let Some(tool) = tool {
-                        match tool.execute(args).await {
+                        match tool.execute(args.clone()).await {
                             Ok(val) => {
                                 // Check if the result indicates a logical failure
                                 // (e.g., BrowserResponse with success: false)
@@ -694,8 +695,10 @@ pub async fn run_agent_loop_streaming(
                                 if let Some(ref hooks) = hook_registry {
                                     let payload = HookPayload::AfterToolCall {
                                         session_key: session_key.clone(),
+                                        turn_id: None,
                                         tool_call_id: Some(tc_id.clone()),
                                         tool_name: tc_name.clone(),
+                                        arguments: Some(args.clone()),
                                         success: !has_error,
                                         result: Some(val.clone()),
                                         channel: channel_for_hooks.clone(),
@@ -716,8 +719,10 @@ pub async fn run_agent_loop_streaming(
                                 if let Some(ref hooks) = hook_registry {
                                     let payload = HookPayload::AfterToolCall {
                                         session_key: session_key.clone(),
+                                        turn_id: None,
                                         tool_call_id: Some(tc_id.clone()),
                                         tool_name: tc_name.clone(),
+                                        arguments: Some(args.clone()),
                                         success: false,
                                         result: None,
                                         channel: channel_for_hooks.clone(),

--- a/crates/agents/src/runner/tests_legacy/streaming.rs
+++ b/crates/agents/src/runner/tests_legacy/streaming.rs
@@ -597,6 +597,7 @@ pub async fn run_agent_loop_streaming(
                 let session_key = session_key_for_hooks.clone();
                 let channel_for_hooks = channel_for_hooks.clone();
                 let tc_name = sanitized.to_string();
+                let tc_id = tc.id.clone();
 
                 if let Some(ref ctx) = tool_context
                     && let (Some(args_obj), Some(ctx_obj)) = (args.as_object_mut(), ctx.as_object())
@@ -649,6 +650,7 @@ pub async fn run_agent_loop_streaming(
                     if let Some(ref hooks) = hook_registry {
                         let payload = HookPayload::BeforeToolCall {
                             session_key: session_key.clone(),
+                            tool_call_id: Some(tc_id.clone()),
                             tool_name: tc_name.clone(),
                             arguments: args.clone(),
                             channel: channel_for_hooks.clone(),
@@ -692,6 +694,7 @@ pub async fn run_agent_loop_streaming(
                                 if let Some(ref hooks) = hook_registry {
                                     let payload = HookPayload::AfterToolCall {
                                         session_key: session_key.clone(),
+                                        tool_call_id: Some(tc_id.clone()),
                                         tool_name: tc_name.clone(),
                                         success: !has_error,
                                         result: Some(val.clone()),
@@ -713,6 +716,7 @@ pub async fn run_agent_loop_streaming(
                                 if let Some(ref hooks) = hook_registry {
                                     let payload = HookPayload::AfterToolCall {
                                         session_key: session_key.clone(),
+                                        tool_call_id: Some(tc_id.clone()),
                                         tool_name: tc_name.clone(),
                                         success: false,
                                         result: None,
@@ -806,6 +810,7 @@ pub async fn run_agent_loop_streaming(
             if let Some(ref hooks) = hook_registry {
                 let payload = HookPayload::ToolResultPersist {
                     session_key: session_key_for_hooks.clone(),
+                    tool_call_id: Some(tc.id.clone()),
                     tool_name: sanitize_tool_name(&tc.name).into_owned(),
                     result: result.clone(),
                     channel: channel_for_hooks.clone(),

--- a/crates/chat/src/agent_loop.rs
+++ b/crates/chat/src/agent_loop.rs
@@ -743,7 +743,7 @@ pub(crate) async fn run_explicit_shell_command(
     // before final delivery. This prevents a concurrent abort from emitting a
     // contradictory aborted terminal after the user already received output.
     commit_terminal_run(terminal_runs, run_id).await;
-    if !final_text.trim().is_empty() {
+    let channel_delivery_succeeded = if !final_text.trim().is_empty() {
         let streamed_target_keys = HashSet::new();
         deliver_channel_replies(
             state,
@@ -753,8 +753,10 @@ pub(crate) async fn run_explicit_shell_command(
             ReplyMedium::Text,
             &streamed_target_keys,
         )
-        .await;
-    }
+        .await
+    } else {
+        true
+    };
 
     let final_payload = build_chat_final_broadcast(
         run_id,
@@ -791,6 +793,7 @@ pub(crate) async fn run_explicit_shell_command(
         None,
     );
     output.final_broadcast = Some(payload);
+    output.channel_delivery_succeeded = channel_delivery_succeeded;
     output
 }
 

--- a/crates/chat/src/agent_loop.rs
+++ b/crates/chat/src/agent_loop.rs
@@ -18,6 +18,7 @@ use {
 
 use {
     moltis_agents::{runner::RunnerEvent, tool_registry::ToolRegistry},
+    moltis_common::hooks::{ChannelBinding, HookAction, HookPayload, HookRegistry},
     moltis_sessions::{PersistedMessage, store::SessionStore},
 };
 
@@ -487,6 +488,8 @@ pub(crate) async fn run_explicit_shell_command(
     run_id: &str,
     terminal_runs: &Arc<RwLock<HashSet<String>>>,
     tool_registry: &Arc<RwLock<ToolRegistry>>,
+    hook_registry: Option<&Arc<HookRegistry>>,
+    hook_channel: Option<ChannelBinding>,
     session_store: Option<&Arc<SessionStore>>,
     session_key: &str,
     command: &str,
@@ -498,7 +501,37 @@ pub(crate) async fn run_explicit_shell_command(
 ) -> AssistantTurnOutput {
     let started = Instant::now();
     let tool_call_id = format!("sh_{}", uuid::Uuid::new_v4().simple());
-    let tool_args = serde_json::json!({ "command": command });
+    let mut tool_args = serde_json::json!({ "command": command });
+
+    let mut hook_block = None;
+    if let Some(hooks) = hook_registry {
+        let payload = HookPayload::BeforeToolCall {
+            session_key: session_key.to_string(),
+            tool_call_id: Some(tool_call_id.clone()),
+            tool_name: "exec".to_string(),
+            arguments: tool_args.clone(),
+            channel: hook_channel.clone(),
+        };
+        match hooks.dispatch(&payload).await {
+            Ok(HookAction::Continue) => {},
+            Ok(HookAction::ModifyPayload(value)) => {
+                if value.get("command").and_then(Value::as_str).is_some() {
+                    tool_args = value;
+                } else {
+                    hook_block = Some(
+                        "BeforeToolCall hook returned arguments without a string `command`"
+                            .to_string(),
+                    );
+                }
+            },
+            Ok(HookAction::Block(reason)) => {
+                hook_block = Some(format!("blocked by hook: {reason}"));
+            },
+            Err(error) => {
+                warn!(%error, "direct /sh BeforeToolCall hook failed; proceeding fail-open");
+            },
+        }
+    }
 
     send_tool_status_to_channels(state, run_id, session_key, "exec", &tool_args).await;
 
@@ -518,10 +551,8 @@ pub(crate) async fn run_explicit_shell_command(
     )
     .await;
 
-    let mut exec_params = serde_json::json!({
-        "command": command,
-        "_session_key": session_key,
-    });
+    let mut exec_params = tool_args.clone();
+    exec_params["_session_key"] = serde_json::json!(session_key);
     if let Some(lang) = accept_language.as_deref() {
         exec_params["_accept_language"] = serde_json::json!(lang);
     }
@@ -537,9 +568,11 @@ pub(crate) async fn run_explicit_shell_command(
         registry.get("exec")
     };
 
-    let exec_result = match exec_tool {
-        Some(tool) => tool.execute(exec_params).await,
-        None => Err(std::io::Error::new(
+    let should_dispatch_after = hook_block.is_none() && exec_tool.is_some();
+    let exec_result = match (hook_block, exec_tool) {
+        (Some(reason), _) => Err(anyhow::anyhow!(reason)),
+        (None, Some(tool)) => tool.execute(exec_params).await,
+        (None, None) => Err(std::io::Error::new(
             std::io::ErrorKind::NotFound,
             "exec tool is not registered",
         )
@@ -551,7 +584,26 @@ pub(crate) async fn run_explicit_shell_command(
 
     match exec_result {
         Ok(result) => {
+            if should_dispatch_after {
+                dispatch_direct_after_tool_call(
+                    hook_registry,
+                    session_key,
+                    &tool_call_id,
+                    true,
+                    Some(result.clone()),
+                    hook_channel.clone(),
+                )
+                .await;
+            }
             let capped = capped_tool_result_payload(&result, 10_000);
+            let persisted_result = apply_direct_tool_result_persist(
+                hook_registry,
+                session_key,
+                &tool_call_id,
+                capped.clone(),
+                hook_channel.clone(),
+            )
+            .await;
             let assistant_tool_call_msg = build_tool_call_assistant_message(
                 tool_call_id.clone(),
                 "exec",
@@ -566,9 +618,9 @@ pub(crate) async fn run_explicit_shell_command(
             let tool_result_msg = PersistedMessage::tool_result_with_run_id(
                 tool_call_id.clone(),
                 "exec",
-                Some(serde_json::json!({ "command": command })),
+                Some(tool_args.clone()),
                 true,
-                Some(capped.clone()),
+                Some(persisted_result),
                 None,
                 run_id,
             );
@@ -610,6 +662,30 @@ pub(crate) async fn run_explicit_shell_command(
         },
         Err(err) => {
             let error_text = err.to_string();
+            if should_dispatch_after {
+                dispatch_direct_after_tool_call(
+                    hook_registry,
+                    session_key,
+                    &tool_call_id,
+                    false,
+                    None,
+                    hook_channel.clone(),
+                )
+                .await;
+            }
+            let persisted_result = apply_direct_tool_result_persist(
+                hook_registry,
+                session_key,
+                &tool_call_id,
+                serde_json::json!({ "error": error_text }),
+                hook_channel,
+            )
+            .await;
+            let persisted_error = persisted_result
+                .get("error")
+                .and_then(Value::as_str)
+                .map(ToOwned::to_owned)
+                .unwrap_or_else(|| persisted_result.to_string());
             let parsed_error = parse_chat_error(&error_text, None);
             let assistant_tool_call_msg = build_tool_call_assistant_message(
                 tool_call_id.clone(),
@@ -622,10 +698,10 @@ pub(crate) async fn run_explicit_shell_command(
             let tool_result_msg = PersistedMessage::tool_result_with_run_id(
                 tool_call_id.clone(),
                 "exec",
-                Some(serde_json::json!({ "command": command })),
+                Some(tool_args),
                 false,
                 None,
-                Some(error_text.clone()),
+                Some(persisted_error),
                 run_id,
             );
             if let Some(session_store) = session_store {
@@ -718,6 +794,60 @@ pub(crate) async fn run_explicit_shell_command(
     output
 }
 
+async fn dispatch_direct_after_tool_call(
+    hook_registry: Option<&Arc<HookRegistry>>,
+    session_key: &str,
+    tool_call_id: &str,
+    success: bool,
+    result: Option<Value>,
+    channel: Option<ChannelBinding>,
+) {
+    let Some(hooks) = hook_registry else {
+        return;
+    };
+    let payload = HookPayload::AfterToolCall {
+        session_key: session_key.to_string(),
+        tool_call_id: Some(tool_call_id.to_string()),
+        tool_name: "exec".to_string(),
+        success,
+        result,
+        channel,
+    };
+    if let Err(error) = hooks.dispatch(&payload).await {
+        warn!(%error, "direct /sh AfterToolCall hook failed");
+    }
+}
+
+async fn apply_direct_tool_result_persist(
+    hook_registry: Option<&Arc<HookRegistry>>,
+    session_key: &str,
+    tool_call_id: &str,
+    mut result: Value,
+    channel: Option<ChannelBinding>,
+) -> Value {
+    let Some(hooks) = hook_registry else {
+        return result;
+    };
+    let payload = HookPayload::ToolResultPersist {
+        session_key: session_key.to_string(),
+        tool_call_id: Some(tool_call_id.to_string()),
+        tool_name: "exec".to_string(),
+        result: result.clone(),
+        channel,
+    };
+    match hooks.dispatch(&payload).await {
+        Ok(HookAction::Continue) => {},
+        Ok(HookAction::ModifyPayload(value)) => result = value,
+        Ok(HookAction::Block(reason)) => {
+            result = serde_json::json!({ "error": format!("blocked by hook: {reason}") });
+        },
+        Err(error) => {
+            warn!(%error, "direct /sh ToolResultPersist hook failed; proceeding fail-open");
+        },
+    }
+    result
+}
+
 /// Resolve the effective tool mode for a provider.
 ///
 /// Combines the provider's `tool_mode()` override with its `supports_tools()`
@@ -774,6 +904,44 @@ mod tests {
     use async_trait::async_trait;
 
     use super::*;
+
+    #[derive(Default)]
+    struct DirectToolLifecycleHook {
+        payloads: std::sync::Mutex<Vec<HookPayload>>,
+    }
+
+    #[async_trait]
+    impl moltis_common::hooks::HookHandler for DirectToolLifecycleHook {
+        fn name(&self) -> &str {
+            "direct-tool-lifecycle"
+        }
+
+        fn events(&self) -> &[moltis_common::hooks::HookEvent] {
+            static EVENTS: [moltis_common::hooks::HookEvent; 2] = [
+                moltis_common::hooks::HookEvent::AfterToolCall,
+                moltis_common::hooks::HookEvent::ToolResultPersist,
+            ];
+            &EVENTS
+        }
+
+        async fn handle(
+            &self,
+            event: moltis_common::hooks::HookEvent,
+            payload: &HookPayload,
+        ) -> moltis_common::Result<HookAction> {
+            self.payloads
+                .lock()
+                .unwrap_or_else(|error| error.into_inner())
+                .push(payload.clone());
+            Ok(
+                if event == moltis_common::hooks::HookEvent::ToolResultPersist {
+                    HookAction::ModifyPayload(serde_json::json!({"redacted": true}))
+                } else {
+                    HookAction::Continue
+                },
+            )
+        }
+    }
 
     struct RecordingStreamOutbound {
         streams_final_replies: bool,
@@ -1116,5 +1284,47 @@ mod tests {
                 .load(Ordering::SeqCst)
         );
         assert_eq!(completed.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn direct_shell_post_and_persist_hooks_share_tool_call_id() {
+        let hook = Arc::new(DirectToolLifecycleHook::default());
+        let mut registry = HookRegistry::new();
+        registry.register(hook.clone());
+        let registry = Arc::new(registry);
+
+        dispatch_direct_after_tool_call(
+            Some(&registry),
+            "session",
+            "sh_call_1",
+            true,
+            Some(serde_json::json!({"exit_code": 0})),
+            None,
+        )
+        .await;
+        let persisted = apply_direct_tool_result_persist(
+            Some(&registry),
+            "session",
+            "sh_call_1",
+            serde_json::json!({"exit_code": 0}),
+            None,
+        )
+        .await;
+
+        assert_eq!(persisted, serde_json::json!({"redacted": true}));
+        let payloads = hook
+            .payloads
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
+        assert_eq!(payloads.len(), 2);
+        for payload in payloads.iter() {
+            match payload {
+                HookPayload::AfterToolCall { tool_call_id, .. }
+                | HookPayload::ToolResultPersist { tool_call_id, .. } => {
+                    assert_eq!(tool_call_id.as_deref(), Some("sh_call_1"));
+                },
+                other => panic!("unexpected payload: {other:?}"),
+            }
+        }
     }
 }

--- a/crates/chat/src/agent_loop.rs
+++ b/crates/chat/src/agent_loop.rs
@@ -507,6 +507,7 @@ pub(crate) async fn run_explicit_shell_command(
     if let Some(hooks) = hook_registry {
         let payload = HookPayload::BeforeToolCall {
             session_key: session_key.to_string(),
+            turn_id: Some(run_id.to_string()),
             tool_call_id: Some(tool_call_id.clone()),
             tool_name: "exec".to_string(),
             arguments: tool_args.clone(),
@@ -588,7 +589,9 @@ pub(crate) async fn run_explicit_shell_command(
                 dispatch_direct_after_tool_call(
                     hook_registry,
                     session_key,
+                    run_id,
                     &tool_call_id,
+                    &tool_args,
                     true,
                     Some(result.clone()),
                     hook_channel.clone(),
@@ -666,7 +669,9 @@ pub(crate) async fn run_explicit_shell_command(
                 dispatch_direct_after_tool_call(
                     hook_registry,
                     session_key,
+                    run_id,
                     &tool_call_id,
+                    &tool_args,
                     false,
                     None,
                     hook_channel.clone(),
@@ -800,7 +805,9 @@ pub(crate) async fn run_explicit_shell_command(
 async fn dispatch_direct_after_tool_call(
     hook_registry: Option<&Arc<HookRegistry>>,
     session_key: &str,
+    turn_id: &str,
     tool_call_id: &str,
+    arguments: &Value,
     success: bool,
     result: Option<Value>,
     channel: Option<ChannelBinding>,
@@ -810,8 +817,10 @@ async fn dispatch_direct_after_tool_call(
     };
     let payload = HookPayload::AfterToolCall {
         session_key: session_key.to_string(),
+        turn_id: Some(turn_id.to_string()),
         tool_call_id: Some(tool_call_id.to_string()),
         tool_name: "exec".to_string(),
+        arguments: Some(arguments.clone()),
         success,
         result,
         channel,
@@ -1299,7 +1308,9 @@ mod tests {
         dispatch_direct_after_tool_call(
             Some(&registry),
             "session",
+            "turn",
             "sh_call_1",
+            &serde_json::json!({"command": "pwd"}),
             true,
             Some(serde_json::json!({"exit_code": 0})),
             None,
@@ -1322,8 +1333,17 @@ mod tests {
         assert_eq!(payloads.len(), 2);
         for payload in payloads.iter() {
             match payload {
-                HookPayload::AfterToolCall { tool_call_id, .. }
-                | HookPayload::ToolResultPersist { tool_call_id, .. } => {
+                HookPayload::AfterToolCall {
+                    turn_id,
+                    tool_call_id,
+                    arguments,
+                    ..
+                } => {
+                    assert_eq!(turn_id.as_deref(), Some("turn"));
+                    assert_eq!(arguments, &Some(serde_json::json!({"command": "pwd"})));
+                    assert_eq!(tool_call_id.as_deref(), Some("sh_call_1"));
+                },
+                HookPayload::ToolResultPersist { tool_call_id, .. } => {
                     assert_eq!(tool_call_id.as_deref(), Some("sh_call_1"));
                 },
                 other => panic!("unexpected payload: {other:?}"),

--- a/crates/chat/src/channel_reply_delivery.rs
+++ b/crates/chat/src/channel_reply_delivery.rs
@@ -34,9 +34,9 @@ async fn deliver_logbook_follow_up(
     logbook_html: &str,
     session_key: &str,
     trace_correlation_key: &str,
-) {
+) -> bool {
     if logbook_html.is_empty() {
-        return;
+        return true;
     }
     match outbound
         .send_html_reporting_ids(&target.account_id, to, logbook_html, None)
@@ -51,6 +51,7 @@ async fn deliver_logbook_follow_up(
                 trace_correlation_key,
             )
             .await;
+            true
         },
         Err(e) => {
             warn!(
@@ -59,6 +60,7 @@ async fn deliver_logbook_follow_up(
                 thread_id = target.thread_id.as_deref().unwrap_or("-"),
                 "failed to send logbook follow-up: {e}"
             );
+            false
         },
     }
 }
@@ -81,7 +83,7 @@ pub(crate) async fn deliver_text_reply(
     reply_to: Option<&str>,
     session_key: &str,
     trace_correlation_key: &str,
-) {
+) -> bool {
     let result = if logbook_html.is_empty() {
         outbound
             .send_text_reporting_ids(&target.account_id, to, text, reply_to)
@@ -107,6 +109,7 @@ pub(crate) async fn deliver_text_reply(
                 trace_correlation_key,
             )
             .await;
+            true
         },
         Err(e) => {
             warn!(
@@ -115,6 +118,7 @@ pub(crate) async fn deliver_text_reply(
                 thread_id = target.thread_id.as_deref().unwrap_or("-"),
                 "failed to send channel reply: {e}"
             );
+            false
         },
     }
 }
@@ -129,7 +133,7 @@ async fn deliver_media_reply(
     reply_to: Option<&str>,
     session_key: &str,
     trace_correlation_key: &str,
-) {
+) -> bool {
     match outbound
         .send_media_reporting_ids(&target.account_id, to, payload, reply_to)
         .await
@@ -143,6 +147,7 @@ async fn deliver_media_reply(
                 trace_correlation_key,
             )
             .await;
+            true
         },
         Err(e) => {
             warn!(
@@ -151,6 +156,7 @@ async fn deliver_media_reply(
                 thread_id = target.thread_id.as_deref().unwrap_or("-"),
                 "failed to send channel voice reply: {e}"
             );
+            false
         },
     }
 }
@@ -165,7 +171,7 @@ pub(crate) async fn deliver_channel_replies_to_targets(
     desired_reply_medium: ReplyMedium,
     status_log: Vec<String>,
     streamed_target_keys: &HashSet<ChannelReplyTargetKey>,
-) {
+) -> bool {
     let session_key = session_key.to_string();
     let trace_correlation_key = trace_correlation_key.to_string();
     let text = text.to_string();
@@ -199,7 +205,7 @@ pub(crate) async fn deliver_channel_replies_to_targets(
 
                         if text_already_streamed {
                             // Text was already streamed — send voice audio only.
-                            deliver_media_reply(
+                            let media_delivered = deliver_media_reply(
                                 &outbound,
                                 feedback.as_deref(),
                                 &target,
@@ -212,7 +218,7 @@ pub(crate) async fn deliver_channel_replies_to_targets(
                             .await;
                             // The answer went out some other way, so the logbook is the
                             // only text message of this turn.
-                            deliver_logbook_follow_up(
+                            let logbook_delivered = deliver_logbook_follow_up(
                                 &outbound,
                                 feedback.as_deref(),
                                 &target,
@@ -222,6 +228,7 @@ pub(crate) async fn deliver_channel_replies_to_targets(
                                 &trace_correlation_key,
                             )
                             .await;
+                            media_delivered && logbook_delivered
                         } else {
                             // Check if transcript fits as Telegram caption (when feature enabled).
                             // When telegram feature is disabled, this evaluates to false and we
@@ -235,7 +242,7 @@ pub(crate) async fn deliver_channel_replies_to_targets(
                             if fits_in_caption {
                                 // Short transcript fits as a caption on the voice message.
                                 payload.text = transcript;
-                                deliver_media_reply(
+                                let media_delivered = deliver_media_reply(
                                     &outbound,
                                     feedback.as_deref(),
                                     &target,
@@ -248,7 +255,7 @@ pub(crate) async fn deliver_channel_replies_to_targets(
                                 .await;
                                 // The answer went out some other way, so the logbook is the
                                 // only text message of this turn.
-                                deliver_logbook_follow_up(
+                                let logbook_delivered = deliver_logbook_follow_up(
                                     &outbound,
                                     feedback.as_deref(),
                                     &target,
@@ -258,10 +265,11 @@ pub(crate) async fn deliver_channel_replies_to_targets(
                                     &trace_correlation_key,
                                 )
                                 .await;
+                                media_delivered && logbook_delivered
                             } else {
                                 // Transcript too long for a caption — send voice
                                 // without caption, then the full text as a follow-up.
-                                deliver_media_reply(
+                                let media_delivered = deliver_media_reply(
                                     &outbound,
                                     feedback.as_deref(),
                                     &target,
@@ -276,7 +284,7 @@ pub(crate) async fn deliver_channel_replies_to_targets(
                                 // of this turn's answer, so it is as much a
                                 // reaction target as a plain text reply and
                                 // goes out through the same attributing path.
-                                deliver_text_reply(
+                                let text_delivered = deliver_text_reply(
                                     &outbound,
                                     feedback.as_deref(),
                                     &target,
@@ -288,6 +296,7 @@ pub(crate) async fn deliver_channel_replies_to_targets(
                                     &trace_correlation_key,
                                 )
                                 .await;
+                                media_delivered && text_delivered
                             }
                         }
                     },
@@ -303,7 +312,7 @@ pub(crate) async fn deliver_channel_replies_to_targets(
                             &session_key,
                             &trace_correlation_key,
                         )
-                        .await;
+                        .await
                     },
                     None => {
                         deliver_text_reply(
@@ -317,7 +326,7 @@ pub(crate) async fn deliver_channel_replies_to_targets(
                             &session_key,
                             &trace_correlation_key,
                         )
-                        .await;
+                        .await
                     },
                 },
                 _ => match tts_payload {
@@ -332,7 +341,7 @@ pub(crate) async fn deliver_channel_replies_to_targets(
                             &session_key,
                             &trace_correlation_key,
                         )
-                        .await;
+                        .await
                     },
                     None if text_already_streamed => {
                         // The answer went out some other way, so the logbook is the
@@ -346,7 +355,7 @@ pub(crate) async fn deliver_channel_replies_to_targets(
                             &session_key,
                             &trace_correlation_key,
                         )
-                        .await;
+                        .await
                     },
                     None => {
                         deliver_text_reply(
@@ -360,18 +369,24 @@ pub(crate) async fn deliver_channel_replies_to_targets(
                             &session_key,
                             &trace_correlation_key,
                         )
-                        .await;
+                        .await
                     },
                 },
             }
         }));
     }
 
+    let mut delivered = true;
     for task in tasks {
-        if let Err(e) = task.await {
-            warn!(error = %e, "channel reply task join failed");
+        match task.await {
+            Ok(target_delivered) => delivered &= target_delivered,
+            Err(e) => {
+                warn!(error = %e, "channel reply task join failed");
+                delivered = false;
+            },
         }
     }
+    delivered
 }
 
 #[cfg(test)]
@@ -389,6 +404,31 @@ mod tests {
     #[derive(Default)]
     struct ReportingOutbound {
         calls: Mutex<Vec<&'static str>>,
+    }
+
+    struct FailingOutbound;
+
+    #[async_trait]
+    impl moltis_channels::ChannelOutbound for FailingOutbound {
+        async fn send_text(
+            &self,
+            _account_id: &str,
+            _to: &str,
+            _text: &str,
+            _reply_to: Option<&str>,
+        ) -> moltis_channels::Result<()> {
+            Err(moltis_channels::Error::unavailable("test delivery failure"))
+        }
+
+        async fn send_media(
+            &self,
+            _account_id: &str,
+            _to: &str,
+            _payload: &ReplyPayload,
+            _reply_to: Option<&str>,
+        ) -> moltis_channels::Result<()> {
+            Err(moltis_channels::Error::unavailable("test delivery failure"))
+        }
     }
 
     #[async_trait]
@@ -660,5 +700,25 @@ mod tests {
 
         let calls = recorder.calls.lock().unwrap_or_else(|e| e.into_inner());
         assert_eq!(*calls, vec!["send_text_reporting_ids"]);
+    }
+
+    #[tokio::test]
+    async fn a_failed_plain_reply_reports_unsuccessful_delivery() {
+        let outbound: Arc<dyn moltis_channels::plugin::ChannelOutbound> = Arc::new(FailingOutbound);
+
+        let delivered = deliver_text_reply(
+            &outbound,
+            None,
+            &reply_target(),
+            "chan",
+            "the answer",
+            "",
+            None,
+            "session",
+            "run",
+        )
+        .await;
+
+        assert!(!delivered);
     }
 }

--- a/crates/chat/src/channels.rs
+++ b/crates/chat/src/channels.rs
@@ -110,7 +110,7 @@ async fn deliver_channel_replies_inner(
         }
         return true;
     }
-    if text.is_empty() {
+    if text.trim().is_empty() {
         let _ = state.drain_channel_status_log(session_key).await;
         if is_channel_session {
             info!(

--- a/crates/chat/src/channels.rs
+++ b/crates/chat/src/channels.rs
@@ -44,8 +44,8 @@ pub(crate) async fn deliver_channel_replies(
     text: &str,
     desired_reply_medium: ReplyMedium,
     streamed_target_keys: &HashSet<ChannelReplyTargetKey>,
-) {
-    if tokio::time::timeout(
+) -> bool {
+    match tokio::time::timeout(
         FINAL_CHANNEL_IO_TIMEOUT,
         deliver_channel_replies_inner(
             state,
@@ -57,13 +57,16 @@ pub(crate) async fn deliver_channel_replies(
         ),
     )
     .await
-    .is_err()
     {
-        warn!(
-            activity_id,
-            session_key, "timed out delivering final channel reply"
-        );
-        note_delivery_failed(state, activity_id).await;
+        Ok(delivered) => delivered,
+        Err(_) => {
+            warn!(
+                activity_id,
+                session_key, "timed out delivering final channel reply"
+            );
+            note_delivery_failed(state, activity_id).await;
+            false
+        },
     }
 }
 
@@ -74,7 +77,7 @@ async fn deliver_channel_replies_inner(
     text: &str,
     desired_reply_medium: ReplyMedium,
     streamed_target_keys: &HashSet<ChannelReplyTargetKey>,
-) {
+) -> bool {
     let drained_targets = state.drain_channel_replies(session_key).await;
     let mut targets = Vec::with_capacity(drained_targets.len());
     let mut streamed_targets = Vec::new();
@@ -105,7 +108,7 @@ async fn deliver_channel_replies_inner(
                 "channel reply delivery skipped: no pending targets after stream dedupe"
             );
         }
-        return;
+        return true;
     }
     if text.is_empty() {
         let _ = state.drain_channel_status_log(session_key).await;
@@ -116,7 +119,7 @@ async fn deliver_channel_replies_inner(
                 "channel reply delivery skipped: empty response text"
             );
         }
-        return;
+        return false;
     }
     if is_channel_session {
         info!(
@@ -138,7 +141,7 @@ async fn deliver_channel_replies_inner(
                 );
             }
             note_delivery_failed(state, activity_id).await;
-            return;
+            return false;
         },
     };
     // Drain buffered status log entries to build a logbook suffix.
@@ -164,9 +167,9 @@ async fn deliver_channel_replies_inner(
                 "channel reply delivery completed via stream-only targets"
             );
         }
-        return;
+        return true;
     }
-    crate::channel_reply_delivery::deliver_channel_replies_to_targets(
+    let delivered = crate::channel_reply_delivery::deliver_channel_replies_to_targets(
         outbound,
         targets,
         session_key,
@@ -178,6 +181,10 @@ async fn deliver_channel_replies_inner(
         streamed_target_keys,
     )
     .await;
+    if !delivered {
+        note_delivery_failed(state, activity_id).await;
+    }
+    delivered
 }
 
 /// Format buffered status log entries into a Telegram expandable blockquote HTML.

--- a/crates/chat/src/channels/tests.rs
+++ b/crates/chat/src/channels/tests.rs
@@ -6,6 +6,130 @@ use {
     std::sync::{Arc, Mutex},
 };
 
+struct PendingTargetRuntime {
+    targets: Mutex<Vec<ChannelReplyTarget>>,
+    tts: moltis_service_traits::NoopTtsService,
+    project: moltis_service_traits::NoopProjectService,
+    mcp: moltis_service_traits::NoopMcpService,
+}
+
+#[async_trait]
+impl ChatRuntime for PendingTargetRuntime {
+    async fn broadcast(&self, _topic: &str, _payload: Value) {}
+
+    async fn push_channel_reply(&self, _session_key: &str, target: ChannelReplyTarget) {
+        self.targets
+            .lock()
+            .unwrap_or_else(|error| error.into_inner())
+            .push(target);
+    }
+
+    async fn drain_channel_replies(&self, _session_key: &str) -> Vec<ChannelReplyTarget> {
+        std::mem::take(
+            &mut *self
+                .targets
+                .lock()
+                .unwrap_or_else(|error| error.into_inner()),
+        )
+    }
+
+    async fn peek_channel_replies(&self, _session_key: &str) -> Vec<ChannelReplyTarget> {
+        self.targets
+            .lock()
+            .unwrap_or_else(|error| error.into_inner())
+            .clone()
+    }
+
+    async fn push_channel_status_log(&self, _session_key: &str, _message: String) {}
+
+    async fn drain_channel_status_log(&self, _session_key: &str) -> Vec<String> {
+        Vec::new()
+    }
+
+    async fn set_run_error(&self, _run_id: &str, _error: String) {}
+
+    async fn active_session_key(&self, _conn_id: &str) -> Option<String> {
+        None
+    }
+
+    async fn active_project_id(&self, _conn_id: &str) -> Option<String> {
+        None
+    }
+
+    fn hostname(&self) -> &str {
+        "test"
+    }
+
+    fn sandbox_router(&self) -> Option<&Arc<moltis_tools::sandbox::SandboxRouter>> {
+        None
+    }
+
+    fn memory_manager(&self) -> Option<&moltis_memory::runtime::DynMemoryRuntime> {
+        None
+    }
+
+    async fn cached_location(&self) -> Option<moltis_config::GeoLocation> {
+        None
+    }
+
+    async fn tts_overrides(
+        &self,
+        _session_key: &str,
+        _channel_key: &str,
+    ) -> (
+        Option<crate::runtime::TtsOverride>,
+        Option<crate::runtime::TtsOverride>,
+    ) {
+        (None, None)
+    }
+
+    fn channel_outbound(&self) -> Option<Arc<dyn moltis_channels::ChannelOutbound>> {
+        None
+    }
+
+    fn channel_stream_outbound(&self) -> Option<Arc<dyn moltis_channels::ChannelStreamOutbound>> {
+        None
+    }
+
+    fn tts_service(&self) -> &dyn moltis_service_traits::TtsService {
+        &self.tts
+    }
+
+    fn project_service(&self) -> &dyn moltis_service_traits::ProjectService {
+        &self.project
+    }
+
+    fn mcp_service(&self) -> &dyn moltis_service_traits::McpService {
+        &self.mcp
+    }
+
+    async fn chat_service(&self) -> Arc<dyn moltis_service_traits::ChatService> {
+        Arc::new(moltis_service_traits::NoopChatService)
+    }
+
+    async fn last_run_error(&self, _run_id: &str) -> Option<String> {
+        None
+    }
+
+    async fn send_push_notification(
+        &self,
+        _title: &str,
+        _body: &str,
+        _url: Option<&str>,
+        _session_key: Option<&str>,
+    ) -> crate::error::Result<usize> {
+        Ok(0)
+    }
+
+    async fn ensure_local_model_cached(&self, _model_id: &str) -> crate::error::Result<bool> {
+        Ok(false)
+    }
+
+    async fn connected_nodes(&self) -> Vec<crate::runtime::ConnectedNodeSummary> {
+        Vec::new()
+    }
+}
+
 #[derive(Debug, Clone)]
 struct SentMedia {
     account_id: String,
@@ -86,6 +210,61 @@ fn telegram_target() -> ChannelReplyTarget {
         message_id: Some("42".into()),
         thread_id: Some("7".into()),
     }
+}
+
+#[tokio::test]
+async fn silent_terminal_response_with_pending_target_is_delivery_failure() {
+    for streamed in [false, true] {
+        for text in ["", "   "] {
+            let target = telegram_target();
+            let streamed_target_keys = if streamed {
+                HashSet::from([ChannelReplyTargetKey::from(&target)])
+            } else {
+                HashSet::new()
+            };
+            let state: Arc<dyn ChatRuntime> = Arc::new(PendingTargetRuntime {
+                targets: Mutex::new(vec![target]),
+                tts: moltis_service_traits::NoopTtsService,
+                project: moltis_service_traits::NoopProjectService,
+                mcp: moltis_service_traits::NoopMcpService,
+            });
+
+            assert!(
+                !deliver_channel_replies(
+                    &state,
+                    "run-1",
+                    "telegram:bot:123",
+                    text,
+                    ReplyMedium::Text,
+                    &streamed_target_keys,
+                )
+                .await,
+                "silent channel response {text:?} (streamed={streamed}) must not count as delivered"
+            );
+        }
+    }
+}
+
+#[tokio::test]
+async fn silent_web_only_response_remains_successful_without_a_channel_target() {
+    let state: Arc<dyn ChatRuntime> = Arc::new(PendingTargetRuntime {
+        targets: Mutex::new(Vec::new()),
+        tts: moltis_service_traits::NoopTtsService,
+        project: moltis_service_traits::NoopProjectService,
+        mcp: moltis_service_traits::NoopMcpService,
+    });
+
+    assert!(
+        deliver_channel_replies(
+            &state,
+            "run-1",
+            "chat:main",
+            "",
+            ReplyMedium::Text,
+            &HashSet::new(),
+        )
+        .await
+    );
 }
 
 #[tokio::test]

--- a/crates/chat/src/lib.rs
+++ b/crates/chat/src/lib.rs
@@ -11,6 +11,7 @@ mod compaction_run;
 mod memory_tools;
 mod message;
 mod models;
+mod outbound_hooks;
 pub mod params;
 mod prompt;
 mod run_with_tools;

--- a/crates/chat/src/outbound_hooks.rs
+++ b/crates/chat/src/outbound_hooks.rs
@@ -1,0 +1,93 @@
+//! Hook helpers for terminal assistant-message delivery.
+
+use {
+    moltis_agents::runner::{AgentRunError, AgentRunResult},
+    moltis_common::hooks::{HookRegistry, MessageSendingOutcome, dispatch_message_sending},
+};
+
+pub(crate) async fn apply_message_sending_to_agent_result(
+    registry: Option<&HookRegistry>,
+    session_key: &str,
+    result: Result<AgentRunResult, AgentRunError>,
+) -> Result<AgentRunResult, AgentRunError> {
+    let mut result = result?;
+    result.text = apply_message_sending_to_text(registry, session_key, &result.text)
+        .await
+        .map_err(|reason| {
+            AgentRunError::Other(anyhow::anyhow!("blocked by MessageSending hook: {reason}"))
+        })?;
+    Ok(result)
+}
+
+pub(crate) async fn apply_message_sending_to_text(
+    registry: Option<&HookRegistry>,
+    session_key: &str,
+    content: &str,
+) -> Result<String, String> {
+    match dispatch_message_sending(registry, session_key, content).await {
+        MessageSendingOutcome::Send(content) => Ok(content),
+        MessageSendingOutcome::Block(reason) => Err(reason),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use {
+        async_trait::async_trait,
+        moltis_common::hooks::{HookAction, HookEvent, HookHandler, HookPayload},
+    };
+
+    use super::*;
+
+    struct MessageHook {
+        action: &'static str,
+    }
+
+    #[async_trait]
+    impl HookHandler for MessageHook {
+        fn name(&self) -> &str {
+            "message-hook"
+        }
+
+        fn events(&self) -> &[HookEvent] {
+            static EVENTS: [HookEvent; 1] = [HookEvent::MessageSending];
+            &EVENTS
+        }
+
+        async fn handle(
+            &self,
+            _event: HookEvent,
+            _payload: &HookPayload,
+        ) -> moltis_common::Result<HookAction> {
+            Ok(match self.action {
+                "modify" => {
+                    HookAction::ModifyPayload(serde_json::json!({"content": "rewritten response"}))
+                },
+                "block" => HookAction::Block("response denied".into()),
+                _ => HookAction::Continue,
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn message_sending_applies_content_replacement() {
+        let mut registry = HookRegistry::new();
+        registry.register(Arc::new(MessageHook { action: "modify" }));
+
+        let text = apply_message_sending_to_text(Some(&registry), "main", "original").await;
+
+        assert_eq!(text, Ok("rewritten response".to_string()));
+    }
+
+    #[tokio::test]
+    async fn message_sending_honors_block() {
+        let mut registry = HookRegistry::new();
+        registry.register(Arc::new(MessageHook { action: "block" }));
+
+        let error = apply_message_sending_to_text(Some(&registry), "main", "original").await;
+
+        assert_eq!(error, Err("response denied".to_string()));
+    }
+}

--- a/crates/chat/src/run_with_tools.rs
+++ b/crates/chat/src/run_with_tools.rs
@@ -51,6 +51,7 @@ use crate::{
     memory_tools::{effective_tool_mode, install_agent_scoped_memory_tools},
     message::apply_voice_reply_suffix,
     models::DisabledModelsStore,
+    outbound_hooks::apply_message_sending_to_agent_result,
     prompt::{
         apply_runtime_tool_filters, build_policy_context, build_tool_context,
         prompt_build_limits_from_config,
@@ -1027,6 +1028,7 @@ pub(crate) async fn run_with_tools(
     }));
 
     let provider_ref = provider.clone();
+    let outbound_hook_registry = hook_registry.clone();
     let first_agent_future = run_agent_loop_streaming_with_limits(
         provider,
         &filtered_registry,
@@ -1192,6 +1194,12 @@ pub(crate) async fn run_with_tools(
         let trimmed = reasoning_text.trim();
         (!trimmed.is_empty()).then(|| trimmed.to_string())
     };
+    let result = apply_message_sending_to_agent_result(
+        outbound_hook_registry.as_deref(),
+        session_key,
+        result,
+    )
+    .await;
     match result {
         Ok(result) => {
             clear_unsupported_model(state, model_store, model_id).await;

--- a/crates/chat/src/run_with_tools.rs
+++ b/crates/chat/src/run_with_tools.rs
@@ -1334,7 +1334,7 @@ pub(crate) async fn run_with_tools(
                 commit_terminal_and_finish_channel_stream(terminal_runs, run_id, None).await
             };
 
-            if !is_silent {
+            let channel_delivery_succeeded = if !is_silent {
                 #[cfg(feature = "push-notifications")]
                 {
                     tracing::info!("push: checking push notification (agent mode)");
@@ -1360,8 +1360,10 @@ pub(crate) async fn run_with_tools(
                     desired_reply_medium,
                     &streamed_target_keys,
                 )
-                .await;
-            }
+                .await
+            } else {
+                true
+            };
             let mut output = build_assistant_turn_output(
                 display_text,
                 UsageSnapshot::new(usage, Some(request_usage)),
@@ -1371,6 +1373,7 @@ pub(crate) async fn run_with_tools(
                 llm_api_response,
             );
             output.final_broadcast = Some(payload_val);
+            output.channel_delivery_succeeded = channel_delivery_succeeded;
             Some(output)
         },
         Err(e) => {

--- a/crates/chat/src/run_with_tools.rs
+++ b/crates/chat/src/run_with_tools.rs
@@ -1334,36 +1334,34 @@ pub(crate) async fn run_with_tools(
                 commit_terminal_and_finish_channel_stream(terminal_runs, run_id, None).await
             };
 
-            let channel_delivery_succeeded = if !is_silent {
-                #[cfg(feature = "push-notifications")]
-                {
-                    tracing::info!("push: checking push notification (agent mode)");
-                    let push_state = Arc::clone(state);
-                    let push_session_key = session_key.to_string();
-                    let push_text = display_text.clone();
-                    let push_order = crate::channel_push::next_push_notification_order();
-                    tokio::spawn(async move {
-                        send_chat_push_notification(
-                            &push_state,
-                            &push_session_key,
-                            &push_text,
-                            push_order,
-                        )
-                        .await;
-                    });
-                }
-                deliver_channel_replies(
-                    state,
-                    run_id,
-                    session_key,
-                    &display_text,
-                    desired_reply_medium,
-                    &streamed_target_keys,
-                )
-                .await
-            } else {
-                true
-            };
+            #[cfg(feature = "push-notifications")]
+            if !is_silent {
+                tracing::info!("push: checking push notification (agent mode)");
+                let push_state = Arc::clone(state);
+                let push_session_key = session_key.to_string();
+                let push_text = display_text.clone();
+                let push_order = crate::channel_push::next_push_notification_order();
+                tokio::spawn(async move {
+                    send_chat_push_notification(
+                        &push_state,
+                        &push_session_key,
+                        &push_text,
+                        push_order,
+                    )
+                    .await;
+                });
+            }
+            // Delivery owns the distinction between no channel target and a
+            // channel-bound response erased by MessageSending.
+            let channel_delivery_succeeded = deliver_channel_replies(
+                state,
+                run_id,
+                session_key,
+                &display_text,
+                desired_reply_medium,
+                &streamed_target_keys,
+            )
+            .await;
             let mut output = build_assistant_turn_output(
                 display_text,
                 UsageSnapshot::new(usage, Some(request_usage)),

--- a/crates/chat/src/service/chat_impl/send.rs
+++ b/crates/chat/src/service/chat_impl/send.rs
@@ -34,7 +34,10 @@ use {
     super::*,
     crate::service::{
         build_persisted_assistant_message,
-        types::{TurnAdmission, commit_successful_turn, commit_terminal_run},
+        types::{
+            TurnAdmission, commit_successful_turn, commit_terminal_run,
+            persist_successful_assistant,
+        },
     },
 };
 
@@ -1299,6 +1302,7 @@ impl LiveChatService {
             // a committed assistant message into an aborted run.
             if let Some(mut assistant_output) = assistant_text {
                 let sent_text = assistant_output.text.clone();
+                let channel_delivery_succeeded = assistant_output.channel_delivery_succeeded;
                 let final_payload = assistant_output.final_broadcast.take();
                 let assistant_msg = (!ephemeral).then(|| {
                     build_persisted_assistant_message(
@@ -1309,26 +1313,19 @@ impl LiveChatService {
                         Some(run_id_clone.clone()),
                     )
                 });
-                commit_successful_turn(
+                let persistence_succeeded = commit_successful_turn(
                     &terminal_runs,
                     &run_id_clone,
                     async {
-                        if let Some(assistant_msg) = assistant_msg
-                            && let Err(e) = session_store
-                                .append(&session_key_clone, &assistant_msg.to_value())
-                                .await
-                        {
-                            warn!("failed to persist assistant message: {e}");
-                        }
-                        if !ephemeral {
-                            crate::channel_feedback::record_web_reply_trace(
-                                &state,
-                                &session_key_clone,
-                                &run_id_clone,
-                            )
-                            .await;
-                        }
-                        crate::channel_acks::note_turn_finished(&state, &run_id_clone, true).await;
+                        persist_successful_assistant(
+                            &state,
+                            &session_store,
+                            &session_key_clone,
+                            &run_id_clone,
+                            assistant_msg,
+                            ephemeral,
+                        )
+                        .await
                     },
                     async {
                         if let Some(payload) = final_payload {
@@ -1337,12 +1334,14 @@ impl LiveChatService {
                     },
                 )
                 .await;
-                moltis_common::hooks::dispatch_message_sent(
-                    sent_hook_registry.as_deref(),
-                    &session_key_clone,
-                    &sent_text,
-                )
-                .await;
+                if persistence_succeeded && channel_delivery_succeeded {
+                    moltis_common::hooks::dispatch_message_sent(
+                        sent_hook_registry.as_deref(),
+                        &session_key_clone,
+                        &sent_text,
+                    )
+                    .await;
+                }
 
                 // Update metadata counts.
                 if !ephemeral && let Ok(count) = session_store.count(&session_key_clone).await {

--- a/crates/chat/src/service/chat_impl/send.rs
+++ b/crates/chat/src/service/chat_impl/send.rs
@@ -686,6 +686,7 @@ impl LiveChatService {
             .filter(|binding| !binding.is_empty());
             let payload = moltis_common::hooks::HookPayload::MessageReceived {
                 session_key: session_key.clone(),
+                turn_id: Some(run_id.clone()),
                 content: text.clone(),
                 channel,
                 channel_binding,

--- a/crates/chat/src/service/chat_impl/send.rs
+++ b/crates/chat/src/service/chat_impl/send.rs
@@ -363,6 +363,12 @@ impl LiveChatService {
             let session_store = Arc::clone(&self.session_store);
             let session_metadata = Arc::clone(&self.session_metadata);
             let tool_registry = Arc::clone(&request_tool_registry);
+            let hook_registry = self.hook_registry.clone();
+            let hook_channel = Some(resolve_channel_runtime_context(
+                &session_key,
+                self.session_metadata.get(&session_key).await.as_ref(),
+            ))
+            .filter(|binding| !binding.is_empty());
             let session_key_clone = session_key.clone();
             let message_queue = Arc::clone(&self.message_queue);
             let state_for_drain = Arc::clone(&self.state);
@@ -395,6 +401,8 @@ impl LiveChatService {
                     &run_id_clone,
                     &terminal_runs,
                     &tool_registry,
+                    hook_registry.as_ref(),
+                    hook_channel,
                     (!ephemeral).then_some(&session_store),
                     &session_key_clone,
                     &shell_command,
@@ -1162,6 +1170,7 @@ impl LiveChatService {
             let extraction_write_mode = persona.config.memory.agent_write_mode;
             let extraction_max_tool_result_bytes = persona.config.tools.max_tool_result_bytes;
             let auto_title_enabled = persona.config.chat.auto_title;
+            let sent_hook_registry = hook_registry.clone();
             let agent_fut = async {
                 if stream_only {
                     run_streaming(
@@ -1180,6 +1189,7 @@ impl LiveChatService {
                         ctx_ref,
                         user_message_index,
                         &discovered_skills,
+                        hook_registry.clone(),
                         Some(&runtime_context),
                         sender_name,
                         (!ephemeral).then_some(&session_store),
@@ -1288,6 +1298,7 @@ impl LiveChatService {
             // Claim terminal ownership before persistence so abort cannot turn
             // a committed assistant message into an aborted run.
             if let Some(mut assistant_output) = assistant_text {
+                let sent_text = assistant_output.text.clone();
                 let final_payload = assistant_output.final_broadcast.take();
                 let assistant_msg = (!ephemeral).then(|| {
                     build_persisted_assistant_message(
@@ -1324,6 +1335,12 @@ impl LiveChatService {
                             broadcast(&state, "chat", payload, BroadcastOpts::default()).await;
                         }
                     },
+                )
+                .await;
+                moltis_common::hooks::dispatch_message_sent(
+                    sent_hook_registry.as_deref(),
+                    &session_key_clone,
+                    &sent_text,
                 )
                 .await;
 

--- a/crates/chat/src/service/types.rs
+++ b/crates/chat/src/service/types.rs
@@ -93,18 +93,49 @@ pub(crate) async fn commit_terminal_run(
     terminal_runs.write().await.insert(run_id.to_string());
 }
 
-pub(in crate::service) async fn commit_successful_turn<P, B>(
+pub(in crate::service) async fn commit_successful_turn<P, B, T>(
     terminal_runs: &Arc<RwLock<HashSet<String>>>,
     run_id: &str,
     persistence: P,
     final_broadcast: B,
-) where
-    P: Future<Output = ()>,
+) -> T
+where
+    P: Future<Output = T>,
     B: Future<Output = ()>,
 {
     commit_terminal_run(terminal_runs, run_id).await;
-    persistence.await;
+    let persistence_result = persistence.await;
     final_broadcast.await;
+    persistence_result
+}
+
+pub(in crate::service) async fn persist_successful_assistant(
+    state: &Arc<dyn ChatRuntime>,
+    session_store: &SessionStore,
+    session_key: &str,
+    run_id: &str,
+    assistant_msg: Option<PersistedMessage>,
+    ephemeral: bool,
+) -> bool {
+    let persisted = if let Some(assistant_msg) = assistant_msg {
+        match session_store
+            .append(session_key, &assistant_msg.to_value())
+            .await
+        {
+            Ok(()) => true,
+            Err(error) => {
+                warn!(%error, "failed to persist assistant message");
+                false
+            },
+        }
+    } else {
+        true
+    };
+    if persisted && !ephemeral {
+        crate::channel_feedback::record_web_reply_trace(state, session_key, run_id).await;
+    }
+    crate::channel_acks::note_turn_finished(state, run_id, true).await;
+    persisted
 }
 
 #[derive(Clone)]
@@ -1143,7 +1174,7 @@ mod tests {
         let terminal_at_persistence = Arc::clone(&terminal);
         let terminal_at_broadcast = Arc::clone(&terminal);
 
-        commit_successful_turn(
+        let persistence_succeeded = commit_successful_turn(
             &terminal,
             "run-1",
             async move {
@@ -1152,6 +1183,7 @@ mod tests {
                     .lock()
                     .unwrap_or_else(|error| error.into_inner())
                     .push("persist");
+                true
             },
             async move {
                 assert!(terminal_at_broadcast.read().await.contains("run-1"));
@@ -1163,6 +1195,7 @@ mod tests {
         )
         .await;
 
+        assert!(persistence_succeeded);
         assert_eq!(*events.lock().unwrap_or_else(|error| error.into_inner()), [
             "persist", "final"
         ]);
@@ -1412,6 +1445,7 @@ mod tests {
                 reasoning: Some("thinking".to_string()),
                 llm_api_response: None,
                 final_broadcast: None,
+                channel_delivery_succeeded: true,
             },
             Some("gpt-4.1".to_string()),
             Some("openai".to_string()),

--- a/crates/chat/src/streaming.rs
+++ b/crates/chat/src/streaming.rs
@@ -514,36 +514,35 @@ pub(crate) async fn run_streaming(
                     )
                     .await;
 
-                    let channel_delivery_succeeded = if !is_silent {
-                        #[cfg(feature = "push-notifications")]
-                        {
-                            tracing::info!("push: checking push notification");
-                            let push_state = Arc::clone(state);
-                            let push_session_key = session_key.to_string();
-                            let push_text = accumulated.clone();
-                            let push_order = crate::channel_push::next_push_notification_order();
-                            tokio::spawn(async move {
-                                send_chat_push_notification(
-                                    &push_state,
-                                    &push_session_key,
-                                    &push_text,
-                                    push_order,
-                                )
-                                .await;
-                            });
-                        }
-                        deliver_channel_replies(
-                            state,
-                            run_id,
-                            session_key,
-                            &accumulated,
-                            desired_reply_medium,
-                            &streamed_target_keys,
-                        )
-                        .await
-                    } else {
-                        true
-                    };
+                    #[cfg(feature = "push-notifications")]
+                    if !is_silent {
+                        tracing::info!("push: checking push notification");
+                        let push_state = Arc::clone(state);
+                        let push_session_key = session_key.to_string();
+                        let push_text = accumulated.clone();
+                        let push_order = crate::channel_push::next_push_notification_order();
+                        tokio::spawn(async move {
+                            send_chat_push_notification(
+                                &push_state,
+                                &push_session_key,
+                                &push_text,
+                                push_order,
+                            )
+                            .await;
+                        });
+                    }
+                    // Always pass the terminal response through delivery. It
+                    // distinguishes a web-only turn from a channel-bound turn
+                    // whose MessageSending hook erased the response.
+                    let channel_delivery_succeeded = deliver_channel_replies(
+                        state,
+                        run_id,
+                        session_key,
+                        &accumulated,
+                        desired_reply_medium,
+                        &streamed_target_keys,
+                    )
+                    .await;
                     let llm_api_response =
                         (!raw_llm_responses.is_empty()).then_some(Value::Array(raw_llm_responses));
                     let mut output = build_assistant_turn_output(

--- a/crates/chat/src/streaming.rs
+++ b/crates/chat/src/streaming.rs
@@ -25,6 +25,8 @@ use {
     moltis_sessions::store::SessionStore,
 };
 
+use moltis_common::hooks::{HookRegistry, dispatch_agent_end};
+
 use crate::{
     agent_loop::{
         ChannelStreamDispatcher, clear_unsupported_model,
@@ -37,6 +39,7 @@ use crate::{
     chat_error::parse_chat_error,
     message::apply_voice_reply_suffix,
     models::DisabledModelsStore,
+    outbound_hooks::apply_message_sending_to_text,
     prompt::prompt_build_limits_from_config,
     runtime::ChatRuntime,
     service::ActiveAssistantDraft,
@@ -132,6 +135,7 @@ pub(crate) async fn run_streaming(
     project_context: Option<&str>,
     user_message_index: usize,
     _skills: &[moltis_skills::types::SkillMetadata],
+    hook_registry: Option<Arc<HookRegistry>>,
     runtime_context: Option<&PromptRuntimeContext>,
     sender_name: Option<String>,
     session_store: Option<&Arc<SessionStore>>,
@@ -395,6 +399,45 @@ pub(crate) async fn run_streaming(
                         broadcast(state, "chat", payload_val, BroadcastOpts::default()).await;
                         return None;
                     }
+
+                    dispatch_agent_end(hook_registry.as_deref(), session_key, &accumulated, 1, 0)
+                        .await;
+                    accumulated = match apply_message_sending_to_text(
+                        hook_registry.as_deref(),
+                        session_key,
+                        &accumulated,
+                    )
+                    .await
+                    {
+                        Ok(content) => content,
+                        Err(reason) => {
+                            let message = format!("blocked by MessageSending hook: {reason}");
+                            state.set_run_error(run_id, message.clone()).await;
+                            let error_obj = parse_chat_error(&message, Some(provider_name));
+                            commit_terminal_and_finish_channel_stream(
+                                terminal_runs,
+                                run_id,
+                                channel_stream_dispatcher.as_mut(),
+                            )
+                            .await;
+                            deliver_channel_error(state, session_key, &error_obj).await;
+                            broadcast(
+                                state,
+                                "chat",
+                                serde_json::json!({
+                                    "runId": run_id,
+                                    "sessionKey": session_key,
+                                    "state": "error",
+                                    "error": error_obj,
+                                    "seq": client_seq,
+                                }),
+                                BroadcastOpts::default(),
+                            )
+                            .await;
+                            return None;
+                        },
+                    };
+                    let is_silent = accumulated.trim().is_empty();
 
                     let assistant_message_index = user_message_index + 1;
 

--- a/crates/chat/src/streaming.rs
+++ b/crates/chat/src/streaming.rs
@@ -400,8 +400,15 @@ pub(crate) async fn run_streaming(
                         return None;
                     }
 
-                    dispatch_agent_end(hook_registry.as_deref(), session_key, &accumulated, 1, 0)
-                        .await;
+                    dispatch_agent_end(
+                        hook_registry.as_deref(),
+                        session_key,
+                        Some(run_id),
+                        &accumulated,
+                        1,
+                        0,
+                    )
+                    .await;
                     accumulated = match apply_message_sending_to_text(
                         hook_registry.as_deref(),
                         session_key,

--- a/crates/chat/src/streaming.rs
+++ b/crates/chat/src/streaming.rs
@@ -507,7 +507,7 @@ pub(crate) async fn run_streaming(
                     )
                     .await;
 
-                    if !is_silent {
+                    let channel_delivery_succeeded = if !is_silent {
                         #[cfg(feature = "push-notifications")]
                         {
                             tracing::info!("push: checking push notification");
@@ -533,8 +533,10 @@ pub(crate) async fn run_streaming(
                             desired_reply_medium,
                             &streamed_target_keys,
                         )
-                        .await;
-                    }
+                        .await
+                    } else {
+                        true
+                    };
                     let llm_api_response =
                         (!raw_llm_responses.is_empty()).then_some(Value::Array(raw_llm_responses));
                     let mut output = build_assistant_turn_output(
@@ -546,6 +548,7 @@ pub(crate) async fn run_streaming(
                         llm_api_response,
                     );
                     output.final_broadcast = Some(payload_val);
+                    output.channel_delivery_succeeded = channel_delivery_succeeded;
                     return Some(output);
                 },
                 StreamEvent::Error(msg) => {

--- a/crates/chat/src/types.rs
+++ b/crates/chat/src/types.rs
@@ -174,6 +174,9 @@ pub(crate) struct AssistantTurnOutput {
     /// Prepared after abortable channel delivery and emitted by the run owner
     /// only after the assistant message has been persisted.
     pub final_broadcast: Option<Value>,
+    /// True when every known channel target accepted its terminal delivery.
+    /// Web-only turns have no channel target and therefore remain successful.
+    pub channel_delivery_succeeded: bool,
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -248,6 +251,7 @@ pub(crate) fn build_assistant_turn_output(
         reasoning,
         llm_api_response,
         final_broadcast: None,
+        channel_delivery_succeeded: true,
     }
 }
 

--- a/crates/common/src/hooks.rs
+++ b/crates/common/src/hooks.rs
@@ -221,6 +221,9 @@ pub enum HookPayload {
     },
     BeforeToolCall {
         session_key: String,
+        /// Stable identifier shared by every event for this tool invocation.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        tool_call_id: Option<String>,
         tool_name: String,
         arguments: Value,
         #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -228,6 +231,9 @@ pub enum HookPayload {
     },
     AfterToolCall {
         session_key: String,
+        /// Stable identifier shared by every event for this tool invocation.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        tool_call_id: Option<String>,
         tool_name: String,
         success: bool,
         result: Option<Value>,
@@ -236,6 +242,9 @@ pub enum HookPayload {
     },
     ToolResultPersist {
         session_key: String,
+        /// Stable identifier shared by every event for this tool invocation.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        tool_call_id: Option<String>,
         tool_name: String,
         result: Value,
         #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -282,6 +291,88 @@ impl HookPayload {
             Self::GatewayStop => HookEvent::GatewayStop,
             Self::Command { .. } => HookEvent::Command,
         }
+    }
+}
+
+/// Effective response after mutable `MessageSending` hooks have run.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MessageSendingOutcome {
+    Send(String),
+    Block(String),
+}
+
+/// Dispatch the mutable response hook and apply its documented
+/// `{ "content": "..." }` replacement shape. Handler failures and malformed
+/// replacements fail open so an observer cannot wedge every response.
+pub async fn dispatch_message_sending(
+    registry: Option<&HookRegistry>,
+    session_key: &str,
+    content: &str,
+) -> MessageSendingOutcome {
+    let Some(registry) = registry else {
+        return MessageSendingOutcome::Send(content.to_string());
+    };
+    let payload = HookPayload::MessageSending {
+        session_key: session_key.to_string(),
+        content: content.to_string(),
+    };
+    match registry.dispatch(&payload).await {
+        Ok(HookAction::Continue) => MessageSendingOutcome::Send(content.to_string()),
+        Ok(HookAction::Block(reason)) => MessageSendingOutcome::Block(reason),
+        Ok(HookAction::ModifyPayload(value)) => {
+            let Some(replacement) = value.get("content").and_then(Value::as_str) else {
+                warn!(
+                    "MessageSending hook ModifyPayload ignored: expected object with `content` string"
+                );
+                return MessageSendingOutcome::Send(content.to_string());
+            };
+            MessageSendingOutcome::Send(replacement.to_string())
+        },
+        Err(error) => {
+            warn!(%error, "MessageSending hook dispatch failed; proceeding fail-open");
+            MessageSendingOutcome::Send(content.to_string())
+        },
+    }
+}
+
+/// Notify observers after the terminal response has been persisted and
+/// delivered to its UI/channel sinks.
+pub async fn dispatch_message_sent(
+    registry: Option<&HookRegistry>,
+    session_key: &str,
+    content: &str,
+) {
+    let Some(registry) = registry else {
+        return;
+    };
+    let payload = HookPayload::MessageSent {
+        session_key: session_key.to_string(),
+        content: content.to_string(),
+    };
+    if let Err(error) = registry.dispatch(&payload).await {
+        warn!(%error, "MessageSent hook dispatch failed");
+    }
+}
+
+/// Notify observers after a successful agent run completes.
+pub async fn dispatch_agent_end(
+    registry: Option<&HookRegistry>,
+    session_key: &str,
+    text: &str,
+    iterations: usize,
+    tool_calls: usize,
+) {
+    let Some(registry) = registry else {
+        return;
+    };
+    let payload = HookPayload::AgentEnd {
+        session_key: session_key.to_string(),
+        text: text.to_string(),
+        iterations,
+        tool_calls,
+    };
+    if let Err(error) = registry.dispatch(&payload).await {
+        warn!(%error, "AgentEnd hook dispatch failed");
     }
 }
 
@@ -776,6 +867,7 @@ mod tests {
     fn modifying_payload() -> HookPayload {
         HookPayload::BeforeToolCall {
             session_key: "test".into(),
+            tool_call_id: Some("call-test".into()),
             tool_name: "exec".into(),
             arguments: serde_json::json!({}),
             channel: None,
@@ -1118,6 +1210,7 @@ mod tests {
         let binding = test_channel_binding();
         let before = HookPayload::BeforeToolCall {
             session_key: "s".into(),
+            tool_call_id: Some("call-1".into()),
             tool_name: "exec".into(),
             arguments: serde_json::json!({"command": "pwd"}),
             channel: Some(binding.clone()),
@@ -1125,7 +1218,12 @@ mod tests {
         let json = serde_json::to_string(&before).unwrap();
         let deser: HookPayload = serde_json::from_str(&json).unwrap();
         match deser {
-            HookPayload::BeforeToolCall { channel, .. } => {
+            HookPayload::BeforeToolCall {
+                tool_call_id,
+                channel,
+                ..
+            } => {
+                assert_eq!(tool_call_id.as_deref(), Some("call-1"));
                 assert_eq!(channel, Some(binding.clone()));
             },
             other => panic!("unexpected payload: {other:?}"),
@@ -1163,6 +1261,7 @@ mod tests {
 
         let after = HookPayload::AfterToolCall {
             session_key: "s".into(),
+            tool_call_id: Some("call-1".into()),
             tool_name: "exec".into(),
             success: true,
             result: Some(serde_json::json!({"cwd": "/tmp"})),
@@ -1171,7 +1270,12 @@ mod tests {
         let json = serde_json::to_string(&after).unwrap();
         let deser: HookPayload = serde_json::from_str(&json).unwrap();
         match deser {
-            HookPayload::AfterToolCall { channel, .. } => {
+            HookPayload::AfterToolCall {
+                tool_call_id,
+                channel,
+                ..
+            } => {
+                assert_eq!(tool_call_id.as_deref(), Some("call-1"));
                 assert_eq!(channel, Some(test_channel_binding()));
             },
             other => panic!("unexpected payload: {other:?}"),
@@ -1179,6 +1283,7 @@ mod tests {
 
         let persist = HookPayload::ToolResultPersist {
             session_key: "s".into(),
+            tool_call_id: Some("call-1".into()),
             tool_name: "exec".into(),
             result: serde_json::json!({"cwd": "/tmp"}),
             channel: Some(test_channel_binding()),
@@ -1186,7 +1291,12 @@ mod tests {
         let json = serde_json::to_string(&persist).unwrap();
         let deser: HookPayload = serde_json::from_str(&json).unwrap();
         match deser {
-            HookPayload::ToolResultPersist { channel, .. } => {
+            HookPayload::ToolResultPersist {
+                tool_call_id,
+                channel,
+                ..
+            } => {
+                assert_eq!(tool_call_id.as_deref(), Some("call-1"));
                 assert_eq!(channel, Some(test_channel_binding()));
             },
             other => panic!("unexpected payload: {other:?}"),
@@ -1203,7 +1313,12 @@ mod tests {
         });
         let payload: HookPayload = serde_json::from_value(json).unwrap();
         match payload {
-            HookPayload::BeforeToolCall { channel, .. } => {
+            HookPayload::BeforeToolCall {
+                tool_call_id,
+                channel,
+                ..
+            } => {
+                assert!(tool_call_id.is_none());
                 assert!(channel.is_none());
             },
             other => panic!("unexpected payload: {other:?}"),
@@ -1234,7 +1349,12 @@ mod tests {
         });
         let payload: HookPayload = serde_json::from_value(json).unwrap();
         match payload {
-            HookPayload::AfterToolCall { channel, .. } => {
+            HookPayload::AfterToolCall {
+                tool_call_id,
+                channel,
+                ..
+            } => {
+                assert!(tool_call_id.is_none());
                 assert!(channel.is_none());
             },
             other => panic!("unexpected payload: {other:?}"),

--- a/crates/common/src/hooks.rs
+++ b/crates/common/src/hooks.rs
@@ -174,6 +174,9 @@ pub enum HookPayload {
     },
     AgentEnd {
         session_key: String,
+        /// Stable identifier shared by every hook event in one admitted turn.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        turn_id: Option<String>,
         text: String,
         iterations: usize,
         tool_calls: usize,
@@ -206,6 +209,9 @@ pub enum HookPayload {
     },
     MessageReceived {
         session_key: String,
+        /// Stable identifier shared by every hook event in one admitted turn.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        turn_id: Option<String>,
         content: String,
         channel: Option<String>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -221,6 +227,9 @@ pub enum HookPayload {
     },
     BeforeToolCall {
         session_key: String,
+        /// Stable identifier shared by every hook event in one admitted turn.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        turn_id: Option<String>,
         /// Stable identifier shared by every event for this tool invocation.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         tool_call_id: Option<String>,
@@ -231,10 +240,16 @@ pub enum HookPayload {
     },
     AfterToolCall {
         session_key: String,
+        /// Stable identifier shared by every hook event in one admitted turn.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        turn_id: Option<String>,
         /// Stable identifier shared by every event for this tool invocation.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         tool_call_id: Option<String>,
         tool_name: String,
+        /// Effective arguments after any `BeforeToolCall` rewrite.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        arguments: Option<Value>,
         success: bool,
         result: Option<Value>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -358,6 +373,7 @@ pub async fn dispatch_message_sent(
 pub async fn dispatch_agent_end(
     registry: Option<&HookRegistry>,
     session_key: &str,
+    turn_id: Option<&str>,
     text: &str,
     iterations: usize,
     tool_calls: usize,
@@ -367,6 +383,7 @@ pub async fn dispatch_agent_end(
     };
     let payload = HookPayload::AgentEnd {
         session_key: session_key.to_string(),
+        turn_id: turn_id.map(ToOwned::to_owned),
         text: text.to_string(),
         iterations,
         tool_calls,
@@ -867,6 +884,7 @@ mod tests {
     fn modifying_payload() -> HookPayload {
         HookPayload::BeforeToolCall {
             session_key: "test".into(),
+            turn_id: None,
             tool_call_id: Some("call-test".into()),
             tool_name: "exec".into(),
             arguments: serde_json::json!({}),
@@ -1021,6 +1039,7 @@ mod tests {
 
         let payload = HookPayload::MessageReceived {
             session_key: "test".into(),
+            turn_id: None,
             content: "hello".into(),
             channel: Some("telegram".into()),
             channel_binding: None,
@@ -1064,6 +1083,7 @@ mod tests {
 
         let payload = HookPayload::MessageReceived {
             session_key: "test".into(),
+            turn_id: None,
             content: "original".into(),
             channel: None,
             channel_binding: None,
@@ -1210,6 +1230,7 @@ mod tests {
         let binding = test_channel_binding();
         let before = HookPayload::BeforeToolCall {
             session_key: "s".into(),
+            turn_id: Some("turn-1".into()),
             tool_call_id: Some("call-1".into()),
             tool_name: "exec".into(),
             arguments: serde_json::json!({"command": "pwd"}),
@@ -1219,10 +1240,12 @@ mod tests {
         let deser: HookPayload = serde_json::from_str(&json).unwrap();
         match deser {
             HookPayload::BeforeToolCall {
+                turn_id,
                 tool_call_id,
                 channel,
                 ..
             } => {
+                assert_eq!(turn_id.as_deref(), Some("turn-1"));
                 assert_eq!(tool_call_id.as_deref(), Some("call-1"));
                 assert_eq!(channel, Some(binding.clone()));
             },
@@ -1231,6 +1254,7 @@ mod tests {
 
         let message = HookPayload::MessageReceived {
             session_key: "s".into(),
+            turn_id: None,
             content: "hello".into(),
             channel: Some("telegram".into()),
             channel_binding: Some(binding.clone()),
@@ -1261,8 +1285,10 @@ mod tests {
 
         let after = HookPayload::AfterToolCall {
             session_key: "s".into(),
+            turn_id: Some("turn-1".into()),
             tool_call_id: Some("call-1".into()),
             tool_name: "exec".into(),
+            arguments: Some(serde_json::json!({"command": "pwd"})),
             success: true,
             result: Some(serde_json::json!({"cwd": "/tmp"})),
             channel: Some(test_channel_binding()),
@@ -1271,11 +1297,15 @@ mod tests {
         let deser: HookPayload = serde_json::from_str(&json).unwrap();
         match deser {
             HookPayload::AfterToolCall {
+                turn_id,
                 tool_call_id,
+                arguments,
                 channel,
                 ..
             } => {
+                assert_eq!(turn_id.as_deref(), Some("turn-1"));
                 assert_eq!(tool_call_id.as_deref(), Some("call-1"));
+                assert_eq!(arguments, Some(serde_json::json!({"command": "pwd"})));
                 assert_eq!(channel, Some(test_channel_binding()));
             },
             other => panic!("unexpected payload: {other:?}"),

--- a/crates/gateway/src/external_agents.rs
+++ b/crates/gateway/src/external_agents.rs
@@ -940,14 +940,16 @@ impl ExternalAgentChatService {
             BroadcastOpts::default(),
         )
         .await;
-        deliver_external_agent_channel_reply(
+        let channel_delivery_succeeded = deliver_external_agent_channel_reply(
             &self.state,
             channel_reply_target,
             &assistant_text,
             &session_key,
         )
         .await;
-        dispatch_message_sent(hook_registry.as_deref(), &session_key, &assistant_text).await;
+        if channel_delivery_succeeded {
+            dispatch_message_sent(hook_registry.as_deref(), &session_key, &assistant_text).await;
+        }
         info!(
             session = %session_key,
             kind = kind.as_str(),
@@ -974,9 +976,9 @@ async fn deliver_external_agent_channel_reply(
     target: Option<moltis_channels::ChannelReplyTarget>,
     text: &str,
     session_key: &str,
-) {
+) -> bool {
     let Some(target) = target else {
-        return;
+        return true;
     };
     if text.trim().is_empty() {
         info!(
@@ -985,7 +987,7 @@ async fn deliver_external_agent_channel_reply(
             chat_id = target.chat_id,
             "external-agent channel reply skipped: empty response text"
         );
-        return;
+        return false;
     }
     let Some(outbound) = state.services.channel_outbound_arc() else {
         warn!(
@@ -994,7 +996,7 @@ async fn deliver_external_agent_channel_reply(
             chat_id = target.chat_id,
             "external-agent channel reply skipped: outbound unavailable"
         );
-        return;
+        return false;
     };
     let to = target.outbound_to().into_owned();
     if let Err(error) = outbound
@@ -1009,7 +1011,9 @@ async fn deliver_external_agent_channel_reply(
             %error,
             "external-agent channel reply failed"
         );
+        return false;
     }
+    true
 }
 
 #[async_trait]

--- a/crates/gateway/src/external_agents.rs
+++ b/crates/gateway/src/external_agents.rs
@@ -11,6 +11,10 @@ mod security;
 use {
     async_trait::async_trait,
     futures::StreamExt,
+    moltis_common::hooks::{
+        HookAction, HookPayload, MessageSendingOutcome, dispatch_agent_end,
+        dispatch_message_sending, dispatch_message_sent,
+    },
     moltis_config::schema::ExternalAgentsConfig,
     moltis_external_agents::{
         AcpPermissionHandler, AgentTransportKind, ContextSnapshot, ExternalAgentEvent,
@@ -591,12 +595,13 @@ impl ExternalAgentChatService {
         session_key: String,
         kind: AgentTransportKind,
     ) -> ServiceResult {
-        let text = params
+        let mut text = params
             .get("text")
             .or_else(|| params.get("message"))
             .and_then(|value| value.as_str())
             .ok_or_else(|| "external agents currently require text input".to_string())?
             .to_string();
+        let hook_registry = self.state.inner.read().await.hook_registry.clone();
         let channel_reply_target = params
             .get("_channel_reply_target")
             .cloned()
@@ -613,6 +618,79 @@ impl ExternalAgentChatService {
                     },
                 }
             });
+        if let Some(ref hooks) = hook_registry {
+            let session_entry = self.session_metadata.get(&session_key).await;
+            let channel_binding = match moltis_channels::resolve_session_channel_binding(
+                &session_key,
+                session_entry
+                    .as_ref()
+                    .and_then(|entry| entry.channel_binding.as_deref()),
+            ) {
+                Ok(binding) => Some(binding).filter(|binding| !binding.is_empty()),
+                Err(error) => {
+                    warn!(
+                        session = %session_key,
+                        %error,
+                        "failed to resolve external-agent hook channel provenance"
+                    );
+                    None
+                },
+            };
+            let payload = HookPayload::MessageReceived {
+                session_key: session_key.clone(),
+                content: text.clone(),
+                channel: params
+                    .get("channel")
+                    .and_then(Value::as_str)
+                    .map(ToOwned::to_owned),
+                channel_binding,
+            };
+            match hooks.dispatch(&payload).await {
+                Ok(HookAction::Continue) => {},
+                Ok(HookAction::ModifyPayload(value)) => {
+                    if let Some(replacement) = value.get("content").and_then(Value::as_str) {
+                        text = replacement.to_string();
+                    } else {
+                        warn!(
+                            session = %session_key,
+                            "external-agent MessageReceived hook modification ignored: expected object with `content` string"
+                        );
+                    }
+                },
+                Ok(HookAction::Block(reason)) => {
+                    crate::broadcast::broadcast(
+                        &self.state,
+                        "chat",
+                        serde_json::json!({
+                            "state": "rejected",
+                            "sessionKey": session_key,
+                            "reason": reason,
+                        }),
+                        BroadcastOpts::default(),
+                    )
+                    .await;
+                    deliver_external_agent_channel_reply(
+                        &self.state,
+                        channel_reply_target,
+                        &reason,
+                        &session_key,
+                    )
+                    .await;
+                    return Ok(serde_json::json!({
+                        "ok": false,
+                        "rejected": true,
+                        "reason": reason,
+                    }));
+                },
+                Err(error) => {
+                    warn!(
+                        session = %session_key,
+                        %error,
+                        "external-agent MessageReceived hook failed; proceeding fail-open"
+                    );
+                },
+            }
+        }
         let seq = params.get("_seq").and_then(|value| value.as_u64());
         let run_id = uuid::Uuid::new_v4().to_string();
         let created_at = now_ms();
@@ -650,6 +728,32 @@ impl ExternalAgentChatService {
             .as_ref()
             .and_then(|selected| selected.effort.as_deref());
         let message_model = selected_model.unwrap_or_else(|| kind.as_str());
+
+        if let Some(ref hooks) = hook_registry {
+            let payload = HookPayload::BeforeAgentStart {
+                session_key: session_key.clone(),
+                model: message_model.to_string(),
+            };
+            match hooks.dispatch(&payload).await {
+                Ok(HookAction::Continue) => {},
+                Ok(HookAction::Block(reason)) => {
+                    return Err(format!("blocked by BeforeAgentStart hook: {reason}").into());
+                },
+                Ok(HookAction::ModifyPayload(_)) => {
+                    warn!(
+                        session = %session_key,
+                        "external-agent BeforeAgentStart modification ignored"
+                    );
+                },
+                Err(error) => {
+                    warn!(
+                        session = %session_key,
+                        %error,
+                        "external-agent BeforeAgentStart hook failed; proceeding fail-open"
+                    );
+                },
+            }
+        }
 
         crate::broadcast::broadcast(
             &self.state,
@@ -711,6 +815,7 @@ impl ExternalAgentChatService {
         let mut thinking_text = String::new();
         let mut token_usage = None;
         let mut external_error = None;
+        let mut tool_calls = 0;
         while let Some(event) = events.next().await {
             match event {
                 ExternalAgentEvent::TextDelta(delta) => {
@@ -752,8 +857,8 @@ impl ExternalAgentChatService {
                 ExternalAgentEvent::Done { usage } => {
                     token_usage = usage;
                 },
-                ExternalAgentEvent::ToolCallStart { .. }
-                | ExternalAgentEvent::ToolCallEnd { .. } => {},
+                ExternalAgentEvent::ToolCallStart { .. } => tool_calls += 1,
+                ExternalAgentEvent::ToolCallEnd { .. } => {},
             }
         }
         if let Some(external_session_id) = session.external_session_id().map(str::to_string) {
@@ -768,6 +873,23 @@ impl ExternalAgentChatService {
             self.external_agents.shutdown_binding(&session_key).await;
             return Err(error.into());
         }
+        dispatch_agent_end(
+            hook_registry.as_deref(),
+            &session_key,
+            &assistant_text,
+            1,
+            tool_calls,
+        )
+        .await;
+        assistant_text =
+            match dispatch_message_sending(hook_registry.as_deref(), &session_key, &assistant_text)
+                .await
+            {
+                MessageSendingOutcome::Send(content) => content,
+                MessageSendingOutcome::Block(reason) => {
+                    return Err(format!("blocked by MessageSending hook: {reason}").into());
+                },
+            };
         let duration_ms = start.elapsed().as_millis() as u64;
         let assistant_msg = PersistedMessage::Assistant {
             content: assistant_text.clone(),
@@ -825,6 +947,7 @@ impl ExternalAgentChatService {
             &session_key,
         )
         .await;
+        dispatch_message_sent(hook_registry.as_deref(), &session_key, &assistant_text).await;
         info!(
             session = %session_key,
             kind = kind.as_str(),

--- a/crates/gateway/src/external_agents.rs
+++ b/crates/gateway/src/external_agents.rs
@@ -601,6 +601,7 @@ impl ExternalAgentChatService {
             .and_then(|value| value.as_str())
             .ok_or_else(|| "external agents currently require text input".to_string())?
             .to_string();
+        let run_id = uuid::Uuid::new_v4().to_string();
         let hook_registry = self.state.inner.read().await.hook_registry.clone();
         let channel_reply_target = params
             .get("_channel_reply_target")
@@ -638,6 +639,7 @@ impl ExternalAgentChatService {
             };
             let payload = HookPayload::MessageReceived {
                 session_key: session_key.clone(),
+                turn_id: Some(run_id.clone()),
                 content: text.clone(),
                 channel: params
                     .get("channel")
@@ -692,7 +694,6 @@ impl ExternalAgentChatService {
             }
         }
         let seq = params.get("_seq").and_then(|value| value.as_u64());
-        let run_id = uuid::Uuid::new_v4().to_string();
         let created_at = now_ms();
         let mut history = self
             .session_store
@@ -876,6 +877,7 @@ impl ExternalAgentChatService {
         dispatch_agent_end(
             hook_registry.as_deref(),
             &session_key,
+            Some(&run_id),
             &assistant_text,
             1,
             tool_calls,

--- a/crates/gateway/src/external_agents/tests.rs
+++ b/crates/gateway/src/external_agents/tests.rs
@@ -7,6 +7,7 @@ use {
         services::GatewayServices,
     },
     futures::{Stream, stream},
+    moltis_common::hooks::{HookAction, HookEvent, HookHandler, HookPayload, HookRegistry},
     moltis_external_agents::{
         ExternalAgentTransport,
         types::{AcpPermissionOption, ExternalAgentStatus},
@@ -14,6 +15,49 @@ use {
     moltis_service_traits::{ExternalAgentService, NoopChatService},
     moltis_sessions::{metadata::SqliteSessionMetadata, store::SessionStore},
 };
+
+#[derive(Default)]
+struct ExternalLifecycleHook {
+    payloads: std::sync::Mutex<Vec<HookPayload>>,
+}
+
+#[async_trait]
+impl HookHandler for ExternalLifecycleHook {
+    fn name(&self) -> &str {
+        "external-lifecycle"
+    }
+
+    fn events(&self) -> &[HookEvent] {
+        static EVENTS: [HookEvent; 5] = [
+            HookEvent::MessageReceived,
+            HookEvent::BeforeAgentStart,
+            HookEvent::AgentEnd,
+            HookEvent::MessageSending,
+            HookEvent::MessageSent,
+        ];
+        &EVENTS
+    }
+
+    async fn handle(
+        &self,
+        event: HookEvent,
+        payload: &HookPayload,
+    ) -> moltis_common::Result<HookAction> {
+        self.payloads
+            .lock()
+            .unwrap_or_else(|error| error.into_inner())
+            .push(payload.clone());
+        Ok(match event {
+            HookEvent::MessageReceived => {
+                HookAction::ModifyPayload(serde_json::json!({"content": "hooked prompt"}))
+            },
+            HookEvent::MessageSending => {
+                HookAction::ModifyPayload(serde_json::json!({"content": "hooked response"}))
+            },
+            _ => HookAction::Continue,
+        })
+    }
+}
 
 #[derive(Default)]
 struct FakeAgentState {
@@ -504,6 +548,79 @@ async fn bound_chat_send_reuses_live_external_session() {
             .and_then(|entry| entry.external_session_id),
         Some("fake-session-1".to_string())
     );
+}
+
+#[tokio::test]
+async fn bound_chat_send_dispatches_complete_hook_lifecycle() {
+    let dir = tempfile::tempdir().unwrap();
+    let session_store = Arc::new(SessionStore::new(dir.path().to_path_buf()));
+    let metadata = Arc::new(SqliteSessionMetadata::new(sqlite_pool().await));
+    let agent_state = Arc::new(FakeAgentState::default());
+    let external_agents = fake_external_agents(Arc::clone(&metadata), Arc::clone(&agent_state));
+    external_agents
+        .bind(serde_json::json!({ "sessionKey": "main", "kind": "codex" }))
+        .await
+        .expect("bind external agent");
+
+    let lifecycle_hook = Arc::new(ExternalLifecycleHook::default());
+    let mut hook_registry = HookRegistry::new();
+    hook_registry.register(lifecycle_hook.clone());
+    let state = test_gateway_state();
+    state.inner.write().await.hook_registry = Some(Arc::new(hook_registry));
+    let chat = test_chat_service_with_state(
+        Arc::clone(&external_agents),
+        Arc::clone(&metadata),
+        Arc::clone(&session_store),
+        state,
+    )
+    .await;
+
+    let result = chat
+        .send(serde_json::json!({ "sessionKey": "main", "text": "hello" }))
+        .await
+        .expect("send external prompt");
+
+    assert_eq!(result["text"], "hooked response");
+    assert_eq!(
+        *agent_state
+            .prompts
+            .lock()
+            .unwrap_or_else(|error| error.into_inner()),
+        vec!["hooked prompt".to_string()]
+    );
+    let history = session_store.read("main").await.expect("read history");
+    assert_eq!(history[0]["content"], "hooked prompt");
+    assert_eq!(history[1]["content"], "hooked response");
+
+    let payloads = lifecycle_hook
+        .payloads
+        .lock()
+        .unwrap_or_else(|error| error.into_inner());
+    assert_eq!(
+        payloads.iter().map(HookPayload::event).collect::<Vec<_>>(),
+        vec![
+            HookEvent::MessageReceived,
+            HookEvent::BeforeAgentStart,
+            HookEvent::AgentEnd,
+            HookEvent::MessageSending,
+            HookEvent::MessageSent,
+        ]
+    );
+    let HookPayload::AgentEnd {
+        text,
+        iterations,
+        tool_calls,
+        ..
+    } = &payloads[2]
+    else {
+        panic!("expected AgentEnd payload");
+    };
+    assert_eq!(text, "reply to hooked prompt");
+    assert_eq!((*iterations, *tool_calls), (1, 0));
+    let HookPayload::MessageSent { content, .. } = &payloads[4] else {
+        panic!("expected MessageSent payload");
+    };
+    assert_eq!(content, "hooked response");
 }
 
 #[tokio::test]

--- a/crates/gateway/src/external_agents/tests.rs
+++ b/crates/gateway/src/external_agents/tests.rs
@@ -258,6 +258,31 @@ struct RecordingOutbound {
     messages: Mutex<Vec<(String, String, String, Option<String>)>>,
 }
 
+struct FailingOutbound;
+
+#[async_trait]
+impl moltis_channels::ChannelOutbound for FailingOutbound {
+    async fn send_text(
+        &self,
+        _account_id: &str,
+        _to: &str,
+        _text: &str,
+        _reply_to: Option<&str>,
+    ) -> moltis_channels::Result<()> {
+        Err(moltis_channels::Error::unavailable("test delivery failure"))
+    }
+
+    async fn send_media(
+        &self,
+        _account_id: &str,
+        _to: &str,
+        _payload: &moltis_common::types::ReplyPayload,
+        _reply_to: Option<&str>,
+    ) -> moltis_channels::Result<()> {
+        Err(moltis_channels::Error::unavailable("test delivery failure"))
+    }
+}
+
 #[async_trait]
 impl moltis_channels::ChannelOutbound for RecordingOutbound {
     async fn send_text(
@@ -666,6 +691,62 @@ async fn bound_chat_send_delivers_external_reply_to_channel_target() {
         "reply to hello".to_string(),
         Some("456".to_string()),
     )]);
+}
+
+#[tokio::test]
+async fn failed_external_channel_delivery_suppresses_message_sent() {
+    let dir = tempfile::tempdir().unwrap();
+    let session_store = Arc::new(SessionStore::new(dir.path().to_path_buf()));
+    let metadata = Arc::new(SqliteSessionMetadata::new(sqlite_pool().await));
+    let agent_state = Arc::new(FakeAgentState::default());
+    let external_agents = fake_external_agents(Arc::clone(&metadata), agent_state);
+    external_agents
+        .bind(serde_json::json!({ "sessionKey": "telegram:bot:123", "kind": "codex" }))
+        .await
+        .expect("bind external agent");
+
+    let lifecycle_hook = Arc::new(ExternalLifecycleHook::default());
+    let mut hook_registry = HookRegistry::new();
+    hook_registry.register(lifecycle_hook.clone());
+    let state = test_gateway_state_with_services(
+        GatewayServices::noop().with_channel_outbound(Arc::new(FailingOutbound)),
+    );
+    state.inner.write().await.hook_registry = Some(Arc::new(hook_registry));
+    let chat = test_chat_service_with_state(
+        Arc::clone(&external_agents),
+        Arc::clone(&metadata),
+        Arc::clone(&session_store),
+        state,
+    )
+    .await;
+
+    chat.send(serde_json::json!({
+        "sessionKey": "telegram:bot:123",
+        "text": "hello",
+        "_channel_reply_target": {
+            "channel_type": "telegram",
+            "account_id": "bot",
+            "chat_id": "123",
+            "message_id": "456",
+            "thread_id": null,
+        },
+    }))
+    .await
+    .expect("complete external agent turn despite channel failure");
+
+    let payloads = lifecycle_hook
+        .payloads
+        .lock()
+        .unwrap_or_else(|error| error.into_inner());
+    assert_eq!(
+        payloads.iter().map(HookPayload::event).collect::<Vec<_>>(),
+        vec![
+            HookEvent::MessageReceived,
+            HookEvent::BeforeAgentStart,
+            HookEvent::AgentEnd,
+            HookEvent::MessageSending,
+        ]
+    );
 }
 
 #[tokio::test]

--- a/crates/gateway/src/server/seed_content.rs
+++ b/crates/gateway/src/server/seed_content.rs
@@ -64,7 +64,7 @@ echo "$(date -Iseconds) tool=$tool" >> /tmp/moltis-hook.log
 - `AgentEnd` — after an agent run completes
 - `AfterToolCall` — after a tool finishes (observe result)
 - `AfterCompaction` — after compaction completes
-- `MessageSent` — after the terminal assistant response is persisted and delivered
+- `MessageSent` — after persistence succeeds and all known channel targets accept delivery
 - `SessionStart` / `SessionEnd` — session lifecycle
 - `GatewayStart` / `GatewayStop` — server lifecycle
 

--- a/crates/gateway/src/server/seed_content.rs
+++ b/crates/gateway/src/server/seed_content.rs
@@ -57,14 +57,14 @@ echo "$(date -Iseconds) tool=$tool" >> /tmp/moltis-hook.log
 - `MessageReceived` — when an inbound channel/UI message arrives;
   `Block(reason)` rejects it, `ModifyPayload({"content": "..."})` rewrites
   the text before the turn begins
-- `MessageSending` — before sending a message to the LLM
+- `MessageSending` — before delivering the terminal assistant response
 - `ToolResultPersist` — before persisting a tool result
 
 **Read-only (parallel dispatch, Block/Modify ignored):**
 - `AgentEnd` — after an agent run completes
 - `AfterToolCall` — after a tool finishes (observe result)
 - `AfterCompaction` — after compaction completes
-- `MessageSent` — after a message is sent
+- `MessageSent` — after the terminal assistant response is persisted and delivered
 - `SessionStart` / `SessionEnd` — session lifecycle
 - `GatewayStart` / `GatewayStop` — server lifecycle
 

--- a/crates/plugins/src/hooks.rs
+++ b/crates/plugins/src/hooks.rs
@@ -128,6 +128,7 @@ mod tests {
     fn test_payload() -> HookPayload {
         HookPayload::BeforeToolCall {
             session_key: "test-session".into(),
+            turn_id: Some("turn-test".into()),
             tool_call_id: Some("call-test".into()),
             tool_name: "exec".into(),
             arguments: serde_json::json!({"command": "ls"}),

--- a/crates/plugins/src/hooks.rs
+++ b/crates/plugins/src/hooks.rs
@@ -128,6 +128,7 @@ mod tests {
     fn test_payload() -> HookPayload {
         HookPayload::BeforeToolCall {
             session_key: "test-session".into(),
+            tool_call_id: Some("call-test".into()),
             tool_name: "exec".into(),
             arguments: serde_json::json!({"command": "ls"}),
             channel: None,

--- a/docs/src/hooks.md
+++ b/docs/src/hooks.md
@@ -63,8 +63,10 @@ retracted; the hook still controls the authoritative terminal response.
 
 `MessageSent` is not emitted when authoritative response persistence fails,
 when a known channel target rejects the final reply, or when channel delivery
-times out. Web-only turns have no channel target; their final UI broadcast is
-emitted after persistence and immediately before `MessageSent`.
+times out. A channel-bound `MessageSending` rewrite to empty content also
+suppresses `MessageSent` because no terminal response was delivered. Web-only
+turns have no channel target; their final UI broadcast is emitted after
+persistence and immediately before `MessageSent`.
 
 ### Read-Only Events (Parallel)
 

--- a/docs/src/hooks.md
+++ b/docs/src/hooks.md
@@ -61,6 +61,11 @@ delivery. `Block(reason)` prevents that terminal response from being persisted
 or delivered. In streaming-only mode, already-emitted deltas cannot be
 retracted; the hook still controls the authoritative terminal response.
 
+`MessageSent` is not emitted when authoritative response persistence fails,
+when a known channel target rejects the final reply, or when channel delivery
+times out. Web-only turns have no channel target; their final UI broadcast is
+emitted after persistence and immediately before `MessageSent`.
+
 ### Read-Only Events (Parallel)
 
 These events run hooks in parallel for performance. They cannot modify or block.
@@ -70,7 +75,7 @@ These events run hooks in parallel for performance. They cannot modify or block.
 | `AfterToolCall` | After a tool completes |
 | `AfterCompaction` | After context is compacted |
 | `AgentEnd` | When agent loop completes |
-| `MessageSent` | After response is delivered |
+| `MessageSent` | After persistence succeeds and all known channel targets accept delivery |
 | `SessionStart` | When a new session begins |
 | `SessionEnd` | When a session ends |
 | `GatewayStart` | When Moltis starts |

--- a/docs/src/hooks.md
+++ b/docs/src/hooks.md
@@ -8,7 +8,7 @@ Hooks let you observe, modify, or block actions at key points in the agent lifec
 ┌──────────────────────────────────────────────────────────────┐
 │                        Agent Loop                            │
 │                                                              │
-│  User Message ─→ BeforeLLMCall ─→ LLM Provider              │
+│  User Message ─→ MessageReceived ─→ BeforeLLMCall ─→ LLM    │
 │                       │                 │                    │
 │                  modify/block      AfterLLMCall              │
 │                                         │                    │
@@ -25,7 +25,9 @@ Hooks let you observe, modify, or block actions at key points in the agent lifec
 │                                         │                    │
 │                                         ▼                    │
 │                              (loop continues or)             │
-│                             Response → MessageSent           │
+│                 AgentEnd → MessageSending → Delivery         │
+│                                              │               │
+│                                         MessageSent          │
 └──────────────────────────────────────────────────────────────┘
 ```
 
@@ -52,6 +54,12 @@ via the originating channel (or broadcast as a `chat` rejection event for web
 clients). `ModifyPayload` must return an object of shape `{"content": "..."}`;
 the `content` string replaces the inbound text before it reaches the model or
 the session store.
+
+For `MessageSending`, `ModifyPayload` uses the same `{"content": "..."}`
+shape and replaces the terminal assistant response before persistence and
+delivery. `Block(reason)` prevents that terminal response from being persisted
+or delivered. In streaming-only mode, already-emitted deltas cannot be
+retracted; the hook still controls the authoritative terminal response.
 
 ### Read-Only Events (Parallel)
 
@@ -112,9 +120,14 @@ Fires after the LLM response is received but before tool calls execute. For stre
 
 ## Channel Provenance
 
-`BeforeToolCall`, `AfterToolCall`, `SessionStart`, and `MessageReceived` currently include channel provenance. The fields are optional so hooks keep working for sessions that do not originate from a channel integration.
+`BeforeToolCall`, `AfterToolCall`, `ToolResultPersist`, `SessionStart`, and `MessageReceived` currently include channel provenance. The fields are optional so hooks keep working for sessions that do not originate from a channel integration.
 
-`MessageReceived` keeps its legacy `channel` string field and adds the richer object as `channel_binding`. `BeforeToolCall`, `AfterToolCall`, and `SessionStart` expose the same richer object as `channel`. `ToolResultPersist` has a schema field reserved for the same shape, but that event is not currently dispatched.
+`MessageReceived` keeps its legacy `channel` string field and adds the richer object as `channel_binding`. `BeforeToolCall`, `AfterToolCall`, `ToolResultPersist`, and `SessionStart` expose the same richer object as `channel`.
+
+Every `BeforeToolCall`, `AfterToolCall`, and `ToolResultPersist` payload also
+includes `tool_call_id`. The same non-empty identifier is retained across all
+events for one invocation, so hooks can correlate a decision, result, and
+persistence record without relying on tool name or event order.
 
 | Field | Type | Description |
 |-------|------|-------------|
@@ -132,6 +145,7 @@ Example `BeforeToolCall` payload excerpt:
 {
   "event": "BeforeToolCall",
   "session_key": "telegram:bot-main:-100123",
+  "tool_call_id": "call_01JXYZ",
   "tool_name": "exec",
   "arguments": {
     "command": "pwd"
@@ -265,6 +279,7 @@ The event payload is passed as JSON on stdin:
 {
   "event": "BeforeToolCall",
   "session_key": "abc123",
+  "tool_call_id": "call_01JXYZ",
   "tool_name": "exec",
   "arguments": {
     "command": "ls -la"


### PR DESCRIPTION
## Summary

- add an optional `tool_call_id` to `BeforeToolCall`, `AfterToolCall`, and `ToolResultPersist`, preserving old JSON payload compatibility while correlating one invocation end to end
- dispatch the previously declared `AgentEnd`, `MessageSending`, and `MessageSent` events for native non-streaming/streaming chat and external-agent outer lifecycles
- apply documented `MessageSending` rewrites and blocks before the authoritative terminal response is persisted and delivered
- emit `MessageSent` only after persistence succeeds and every known channel target accepts terminal delivery; suppress it on persistence failure, channel failure, skipped delivery, timeout, or a channel-bound empty/whitespace `MessageSending` rewrite
- let direct `/sh` commands be rewritten or blocked before execution and expose their before/after/persistence tool events under one stable call ID
- document lifecycle ordering, mutation shape, channel provenance, stable IDs, and the streaming-delta limitation

Closes #1254.
Closes #1255.

```mermaid
flowchart LR
    U[Inbound message] --> MR[MessageReceived]
    MR --> BAS[BeforeAgentStart]
    BAS --> L[Native or external agent loop]
    L --> BT[BeforeToolCall]
    BT --> X[Tool execution]
    X --> AT[AfterToolCall]
    AT --> TP[ToolResultPersist]
    TP --> L
    L --> AE[AgentEnd]
    AE --> MS[MessageSending]
    MS --> P[Persist terminal response]
    P --> D[Deliver to known channel targets]
    D -->|all accepted| MD[MessageSent]
    P -->|failed| NO[No MessageSent]
    D -->|failed, skipped, timed out, or empty rewrite| NO

    DS[Direct /sh] --> DBT[BeforeToolCall]
    DBT --> DX[Shell execution]
    DX --> DAT[AfterToolCall]
    DAT --> DTP[ToolResultPersist]

    ID[one stable tool_call_id] -. correlates .-> BT
    ID -. correlates .-> AT
    ID -. correlates .-> TP
    DID[one direct-shell tool_call_id] -. correlates .-> DBT
    DID -. correlates .-> DAT
    DID -. correlates .-> DTP
```

External-agent subprocesses remain opaque to Moltis: Moltis emits the outer message/agent lifecycle, while tool hooks inside Codex or another external agent remain the responsibility of that agent's own hook adapter. Moltis does not fabricate tool events it cannot gate. Direct `/sh` exposes only its tool lifecycle; it does not fabricate a model-agent lifecycle.

## Validation Completed & Remaining

### Completed

- [x] pinned nightly `cargo fmt --all -- --check`
- [x] `./scripts/check-file-size.sh`
- [x] `cargo clippy -p moltis-common -p moltis-agents -p moltis-chat -p moltis-gateway --all-targets -- -D warnings -A clippy::nonminimal_bool`
- [x] `cargo test -p moltis-chat --all-features` — 217 tests
- [x] `cargo test -p moltis-plugins` — 41 tests
- [x] `cargo test -p moltis-common hooks` — 20 tests
- [x] `cargo test -p moltis-agents test_tool_hook_lifecycle_shares_stable_call_id` — 1 test
- [x] `cargo test -p moltis-agents agent_end_hook` — 2 tests
- [x] `cargo test -p moltis-gateway external_agents` — 27 tests, including failed-channel suppression of `MessageSent`
- [x] `./scripts/local-validate.sh 1257` on `bdfb4b3f` — format, Biome, TypeScript, i18n, zizmor, install, lockfile, default-feature workspace lint/build, and targeted-test gates passed and statuses were published; browser E2E was explicitly skipped to avoid terminating shared local service ports
- [x] cross-repository black-box process-hook E2E via `speakeasy-api/agenthooks` against the rebuilt binary — PASS in 119.31s

The complete `moltis-chat --all-features` suite, the complete `moltis-plugins` suite, and all hook/external-agent target suites pass after the latest review fixes. Full-workspace validation also caught and fixed the stale plugin `BeforeToolCall` fixture so it carries the new optional `turn_id`.

The validation host is AMD/Linux and has no CUDA toolkit, so full-workspace validation used the repository's default feature set while `moltis-chat` was separately tested with all features. The portable release artifact reports `moltis 20260902.02`, has no missing dynamic dependencies, accepts `reasoning_effort = "max"`, and passed the real process-hook E2E with isolated temporary configuration.

### Remaining

- [ ] hosted CI
- [ ] maintainer review

## Manual QA

1. Verified a model-issued shell call emits `BeforeToolCall`, `AfterToolCall`, and `ToolResultPersist` with the same non-empty native `tool_call_id`.
2. Verified a successful response emits a correlated `MessageSending` followed by `MessageSent`, matching on session and content.
3. Verified failed external-channel delivery suppresses `MessageSent` while retaining the prior lifecycle events.
4. Verified channel-bound empty and whitespace-only `MessageSending` rewrites suppress `MessageSent`, while web-only turns retain success semantics.
5. Verified a `BeforeToolCall` denial of direct `/sh touch <marker>` prevents marker creation.
6. Verified a model-issued tool denial prevents execution and a modified shell input becomes the command actually executed.
7. Verified the installed and running executable hashes match, and both local and public `/health` endpoints report `20260902.02` after deployment.

For streaming-only responses, deltas sent before generation completes cannot be retracted. `MessageSending` still controls the final authoritative response and persistence.

