### PR TITLE
fix(cron): treat active_hours end="24:00" as end-of-day

### DIFF
--- a/crates/cron/src/heartbeat.rs
+++ b/crates/cron/src/heartbeat.rs
@@ -134,16 +134,15 @@ pub fn is_within_active_hours(start: &str, end: &str, timezone: &str) -> bool {
         Some(t) => t,
         None => return true, // invalid config → always active
     };
-    let end_time = match parse_hhmm(end) {
-        Some(t) => t,
-        None => return true,
-    };
-
-    // "24:00" means end-of-day.
+    // "24:00" means end-of-day. chrono's `%H` rejects hour 24, so this must
+    // run before parsing `end`.
     let end_minutes = if end == "24:00" {
         24 * 60
     } else {
-        end_time.hour() * 60 + end_time.minute()
+        match parse_hhmm(end) {
+            Some(t) => t.hour() * 60 + t.minute(),
+            None => return true,
+        }
     };
     let start_minutes = start_time.hour() * 60 + start_time.minute();
 
@@ -273,6 +272,17 @@ fn current_minutes(timezone: &str) -> u32 {
 mod tests {
     use super::*;
 
+    /// Fixed-offset zones, no DST, spaced so that at any instant exactly 4 of
+    /// the 6 local times fall inside an 08:00–24:00 window and 2 outside.
+    const TIMEZONES: [&str; 6] = [
+        "Etc/GMT+12",
+        "Etc/GMT+8",
+        "Etc/GMT+4",
+        "UTC",
+        "Etc/GMT-4",
+        "Etc/GMT-8",
+    ];
+
     // ── strip_heartbeat_token ────────────────────────────────────────────
 
     #[test]
@@ -356,6 +366,34 @@ mod tests {
     #[test]
     fn invalid_time_always_active() {
         assert!(is_within_active_hours("invalid", "24:00", "local"));
+    }
+
+    #[test]
+    fn end_2400_suppresses_before_start_of_default_window() {
+        // Default config. `start` has a value that parses, so only `end`
+        // decides the parse here; an overnight local time must be outside.
+        let outside: Vec<&str> = TIMEZONES
+            .iter()
+            .copied()
+            .filter(|tz| !is_within_active_hours("08:00", "24:00", tz))
+            .collect();
+        assert_eq!(
+            outside.len(),
+            2,
+            "expected 4 of 6 zones inside an 08:00–24:00 window and 2 outside, got outside: {outside:?}"
+        );
+    }
+
+    #[test]
+    fn full_day_window_2400_end_is_always_active() {
+        assert!(is_within_active_hours("00:00", "24:00", "Etc/GMT+12"));
+        assert!(is_within_active_hours("00:00", "24:00", "UTC"));
+        assert!(is_within_active_hours("00:00", "24:00", "Etc/GMT-8"));
+    }
+
+    #[test]
+    fn start_2400_is_invalid_and_stays_always_active() {
+        assert!(is_within_active_hours("24:00", "17:00", "UTC"));
     }
 
     #[test]

--- a/crates/cron/src/heartbeat.rs
+++ b/crates/cron/src/heartbeat.rs
@@ -1,6 +1,6 @@
 //! Heartbeat logic: token stripping, empty-content detection, active-hours check.
 
-use chrono::{Local, NaiveTime, Timelike, Utc};
+use chrono::{DateTime, Local, NaiveTime, Timelike, Utc};
 
 /// The sentinel token an LLM returns when nothing noteworthy is happening.
 pub const HEARTBEAT_OK: &str = "HEARTBEAT_OK";
@@ -130,6 +130,10 @@ pub fn is_heartbeat_content_empty(content: &str) -> bool {
 /// Handles overnight windows (e.g. start=22:00, end=06:00).
 /// If timezone is "local" or empty, uses the system local time.
 pub fn is_within_active_hours(start: &str, end: &str, timezone: &str) -> bool {
+    is_within_active_hours_at(start, end, timezone, &Utc::now())
+}
+
+fn is_within_active_hours_at(start: &str, end: &str, timezone: &str, now: &DateTime<Utc>) -> bool {
     let start_time = match parse_hhmm(start) {
         Some(t) => t,
         None => return true, // invalid config → always active
@@ -146,7 +150,7 @@ pub fn is_within_active_hours(start: &str, end: &str, timezone: &str) -> bool {
     };
     let start_minutes = start_time.hour() * 60 + start_time.minute();
 
-    let now_minutes = current_minutes(timezone);
+    let now_minutes = current_minutes_at(timezone, now);
 
     if start_minutes <= end_minutes {
         // Normal window: 08:00–24:00
@@ -254,23 +258,23 @@ fn parse_hhmm(s: &str) -> Option<NaiveTime> {
     NaiveTime::parse_from_str(s, "%H:%M").ok()
 }
 
-fn current_minutes(timezone: &str) -> u32 {
+fn current_minutes_at(timezone: &str, now: &DateTime<Utc>) -> u32 {
     if timezone.is_empty() || timezone == "local" {
-        let local = Local::now();
+        let local = now.with_timezone(&Local);
         local.hour() * 60 + local.minute()
     } else if let Ok(tz) = timezone.parse::<chrono_tz::Tz>() {
-        let dt = Utc::now().with_timezone(&tz);
+        let dt = now.with_timezone(&tz);
         dt.hour() * 60 + dt.minute()
     } else {
         // Fallback to local on invalid tz.
-        let local = Local::now();
+        let local = now.with_timezone(&Local);
         local.hour() * 60 + local.minute()
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use {super::*, chrono::TimeZone};
 
     /// Fixed-offset zones, no DST, spaced so that at any instant exactly 4 of
     /// the 6 local times fall inside an 08:00–24:00 window and 2 outside.
@@ -370,12 +374,11 @@ mod tests {
 
     #[test]
     fn end_2400_suppresses_before_start_of_default_window() {
-        // Default config. `start` has a value that parses, so only `end`
-        // decides the parse here; an overnight local time must be outside.
+        let now = Utc.with_ymd_and_hms(2026, 1, 1, 12, 0, 0).unwrap();
         let outside: Vec<&str> = TIMEZONES
             .iter()
             .copied()
-            .filter(|tz| !is_within_active_hours("08:00", "24:00", tz))
+            .filter(|tz| !is_within_active_hours_at("08:00", "24:00", tz, &now))
             .collect();
         assert_eq!(
             outside.len(),


### PR DESCRIPTION
## Summary

`is_within_active_hours` parsed `end` before its own "24:00" special case. chrono's `%H` rejects hour 24, so with the documented default window (`start = "08:00"`, `end = "24:00"`) the parse failed and the invalid-config fail-open returned always-active at every hour, leaving the `24 * 60` end-of-day branch unreachable dead code. The sentinel is now checked before parsing, so `end = "24:00"` means [08:00, 24:00).

The sentinel stays end-only: `start = "24:00"` keeps failing open like any other invalid bound, same as before.

Fixes #1223

## Root cause

`NaiveTime::parse_from_str("24:00", "%H:%M")` is `Err(OutOfRange)` on the locked chrono (0.4.44), so `parse_hhmm(end)` returned `None` for the shipped default and the function returned `true` through the invalid-config branch before ever reaching the special case written for exactly that value.

## Validation

### Completed

- [x] before, on current `main`: the new default-window test fails with `outside: []`, every one of six fixed-offset zones reads inside the 08:00-24:00 window at the same instant
- [x] `cargo test -p moltis-cron`: 143 passed (140 existing + 3 new)
- [x] `cargo fmt --all -- --check`: clean
- [x] `cargo clippy -Z unstable-options -p moltis-cron --all-targets -- -D warnings`: clean

The regression uses a fixed instant, 2026-01-01 12:00 UTC, across six fixed-offset zones. It checks both sides of the default active-hours window without depending on the wall clock.

### Remaining

- [ ] `./scripts/local-validate.sh <PR>`

## Notes

- nothing on `main` calls `is_within_active_hours` yet, so this patch alone doesn't change what a running server does. #1208 wires the window into the scheduler for #1205; with both landed, a default config stops taking heartbeat turns between 00:00 and 08:00, which is what the config template and the schema docs already promise for `end = "24:00"`.
- no full session export to attach here; the summary and root cause above cover the whole investigation.
