### PR TITLE
fix(tls): restrict ALPN to HTTP/1.1

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -244,6 +244,7 @@ in `default_sandbox_packages()`. CLI: `moltis sandbox {list,build,remove,clean}`
 ## Security
 
 - **WebSocket Origin validation**: `server.rs` rejects cross-origin WS upgrades (403). Loopback variants equivalent.
+- **TLS ALPN**: Advertise HTTP/1.1 only while the gateway lacks RFC 8441 WebSocket-over-HTTP/2 support.
 - **SSRF protection**: `web_fetch.rs` blocks loopback/private/link-local/CGNAT IPs. Preserve this on changes.
 - **Secrets**: Use `secrecy::Secret<String>` for all passwords/keys/tokens. `expose_secret()` only at consumption point. Manual `Debug` impl with `[REDACTED]`. Scope `RwLock` read guards in blocks to avoid deadlocks. See `crates/oauth/src/types.rs` for serde helpers.
 - **Never commit** passwords, credentials, `.env` with real values, or PII.

--- a/crates/tls/src/certs.rs
+++ b/crates/tls/src/certs.rs
@@ -340,7 +340,9 @@ pub(crate) fn load_rustls_config(cert_path: &Path, key_path: &Path) -> Result<Se
         .with_no_client_auth()
         .with_single_cert(certs, key)
         .context("build rustls ServerConfig")?;
-    config.alpn_protocols = vec![b"h2".to_vec(), b"http/1.1".to_vec()];
+    // Hyper does not enable RFC 8441 extended CONNECT, so advertising HTTP/2
+    // here makes browsers negotiate a protocol that cannot upgrade WebSockets.
+    config.alpn_protocols = vec![b"http/1.1".to_vec()];
     Ok(config)
 }
 
@@ -389,8 +391,8 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let mgr = FsCertManager::with_dir(tmp.path().to_path_buf());
         let (_ca, cert, key) = mgr.ensure_certs(&[]).unwrap();
-        let config = mgr.build_rustls_config(&cert, &key);
-        assert!(config.is_ok());
+        let config = mgr.build_rustls_config(&cert, &key).unwrap();
+        assert_eq!(config.alpn_protocols, [b"http/1.1"]);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- advertise only HTTP/1.1 over TLS until RFC 8441 WebSocket upgrades are supported
- pin the ALPN list in the existing TLS config test
- document the protocol constraint in contributor guidance

Fixes #245.

## Validation

### Completed
- [x] `cargo test -p moltis-tls` (18 passed)
- [x] `cargo clippy -p moltis-tls --all-targets -- -D warnings`
- [x] pinned-nightly `cargo fmt -p moltis-tls -- --check`
- [x] changelog guard

### Remaining
- [ ] CI

## Manual QA
Not run; the regression directly verifies the rustls ALPN configuration used by TLS listeners.
