### PR TITLE
fix(exec): report missing shell accurately

### DIFF
--- a/crates/tools/src/exec.rs
+++ b/crates/tools/src/exec.rs
@@ -1,4 +1,9 @@
-use std::{collections::HashMap, path::PathBuf, sync::Arc, time::Duration};
+use std::{
+    collections::HashMap,
+    path::{Path, PathBuf},
+    sync::Arc,
+    time::Duration,
+};
 
 #[cfg(feature = "metrics")]
 use std::time::Instant;
@@ -147,6 +152,24 @@ async fn read_output_limited(
     Ok(output)
 }
 
+/// Resolve the ambiguous `NotFound` spawn error without blaming a valid working directory.
+fn exec_start_error(error: std::io::Error, working_dir: Option<&Path>) -> Error {
+    if error.kind() != std::io::ErrorKind::NotFound {
+        return Error::message(format!("failed to start command: {error}"));
+    }
+
+    if let Some(dir) = working_dir
+        && !dir.is_dir()
+    {
+        return Error::message(format!(
+            "failed to start command: working directory '{}' does not exist",
+            dir.display()
+        ));
+    }
+
+    Error::message("failed to start command: shell 'sh' not found in PATH")
+}
+
 /// Execute a shell command with timeout and output limits.
 #[tracing::instrument(skip(command, opts), fields(timeout_secs = opts.timeout.as_secs()))]
 pub async fn exec_command(command: &str, opts: &ExecOpts) -> Result<ExecResult> {
@@ -170,20 +193,8 @@ pub async fn exec_command(command: &str, opts: &ExecOpts) -> Result<ExecResult> 
     cmd.stderr(std::process::Stdio::piped());
     // Prevent the child from inheriting stdin.
     cmd.stdin(std::process::Stdio::null());
-    let mut child = OwnedProcessTree::spawn(cmd).map_err(|e| {
-        if e.kind() == std::io::ErrorKind::NotFound {
-            if let Some(ref dir) = opts.working_dir {
-                Error::message(format!(
-                    "failed to start command: working directory '{}' does not exist",
-                    dir.display()
-                ))
-            } else {
-                Error::message("failed to start command: shell 'sh' not found")
-            }
-        } else {
-            Error::message(format!("failed to start command: {e}"))
-        }
-    })?;
+    let mut child = OwnedProcessTree::spawn(cmd)
+        .map_err(|error| exec_start_error(error, opts.working_dir.as_deref()))?;
 
     let stdout = child
         .take_stdout()

--- a/crates/tools/src/exec/tests.rs
+++ b/crates/tools/src/exec/tests.rs
@@ -986,6 +986,31 @@ async fn test_exec_command_bad_working_dir_error_message() {
     );
 }
 
+#[cfg(unix)]
+#[tokio::test]
+async fn test_exec_command_missing_shell_reports_shell_when_working_dir_exists() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let opts = ExecOpts {
+        working_dir: Some(temp_dir.path().to_path_buf()),
+        env: vec![(
+            "PATH".to_owned(),
+            temp_dir.path().to_string_lossy().into_owned(),
+        )],
+        ..Default::default()
+    };
+
+    let err = exec_command("echo hello", &opts).await.unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("shell 'sh' not found"),
+        "error should identify the missing shell, got: {msg}"
+    );
+    assert!(
+        !msg.contains("working directory"),
+        "error should not blame an existing working directory, got: {msg}"
+    );
+}
+
 #[tokio::test]
 async fn test_completion_callback_fires() {
     let called = Arc::new(AtomicBool::new(false));


### PR DESCRIPTION
Closes #279.

Classifies spawn `NotFound` errors using the configured working directory, so an existing directory no longer hides a missing `sh` in `PATH`.

Tests: the focused default-feature tests pass, and `cargo check -p moltis-tools` passes. The reduced-feature crate suite passes 915/916; its WASM availability test requires the disabled default WASM feature. The repository's pinned nightly formatter was unavailable locally.

AI-assisted; this summary includes the relevant implementation and validation context. The full local session is omitted because it contains unrelated workspace details.
